### PR TITLE
Added latest CMAKE version to bionic and fixed git visibility on PATH on centos7.4 dependency images

### DIFF
--- a/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
+++ b/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
@@ -19,3 +19,9 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
 add-apt-repository -y ppa:git-core/ppa
 apt-get update
 apt-get install -y git
+
+# Install latest version of CMAKE
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
+apt-get update
+apt-get install -y cmake

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -13,7 +13,10 @@ RUN cd /root && ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/insta
 ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
 # Enable gcc 7
-RUN echo -e "\nsource /opt/rh/devtoolset-7/enable" >> /root/.bashrc
+RUN ln -s /opt/rh/devtoolset-7/enable /etc/profile.d/devtoolset.sh
 
 # Enable git 2.27
-RUN echo -e "\nsource /opt/rh/rh-git227/enable" >> /root/.bashrc
+RUN ln -s /opt/rh/rh-git227/enable /etc/profile.d/git.sh
+
+# Load .bashrc for non-interactive bash shells
+ENV BASH_ENV=/root/.bashrc


### PR DESCRIPTION
# Changes
- Updated the prebuilt packages script for bionic to install latest version of CMAKE, vesion `2.10` is installed currently and `2.20+` is needed to build CLP Core
- Updated Dockerfile for centos7.4 to load bashrc for noninteractive shells

# Validation
Tested dependency image build workflow on fork