### PR TITLE
Forcibly enable the SCL git package in the centos 7.4 dependency image; Minor refactoring of Docker files

### DIFF
--- a/components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:bionic
 
-RUN mkdir -p /root/tools/docker-images/clp-env-base-bionic
-ADD ./tools/docker-images/clp-env-base-bionic/setup-scripts /root/tools/docker-images/clp-env-base-bionic/setup-scripts
+WORKDIR /root
 
-RUN mkdir -p /root/tools/scripts/lib_install
-ADD ./tools/scripts/lib_install /root/tools/scripts/lib_install
+RUN mkdir -p ./tools/docker-images/clp-env-base-bionic
+ADD ./tools/docker-images/clp-env-base-bionic/setup-scripts ./tools/docker-images/clp-env-base-bionic/setup-scripts
 
-RUN cd /root && ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
-RUN cd /root && ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-packages-from-source.sh
+RUN mkdir -p ./tools/scripts/lib_install
+ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
+
+RUN ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
+RUN ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-packages-from-source.sh

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -1,13 +1,15 @@
 FROM centos:centos7.4.1708
 
-RUN mkdir -p /root/tools/docker-images/clp-env-base-centos7.4
-ADD ./tools/docker-images/clp-env-base-centos7.4/setup-scripts /root/tools/docker-images/clp-env-base-centos7.4/setup-scripts
+WORKDIR /root
 
-RUN mkdir -p /root/tools/scripts/lib_install
-ADD ./tools/scripts/lib_install /root/tools/scripts/lib_install
+RUN mkdir -p ./tools/docker-images/clp-env-base-centos7.4
+ADD ./tools/docker-images/clp-env-base-centos7.4/setup-scripts ./tools/docker-images/clp-env-base-centos7.4/setup-scripts
 
-RUN cd /root && ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-prebuilt-packages.sh
-RUN cd /root && ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-packages-from-source.sh
+RUN mkdir -p ./tools/scripts/lib_install
+ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
+
+RUN ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-prebuilt-packages.sh
+RUN ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-packages-from-source.sh
 
 # Set PKG_CONFIG_PATH since CentOS doesn't look in /usr/local by default
 ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
@@ -16,7 +18,9 @@ ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
 RUN ln -s /opt/rh/devtoolset-7/enable /etc/profile.d/devtoolset.sh
 
 # Enable git 2.27
-RUN ln -s /opt/rh/rh-git227/enable /etc/profile.d/git.sh
+# NOTE: We use a script to enable the SCL git package on each git call because some Github actions
+#       cannot be forced to use a bash shell that loads .bashrc
+RUN cp ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/git /usr/bin/git
 
 # Load .bashrc for non-interactive bash shells
 ENV BASH_ENV=/root/.bashrc

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/git
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/git
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /opt/rh/rh-git227/enable
+git "$@"

--- a/components/core/tools/docker-images/clp-env-base-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-focal/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:focal
 
-RUN mkdir -p /root/tools/docker-images/clp-env-base-focal
-ADD ./tools/docker-images/clp-env-base-focal/setup-scripts /root/tools/docker-images/clp-env-base-focal/setup-scripts
+WORKDIR /root
 
-RUN mkdir -p /root/tools/scripts/lib_install
-ADD ./tools/scripts/lib_install /root/tools/scripts/lib_install
+RUN mkdir -p ./tools/docker-images/clp-env-base-focal
+ADD ./tools/docker-images/clp-env-base-focal/setup-scripts ./tools/docker-images/clp-env-base-focal/setup-scripts
 
-RUN cd /root && ./tools/docker-images/clp-env-base-focal/setup-scripts/install-prebuilt-packages.sh
-RUN cd /root && ./tools/docker-images/clp-env-base-focal/setup-scripts/install-packages-from-source.sh
+RUN mkdir -p ./tools/scripts/lib_install
+ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
+
+RUN ./tools/docker-images/clp-env-base-focal/setup-scripts/install-prebuilt-packages.sh
+RUN ./tools/docker-images/clp-env-base-focal/setup-scripts/install-packages-from-source.sh

--- a/tools/docker-images/clp-execution-base-focal/Dockerfile
+++ b/tools/docker-images/clp-execution-base-focal/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:focal
 
-RUN mkdir -p /root/tools/docker-images/clp-execution-base-focal
-ADD ./tools/docker-images/clp-execution-base-focal/setup-scripts /root/tools/docker-images/clp-execution-base-focal/setup-scripts
+WORKDIR /root
 
-RUN mkdir -p /root/tools/scripts/lib_install
-ADD ./components/core/tools/scripts/lib_install /root/tools/scripts/lib_install
+RUN mkdir -p ./tools/docker-images/clp-execution-base-focal
+ADD ./tools/docker-images/clp-execution-base-focal/setup-scripts ./tools/docker-images/clp-execution-base-focal/setup-scripts
 
-RUN cd /root && ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
-RUN cd /root && ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-packages-from-source.sh
+RUN mkdir -p ./tools/scripts/lib_install
+ADD ./components/core/tools/scripts/lib_install ./tools/scripts/lib_install
+
+RUN ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
+RUN ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-packages-from-source.sh


### PR DESCRIPTION
Necessary for some Github actions that cannot be configured to use a bash shell with .bashrc loaded