### PR TITLE
Added Workflow Dependencies

### DIFF
--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -1,4 +1,4 @@
-name: Test Building CLP Core on Ubuntu Focal, Bionic and Centos 7.4
+name: build-clp-core
 
 on:
   push:
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/clp-core-build.yaml'
   workflow_dispatch:
   workflow_run:
-    workflows: ["Build and Publish Image with Dependencies to Build CLP Core"]
+    workflows: ["generate-build-dependency-image"]
     branches: [main]
     types:
       - completed

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -18,7 +18,7 @@ on:
     types:
       - completed
 
-concurrency: build-${{github.ref}} 
+concurrency: build-${{github.ref}}
 
 jobs:
   build-focal:

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -13,7 +13,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME_BASE: ${{github.repository}}/clp-core-dependencies-x86
 
-concurrency: build-${{github.ref}} 
+concurrency: build-${{github.ref}}
 
 jobs:
   build:

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Image with Dependencies to Build CLP Core
+name: generate-build-dependency-image
 
 on:
   push:

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Image with Execution Dependencies
+name: generate-execution-dependency-image
 
 on:
   push:


### PR DESCRIPTION
Changes
- The clp core build workflow requires the newest version of the dependency images published by the clp dependencies build workflow
- Added a concurrency group to pause the clp core build workflow if there is a concurrent dependency build workflow running
- Added a trigger to the clp core build workflow on the completion of a dependency build workflow

Validation
- Tested workflows on fork