### PR TITLE
Update Celery to 5.2.2 to prevent CVE-2021-23727

### DIFF
--- a/components/job-orchestration/requirements.txt
+++ b/components/job-orchestration/requirements.txt
@@ -1,6 +1,6 @@
 python-Levenshtein
 pika==1.2.0
-celery==5.1.2
+celery==5.2.2
 msgpack~=1.0.2
 zstandard~=0.15.2
 mysql-connector-python==8.0.26


### PR DESCRIPTION
# References
CVE-2021-23727

# Validation performed
* Built package with Celery 5.2.2
* Compressed and decompressed a dataset
* Diffed the dataset with the decompressed output to ensure lossless compression
