### PR TITLE
Refactor library installation scripts and add ability to specify output directory for generated .deb package.

### DIFF
--- a/components/core/tools/scripts/lib_install/fmtlib.sh
+++ b/components/core/tools/scripts/lib_install/fmtlib.sh
@@ -3,77 +3,81 @@
 # Exit on any error
 set -e
 
-cUsage="Usage: ${BASH_SOURCE[0]} <version>"
+cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then
     echo $cUsage
     exit
 fi
 version=$1
 
-echo "Checking for elevated privileges..."
-if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-  sudo echo "Script can elevate privileges."
-fi
-
-# Get number of cpu cores
-num_cpus=$(grep -c ^processor /proc/cpuinfo)
-
 package_name=fmtlib
-
-# Create temp dir for installation
 temp_dir=/tmp/${package_name}-installation
-mkdir -p $temp_dir
+deb_output_dir=${temp_dir}
+if [[ "$#" -gt 1 ]] ; then
+  deb_output_dir="$(readlink -f "$2")"
+  if [ ! -d ${deb_output_dir} ] ; then
+    echo "${deb_output_dir} does not exist or is not a directory"
+    exit
+  fi
+fi
 
 # Check if already installed
 set +e
 dpkg -l ${package_name}
 installed=$?
 set -e
-
-# Install if necessary
-if [ $installed -ne 0 ] ; then
-  # Download and build
-  cd $temp_dir
-  extracted_dir=${temp_dir}/fmt-${version}
-  if [ ! -e ${extracted_dir} ] ; then
-    tar_filename=${version}.tar.gz
-    if [ ! -e ${tar_filename} ] ; then
-      wget https://github.com/fmtlib/fmt/archive/refs/tags/${tar_filename}
-    fi
-
-    tar -xf ${tar_filename}
-  fi
-
-  cd ${extracted_dir}
-  mkdir -p cmake-build-release
-  cd cmake-build-release
-
-  # Build
-  cmake ../
-  make -j${num_cpus}
-
-  # Check if checkinstall is installed
-  set +e
-  command -v checkinstall
-  checkinstall_installed=$?
-  set -e
-
-  # Install
-  if [ $checkinstall_installed -ne 0 ] ; then
-    # checkinstall is not installed, so install without building a deb package
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo make install
-    else
-      make install
-    fi
-  else
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y
-    else
-      checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y
-    fi
-  fi
+if [ $installed -eq 0 ] ; then
+  # Nothing to do
+  exit
 fi
+
+echo "Checking for elevated privileges..."
+privileged_command_prefix=""
+if [ ${EUID:-$(id -u)} -ne 0 ] ; then
+  sudo echo "Script can elevate privileges."
+  privileged_command_prefix="${privileged_command_prefix} sudo"
+fi
+
+# Install dependencies
+export DEBIAN_FRONTEND=noninteractive
+${privileged_command_prefix} apt-get update
+${privileged_command_prefix} apt-get install -y cmake curl g++
+
+# Get number of cpu cores
+num_cpus=$(grep -c ^processor /proc/cpuinfo)
+
+# Download
+mkdir -p $temp_dir
+cd $temp_dir
+extracted_dir=${temp_dir}/fmt-${version}
+if [ ! -e ${extracted_dir} ] ; then
+  tar_filename=${version}.tar.gz
+  if [ ! -e ${tar_filename} ] ; then
+    curl -fsSL https://github.com/fmtlib/fmt/archive/refs/tags/${tar_filename} -o ${tar_filename}
+  fi
+
+  tar -xf ${tar_filename}
+fi
+
+# Build
+cd ${extracted_dir}
+mkdir -p cmake-build-release
+cd cmake-build-release
+cmake ../
+make -j${num_cpus}
+
+# Check if checkinstall is installed
+set +e
+command -v checkinstall
+checkinstall_installed=$?
+set -e
+
+# Install
+install_command_prefix="${privileged_command_prefix}"
+if [ $checkinstall_installed -eq 0 ] ; then
+  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+fi
+${install_command_prefix} make install
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/libarchive.sh
+++ b/components/core/tools/scripts/lib_install/libarchive.sh
@@ -3,76 +3,82 @@
 # Exit on any error
 set -e
 
-cUsage="Usage: ${BASH_SOURCE[0]} <version>"
+cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then
     echo $cUsage
     exit
 fi
 version=$1
 
-echo "Checking for elevated privileges..."
-if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-  sudo echo "Script can elevate privileges."
-fi
-
-# Get number of cpu cores
-num_cpus=$(grep -c ^processor /proc/cpuinfo)
-
 package_name=libarchive
-
-# Create temp dir for installation
 temp_dir=/tmp/${package_name}-installation
-mkdir -p $temp_dir
+deb_output_dir=${temp_dir}
+if [[ "$#" -gt 1 ]] ; then
+  deb_output_dir="$(readlink -f "$2")"
+  if [ ! -d ${deb_output_dir} ] ; then
+    echo "${deb_output_dir} does not exist or is not a directory"
+    exit
+  fi
+fi
 
 # Check if already installed
 set +e
 dpkg -l ${package_name}
 installed=$?
 set -e
-
-# Install if necessary
-if [ $installed -ne 0 ] ; then
-  # Download and build
-  cd $temp_dir
-  extracted_dir=${temp_dir}/${package_name}-${version}
-  if [ ! -e ${extracted_dir} ] ; then
-    tar_filename=${package_name}-${version}.tar.gz
-    if [ ! -e ${tar_filename} ] ; then
-      wget https://www.libarchive.org/downloads/${tar_filename}
-    fi
-
-    tar -xf ${tar_filename}
-  fi
-
-  cd ${extracted_dir}
-  mkdir -p cmake-build-release
-  cd cmake-build-release
-  # NOTE: Disable expat so the static libarchive doesn't look for it at link time
-  cmake -DENABLE_EXPAT=OFF ../
-  make -j${num_cpus}
-
-  # Check if checkinstall is installed
-  set +e
-  command -v checkinstall
-  checkinstall_installed=$?
-  set -e
-
-  # Install
-  if [ $checkinstall_installed -ne 0 ] ; then
-    # checkinstall is not installed, so install without building a deb package
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo make install
-    else
-      make install
-    fi
-  else
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y
-    else
-      checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y
-    fi
-  fi
+if [ $installed -eq 0 ] ; then
+  # Nothing to do
+  exit
 fi
+
+echo "Checking for elevated privileges..."
+privileged_command_prefix=""
+if [ ${EUID:-$(id -u)} -ne 0 ] ; then
+  sudo echo "Script can elevate privileges."
+  privileged_command_prefix="${privileged_command_prefix} sudo"
+fi
+
+# Install dependencies
+export DEBIAN_FRONTEND=noninteractive
+${privileged_command_prefix} apt-get update
+${privileged_command_prefix} apt-get install -y cmake curl
+
+# Get number of cpu cores
+num_cpus=$(grep -c ^processor /proc/cpuinfo)
+
+# Download
+mkdir -p $temp_dir
+cd $temp_dir
+extracted_dir=${temp_dir}/${package_name}-${version}
+if [ ! -e ${extracted_dir} ] ; then
+  tar_filename=${package_name}-${version}.tar.gz
+  if [ ! -e ${tar_filename} ] ; then
+    curl -fsSL https://www.libarchive.org/downloads/${tar_filename} -o ${tar_filename}
+  fi
+
+  tar -xf ${tar_filename}
+fi
+
+# Build
+cd ${extracted_dir}
+mkdir -p cmake-build-release
+cd cmake-build-release
+# NOTE: Disable expat so the static libarchive doesn't look for it at link time
+cmake -DENABLE_EXPAT=OFF ../
+make -j${num_cpus}
+
+# Check if checkinstall is installed
+set +e
+command -v checkinstall
+checkinstall_installed=$?
+set -e
+
+# Install
+install_command_prefix="${privileged_command_prefix}"
+if [ $checkinstall_installed -eq 0 ] ; then
+  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+fi
+${install_command_prefix} make install
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/mariadb-connector-c.sh
+++ b/components/core/tools/scripts/lib_install/mariadb-connector-c.sh
@@ -3,84 +3,87 @@
 # Exit on any error
 set -e
 
-cUsage="Usage: ${BASH_SOURCE[0]} <version>"
+cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then
     echo $cUsage
     exit
 fi
 version=$1
 
-echo "Checking for elevated privileges..."
-if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-  sudo echo "Script can elevate privileges."
-fi
-
 package_name=libmariadb-dev
-
-# Create temp dir for installation
 temp_dir=/tmp/${package_name}-installation
-mkdir -p $temp_dir
+deb_output_dir=${temp_dir}
+if [[ "$#" -gt 1 ]] ; then
+  deb_output_dir="$(readlink -f "$2")"
+  if [ ! -d ${deb_output_dir} ] ; then
+    echo "${deb_output_dir} does not exist or is not a directory"
+    exit
+  fi
+fi
 
 # Check if already installed
 set +e
 dpkg -l ${package_name}
 installed=$?
 set -e
-
-# Install if necessary
-if [ $installed -ne 0 ] ; then
-  # Get OS version
-  source /etc/os-release
-  if [ $ID = "ubuntu" ] ; then
-    os_version=ubuntu-$UBUNTU_CODENAME
-  elif [ $ID = "centos" ] ; then
-    os_version=centos${VERSION_ID}
-  fi
-
-  # Download
-  cd $temp_dir
-  extracted_dir=${temp_dir}/mariadb-connector-c-${version}-${os_version}-amd64
-  if [ ! -e ${extracted_dir} ] ; then
-    tar_filename=mariadb-connector-c-${version}-${os_version}-amd64.tar.gz
-    if [ ! -e ${tar_filename} ] ; then
-      wget https://downloads.mariadb.com/Connectors/c/connector-c-${version}/${tar_filename}
-    fi
-
-    tar -xf ${tar_filename}
-  fi
-
-  cd ${extracted_dir}
-
-  # Check if checkinstall is installed
-  set +e
-  command -v checkinstall
-  checkinstall_installed=$?
-  set -e
-
-  # Install
-  install_dir=/usr/local
-  if [ $checkinstall_installed -ne 0 ] ; then
-    # checkinstall is not installed, so install without building a deb package
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo mkdir -p ${install_dir}
-      sudo rsync -a . ${install_dir}/
-    else
-      mkdir -p ${install_dir}
-      rsync -a . ${install_dir}/
-    fi
-  else
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo mkdir -p ${install_dir}
-      sudo checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y rsync -a . ${install_dir}/
-    else
-      mkdir -p ${install_dir}
-      checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y rsync -a . ${install_dir}/
-    fi
-  fi
-
-  # Update ld cache
-  ldconfig ${install_dir}/lib/mariadb
+if [ $installed -eq 0 ] ; then
+  # Nothing to do
+  exit
 fi
+
+echo "Checking for elevated privileges..."
+privileged_command_prefix=""
+if [ ${EUID:-$(id -u)} -ne 0 ] ; then
+  sudo echo "Script can elevate privileges."
+  privileged_command_prefix="${privileged_command_prefix} sudo"
+fi
+
+# Install dependencies
+export DEBIAN_FRONTEND=noninteractive
+${privileged_command_prefix} apt-get update
+${privileged_command_prefix} apt-get install -y curl rsync
+
+# Get OS version
+source /etc/os-release
+if [ $ID = "ubuntu" ] ; then
+  os_version=ubuntu-$UBUNTU_CODENAME
+elif [ $ID = "centos" ] ; then
+  os_version=centos${VERSION_ID}
+fi
+
+# Download
+mkdir -p $temp_dir
+cd $temp_dir
+extracted_dir=${temp_dir}/mariadb-connector-c-${version}-${os_version}-amd64
+if [ ! -e ${extracted_dir} ] ; then
+  tar_filename=mariadb-connector-c-${version}-${os_version}-amd64.tar.gz
+  if [ ! -e ${tar_filename} ] ; then
+    curl -fsSL https://downloads.mariadb.com/Connectors/c/connector-c-${version}/${tar_filename} -o ${tar_filename}
+  fi
+
+  tar -xf ${tar_filename}
+fi
+
+cd ${extracted_dir}
+
+# Check if checkinstall is installed
+set +e
+command -v checkinstall
+checkinstall_installed=$?
+set -e
+
+# Install
+install_dir=/usr/local
+${privileged_command_prefix} mkdir -p ${install_dir}
+
+install_command_prefix="${privileged_command_prefix}"
+if [ $checkinstall_installed -eq 0 ] ; then
+  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+fi
+${install_command_prefix} rsync -a . ${install_dir}/
+
+# Update ld cache
+${privileged_command_prefix} ldconfig ${install_dir}/lib/mariadb
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -3,76 +3,82 @@
 # Exit on any error
 set -e
 
-cUsage="Usage: ${BASH_SOURCE[0]} <version>"
+cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then
     echo $cUsage
     exit
 fi
 version=$1
 
-echo "Checking for elevated privileges..."
-if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-  sudo echo "Script can elevate privileges."
-fi
-
-# Get number of cpu cores
-num_cpus=$(grep -c ^processor /proc/cpuinfo)
-
 package_name=libspdlog-dev
-
-# Create temp dir for installation
 temp_dir=/tmp/${package_name}-installation
-mkdir -p $temp_dir
+deb_output_dir=${temp_dir}
+if [[ "$#" -gt 1 ]] ; then
+  deb_output_dir="$(readlink -f "$2")"
+  if [ ! -d ${deb_output_dir} ] ; then
+    echo "${deb_output_dir} does not exist or is not a directory"
+    exit
+  fi
+fi
 
 # Check if already installed
 set +e
 dpkg -l ${package_name}
 installed=$?
 set -e
-
-# Install if necessary
-if [ $installed -ne 0 ] ; then
-  # Download and build
-  cd $temp_dir
-  extracted_dir=${temp_dir}/spdlog-${version}
-  if [ ! -e ${extracted_dir} ] ; then
-    tar_filename=v${version}.tar.gz
-    if [ ! -e ${tar_filename} ] ; then
-      wget https://github.com/gabime/spdlog/archive/${tar_filename}
-    fi
-
-    tar -xf ${tar_filename}
-  fi
-
-  cd ${extracted_dir}
-  mkdir -p build
-  cd build
-  cmake ../
-  make -j${num_cpus}
-
-  # Check if checkinstall is installed
-  set +e
-  command -v checkinstall
-  checkinstall_installed=$?
-  set -e
-
-  # Install
-  # NOTE: We use "1:${version}" to override the version installed by Ubuntu 18.04
-  if [ $checkinstall_installed -ne 0 ] ; then
-    # checkinstall is not installed, so install without building a deb package
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo make install
-    else
-      make install
-    fi
-  else
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo checkinstall --pkgname "${package_name}" --pkgversion "1:${version}" --provides "${package_name}" --nodoc -y
-    else
-      checkinstall --pkgname "${package_name}" --pkgversion "1:${version}" --provides "${package_name}" --nodoc -y
-    fi
-  fi
+if [ $installed -eq 0 ] ; then
+  # Nothing to do
+  exit
 fi
+
+echo "Checking for elevated privileges..."
+privileged_command_prefix=""
+if [ ${EUID:-$(id -u)} -ne 0 ] ; then
+  sudo echo "Script can elevate privileges."
+  privileged_command_prefix="${privileged_command_prefix} sudo"
+fi
+
+# Install dependencies
+export DEBIAN_FRONTEND=noninteractive
+${privileged_command_prefix} apt-get update
+${privileged_command_prefix} apt-get install -y cmake curl g++
+
+# Get number of cpu cores
+num_cpus=$(grep -c ^processor /proc/cpuinfo)
+
+# Download
+mkdir -p $temp_dir
+cd $temp_dir
+extracted_dir=${temp_dir}/spdlog-${version}
+if [ ! -e ${extracted_dir} ] ; then
+  tar_filename=v${version}.tar.gz
+  if [ ! -e ${tar_filename} ] ; then
+    curl -fsSL https://github.com/gabime/spdlog/archive/${tar_filename} -o ${tar_filename}
+  fi
+
+  tar -xf ${tar_filename}
+fi
+
+# Build
+cd ${extracted_dir}
+mkdir -p build
+cd build
+cmake ../
+make -j${num_cpus}
+
+# Check if checkinstall is installed
+set +e
+command -v checkinstall
+checkinstall_installed=$?
+set -e
+
+# Install
+install_command_prefix="${privileged_command_prefix}"
+if [ $checkinstall_installed -eq 0 ] ; then
+  # NOTE: We use "1:${version}" to override the version installed by Ubuntu 18.04
+  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '1:${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+fi
+${install_command_prefix} make install
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/zstandard.sh
+++ b/components/core/tools/scripts/lib_install/zstandard.sh
@@ -3,75 +3,81 @@
 # Exit on any error
 set -e
 
-cUsage="Usage: ${BASH_SOURCE[0]} <version>"
+cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then
     echo $cUsage
     exit
 fi
 version=$1
 
-echo "Checking for elevated privileges..."
-if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-  sudo echo "Script can elevate privileges."
-fi
-
-# Get number of cpu cores
-num_cpus=$(grep -c ^processor /proc/cpuinfo)
-
 package_name=libzstd
-
-# Create temp dir for installation
 temp_dir=/tmp/${package_name}-installation
-mkdir -p $temp_dir
+deb_output_dir=${temp_dir}
+if [[ "$#" -gt 1 ]] ; then
+  deb_output_dir="$(readlink -f "$2")"
+  if [ ! -d ${deb_output_dir} ] ; then
+    echo "${deb_output_dir} does not exist or is not a directory"
+    exit
+  fi
+fi
 
 # Check if already installed
 set +e
 dpkg -l ${package_name}
 installed=$?
 set -e
-
-# Install if necessary
-if [ $installed -ne 0 ] ; then
-  # Download and build
-  cd $temp_dir
-  extracted_dir=${temp_dir}/zstd-${version}
-  if [ ! -e ${extracted_dir} ] ; then
-    tar_filename=zstd-${version}.tar.gz
-    if [ ! -e ${tar_filename} ] ; then
-      wget https://github.com/facebook/zstd/releases/download/v${version}/${tar_filename}
-    fi
-
-    tar -xf ${tar_filename}
-  fi
-
-  cd ${extracted_dir}/build/cmake
-  mkdir cmake-build-release
-  cd cmake-build-release
-  cmake ../
-  make -j${num_cpus}
-
-  # Check if checkinstall is installed
-  set +e
-  command -v checkinstall
-  checkinstall_installed=$?
-  set -e
-
-  # Install
-  if [ $checkinstall_installed -ne 0 ] ; then
-    # checkinstall is not installed, so install without building a deb package
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo make install
-    else
-      make install
-    fi
-  else
-    if [ ${EUID:-$(id -u)} -ne 0 ] ; then
-      sudo checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y
-    else
-      checkinstall --pkgname "${package_name}" --pkgversion "${version}" --provides "${package_name}" --nodoc -y
-    fi
-  fi
+if [ $installed -eq 0 ] ; then
+  # Nothing to do
+  exit
 fi
+
+echo "Checking for elevated privileges..."
+privileged_command_prefix=""
+if [ ${EUID:-$(id -u)} -ne 0 ] ; then
+  sudo echo "Script can elevate privileges."
+  privileged_command_prefix="${privileged_command_prefix} sudo"
+fi
+
+# Install dependencies
+export DEBIAN_FRONTEND=noninteractive
+${privileged_command_prefix} apt-get update
+${privileged_command_prefix} apt-get install -y cmake curl g++
+
+# Get number of cpu cores
+num_cpus=$(grep -c ^processor /proc/cpuinfo)
+
+# Download
+mkdir -p $temp_dir
+cd $temp_dir
+extracted_dir=${temp_dir}/zstd-${version}
+if [ ! -e ${extracted_dir} ] ; then
+  tar_filename=zstd-${version}.tar.gz
+  if [ ! -e ${tar_filename} ] ; then
+    curl -fsSL https://github.com/facebook/zstd/releases/download/v${version}/${tar_filename} -o ${tar_filename}
+  fi
+
+  tar -xf ${tar_filename}
+fi
+
+# Build
+cd ${extracted_dir}/build/cmake
+mkdir -p cmake-build-release
+cd cmake-build-release
+cmake ../
+make -j${num_cpus}
+
+# Check if checkinstall is installed
+set +e
+command -v checkinstall
+checkinstall_installed=$?
+set -e
+
+# Install
+install_command_prefix="${privileged_command_prefix}"
+if [ $checkinstall_installed -eq 0 ] ; then
+  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+fi
+${install_command_prefix} make install
 
 # Clean up
 rm -rf $temp_dir


### PR DESCRIPTION
# Description
* Refactor CLP core's library installation scripts to be simpler
* Add the ability to specify an output directory for the .deb package generated by building the package (useful to avoid recompilation on a different machine)

# Validation performed
<!-- What tests and validation you performed on the change -->
* Built clp-env-base:focal docker image and verified that CLP's core could be built within it.
