### PR TITLE
Bugfix: Extract dependency installation from CLP core's library installation scripts; Replace usage of wget with curl.

### DIFF
--- a/components/core/README.md
+++ b/components/core/README.md
@@ -57,15 +57,16 @@ A handful of packages and libraries are required to build CLP. There are two opt
 
 If you're using apt-get, you can use the following command to install all:
 ```shell
-sudo apt-get install -y ca-certificates checkinstall cmake build-essential \
+sudo apt-get install -y ca-certificates checkinstall cmake curl build-essential \
 libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev \
-libssl-dev pkg-config rsync wget zlib1g-dev
+libssl-dev pkg-config rsync zlib1g-dev
 ```
 
 This will download:
 * ca-certificates
 * checkinstall
 * cmake
+* curl
 * build-essential
 * libboost-filesystem-dev
 * libboost-iostreams-dev
@@ -73,7 +74,6 @@ This will download:
 * libssl-dev
 * pkg-config
 * rsync
-* wget
 * zlib1g-dev
 
 *Libraries*

--- a/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
+++ b/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
@@ -5,6 +5,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ca-certificates \
   checkinstall \
   cmake \
+  curl \
   build-essential \
   libboost-filesystem-dev \
   libboost-iostreams-dev \
@@ -13,8 +14,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   python3 \
   python3-pip \
   rsync \
-  software-properties-common \
-  wget
+  software-properties-common
 
 # Install latest version of git
 add-apt-repository -y ppa:git-core/ppa
@@ -22,7 +22,7 @@ apt-get update
 apt-get install -y git
 
 # Install latest version of CMAKE
-wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+curl -fsSl https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
 apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
 apt-get update
 apt-get install -y cmake

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-boost.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-boost.sh
@@ -29,7 +29,7 @@ cd $temp_dir
 
 # Download source
 tar_filename=boost_${version_with_underscores}.tar.gz
-wget https://boostorg.jfrog.io/artifactory/main/release/${version}/source/${tar_filename}
+curl -fsSL https://boostorg.jfrog.io/artifactory/main/release/${version}/source/${tar_filename} -o ${tar_filename}
 tar xzf ${tar_filename}
 cd boost_${version_with_underscores}
 

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-cmake.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-cmake.sh
@@ -28,7 +28,7 @@ cd $temp_dir
 
 # Download source
 tar_filename=cmake-${version}.tar.gz
-wget https://github.com/Kitware/CMake/releases/download/v${version}/${tar_filename}
+curl -fsSL https://github.com/Kitware/CMake/releases/download/v${version}/${tar_filename} -o ${tar_filename}
 tar xzf ${tar_filename}
 cd cmake-${version}
 

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-prebuilt-packages.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-prebuilt-packages.sh
@@ -11,7 +11,6 @@ yum install -y \
   python3 \
   python3-pip \
   rsync \
-  wget \
   zlib-static
 
 # Install packages from CentOS' software collections repository (centos-release-scl)

--- a/components/core/tools/docker-images/clp-env-base-focal/setup-scripts/install-prebuilt-packages.sh
+++ b/components/core/tools/docker-images/clp-env-base-focal/setup-scripts/install-prebuilt-packages.sh
@@ -5,6 +5,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ca-certificates \
   checkinstall \
   cmake \
+  curl \
   build-essential \
   git \
   libboost-filesystem-dev \
@@ -15,5 +16,4 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   python3 \
   python3-pip \
   rsync \
-  wget \
   zlib1g-dev

--- a/components/core/tools/scripts/lib_install/fmtlib.sh
+++ b/components/core/tools/scripts/lib_install/fmtlib.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Dependencies:
+# - cmake
+# - curl
+# - g++
+# NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
+
 # Exit on any error
 set -e
 
@@ -37,11 +43,6 @@ if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
   privileged_command_prefix="${privileged_command_prefix} sudo"
 fi
-
-# Install dependencies
-export DEBIAN_FRONTEND=noninteractive
-${privileged_command_prefix} apt-get update
-${privileged_command_prefix} apt-get install -y cmake curl g++
 
 # Get number of cpu cores
 num_cpus=$(grep -c ^processor /proc/cpuinfo)

--- a/components/core/tools/scripts/lib_install/libarchive.sh
+++ b/components/core/tools/scripts/lib_install/libarchive.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Dependencies:
+# - cmake
+# - curl
+# NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
+
 # Exit on any error
 set -e
 
@@ -37,11 +42,6 @@ if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
   privileged_command_prefix="${privileged_command_prefix} sudo"
 fi
-
-# Install dependencies
-export DEBIAN_FRONTEND=noninteractive
-${privileged_command_prefix} apt-get update
-${privileged_command_prefix} apt-get install -y cmake curl
 
 # Get number of cpu cores
 num_cpus=$(grep -c ^processor /proc/cpuinfo)

--- a/components/core/tools/scripts/lib_install/lz4.sh
+++ b/components/core/tools/scripts/lib_install/lz4.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Dependencies:
+# - curl
+# - make
+# - gcc
+# NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
+
 # Exit on any error
 set -e
 
@@ -37,11 +43,6 @@ if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
   privileged_command_prefix="${privileged_command_prefix} sudo"
 fi
-
-# Install dependencies
-export DEBIAN_FRONTEND=noninteractive
-${privileged_command_prefix} apt-get update
-${privileged_command_prefix} apt-get install -y curl make gcc
 
 # Get number of cpu cores
 num_cpus=$(grep -c ^processor /proc/cpuinfo)

--- a/components/core/tools/scripts/lib_install/mariadb-connector-c.sh
+++ b/components/core/tools/scripts/lib_install/mariadb-connector-c.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Dependencies:
+# - curl
+# - rsync
+# NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
+
 # Exit on any error
 set -e
 
@@ -37,11 +42,6 @@ if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
   privileged_command_prefix="${privileged_command_prefix} sudo"
 fi
-
-# Install dependencies
-export DEBIAN_FRONTEND=noninteractive
-${privileged_command_prefix} apt-get update
-${privileged_command_prefix} apt-get install -y curl rsync
 
 # Get OS version
 source /etc/os-release

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Dependencies:
+# - cmake
+# - curl
+# - g++
+# NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
+
 # Exit on any error
 set -e
 
@@ -37,11 +43,6 @@ if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
   privileged_command_prefix="${privileged_command_prefix} sudo"
 fi
-
-# Install dependencies
-export DEBIAN_FRONTEND=noninteractive
-${privileged_command_prefix} apt-get update
-${privileged_command_prefix} apt-get install -y cmake curl g++
 
 # Get number of cpu cores
 num_cpus=$(grep -c ^processor /proc/cpuinfo)

--- a/components/core/tools/scripts/lib_install/zstandard.sh
+++ b/components/core/tools/scripts/lib_install/zstandard.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Dependencies:
+# - cmake
+# - curl
+# - g++
+# NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
+
 # Exit on any error
 set -e
 
@@ -37,11 +43,6 @@ if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
   privileged_command_prefix="${privileged_command_prefix} sudo"
 fi
-
-# Install dependencies
-export DEBIAN_FRONTEND=noninteractive
-${privileged_command_prefix} apt-get update
-${privileged_command_prefix} apt-get install -y cmake curl g++
 
 # Get number of cpu cores
 num_cpus=$(grep -c ^processor /proc/cpuinfo)

--- a/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y checkinstall \
-                                                  python3 \
-                                                  rsync \
-                                                  wget
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  checkinstall \
+  curl \
+  python3 \
+  rsync


### PR DESCRIPTION
# References
Fixes bug in #57 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
* Rely on users / containers installing the necessary dependencies for the library installation scripts rather than having them in the scripts themselves. This is because each distro may be have different package managers, etc. which make the scripts unwieldy.
* Replace wget with curl since curl is preinstalled in some Linux distributions.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Built all docker images successfully.
* Verified CLP's core builds in each dependency container.
* Verified CLP runs in the execution container.
