### PR TITLE
Refactor Workflows & block docker push on PR

### DIFF
--- a/.github/actions/clp-docker-build-push-action/action.yaml
+++ b/.github/actions/clp-docker-build-push-action/action.yaml
@@ -26,12 +26,25 @@ runs:
       uses: docker/metadata-action@v2
       with:
         images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
-        
+    
+    # Build docker image without pushing on PR
+    - name: Build Docker image
+      uses: docker/build-push-action@v2
+      if: github.event_name == 'pull_request'
+      with:
+        context: ${{inputs.context}}
+        file: ${{inputs.file}}
+        push: false
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
+      if: github.event_name != 'pull_request'
       with:
         context: ${{inputs.context}}
         file: ${{inputs.file}}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/actions/clp-docker-build-push-action/action.yaml
+++ b/.github/actions/clp-docker-build-push-action/action.yaml
@@ -21,6 +21,13 @@ runs:
   using: "composite"
   steps:
 
+    - name: Log in to the Github Packages Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@v2

--- a/.github/actions/clp-docker-build-push-action/action.yaml
+++ b/.github/actions/clp-docker-build-push-action/action.yaml
@@ -17,6 +17,10 @@ inputs:
     required: false
     default: ./Dockerfile
 
+  token:
+    description: "Registry token"
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -26,7 +30,7 @@ runs:
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ inputs.token }}
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -62,13 +62,6 @@ jobs:
       - name: Extract Binaries Bundle
         run: tar -xvf clp-binaries-focal.tar
         working-directory: ${{github.workspace}}/binaries
-
-      - name: Log in to the Github Packages Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Build and Push Ubuntu Focal Docker Image
         uses: ./.github/actions/clp-docker-build-push-action

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -69,6 +69,7 @@ jobs:
           image_name: ${{env.IMAGE_NAME_BASE}}-ubuntu-focal
           context: ${{github.workspace}}/binaries
           file: components/core/tools/docker-images/clp-core-focal/Dockerfile
+          token: ${{secrets.GITHUB_TOKEN}}
 
   build-bionic:
     runs-on: ubuntu-latest

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -60,7 +60,7 @@ jobs:
 
   build-centos:
     runs-on: ubuntu-20.04
-    name: Build Image - Centos7.4
+    name: Build Image - CentOS 7.4
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -22,13 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
-      - name: Log in to the Github Packages Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
     
       - name: Build and Push Ubuntu Focal Docker Image
         uses: ./.github/actions/clp-docker-build-push-action
@@ -43,13 +36,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
-      - name: Log in to the Github Packages Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Ubuntu Bionic Docker Image
         uses: ./.github/actions/clp-docker-build-push-action
@@ -64,13 +50,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
-      - name: Log in to the Github Packages Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Centos7.4 Docker Image
         uses: ./.github/actions/clp-docker-build-push-action

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -29,6 +29,7 @@ jobs:
           image_name: ${{env.IMAGE_NAME_BASE}}-ubuntu-focal
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-focal/Dockerfile
+          token: ${{secrets.GITHUB_TOKEN}}
 
   build-ubuntu-bionic:
     runs-on: ubuntu-20.04
@@ -43,6 +44,7 @@ jobs:
           image_name: ${{env.IMAGE_NAME_BASE}}-ubuntu-bionic
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
+          token: ${{secrets.GITHUB_TOKEN}}
 
   build-centos:
     runs-on: ubuntu-20.04
@@ -57,3 +59,4 @@ jobs:
           image_name: ${{env.IMAGE_NAME_BASE}}-centos7.4
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+          token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -16,9 +16,9 @@ env:
 concurrency: build-${{github.ref}}
 
 jobs:
-  build:
+  build-ubuntu-focal:
     runs-on: ubuntu-20.04
-    name: Build Image
+    name: Build Image - Ubuntu Focal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -37,6 +37,20 @@ jobs:
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-focal/Dockerfile
 
+  build-ubuntu-bionic:
+    runs-on: ubuntu-20.04
+    name: Build Image - Ubuntu Bionic
+    steps:
+     - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Log in to the Github Packages Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Ubuntu Bionic Docker Image
         uses: ./.github/actions/clp-docker-build-push-action
         with:
@@ -44,6 +58,19 @@ jobs:
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
 
+  build-centos:
+    runs-on: ubuntu-20.04
+    name: Build Image - Centos7.4
+    steps:
+     - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Log in to the Github Packages Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Centos7.4 Docker Image
         uses: ./.github/actions/clp-docker-build-push-action

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build Image - Ubuntu Bionic
     steps:
-     - name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
       
       - name: Log in to the Github Packages Container registry
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build Image - Centos7.4
     steps:
-     - name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
       
       - name: Log in to the Github Packages Container registry

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -21,13 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Log in to the Github Packages Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push Docker image
         uses: ./.github/actions/clp-docker-build-push-action
         with:

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -26,3 +26,4 @@ jobs:
         with:
           image_name: ${{env.IMAGE_NAME}}
           file: ./tools/docker-images/clp-execution-base-focal/Dockerfile
+          token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# References

# Description
- Github Build Worfklows have been failing in every PR because the local `clp-docker-build-push-action`, which is used across several workflows, builds a docker image and tries to push it to `ghcr` - pushing to the registry from a PR is blocked, causing failed execution of workflows
- The `generate-build-dependency-image` workflow currently takes upwards of 40 mins to finish. Reorganize different build steps in the workflow to execute in paralell - takes 20 mins to finish.

# Validation performed
- Using this PR to validate no docker image push on PRs
- https://github.com/NamanGulati/clp/actions/runs/2156157051
