### PR TITLE
Extend passthrough compression to the dictionaries

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -7,6 +7,17 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
+# Set general compressor
+set(GENERAL_COMPRESSOR "zstd" CACHE STRING "The general-purpose compressor used as the 2nd-stage compressor")
+set_property(CACHE GENERAL_COMPRESSOR PROPERTY STRINGS passthrough zstd)
+if ("${GENERAL_COMPRESSOR}" STREQUAL "passthrough")
+    add_definitions(-DUSE_PASSTHROUGH_COMPRESSION=1)
+    message(STATUS "Using passthrough compression")
+elseif ("${GENERAL_COMPRESSOR}" STREQUAL "zstd")
+    add_definitions(-DUSE_ZSTD_COMPRESSION=1)
+    message(STATUS "Using Zstandard compression")
+endif()
+
 # Add local CMake module directory to CMake's modules path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
@@ -22,9 +33,6 @@ add_definitions(-DPROF_ENABLED=0)
 
 # Flush to disk switch
 add_definitions(-DFLUSH_TO_DISK_ENABLED=1)
-
-# Passthrough compression switch
-add_definitions(-DUSE_PASSTHROUGH_COMPRESSION=0)
 
 # Make off_t 64-bit
 add_definitions(-D_FILE_OFFSET_BITS=64)

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -16,6 +16,8 @@ if ("${GENERAL_COMPRESSOR}" STREQUAL "passthrough")
 elseif ("${GENERAL_COMPRESSOR}" STREQUAL "zstd")
     add_definitions(-DUSE_ZSTD_COMPRESSION=1)
     message(STATUS "Using Zstandard compression")
+else()
+    message(SEND_ERROR "GENERAL_COMPRESSOR=${GENERAL_COMPRESSOR} is unimplemented.")
 endif()
 
 # Add local CMake module directory to CMake's modules path

--- a/components/core/cmake/utils.cmake
+++ b/components/core/cmake/utils.cmake
@@ -19,6 +19,8 @@ set(SOURCE_FILES_make-dictionaries-readable
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ReaderInterface.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/Decompressor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/Decompressor.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/passthrough/Decompressor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/passthrough/Decompressor.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/zstd/Decompressor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/zstd/Decompressor.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Utils.cpp

--- a/components/core/src/DictionaryReader.hpp
+++ b/components/core/src/DictionaryReader.hpp
@@ -13,6 +13,7 @@
 #include "DictionaryEntry.hpp"
 #include "FileReader.hpp"
 #include "Profiler.hpp"
+#include "streaming_compression/passthrough/Decompressor.hpp"
 #include "streaming_compression/zstd/Decompressor.hpp"
 #include "Utils.hpp"
 
@@ -102,12 +103,16 @@ protected:
     // Variables
     bool m_is_open;
     FileReader m_dictionary_file_reader;
-    streaming_compression::zstd::Decompressor m_dictionary_decompressor;
     FileReader m_segment_index_file_reader;
+#if USE_PASSTHROUGH_COMPRESSION
+    streaming_compression::passthrough::Decompressor m_dictionary_decompressor;
+    streaming_compression::passthrough::Decompressor m_segment_index_decompressor;
+#elif USE_ZSTD_COMPRESSION
+    streaming_compression::zstd::Decompressor m_dictionary_decompressor;
     streaming_compression::zstd::Decompressor m_segment_index_decompressor;
+#endif
     size_t m_num_segments_read_from_index;
     std::vector<EntryType> m_entries;
-
 };
 
 template <typename DictionaryIdType, typename EntryType>

--- a/components/core/src/DictionaryReader.hpp
+++ b/components/core/src/DictionaryReader.hpp
@@ -110,6 +110,8 @@ protected:
 #elif USE_ZSTD_COMPRESSION
     streaming_compression::zstd::Decompressor m_dictionary_decompressor;
     streaming_compression::zstd::Decompressor m_segment_index_decompressor;
+#else
+    static_assert(false, "Unsupported compression mode.");
 #endif
     size_t m_num_segments_read_from_index;
     std::vector<EntryType> m_entries;

--- a/components/core/src/DictionaryWriter.hpp
+++ b/components/core/src/DictionaryWriter.hpp
@@ -15,7 +15,10 @@
 #include "Defs.h"
 #include "dictionary_utils.hpp"
 #include "FileWriter.hpp"
+#include "streaming_compression/passthrough/Compressor.hpp"
+#include "streaming_compression/passthrough/Decompressor.hpp"
 #include "streaming_compression/zstd/Compressor.hpp"
+#include "streaming_compression/zstd/Decompressor.hpp"
 #include "TraceableException.hpp"
 
 /**
@@ -96,9 +99,14 @@ protected:
 
     // Variables related to on-disk storage
     FileWriter m_dictionary_file_writer;
-    streaming_compression::zstd::Compressor m_dictionary_compressor;
     FileWriter m_segment_index_file_writer;
+#if USE_PASSTHROUGH_COMPRESSION
+    streaming_compression::passthrough::Compressor m_dictionary_compressor;
+    streaming_compression::passthrough::Compressor m_segment_index_compressor;
+#elif USE_ZSTD_COMPRESSION
+    streaming_compression::zstd::Compressor m_dictionary_compressor;
     streaming_compression::zstd::Compressor m_segment_index_compressor;
+#endif
     size_t m_num_segments_in_index;
 
     value_to_id_t m_value_to_id;
@@ -182,9 +190,14 @@ void DictionaryWriter<DictionaryIdType, EntryType>::open_and_preload (const std:
     m_max_id = max_id;
 
     FileReader dictionary_file_reader;
-    streaming_compression::zstd::Decompressor dictionary_decompressor;
     FileReader segment_index_file_reader;
+#if USE_PASSTHROUGH_COMPRESSION
+    streaming_compression::passthrough::Decompressor dictionary_decompressor;
+    streaming_compression::passthrough::Decompressor segment_index_decompressor;
+#elif USE_ZSTD_COMPRESSION
+    streaming_compression::zstd::Decompressor dictionary_decompressor;
     streaming_compression::zstd::Decompressor segment_index_decompressor;
+#endif
     constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024; // 64 KB
     open_dictionary_for_reading(dictionary_path, segment_index_path, cDecompressorFileReadBufferCapacity, dictionary_file_reader, dictionary_decompressor,
                                 segment_index_file_reader, segment_index_decompressor);

--- a/components/core/src/DictionaryWriter.hpp
+++ b/components/core/src/DictionaryWriter.hpp
@@ -106,6 +106,8 @@ protected:
 #elif USE_ZSTD_COMPRESSION
     streaming_compression::zstd::Compressor m_dictionary_compressor;
     streaming_compression::zstd::Compressor m_segment_index_compressor;
+#else
+    static_assert(false, "Unsupported compression mode.");
 #endif
     size_t m_num_segments_in_index;
 
@@ -197,6 +199,8 @@ void DictionaryWriter<DictionaryIdType, EntryType>::open_and_preload (const std:
 #elif USE_ZSTD_COMPRESSION
     streaming_compression::zstd::Decompressor dictionary_decompressor;
     streaming_compression::zstd::Decompressor segment_index_decompressor;
+#else
+    static_assert(false, "Unsupported compression mode.");
 #endif
     constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024; // 64 KB
     open_dictionary_for_reading(dictionary_path, segment_index_path, cDecompressorFileReadBufferCapacity, dictionary_file_reader, dictionary_decompressor,

--- a/components/core/src/LogTypeDictionaryEntry.cpp
+++ b/components/core/src/LogTypeDictionaryEntry.cpp
@@ -108,7 +108,7 @@ void LogTypeDictionaryEntry::clear () {
     m_var_positions.clear();
 }
 
-void LogTypeDictionaryEntry::write_to_file (streaming_compression::zstd::Compressor& compressor) const {
+void LogTypeDictionaryEntry::write_to_file (streaming_compression::Compressor& compressor) const {
     compressor.write_numeric_value(m_id);
     compressor.write_numeric_value<uint8_t>(m_verbosity);
 
@@ -118,7 +118,7 @@ void LogTypeDictionaryEntry::write_to_file (streaming_compression::zstd::Compres
     compressor.write_string(escaped_value);
 }
 
-ErrorCode LogTypeDictionaryEntry::try_read_from_file (streaming_compression::zstd::Decompressor& decompressor) {
+ErrorCode LogTypeDictionaryEntry::try_read_from_file (streaming_compression::Decompressor& decompressor) {
     clear();
 
     ErrorCode error_code;
@@ -180,7 +180,7 @@ ErrorCode LogTypeDictionaryEntry::try_read_from_file (streaming_compression::zst
     return error_code;
 }
 
-void LogTypeDictionaryEntry::read_from_file (streaming_compression::zstd::Decompressor& decompressor) {
+void LogTypeDictionaryEntry::read_from_file (streaming_compression::Decompressor& decompressor) {
     auto error_code = try_read_from_file(decompressor);
     if (ErrorCode_Success != error_code) {
         throw OperationFailed(error_code, __FILENAME__, __LINE__);

--- a/components/core/src/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/LogTypeDictionaryEntry.hpp
@@ -126,19 +126,19 @@ public:
      * Writes an entry to file
      * @param compressor
      */
-    void write_to_file (streaming_compression::zstd::Compressor& compressor) const;
+    void write_to_file (streaming_compression::Compressor& compressor) const;
     /**
      * Tries to read an entry from the given decompressor
      * @param decompressor
-     * @return Same as streaming_compression::zstd::Decompressor::try_read_numeric_value
-     * @return Same as streaming_compression::zstd::Decompressor::try_read_string
+     * @return Same as streaming_compression::Decompressor::try_read_numeric_value
+     * @return Same as streaming_compression::Decompressor::try_read_string
      */
-    ErrorCode try_read_from_file (streaming_compression::zstd::Decompressor& decompressor);
+    ErrorCode try_read_from_file (streaming_compression::Decompressor& decompressor);
     /**
      * Reads an entry from the given decompressor
      * @param decompressor
      */
-    void read_from_file (streaming_compression::zstd::Decompressor& decompressor);
+    void read_from_file (streaming_compression::Decompressor& decompressor);
 
 private:
     // Methods
@@ -152,6 +152,5 @@ private:
     LogVerbosity m_verbosity;
     std::vector<size_t> m_var_positions;
 };
-
 
 #endif // LOGTYPEDICTIONARYENTRY_HPP

--- a/components/core/src/VariableDictionaryEntry.cpp
+++ b/components/core/src/VariableDictionaryEntry.cpp
@@ -4,13 +4,13 @@ size_t VariableDictionaryEntry::get_data_size () const {
     return sizeof(m_id) + m_value.length() + m_ids_of_segments_containing_entry.size() * sizeof(segment_id_t);
 }
 
-void VariableDictionaryEntry::write_to_file (streaming_compression::zstd::Compressor& compressor) const {
+void VariableDictionaryEntry::write_to_file (streaming_compression::Compressor& compressor) const {
     compressor.write_numeric_value(m_id);
     compressor.write_numeric_value<uint64_t>(m_value.length());
     compressor.write_string(m_value);
 }
 
-ErrorCode VariableDictionaryEntry::try_read_from_file (streaming_compression::zstd::Decompressor& decompressor) {
+ErrorCode VariableDictionaryEntry::try_read_from_file (streaming_compression::Decompressor& decompressor) {
     ErrorCode error_code;
 
     error_code = decompressor.try_read_numeric_value<variable_dictionary_id_t>(m_id);
@@ -31,7 +31,7 @@ ErrorCode VariableDictionaryEntry::try_read_from_file (streaming_compression::zs
     return error_code;
 }
 
-void VariableDictionaryEntry::read_from_file (streaming_compression::zstd::Decompressor& decompressor) {
+void VariableDictionaryEntry::read_from_file (streaming_compression::Decompressor& decompressor) {
     auto error_code = try_read_from_file(decompressor);
     if (ErrorCode_Success != error_code) {
         throw OperationFailed(error_code, __FILENAME__, __LINE__);

--- a/components/core/src/VariableDictionaryEntry.hpp
+++ b/components/core/src/VariableDictionaryEntry.hpp
@@ -50,19 +50,19 @@ public:
      * Writes an entry to file
      * @param compressor
      */
-    void write_to_file (streaming_compression::zstd::Compressor& compressor) const;
+    void write_to_file (streaming_compression::Compressor& compressor) const;
     /**
      * Tries to read an entry from the given decompressor
      * @param decompressor
-     * @return Same as streaming_compression::zstd::Decompressor::try_read_numeric_value
-     * @return Same as streaming_compression::zstd::Decompressor::try_read_string
+     * @return Same as streaming_compression::Decompressor::try_read_numeric_value
+     * @return Same as streaming_compression::Decompressor::try_read_string
      */
-    ErrorCode try_read_from_file (streaming_compression::zstd::Decompressor& decompressor);
+    ErrorCode try_read_from_file (streaming_compression::Decompressor& decompressor);
     /**
      * Reads an entry from the given decompressor
      * @param decompressor
      */
-    void read_from_file (streaming_compression::zstd::Decompressor& decompressor);
+    void read_from_file (streaming_compression::Decompressor& decompressor);
 };
 
 #endif // VARIABLEDICTIONARYENTRY_HPP

--- a/components/core/src/dictionary_utils.cpp
+++ b/components/core/src/dictionary_utils.cpp
@@ -1,8 +1,8 @@
 #include "dictionary_utils.hpp"
 
 void open_dictionary_for_reading (const std::string& dictionary_path, const std::string& segment_index_path, size_t decompressor_file_read_buffer_capacity,
-                                  FileReader& dictionary_file_reader, streaming_compression::zstd::Decompressor& dictionary_decompressor,
-                                  FileReader& segment_index_file_reader, streaming_compression::zstd::Decompressor& segment_index_decompressor)
+                                  FileReader& dictionary_file_reader, streaming_compression::Decompressor& dictionary_decompressor,
+                                  FileReader& segment_index_file_reader, streaming_compression::Decompressor& segment_index_decompressor)
 {
     dictionary_file_reader.open(dictionary_path);
     // Skip header

--- a/components/core/src/dictionary_utils.hpp
+++ b/components/core/src/dictionary_utils.hpp
@@ -6,11 +6,11 @@
 
 // Project headers
 #include "FileReader.hpp"
-#include "streaming_compression/zstd/Decompressor.hpp"
+#include "streaming_compression/Decompressor.hpp"
 
 void open_dictionary_for_reading (const std::string& dictionary_path, const std::string& segment_index_path, size_t decompressor_file_read_buffer_capacity,
-                                  FileReader& dictionary_file_reader, streaming_compression::zstd::Decompressor& dictionary_decompressor,
-                                  FileReader& segment_index_file_reader, streaming_compression::zstd::Decompressor& segment_index_decompressor);
+                                  FileReader& dictionary_file_reader, streaming_compression::Decompressor& dictionary_decompressor,
+                                  FileReader& segment_index_file_reader, streaming_compression::Decompressor& segment_index_decompressor);
 
 uint64_t read_dictionary_header (FileReader& file_reader);
 

--- a/components/core/src/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/streaming_archive/reader/Segment.hpp
@@ -60,8 +60,9 @@ namespace streaming_archive { namespace reader {
         streaming_compression::passthrough::Decompressor m_decompressor;
 #elif USE_ZSTD_COMPRESSION
         streaming_compression::zstd::Decompressor m_decompressor;
+#else
+        static_assert(false, "Unsupported compression mode.");
 #endif
-
     };
 } }
 

--- a/components/core/src/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/streaming_archive/reader/Segment.hpp
@@ -58,7 +58,7 @@ namespace streaming_archive { namespace reader {
 
 #if USE_PASSTHROUGH_COMPRESSION
         streaming_compression::passthrough::Decompressor m_decompressor;
-#else
+#elif USE_ZSTD_COMPRESSION
         streaming_compression::zstd::Decompressor m_decompressor;
 #endif
 

--- a/components/core/src/streaming_archive/writer/Segment.cpp
+++ b/components/core/src/streaming_archive/writer/Segment.cpp
@@ -41,8 +41,7 @@ namespace streaming_archive { namespace writer {
         m_file_writer.open(m_segment_path, FileWriter::OpenMode::CREATE_FOR_WRITING);
 #if USE_PASSTHROUGH_COMPRESSION
         m_compressor.open(m_file_writer);
-#else
-        // Configure a zstd streaming compressor
+#elif USE_ZSTD_COMPRESSION
         m_compressor.open(m_file_writer, compression_level);
 #endif
     }

--- a/components/core/src/streaming_archive/writer/Segment.cpp
+++ b/components/core/src/streaming_archive/writer/Segment.cpp
@@ -43,6 +43,8 @@ namespace streaming_archive { namespace writer {
         m_compressor.open(m_file_writer);
 #elif USE_ZSTD_COMPRESSION
         m_compressor.open(m_file_writer, compression_level);
+#else
+        static_assert(false, "Unsupported compression mode.");
 #endif
     }
 

--- a/components/core/src/streaming_archive/writer/Segment.hpp
+++ b/components/core/src/streaming_archive/writer/Segment.hpp
@@ -77,7 +77,7 @@ namespace streaming_archive { namespace writer {
         FileWriter m_file_writer;
 #if USE_PASSTHROUGH_COMPRESSION
         streaming_compression::passthrough::Compressor m_compressor;
-#else
+#elif USE_ZSTD_COMPRESSION
         streaming_compression::zstd::Compressor m_compressor;
 #endif
     };

--- a/components/core/src/streaming_archive/writer/Segment.hpp
+++ b/components/core/src/streaming_archive/writer/Segment.hpp
@@ -79,6 +79,8 @@ namespace streaming_archive { namespace writer {
         streaming_compression::passthrough::Compressor m_compressor;
 #elif USE_ZSTD_COMPRESSION
         streaming_compression::zstd::Compressor m_compressor;
+#else
+        static_assert(false, "Unsupported compression mode.");
 #endif
     };
 } }

--- a/components/core/src/streaming_compression/Decompressor.hpp
+++ b/components/core/src/streaming_compression/Decompressor.hpp
@@ -38,10 +38,10 @@ namespace streaming_compression {
         // Methods
         /**
          * Initialize streaming decompressor to decompress from the specified compressed data buffer
-         * @param compressed_data_buf
-         * @param compressed_data_buf_size
+         * @param compressed_data_buffer
+         * @param compressed_data_buffer_size
          */
-        virtual void open (const char* compressed_data_buf, size_t compressed_data_buf_size) = 0;
+        virtual void open (const char* compressed_data_buffer, size_t compressed_data_buffer_size) = 0;
         /**
          * Initializes the decompressor to decompress from an open file
          * @param file_reader

--- a/components/core/src/streaming_compression/Decompressor.hpp
+++ b/components/core/src/streaming_compression/Decompressor.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 // Project headers
+#include "../FileReader.hpp"
 #include "../ReaderInterface.hpp"
 #include "../TraceableException.hpp"
 #include "Constants.hpp"
@@ -35,6 +36,18 @@ namespace streaming_compression {
         Decompressor& operator = (const Decompressor&) = delete;
 
         // Methods
+        /**
+         * Initialize streaming decompressor to decompress from the specified compressed data buffer
+         * @param compressed_data_buf
+         * @param compressed_data_buf_size
+         */
+        virtual void open (const char* compressed_data_buf, size_t compressed_data_buf_size) = 0;
+        /**
+         * Initializes the decompressor to decompress from an open file
+         * @param file_reader
+         * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time
+         */
+        virtual void open (FileReader& file_reader, size_t file_read_buffer_capacity) = 0;
         /**
          * Closes decompression stream
          */

--- a/components/core/src/streaming_compression/passthrough/Decompressor.cpp
+++ b/components/core/src/streaming_compression/passthrough/Decompressor.cpp
@@ -5,41 +5,54 @@
 
 namespace streaming_compression { namespace passthrough {
     ErrorCode Decompressor::try_read (char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) {
-        if (nullptr == m_compressed_data_buf) {
-            return ErrorCode_NotInit;
+        if (InputType::NotInitialized == m_input_type) {
+            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
         }
         if (nullptr == buf) {
-            return ErrorCode_BadParam;
+            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
         }
 
-        if (m_compressed_data_buf_len == m_decompressed_stream_pos) {
-            return ErrorCode_EndOfFile;
-        }
+        if (InputType::CompressedDataBuf == m_input_type) {
+            if (m_compressed_data_buf_len == m_decompressed_stream_pos) {
+                return ErrorCode_EndOfFile;
+            }
 
-        num_bytes_read = std::min(num_bytes_to_read, m_compressed_data_buf_len - m_decompressed_stream_pos);
-        memcpy(buf, &m_compressed_data_buf[m_decompressed_stream_pos], num_bytes_read);
+            num_bytes_read = std::min(num_bytes_to_read, m_compressed_data_buf_len - m_decompressed_stream_pos);
+            memcpy(buf, &m_compressed_data_buf[m_decompressed_stream_pos], num_bytes_read);
+        } else if (InputType::File == m_input_type) {
+            auto error_code = m_file_reader->try_read(buf, num_bytes_to_read, num_bytes_read);
+            if (ErrorCode_Success != error_code) {
+                return error_code;
+            }
+        }
         m_decompressed_stream_pos += num_bytes_read;
 
         return ErrorCode_Success;
     }
 
     ErrorCode Decompressor::try_seek_from_begin (size_t pos) {
-        if (nullptr == m_compressed_data_buf) {
-            return ErrorCode_NotInit;
+        if (InputType::NotInitialized == m_input_type) {
+            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
         }
 
-        if (pos > m_compressed_data_buf_len) {
-            return ErrorCode_Truncated;
+        if (InputType::CompressedDataBuf == m_input_type) {
+            if (pos > m_compressed_data_buf_len) {
+                return ErrorCode_Truncated;
+            }
+        } else if (InputType::File == m_input_type) {
+            auto error_code = m_file_reader->try_seek_from_begin(pos);
+            if (ErrorCode_Success != error_code) {
+                return error_code;
+            }
         }
-
         m_decompressed_stream_pos = pos;
 
         return ErrorCode_Success;
     }
 
     ErrorCode Decompressor::try_get_pos (size_t& pos) {
-        if (nullptr == m_compressed_data_buf) {
-            return ErrorCode_NotInit;
+        if (InputType::NotInitialized == m_input_type) {
+            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
         }
 
         pos = m_decompressed_stream_pos;
@@ -47,9 +60,35 @@ namespace streaming_compression { namespace passthrough {
         return ErrorCode_Success;
     }
 
+    void Decompressor::open (const char* compressed_data_buf, size_t compressed_data_buf_size) {
+        if (InputType::NotInitialized != m_input_type) {
+            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
+        }
+
+        m_compressed_data_buf = compressed_data_buf;
+        m_compressed_data_buf_len = compressed_data_buf_size;
+        m_decompressed_stream_pos = 0;
+        m_input_type = InputType::CompressedDataBuf;
+    }
+
+    void Decompressor::open (FileReader& file_reader, size_t file_read_buffer_capacity) {
+        if (InputType::NotInitialized != m_input_type) {
+            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
+        }
+
+        m_file_reader = &file_reader;
+        m_decompressed_stream_pos = 0;
+        m_input_type = InputType::File;
+    }
+
     void Decompressor::close () {
-        m_compressed_data_buf = nullptr;
-        m_compressed_data_buf_len = 0;
+        if (InputType::CompressedDataBuf == m_input_type) {
+            m_compressed_data_buf = nullptr;
+            m_compressed_data_buf_len = 0;
+        } else if (InputType::File == m_input_type) {
+            m_file_reader = nullptr;
+        }
+        m_input_type = InputType::NotInitialized;
     }
 
     ErrorCode Decompressor::get_decompressed_stream_region (size_t decompressed_stream_pos, char* extraction_buf, size_t extraction_len) {
@@ -60,11 +99,5 @@ namespace streaming_compression { namespace passthrough {
 
         error_code = try_read_exact_length(extraction_buf, extraction_len);
         return error_code;
-    }
-
-    void Decompressor::open (const char* compressed_data_buf, size_t compressed_data_buf_size) {
-        m_compressed_data_buf = compressed_data_buf;
-        m_compressed_data_buf_len = compressed_data_buf_size;
-        m_decompressed_stream_pos = 0;
     }
 } }

--- a/components/core/src/streaming_compression/passthrough/Decompressor.hpp
+++ b/components/core/src/streaming_compression/passthrough/Decompressor.hpp
@@ -25,8 +25,8 @@ namespace streaming_compression { namespace passthrough {
         };
 
         // Constructors
-        Decompressor () : ::streaming_compression::Decompressor(CompressorType::Passthrough), m_compressed_data_buf(nullptr), m_compressed_data_buf_len(0),
-                m_decompressed_stream_pos(0) {}
+        Decompressor () : ::streaming_compression::Decompressor(CompressorType::Passthrough), m_input_type(InputType::NotInitialized),
+                m_compressed_data_buf(nullptr), m_compressed_data_buf_len(0), m_decompressed_stream_pos(0) {}
 
         // Destructor
         ~Decompressor () = default;
@@ -64,6 +64,8 @@ namespace streaming_compression { namespace passthrough {
         ErrorCode try_get_pos (size_t& pos) override;
 
         // Methods implementing the Decompressor interface
+        void open (const char* compressed_data_buf, size_t compressed_data_buf_size) override;
+        void open (FileReader& file_reader, size_t file_read_buffer_capacity) override;
         void close () override;
         /**
          * Decompresses and copies the range of uncompressed data described by decompressed_stream_pos and extraction_len into extraction_buf
@@ -75,16 +77,17 @@ namespace streaming_compression { namespace passthrough {
          */
         ErrorCode get_decompressed_stream_region (size_t decompressed_stream_pos, char* extraction_buf, size_t extraction_len) override;
 
-        // Methods
-        /**
-         * Initialize streaming decompressor to decompress from the specified compressed data buffer
-         * @param compressed_data_buf
-         * @param compressed_data_buf_size
-         */
-        void open (const char* compressed_data_buf, size_t compressed_data_buf_size);
     private:
+        enum class InputType {
+            NotInitialized,
+            CompressedDataBuf,
+            File
+        };
 
         // Variables
+        InputType m_input_type;
+
+        FileReader* m_file_reader;
         const char* m_compressed_data_buf;
         size_t m_compressed_data_buf_len;
 

--- a/components/core/src/streaming_compression/zstd/Decompressor.cpp
+++ b/components/core/src/streaming_compression/zstd/Decompressor.cpp
@@ -128,7 +128,6 @@ namespace streaming_compression { namespace zstd {
         }
         m_input_type = InputType::CompressedDataBuf;
 
-        // Configure input stream
         m_compressed_stream_block = {compressed_data_buf, compressed_data_buf_size, 0};
 
         reset_stream();

--- a/components/core/src/streaming_compression/zstd/Decompressor.hpp
+++ b/components/core/src/streaming_compression/zstd/Decompressor.hpp
@@ -75,6 +75,8 @@ namespace streaming_compression { namespace zstd {
         ErrorCode try_get_pos (size_t& pos) override;
 
         // Methods implementing the Decompressor interface
+        void open (const char* compressed_data_buf, size_t compressed_data_buf_size) override;
+        void open (FileReader& file_reader, size_t file_read_buffer_capacity) override;
         void close () override;
         /**
          * Decompresses and copies the range of uncompressed data described by decompressed_stream_pos and extraction_len into extraction_buf
@@ -88,13 +90,6 @@ namespace streaming_compression { namespace zstd {
 
         // Methods
         /***
-         * Initialize streaming decompressor to decompress from the specified compressed data buffer
-         * @param compressed_data_buf
-         * @param compressed_data_buf_size
-         */
-        void open (const char* compressed_data_buf, size_t compressed_data_buf_size);
-
-        /***
          * Initialize streaming decompressor to decompress from a compressed file specified by the given path
          * @param compressed_file_path
          * @param decompressed_stream_block_size
@@ -103,12 +98,6 @@ namespace streaming_compression { namespace zstd {
          */
         ErrorCode open (const std::string& compressed_file_path);
 
-        /**
-         * Initializes the decompressor to decompress from an open file
-         * @param file_reader
-         * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time
-         */
-        void open (FileReader& file_reader, size_t file_read_buffer_capacity);
     private:
         // Enum class
         enum class InputType {


### PR DESCRIPTION
# Description
* Extends passthrough compression to the dictionaries.
* Updates the passthrough compressor/decompressor classes to support compression/decompression from file.
* Adds a new CMake property to choose between Zstandard and Passthrough compression.

# Validation performed
* Compressed and decompressed a log dataset losslessly.