### PR TITLE
Fix for #61 and a few associated changes

### DIFF
--- a/components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
@@ -10,3 +10,7 @@ ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
 RUN ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
 RUN ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-packages-from-source.sh
+
+# Reset the working directory so that it's accessible by any user who runs the
+# container
+WORKDIR /

--- a/components/core/tools/docker-images/clp-env-base-bionic/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-bionic/build.sh
@@ -3,4 +3,4 @@
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 component_root=${script_dir}/../../../
 
-docker build -t clp-env-base:bionic ${component_root} --file ${script_dir}/Dockerfile
+docker build -t clp-core-dependencies-x86-ubuntu-bionic:dev ${component_root} --file ${script_dir}/Dockerfile

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -24,3 +24,7 @@ RUN cp ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/git /usr/bin/g
 
 # Load .bashrc for non-interactive bash shells
 ENV BASH_ENV=/etc/bashrc
+
+# Reset the working directory so that it's accessible by any user who runs the
+# container
+WORKDIR /

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/build.sh
@@ -3,4 +3,4 @@
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 component_root=${script_dir}/../../../
 
-docker build -t clp-env-base:centos7.4 ${component_root} --file ${script_dir}/Dockerfile
+docker build -t clp-core-dependencies-x86-centos7.4:dev ${component_root} --file ${script_dir}/Dockerfile

--- a/components/core/tools/docker-images/clp-env-base-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-focal/Dockerfile
@@ -10,3 +10,7 @@ ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
 RUN ./tools/docker-images/clp-env-base-focal/setup-scripts/install-prebuilt-packages.sh
 RUN ./tools/docker-images/clp-env-base-focal/setup-scripts/install-packages-from-source.sh
+
+# Reset the working directory so that it's accessible by any user who runs the
+# container
+WORKDIR /

--- a/components/core/tools/docker-images/clp-env-base-focal/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-focal/build.sh
@@ -3,4 +3,4 @@
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 component_root=${script_dir}/../../../
 
-docker build -t clp-env-base:focal ${component_root} --file ${script_dir}/Dockerfile
+docker build -t clp-core-dependencies-x86-ubuntu-focal:dev ${component_root} --file ${script_dir}/Dockerfile

--- a/tools/docker-images/clp-execution-base-focal/Dockerfile
+++ b/tools/docker-images/clp-execution-base-focal/Dockerfile
@@ -10,3 +10,7 @@ ADD ./components/core/tools/scripts/lib_install ./tools/scripts/lib_install
 
 RUN ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
 RUN ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-packages-from-source.sh
+
+# Reset the working directory so that it's accessible by any user who runs the
+# container
+WORKDIR /

--- a/tools/docker-images/clp-execution-base-focal/build.sh
+++ b/tools/docker-images/clp-execution-base-focal/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+repo_root=${script_dir}/../../../
+
+docker build -t clp-execution-x86-ubuntu-focal:dev ${repo_root} --file ${script_dir}/Dockerfile


### PR DESCRIPTION
# References
#61 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
- Set the working directory of all containers so that it's accessible by any non-root user
- Add a script to build `tools/docker-images/clp-execution-base-focal`
- Make the names of all containers consistent with those on GitHub

# Validation performed
<!-- What tests and validation you performed on the change -->
* Built all containers using the associated build scripts.
* Verified that they could all be run as a non-root user (`docker run -it -u$(id -u):$(id -g) <container image> /bin/bash`)
