### PR TITLE
Trigger clp-execution-image-build workflow on changes to clp-execution-base-focal container files (fixes #63).

### DIFF
--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['main']
     paths:
-      - './tools/docker-images/clp-execution-base-focal/**'
+      - 'tools/docker-images/clp-execution-base-focal/**'
       - 'components/core/tools/scripts/lib_install/**'
       - '.github/workflows/clp-execution-image-build.yaml'
   workflow_dispatch:


### PR DESCRIPTION
# References
#63 

# Description
It seems GitHub doesn't like a preceding `./` in the monitored paths for a workflow, so this change removes it.

# Validation performed
Tested the workflow was triggered in a forked clp repo.

