### PR TITLE
Add script to run commands in CLP core's dependency container

### DIFF
--- a/components/core/tools/scripts/utils/README.md
+++ b/components/core/tools/scripts/utils/README.md
@@ -1,0 +1,8 @@
+This directory contains uncategorized utility scripts.
+
+* `run-in-container.sh` can be used to run a command (e.g., `make`), in a 
+  container containing the core component's dependencies.
+  * All commands are run from the root of the core component.
+  * This is useful if, for instance, you're developing on Ubuntu 18.04 but the
+    package uses Ubuntu 20.04; you can build in the Ubuntu 20.04 container to
+    avoid compatibility issues.

--- a/components/core/tools/scripts/utils/run-in-container.sh
+++ b/components/core/tools/scripts/utils/run-in-container.sh
@@ -13,6 +13,6 @@ docker run \
   -i \
   --rm \
   -u"$(id -u):$(id -g)" \
-  -v"$(readlink -f "$component_root")":"$container_component_root" \
+  --mount "type=bind,src=$(readlink -f "$component_root"),dst=$container_component_root" \
   -w "$container_component_root" \
   ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-focal:main "$@"

--- a/components/core/tools/scripts/utils/run-in-container.sh
+++ b/components/core/tools/scripts/utils/run-in-container.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+component_root="$script_dir/../../../"
+
+# Run the user's command in the container, relative to the root of this
+# component
+container_component_root=/mnt/clp
+docker run \
+  -i \
+  --rm \
+  -u"$(id -u):$(id -g)" \
+  -v"$(readlink -f "$component_root")":"$container_component_root" \
+  -w "$container_component_root" \
+  ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-focal:main "$@"


### PR DESCRIPTION
<!--# References-->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The package currently runs in an Ubuntu 20.04 container, so to develop CLP core and run it in the package, you either have to be developing on Ubuntu 20.04 already or you have to rebuild the package every time you change CLP core.

This change adds a script that allows us to build CLP core in an Ubuntu 20.04 container containing CLP core's dependencies. The built binaries can then be copied to the package without rebuilding the package. Note that the script runs any command you give it from the root of CLP core.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Used the script to build CLP core from an Ubuntu 18.04 machine.
* Tested that the built binaries worked in the CLP package.
