### PR TITLE
Bug-fix: Undo logic error in how database timestamp filtering criteria was set (fixes #69).

### DIFF
--- a/components/core/src/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/streaming_archive/MetadataDB.cpp
@@ -128,12 +128,18 @@ namespace streaming_archive {
         // Add clauses
         bool clause_exists = false;
         if (cEpochTimeMin != ts_begin) {
-            fmt::format_to(statement_buffer_ix, " WHERE {} >= ?{}", streaming_archive::cMetadataDB::File::BeginTimestamp,
+            // If the end-timestamp of the file is less than the given begin-
+            // timestamp, messages within the file are guaranteed to be outside
+            // the timestamp range. So this filters for the opposite.
+            fmt::format_to(statement_buffer_ix, " WHERE {} >= ?{}", streaming_archive::cMetadataDB::File::EndTimestamp,
                            enum_to_underlying_type(FilesTableFieldIndexes::BeginTimestamp) + 1);
             clause_exists = true;
         }
         if (cEpochTimeMax != ts_end) {
-            fmt::format_to(statement_buffer_ix, " {} {} <= ?{}", clause_exists ? "AND" : "WHERE", streaming_archive::cMetadataDB::File::EndTimestamp,
+            // If the begin-timestamp of the file is greater than the given end-
+            // timestamp, messages within the file are guaranteed to be outside
+            // the timestamp range. So this filters for the opposite.
+            fmt::format_to(statement_buffer_ix, " {} {} <= ?{}", clause_exists ? "AND" : "WHERE", streaming_archive::cMetadataDB::File::BeginTimestamp,
                            enum_to_underlying_type(FilesTableFieldIndexes::EndTimestamp) + 1);
             clause_exists = true;
         }


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#69 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

* The timestamp filtering criteria for filtering files from the database was flawed: It only returned files that fit entirely within the given timestamp range, rather than also returning those which partially overlapped with the given timestamp range.
* This change fixes that and adds a comment so the next developer doesn't make the same silly mistake.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Compressed the dataset mentioned by the issue.
* Verified the searches mentioned by the issue worked.
* Verified that searches with a timestamp filter that overlapped with a certain file's timestamp range worked, no matter if it the overlap was a complete or partial.
