### PR TITLE
Allow an empty log type (fixes #75).

### DIFF
--- a/components/core/src/LogTypeDictionaryWriter.cpp
+++ b/components/core/src/LogTypeDictionaryWriter.cpp
@@ -9,9 +9,6 @@ bool LogTypeDictionaryWriter::add_entry (LogTypeDictionaryEntry& logtype_entry, 
     bool is_new_entry = false;
 
     const string& value = logtype_entry.get_value();
-    if (value.empty()) {
-        throw OperationFailed(ErrorCode_Corrupt, __FILENAME__, __LINE__);
-    }
     const auto ix = m_value_to_id.find(value);
     if (m_value_to_id.end() != ix) {
         // Entry exists so get its ID


### PR DESCRIPTION
# References
#75 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Removed the check which prevents compressing messages with just a timestamp and no content.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated compressing and decompressing logs including those containing messages with no content.
* Validated searching the same logs.

