### PR TITLE
Improvements to the profiling code

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -284,7 +284,7 @@ target_link_libraries(clp
         ZStd::ZStd
         )
 target_compile_features(clp
-        PRIVATE cxx_std_14
+        PRIVATE cxx_std_17
         )
 
 set(SOURCE_FILES_clg
@@ -404,7 +404,7 @@ target_link_libraries(clg
         ZStd::ZStd
         )
 target_compile_features(clg
-        PRIVATE cxx_std_14
+        PRIVATE cxx_std_17
         )
 
 set(SOURCE_FILES_clo
@@ -517,7 +517,7 @@ target_link_libraries(clo
         ZStd::ZStd
         )
 target_compile_features(clo
-        PRIVATE cxx_std_14
+        PRIVATE cxx_std_17
         )
 
 set(SOURCE_FILES_unitTest
@@ -628,7 +628,7 @@ target_link_libraries(unitTest
         ZStd::ZStd
         )
 target_compile_features(unitTest
-        PRIVATE cxx_std_14
+        PRIVATE cxx_std_17
         )
 
 include(cmake/utils.cmake)

--- a/components/core/README.md
+++ b/components/core/README.md
@@ -23,7 +23,7 @@ CLP's core is the low-level component that performs compression, decompression, 
 
 * We have built and tested CLP on **Ubuntu 18.04 (bionic)** and **Ubuntu 20.04 (focal)**.
   * If you have trouble building for another OS, file an issue and we may be able to help.
-* A compiler that supports c++14
+* A compiler that supports C++17 (e.g., gcc-8)
 
 ## Building
 

--- a/components/core/cmake/utils.cmake
+++ b/components/core/cmake/utils.cmake
@@ -44,5 +44,5 @@ target_link_libraries(make-dictionaries-readable
         ZStd::ZStd
         )
 target_compile_features(make-dictionaries-readable
-        PRIVATE cxx_std_14
+        PRIVATE cxx_std_17
         )

--- a/components/core/src/DictionaryReader.hpp
+++ b/components/core/src/DictionaryReader.hpp
@@ -12,7 +12,6 @@
 #include "dictionary_utils.hpp"
 #include "DictionaryEntry.hpp"
 #include "FileReader.hpp"
-#include "Profiler.hpp"
 #include "streaming_compression/passthrough/Decompressor.hpp"
 #include "streaming_compression/zstd/Decompressor.hpp"
 #include "Utils.hpp"
@@ -174,7 +173,6 @@ void DictionaryReader<DictionaryIdType, EntryType>::read_new_entries () {
         }
     }
 
-    PROFILER_FRAGMENTED_MEASUREMENT_START(SegmentIndexRead)
     // Read segment index header
     auto num_segments = read_segment_index_header(m_segment_index_file_reader);
 
@@ -189,7 +187,6 @@ void DictionaryReader<DictionaryIdType, EntryType>::read_new_entries () {
             read_segment_ids();
         }
     }
-    PROFILER_FRAGMENTED_MEASUREMENT_STOP(SegmentIndexRead)
 }
 
 template <typename DictionaryIdType, typename EntryType>

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -5,7 +5,6 @@
 
 // Project headers
 #include "EncodedVariableInterpreter.hpp"
-#include "Profiler.hpp"
 #include "Utils.hpp"
 
 using std::string;
@@ -502,9 +501,7 @@ bool Grep::search_and_decompress (const Query& query, Archive& archive, File& co
     while (false == matched) {
         // Find matching message
         const SubQuery* matching_sub_query = nullptr;
-        PROFILER_FRAGMENTED_MEASUREMENT_START(MessageSearch)
         bool message_found = find_matching_message(query, archive, matching_sub_query, compressed_file, compressed_msg);
-        PROFILER_FRAGMENTED_MEASUREMENT_STOP(MessageSearch)
         if (false == message_found) {
             return false;
         }

--- a/components/core/src/Profiler.cpp
+++ b/components/core/src/Profiler.cpp
@@ -1,44 +1,7 @@
 #include "Profiler.hpp"
 
-using std::atomic_uint64_t;
-using std::chrono::duration;
-using std::chrono::duration_cast;
-using std::chrono::high_resolution_clock;
-using std::nano;
 using std::unique_ptr;
 using std::vector;
 
-unique_ptr<vector<atomic_uint64_t>> Profiler::m_fragmented_measurement_begin_timestamps_ns;
-unique_ptr<vector<atomic_uint64_t>> Profiler::m_fragmented_measurement_durations_ns;
-unique_ptr<vector<atomic_uint64_t>> Profiler::m_continuous_measurement_begin_timestamps_ns;
-unique_ptr<vector<atomic_uint64_t>> Profiler::m_continuous_measurement_durations_ns;
-
-void Profiler::init () {
-    m_fragmented_measurement_begin_timestamps_ns = std::make_unique<vector<atomic_uint64_t>>((size_t) FragmentedMeasurementIndex::Length);
-    m_fragmented_measurement_durations_ns = std::make_unique<vector<atomic_uint64_t>>((size_t) FragmentedMeasurementIndex::Length);
-    for (size_t i = 0; i < m_fragmented_measurement_durations_ns->size(); ++i) {
-        (*m_fragmented_measurement_durations_ns)[i] = 0;
-    }
-
-    m_continuous_measurement_begin_timestamps_ns = std::make_unique<vector<atomic_uint64_t>>((size_t) ContinuousMeasurementIndex::Length);
-    m_continuous_measurement_durations_ns = std::make_unique<vector<atomic_uint64_t>>((size_t) ContinuousMeasurementIndex::Length);
-    for (size_t i = 0; i < m_continuous_measurement_durations_ns->size(); ++i) {
-        (*m_continuous_measurement_durations_ns)[i] = 0;
-    }
-}
-
-void Profiler::start_measurement (unique_ptr<vector<atomic_uint64_t>>& begin_timestamps_in_nanoseconds, size_t index) {
-    (*begin_timestamps_in_nanoseconds)[index] = duration_cast<duration<uint64_t, nano>>(high_resolution_clock::now().time_since_epoch()).count();
-}
-
-void Profiler::stop_measurement (unique_ptr<vector<atomic_uint64_t>>& begin_timestamps_in_nanoseconds,
-                                 unique_ptr<vector<atomic_uint64_t>>& durations_in_nanoseconds, size_t index)
-{
-    auto begin_timestamp = (*begin_timestamps_in_nanoseconds)[index].load();
-    uint64_t end_timestamp = duration_cast<duration<uint64_t, nano>>(high_resolution_clock::now().time_since_epoch()).count();
-    if (end_timestamp >= begin_timestamp) {
-        (*durations_in_nanoseconds)[index] += end_timestamp - begin_timestamp;
-    } else {
-        (*durations_in_nanoseconds)[index] += (UINT64_MAX - begin_timestamp) + end_timestamp;
-    }
-}
+vector<Stopwatch>* Profiler::m_fragmented_measurements = nullptr;
+vector<Stopwatch>* Profiler::m_continuous_measurements = nullptr;

--- a/components/core/src/Profiler.hpp
+++ b/components/core/src/Profiler.hpp
@@ -2,141 +2,159 @@
 #define PROFILER_HPP
 
 // C++ libraries
-#include <atomic>
-#include <memory>
 #include <vector>
 
 // Project headers
 #include "Stopwatch.hpp"
+#include "Utils.hpp"
 
 /**
- * Class to perform global profiling of any program in the package.
+ * Class to time code.
  * There are two types of measurements:
- * - Fragmented measurements where a user needs to time a multiple, separated instances of an operation.
- * - Continuous measurements where a user needs to time a single, continuous operation.
+ * - Continuous measurements where a user needs to time a single, continuous
+ *   operation.
+ * - Fragmented measurements where a user needs to time multiple,
+ *   separated instances of an operation. For example if we want to get the
+ *   total run time taken for inserting entries into a dictionary, we could
+ *   wrap the insertion with a fragmented measurement.
  *
- * To add an operation, add it to the relevant enum and add a flag indicating whether it's enabled to the relevant flags enum.
+ * To add a measurement, add it to the ContinuousMeasurementIndex or
+ * FragmentedMeasurementIndex enums and add a corresponding enable flag to
+ * cContinuousMeasurementEnabled or cFragmentedMeasurementEnabled. The flags
+ * allow enabling/disabling specific measurements such that a disabled
+ * measurement will not affect the performance of the program (except for
+ * extra heap storage).
  *
- * Measurements that are disabled will not affect the performance of the program (except for extra heap storage) so long as the user uses the profiling
- * preprocessor macros below.
+ * Two implementation details allow this class to avoid inducing overhead
+ * when profiling is disabled:
+ * - All methods bodies are defined in the header, guarded by
+ *   `if constexpr (PROF_ENABLED)`. When profiling is disabled, the compiler
+ *   will detect the empty body and won't add any code to the binary; if
+ *   the methods were instead defined in the .cpp file, the compiler would
+ *   still generate an empty method.
+ * - The methods use the measurement enum as a template parameter to
+ *   indicate which measurement the method call is for. So at compile-time,
+ *   for each measurement, the compiler can use the enable flag to determine
+ *   whether to generate code to do the measurement or whether to do
+ *   nothing.
  */
 class Profiler {
 public:
     // Types
-    enum class FragmentedMeasurementIndex : size_t {
-        SegmentRead = 0,
-        LogtypeDictRead,
-        VarDictRead,
-        MessageSearch,
-        SegmentIndexRead,
-        ColumnsAlloc,
-        Length
-    };
-    enum class FragmentedMeasurementEnabled : bool {
-        SegmentRead = true,
-        LogtypeDictRead = true,
-        VarDictRead = true,
-        MessageSearch = true,
-        SegmentIndexRead = true,
-        ColumnsAlloc = true,
-    };
     enum class ContinuousMeasurementIndex : size_t {
-        PipelineRequest = 0,
+        Compression = 0,
+        Search,
         Length
     };
-    enum class ContinuousMeasurementEnabled : bool {
-        PipelineRequest = true,
+    enum class FragmentedMeasurementIndex : size_t {
+        Length
     };
+
+    // Constants
+    // NOTE: We use lambdas so that we can programmatically initialize the constexpr array
+    static constexpr auto cContinuousMeasurementEnabled = []() {
+        std::array<bool, enum_to_underlying_type (ContinuousMeasurementIndex::Length)> enabled{};
+        enabled[enum_to_underlying_type (ContinuousMeasurementIndex::Compression)] = true;
+        enabled[enum_to_underlying_type (ContinuousMeasurementIndex::Search)] = true;
+        return enabled;
+    }();
+    static constexpr auto cFragmentedMeasurementEnabled = []() {
+        std::array<bool, enum_to_underlying_type(FragmentedMeasurementIndex::Length)> enabled{};
+        return enabled;
+    }();
 
     // Methods
     /**
      * Static initializer for class. This must be called before using the class.
      */
-    static void init ();
-
-    static void start_continuous_measurement (ContinuousMeasurementIndex index) {
-        (*m_continuous_measurement_durations_ns)[(size_t)index] = 0;
-        start_measurement(m_continuous_measurement_begin_timestamps_ns, (size_t)index);
+    static void init () {
+        if constexpr (PROF_ENABLED) {
+            m_continuous_measurements = new std::vector<Stopwatch>(
+                    enum_to_underlying_type(ContinuousMeasurementIndex::Length));
+            m_fragmented_measurements = new std::vector<Stopwatch>(
+                    enum_to_underlying_type(FragmentedMeasurementIndex::Length));
+        }
     }
 
-    static void stop_continuous_measurement (ContinuousMeasurementIndex index) {
-        stop_measurement(m_continuous_measurement_begin_timestamps_ns, m_continuous_measurement_durations_ns, (size_t)index);
+    template<ContinuousMeasurementIndex index>
+    static void start_continuous_measurement () {
+        if constexpr (PROF_ENABLED && cContinuousMeasurementEnabled[enum_to_underlying_type(index)])
+        {
+            auto& stopwatch = (*m_continuous_measurements)[enum_to_underlying_type(index)];
+            stopwatch.reset();
+            stopwatch.start();
+        }
     }
 
-    static uint64_t get_continuous_measurement_begin_ns (ContinuousMeasurementIndex index) {
-        return (*m_continuous_measurement_begin_timestamps_ns)[(size_t)index].load();
+    template<ContinuousMeasurementIndex index>
+    static void stop_continuous_measurement () {
+        if constexpr (PROF_ENABLED && cContinuousMeasurementEnabled[enum_to_underlying_type(index)])
+        {
+            (*m_continuous_measurements)[enum_to_underlying_type(index)].stop();
+        }
     }
 
-    static uint64_t get_continuous_measurement_duration_ns (ContinuousMeasurementIndex index) {
-        return (*m_continuous_measurement_durations_ns)[(size_t)index].load();
+    template<ContinuousMeasurementIndex index>
+    static double get_continuous_measurement_in_seconds () {
+        if constexpr (PROF_ENABLED) {
+            return (*m_continuous_measurements)[enum_to_underlying_type(
+                    index)].get_time_taken_in_seconds();
+        } else {
+            return 0;
+        }
     }
 
-    static void start_fragmented_measurement (FragmentedMeasurementIndex index) {
-        start_measurement(m_fragmented_measurement_begin_timestamps_ns, (size_t)index);
+    template<FragmentedMeasurementIndex index>
+    static void start_fragmented_measurement () {
+        if constexpr (PROF_ENABLED && cFragmentedMeasurementEnabled[enum_to_underlying_type(index)])
+        {
+            (*m_fragmented_measurements)[enum_to_underlying_type(index)].start();
+        }
     }
 
-    static void stop_fragmented_measurement (FragmentedMeasurementIndex index) {
-        stop_measurement(m_fragmented_measurement_begin_timestamps_ns, m_fragmented_measurement_durations_ns, (size_t)index);
+    template<FragmentedMeasurementIndex index>
+    static void stop_fragmented_measurement () {
+        if constexpr (PROF_ENABLED && cFragmentedMeasurementEnabled[enum_to_underlying_type(index)])
+        {
+            (*m_fragmented_measurements)[enum_to_underlying_type(index)].stop();
+        }
     }
 
-    static void reset_fragmented_measurement (FragmentedMeasurementIndex index) {
-        (*m_fragmented_measurement_durations_ns)[(size_t)index] = 0;
+    template<FragmentedMeasurementIndex index>
+    static void reset_fragmented_measurement () {
+        if constexpr (PROF_ENABLED && cFragmentedMeasurementEnabled[enum_to_underlying_type(index)])
+        {
+            (*m_fragmented_measurements)[enum_to_underlying_type(index)].reset();
+        }
     }
 
-    static void increment_fragmented_measurement (FragmentedMeasurementIndex index, uint64_t duration_ns) {
-        (*m_fragmented_measurement_durations_ns)[(size_t)index] += duration_ns;
-    }
-
-    static uint64_t get_fragmented_measurement (FragmentedMeasurementIndex index) {
-        return (*m_fragmented_measurement_durations_ns)[(size_t)index].load();
+    template<FragmentedMeasurementIndex index>
+    static double get_fragmented_measurement_in_seconds () {
+        if constexpr (PROF_ENABLED) {
+            return (*m_fragmented_measurements)[enum_to_underlying_type(index)]
+                    .get_time_taken_in_seconds();
+        } else {
+            return 0;
+        }
     }
 
 private:
-    // Methods
-    static void start_measurement (std::unique_ptr<std::vector<std::atomic_uint64_t>>& begin_timestamps_in_nanoseconds, size_t index);
-    static void stop_measurement (std::unique_ptr<std::vector<std::atomic_uint64_t>>& begin_timestamps_in_nanoseconds,
-                                  std::unique_ptr<std::vector<std::atomic_uint64_t>>& durations_in_nanoseconds, size_t index);
-
-    // Variables
-    static std::unique_ptr<std::vector<std::atomic_uint64_t>> m_fragmented_measurement_begin_timestamps_ns;
-    static std::unique_ptr<std::vector<std::atomic_uint64_t>> m_fragmented_measurement_durations_ns;
-    static std::unique_ptr<std::vector<std::atomic_uint64_t>> m_continuous_measurement_begin_timestamps_ns;
-    static std::unique_ptr<std::vector<std::atomic_uint64_t>> m_continuous_measurement_durations_ns;
+    static std::vector<Stopwatch>* m_fragmented_measurements;
+    static std::vector<Stopwatch>* m_continuous_measurements;
 };
 
-// Profiling macros
-#define PROFILER_INITIALIZE() if (PROF_ENABLED) { \
-    Profiler::init(); \
-}
-
-#define PROFILER_FRAGMENTED_MEASUREMENT_START(NAME) \
-    if (PROF_ENABLED && (bool)Profiler::FragmentedMeasurementEnabled::NAME) { \
-        Profiler::start_fragmented_measurement(Profiler::FragmentedMeasurementIndex::NAME); \
+// Macros to log the measurements
+// NOTE: We use macros so that we can add the measurement index to the log (not
+// easy to do with templates).
+#define LOG_CONTINUOUS_MEASUREMENT(x) \
+    if (PROF_ENABLED && Profiler::cContinuousMeasurementEnabled[enum_to_underlying_type(x)]) { \
+        SPDLOG_INFO("{} took {} s", #x, \
+                    Profiler::get_continuous_measurement_in_seconds<x>()); \
     }
-#define PROFILER_FRAGMENTED_MEASUREMENT_STOP(NAME) \
-    if (PROF_ENABLED && (bool)Profiler::FragmentedMeasurementEnabled::NAME) { \
-        Profiler::stop_fragmented_measurement(Profiler::FragmentedMeasurementIndex::NAME); \
-    }
-#define PROFILER_FRAGMENTED_MEASUREMENT_RESET(NAME) \
-    if (PROF_ENABLED && (bool)Profiler::FragmentedMeasurementEnabled::NAME) { \
-        Profiler::reset_fragmented_measurement(Profiler::FragmentedMeasurementIndex::NAME); \
-    }
-#define PROFILER_FRAGMENTED_MEASUREMENT_INCREMENT(NAME, DURATION_NS) \
-    if (PROF_ENABLED && (bool)Profiler::FragmentedMeasurementEnabled::NAME) { \
-        Profiler::increment_fragmented_measurement(Profiler::FragmentedMeasurementIndex::NAME, DURATION_NS); \
+#define LOG_FRAGMENTED_MEASUREMENT(x) \
+    if (PROF_ENABLED && Profiler::cFragmentedMeasurementEnabled[enum_to_underlying_type(x)]) { \
+        SPDLOG_INFO("{} took {} s", #x, \
+                    Profiler::get_fragmented_measurement_in_seconds<x>()); \
     }
 
-#define PROFILER_CONTINUOUS_MEASUREMENT_START(NAME) \
-    if (PROF_ENABLED && (bool)Profiler::ContinuousMeasurementEnabled::NAME) { \
-        Profiler::start_continuous_measurement(Profiler::ContinuousMeasurementIndex::NAME); \
-    }
-#define PROFILER_CONTINUOUS_MEASUREMENT_STOP(NAME) \
-    if (PROF_ENABLED && (bool)Profiler::ContinuousMeasurementEnabled::NAME) { \
-        Profiler::stop_continuous_measurement(Profiler::ContinuousMeasurementIndex::NAME); \
-    }
-
-#define PROFILER_START_STOPWATCH(NAME) \
-    if (PROF_ENABLED) NAME.start();
-#define PROFILER_STOP_STOPWATCH(NAME) \
-    if (PROF_ENABLED) NAME.stop();
 #endif // PROFILER_HPP

--- a/components/core/src/Profiler.hpp
+++ b/components/core/src/Profiler.hpp
@@ -10,6 +10,7 @@
 
 /**
  * Class to time code.
+ *
  * There are two types of measurements:
  * - Continuous measurements where a user needs to time a single, continuous
  *   operation.
@@ -24,6 +25,9 @@
  * allow enabling/disabling specific measurements such that a disabled
  * measurement will not affect the performance of the program (except for
  * extra heap storage).
+ *
+ * To log a measurement, use LOG_CONTINUOUS_MEASUREMENT or
+ * LOG_FRAGMENTED_MEASUREMENT, passing in the relevant measurement index enum.
  *
  * Two implementation details allow this class to avoid inducing overhead
  * when profiling is disabled:

--- a/components/core/src/Stopwatch.cpp
+++ b/components/core/src/Stopwatch.cpp
@@ -5,18 +5,18 @@ Stopwatch::Stopwatch () {
 }
 
 void Stopwatch::start () {
-    m_begin = std::chrono::high_resolution_clock::now();
+    m_begin = std::chrono::steady_clock::now();
 }
 
 void Stopwatch::stop () {
-    m_end = std::chrono::high_resolution_clock::now();
+    auto end = std::chrono::steady_clock::now();
 
-    std::chrono::duration<uint64_t, std::nano> time_taken = m_end - m_begin;
+    auto time_taken = end - m_begin;
     m_time_taken += time_taken;
 }
 
 void Stopwatch::reset () {
-    m_time_taken = std::chrono::high_resolution_clock::duration::zero();
+    m_time_taken = std::chrono::steady_clock::duration::zero();
 }
 
 double Stopwatch::get_time_taken_in_seconds () {

--- a/components/core/src/Stopwatch.hpp
+++ b/components/core/src/Stopwatch.hpp
@@ -17,12 +17,10 @@ public:
     void reset ();
 
     double get_time_taken_in_seconds ();
-    uint64_t get_time_taken_in_nanoseconds () const { return m_time_taken.count(); }
 
 private:
     // Variables
-    std::chrono::time_point<std::chrono::high_resolution_clock> m_begin;
-    std::chrono::time_point<std::chrono::high_resolution_clock> m_end;
+    std::chrono::time_point<std::chrono::steady_clock> m_begin;
     std::chrono::duration<uint64_t, std::nano> m_time_taken;
 };
 

--- a/components/core/src/Utils.cpp
+++ b/components/core/src/Utils.cpp
@@ -17,9 +17,6 @@
 // spdlog
 #include <spdlog/spdlog.h>
 
-// Project headers
-#include "Profiler.hpp"
-
 using std::list;
 using std::string;
 using std::vector;

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -321,7 +321,7 @@ int main (int argc, const char* argv[]) {
         // NOTE: We can't log an exception if the logger couldn't be constructed
         return -1;
     }
-    PROFILER_INITIALIZE()
+    Profiler::init();
     TimestampPattern::init();
 
     CommandLineArguments command_line_args("clg");
@@ -335,6 +335,8 @@ int main (int argc, const char* argv[]) {
             // Continue processing
             break;
     }
+
+    Profiler::start_continuous_measurement<Profiler::ContinuousMeasurementIndex::Search>();
 
     // Create vector of search strings
     vector<string> search_strings;
@@ -406,6 +408,9 @@ int main (int argc, const char* argv[]) {
     }
 
     global_metadata_db->close();
+
+    Profiler::stop_continuous_measurement<Profiler::ContinuousMeasurementIndex::Search>();
+    LOG_CONTINUOUS_MEASUREMENT(Profiler::ContinuousMeasurementIndex::Search)
 
     return 0;
 }

--- a/components/core/src/clo/clo.cpp
+++ b/components/core/src/clo/clo.cpp
@@ -252,7 +252,7 @@ int main (int argc, const char* argv[]) {
         // NOTE: We can't log an exception if the logger couldn't be constructed
         return -1;
     }
-    PROFILER_INITIALIZE()
+    Profiler::init();
     TimestampPattern::init();
 
     CommandLineArguments command_line_args("clo");

--- a/components/core/src/clp/clp.cpp
+++ b/components/core/src/clp/clp.cpp
@@ -32,7 +32,7 @@ int main (int argc, const char* argv[]) {
         // NOTE: We can't log an exception if the logger couldn't be constructed
         return -1;
     }
-    PROFILER_INITIALIZE()
+    Profiler::init();
     TimestampPattern::init();
 
     clp::CommandLineArguments command_line_args("clp");
@@ -48,6 +48,8 @@ int main (int argc, const char* argv[]) {
     }
 
     vector<string> input_paths = command_line_args.get_input_paths();
+
+    Profiler::start_continuous_measurement<Profiler::ContinuousMeasurementIndex::Compression>();
 
     // Read input paths from file if necessary
     if (false == command_line_args.get_path_list_path().empty()) {
@@ -106,6 +108,9 @@ int main (int argc, const char* argv[]) {
             return -1;
         }
     }
+
+    Profiler::stop_continuous_measurement<Profiler::ContinuousMeasurementIndex::Compression>();
+    LOG_CONTINUOUS_MEASUREMENT(Profiler::ContinuousMeasurementIndex::Compression)
 
     return 0;
 }

--- a/components/core/src/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/streaming_archive/reader/Archive.cpp
@@ -16,7 +16,6 @@
 
 // Project headers
 #include "../../EncodedVariableInterpreter.hpp"
-#include "../../Profiler.hpp"
 #include "../../Stopwatch.hpp"
 #include "../../Utils.hpp"
 #include "../Constants.hpp"
@@ -124,12 +123,8 @@ namespace streaming_archive { namespace reader {
     }
 
     void Archive::refresh_dictionaries () {
-        PROFILER_FRAGMENTED_MEASUREMENT_START(LogtypeDictRead)
         m_logtype_dictionary.read_new_entries();
-        PROFILER_FRAGMENTED_MEASUREMENT_STOP(LogtypeDictRead)
-        PROFILER_FRAGMENTED_MEASUREMENT_START(VarDictRead)
         m_var_dictionary.read_new_entries();
-        PROFILER_FRAGMENTED_MEASUREMENT_STOP(VarDictRead)
     }
 
     ErrorCode Archive::open_file (File& file, MetadataDB::FileIterator& file_metadata_ix, bool read_ahead) {

--- a/components/core/src/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/streaming_archive/writer/Archive.cpp
@@ -21,7 +21,6 @@
 
 // Project headers
 #include "../../EncodedVariableInterpreter.hpp"
-#include "../../Profiler.hpp"
 #include "../../Utils.hpp"
 #include "../Constants.hpp"
 

--- a/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
+++ b/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
@@ -7,6 +7,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   cmake \
   curl \
   build-essential \
+  gcc-8 \
+  g++-8 \
   libboost-filesystem-dev \
   libboost-iostreams-dev \
   libboost-program-options-dev \
@@ -26,3 +28,6 @@ curl -fsSl https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null |
 apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
 apt-get update
 apt-get install -y cmake
+
+# Switch to gcc-8
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -14,8 +14,8 @@ RUN ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-packages-
 # Set PKG_CONFIG_PATH since CentOS doesn't look in /usr/local by default
 ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
-# Enable gcc 7
-RUN ln -s /opt/rh/devtoolset-7/enable /etc/profile.d/devtoolset.sh
+# Enable gcc 8
+RUN ln -s /opt/rh/devtoolset-8/enable /etc/profile.d/devtoolset.sh
 
 # Enable git 2.27
 # NOTE: We use a script to enable the SCL git package on each git call because some Github actions

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-prebuilt-packages.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-prebuilt-packages.sh
@@ -15,5 +15,5 @@ yum install -y \
 
 # Install packages from CentOS' software collections repository (centos-release-scl)
 yum install -y \
-  devtoolset-7 \
+  devtoolset-8 \
   rh-git227


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Before open-sourcing, some old profiling code was not removed and even though everything was single-threaded, the Profiler class was still using atomics to store measurements. This change resolves those issues and makes some other improvements:

- Remove remnants of old profiling
- Use Stopwatch instead of atomics for Profiler measurements to avoid the overhead for single-threaded code (multi-threaded code can use a different Profiler implementation in the future)
- Use templates instead of macros for more compile-time checking
- Switch from C++14 to C++17 to support the above changes

# Validation performed
<!-- What tests and validation you performed on the change -->
- Tested that when `PROF_ENABLED=0`, profiling was disabled and used `objdump -d` to verify that no profiling code was added to the binaries.
- Tested that when `PROF_ENABLED=1`, the existing profiling code runs.
- Tested when a single profiling measurement is disabled, the code for that specific measurement is not added to the binary.