### PR TITLE
Fix out-of-bounds access when doing wildcard match without prefix and suffix '*'.

### DIFF
--- a/components/core/src/DictionaryReader.hpp
+++ b/components/core/src/DictionaryReader.hpp
@@ -234,7 +234,7 @@ void DictionaryReader<DictionaryIdType, EntryType>::get_entries_matching_wildcar
                                                                                           std::unordered_set<const EntryType*>& entries) const
 {
     for (const auto& entry : m_entries) {
-        if (wildCardMatch(entry.get_value(), wildcard_string, false == ignore_case)) {
+        if (wildcard_match_unsafe(entry.get_value(), wildcard_string, false == ignore_case)) {
             entries.insert(&entry);
         }
     }

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -377,8 +377,13 @@ bool Grep::process_raw_query (const Archive& archive, const string& search_strin
     query.set_search_end_timestamp(search_end_ts);
     query.set_ignore_case(ignore_case);
 
+    // Add prefix and suffix '*' to make the search a sub-string match
+    string processed_search_string = "*";
+    processed_search_string += search_string;
+    processed_search_string += '*';
+
     // Clean-up search string
-    string processed_search_string = clean_up_wildcard_search_string(search_string);
+    processed_search_string = clean_up_wildcard_search_string(processed_search_string);
     query.set_search_string(processed_search_string);
 
     // Replace non-greedy wildcards with greedy wildcards since we currently have no support for searching compressed files with non-greedy wildcards
@@ -717,7 +722,8 @@ size_t Grep::search_and_output (const Query& query, size_t limit, Archive& archi
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required()) ||
             (query.contains_sub_queries() == false && query.search_string_matches_all() == false))
         {
-            bool matched = wildCardMatch(decompressed_msg, query.get_search_string(), query.get_ignore_case() == false);
+            bool matched = wildcard_match_unsafe(decompressed_msg, query.get_search_string(),
+                                                 query.get_ignore_case() == false);
             if (!matched) {
                 continue;
             }
@@ -756,7 +762,8 @@ bool Grep::search_and_decompress (const Query& query, Archive& archive, File& co
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required()) ||
             (query.contains_sub_queries() == false && query.search_string_matches_all() == false))
         {
-            matched = wildCardMatch(decompressed_msg, query.get_search_string(), query.get_ignore_case() == false);
+            matched = wildcard_match_unsafe(decompressed_msg, query.get_search_string(),
+                                            query.get_ignore_case() == false);
         } else {
             matched = true;
         }
@@ -791,7 +798,8 @@ size_t Grep::search (const Query& query, size_t limit, Archive& archive, File& c
                 break;
             }
 
-            bool matched = wildCardMatch(decompressed_msg, query.get_search_string(), query.get_ignore_case() == false);
+            bool matched = wildcard_match_unsafe(decompressed_msg, query.get_search_string(),
+                                                 query.get_ignore_case() == false);
             if (!matched) {
                 continue;
             }

--- a/components/core/src/Utils.hpp
+++ b/components/core/src/Utils.hpp
@@ -75,13 +75,15 @@ bool is_wildcard (char c);
 
 /**
  * Cleans wildcard search string
- * - Removes consecutive '*'
- * - Removes escaping from non-wildcard characters
- * - Adds wildcard to beginning and end of string
+ * <ul>
+ *   <li>Removes consecutive '*'</li>
+ *   <li>Removes escaping from non-wildcard characters</li>
+ *   <li>Removes dangling escape character from the end of the string</li>
+ * </ul>
  * @param str Wildcard search string to clean
  * @return Cleaned wildcard search string
  */
-std::string clean_up_wildcard_search_string (const std::string& str);
+std::string clean_up_wildcard_search_string (std::string_view str);
 
 /**
  * Converts the given string to a 64-bit integer if possible
@@ -172,28 +174,36 @@ std::string get_unambiguous_path (const std::string& path);
 std::string replace_characters (const char* characters_to_escape, const char* replacement_characters, const std::string& value, bool escape);
 
 /**
- * Perform wildcard match
- * @param string_tame A cpp string without wildcards
- * @param string_wild A (potentially) corresponding cpp string with wildcards
- * @return
+ * Same as ``wildcard_match_unsafe_case_sensitive`` except this method allows
+ * the caller to specify whether the match should be case sensitive.
+ *
+ * @param tame The literal string
+ * @param wild The wildcard string
+ * @param case_sensitive_match Whether to consider case when matching
+ * @return Whether the two strings match
  */
-bool wildCardMatch_caseSensitive (
-        const std::string& string_tame,
-        const std::string& string_wild
-);
-
+bool wildcard_match_unsafe (std::string_view tame, std::string_view wild,
+                            bool case_sensitive_match = true);
 /**
- * Perform wildcard match with case sentivity flag
- * @param string_tame A string without wildcards
- * @param string_wild A (potentially) corresponding string with wildcards
- * @param isCaseSensitive
- * @return
+ * Checks if a string matches a wildcard string. Two wildcards are currently
+ * supported: '*' to match 0 or more characters, and '?' to match any single
+ * character. Each can be escaped using a preceding '\'. Other characters which
+ * are escaped are treated as normal characters.
+ * <br/>
+ * This method is optimized for performance by omitting some checks on the
+ * wildcard string that are unnecessary if the caller cleans up the wildcard
+ * string as follows:
+ * <ul>
+ *   <li>The wildcard string should not contain consecutive '*'.</li>
+ *   <li>The wildcard string should not contain an escape character without a
+ *   character following it.</li>
+ * </ul>
+ *
+ * @param tame The literal string
+ * @param wild The wildcard string
+ * @return Whether the two strings match
  */
-bool wildCardMatch (
-        const std::string& string_tame,
-        const std::string& string_wild,
-        const bool isCaseSensitive
-);
+bool wildcard_match_unsafe_case_sensitive (std::string_view tame, std::string_view wild);
 
 /**
  * Maps a given file into memory

--- a/components/core/tests/test-Utils.cpp
+++ b/components/core/tests/test-Utils.cpp
@@ -23,15 +23,15 @@ TEST_CASE("clean_up_wildcard_search_string", "[clean_up_wildcard_search_string]"
 
     // No wildcards
     str = "test";
-    REQUIRE(clean_up_wildcard_search_string(str) == "*test*");
+    REQUIRE(clean_up_wildcard_search_string(str) == "test");
 
     // Only '?'
     str = "?est";
-    REQUIRE(clean_up_wildcard_search_string(str) == "*?est*");
+    REQUIRE(clean_up_wildcard_search_string(str) == "?est");
 
     // Normal case
-    str = "***t**st?**";
-    REQUIRE(clean_up_wildcard_search_string(str) == "*t*st?*");
+    str = "***t**\\*s\\?t?**";
+    REQUIRE(clean_up_wildcard_search_string(str) == "*t*\\*s\\?t?*");
 
     // Abnormal cases
     str = "***";
@@ -41,7 +41,13 @@ TEST_CASE("clean_up_wildcard_search_string", "[clean_up_wildcard_search_string]"
     REQUIRE(clean_up_wildcard_search_string(str) == "*?*");
 
     str = "?";
-    REQUIRE(clean_up_wildcard_search_string(str) == "*?*");
+    REQUIRE(clean_up_wildcard_search_string(str) == "?");
+
+    str = "?";
+    REQUIRE(clean_up_wildcard_search_string(str) == "?");
+
+    str = "a\\bc\\";
+    REQUIRE(clean_up_wildcard_search_string(str) == "abc");
 }
 
 TEST_CASE("convert_string_to_int64", "[convert_string_to_int64]") {
@@ -230,296 +236,227 @@ SCENARIO("Test case sensitive wild card match in all possible ways", "[wildcard]
     WHEN("Match is expected if wild card character is \"*\"") {
         GIVEN("Single wild with no suffix char") {
             tameString = "abcd", wildString = "a*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Multiple wild with no suffix char") {
-            tameString = "abcd", wildString = "a**";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Multiple wild with no suffix char") {
-            tameString = "abcd", wildString = "a***";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild with no prefix char") {
             tameString = "abcd", wildString = "*d";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Multiple wild with no prefix char") {
-            tameString = "abcd", wildString = "**d";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Multiple wild with no prefix char") {
-            tameString = "abcd", wildString = "***d";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild on both side & has 1st char as literal") {
             tameString = "abcd", wildString = "*a*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild on both side & has middle char as literal") {
             tameString = "abcd", wildString = "*b*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild on both side & has last char as literal") {
             tameString = "abcd", wildString = "*d*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Single wild on left side, multiple on right, 1st char as literal") {
-            tameString = "abcd", wildString = "*a**";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Single wild on left side, multiple on right, middle char as literal") {
-            tameString = "abcd", wildString = "*b**";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Single wild on left side, multiple on right, last char as literal") {
-            tameString = "abcd", wildString = "*d**";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Single wild on right side, multiple on left, 1st char as literal") {
-            tameString = "abcd", wildString = "**a*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Single wild on right side, multiple on left, middle char as literal") {
-            tameString = "abcd", wildString = "**b*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Single wild on right side, multiple on left, last char as literal") {
-            tameString = "abcd", wildString = "**d*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Multiple wild anywhere") {
-            tameString = "abcdef", wildString = "a*b**c******d*ef";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild only") {
             tameString = "abcd", wildString = "*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Some wild only") {
-            tameString = "abcd", wildString = "***";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Lots of wild only") {
-            tameString = "abcd", wildString = "********";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
     }
 
     WHEN("Match is expected if Wild card character is \"?\"") {
         GIVEN("Single wild in the middle") {
             tameString = "abcd", wildString = "a?cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild in the beginning") {
             tameString = "abcd", wildString = "?bcd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild at the end") {
             tameString = "abcd", wildString = "abc?";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
 
         GIVEN("Multiple wild in the middle") {
             tameString = "abcd", wildString = "a??d";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Multiple wild in the beginning") {
             tameString = "abcd", wildString = "??cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Multiple wild in the end") {
             tameString = "abcd", wildString = "ab??";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Single wild in the beginning and end") {
             tameString = "abcd", wildString = "?bc?";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Multiple wild anywhere") {
             tameString = "abcdef", wildString = "a?c?ef";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("All wild") {
             tameString = "abcd", wildString = "????";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
     }
 
     WHEN("Match is expected if wild card character has both \"*\" and \"?\"") {
         GIVEN("Wild begins with \"*?\" pattern with 0 matched char for \"*\"") {
             tameString = "abcd", wildString = "*?bcd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild begins with \"?*\" pattern with 0 matched char for \"*\"") {
             tameString = "abcd", wildString = "?*bcd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild begins with \"*?\" pattern with 1 matched char for \"*\"") {
             tameString = "abcd", wildString = "*?cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild begins with \"?*\" pattern with 1 matched char for \"*\"") {
             tameString = "abcd", wildString = "*?cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild ends with \"*?\" pattern with 0 matched char for \"*\"") {
             tameString = "abcd", wildString = "abc*?";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild ends with \"?*\" pattern with 0 matched char for \"*\"") {
             tameString = "abcd", wildString = "abc*?";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild ends with \"*?\" pattern with 1 matched char for \"*\"") {
             tameString = "abcd", wildString = "ab*?";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild ends with \"?*\" pattern with 1 matched char for \"*\"") {
             tameString = "abcd", wildString = "ab?*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild begins with exactly \"*?\" pattern") {
             tameString = "abcd", wildString = "*?";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Wild begins with exactly \"?*\" pattern") {
             tameString = "abcd", wildString = "?*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
     }
 
     WHEN("Match unexpected containing wild card character(s)") {
         GIVEN("Missing literal character w/ \"*\"") {
             tameString = "abcd", wildString = "ac*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == false);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == false);
         }
 
         GIVEN("More literals in wild than tame w/ \"*\" in the middle") {
             tameString = "abcd", wildString = "abc*de";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == false);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == false);
         }
 
         GIVEN("MISSING matching literals in the beginning with \"*\" in the middle") {
             tameString = "abcd", wildString = "b**d";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == false);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == false);
         }
 
         GIVEN("MISSING matching literals in the end with \"*\" in the middle") {
             tameString = "abcd", wildString = "a**c";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == false);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == false);
         }
 
-        GIVEN("MISSING matching literals in the beginning with both \"*\" and \"?\" in the middle") {
+        GIVEN("MISSING matching literals in the beginning with both \"*\" and \"?\" in the middle")
+        {
             tameString = "abcd", wildString = "b*?d";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == false);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == false);
         }
 
         GIVEN("MISSING matching literals in the beginning with \"?\" at the beginning") {
             tameString = "abcd", wildString = "?cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == false);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == false);
         }
 
         GIVEN("MISSING matching literals in the end with both \"?\" at the end") {
             tameString = "abcd", wildString = "ab?";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == false);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == false);
         }
     }
 
     WHEN("Match is expected when escape character(s) are used") {
         GIVEN("Escaping \"*\"") {
             tameString = "a*cd", wildString = "a\\*cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"?\"") {
             tameString = "a?cd", wildString = "a\\?cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"*\" and \"?\"") {
             tameString = "a?c*e", wildString = "a\\?c\\*e";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"\\\"") {
             tameString = "a\\cd", wildString = "a\\\\cd";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"?\" when fast forwarding") {
             tameString = "abc?e", wildString = "a*\\?e";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"*\" when fast forwarding") {
             tameString = "abc*e", wildString = "a*\\*e";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"\\\" when fast forwarding") {
             tameString = "abc\\e", wildString = "a*\\\\e";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"?\" when rewinding") {
             tameString = "\\ab\\ab\\c?ef", wildString = "*ab\\\\c\\?*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"*\" when rewinding") {
             tameString = "\\ab\\ab\\c*ef", wildString = "*ab\\\\c\\**";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Escaping \"\\\" when rewinding") {
             tameString = "\\ab\\ab\\c\\ef", wildString = "*ab\\\\c\\\\*";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
 
         GIVEN("Silently ignore unsupported escape sequence \\a") {
             tameString = "ab?d", wildString = "\\ab?d";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
-        }
-
-        GIVEN("Silently ignore improper escape sequence at the end") {
-            tameString = "abcd", wildString = "abcd\\";
-            REQUIRE(wildCardMatch_caseSensitive(tameString, wildString) == true);
+            REQUIRE(wildcard_match_unsafe_case_sensitive(tameString, wildString) == true);
         }
     }
 
@@ -530,12 +467,15 @@ SCENARIO("Test case sensitive wild card match in all possible ways", "[wildcard]
         bool isCaseSensitive = false;
         GIVEN("All lower case tame and all upper case wild") {
             tameString = "abcde", wildString = "A?C*";
-            REQUIRE(wildCardMatch(tameString, wildString, isCaseSensitive) == true);
+            REQUIRE(wildcard_match_unsafe(tameString, wildString, isCaseSensitive) == true);
         }
 
         GIVEN("All lower case tame and mixed lower and upper case wild") {
             tameString = "abcde", wildString = "A?c*";
-            REQUIRE(wildCardMatch(tameString, wildString, isCaseSensitive) == true);
+            REQUIRE(wildcard_match_unsafe(tameString, wildString, isCaseSensitive) == true);
+
+            tameString = "abcde", wildString = "A?c*";
+            REQUIRE(wildcard_match_unsafe(tameString, wildString, isCaseSensitive) == true);
         }
     }
 
@@ -543,125 +483,122 @@ SCENARIO("Test case sensitive wild card match in all possible ways", "[wildcard]
         bool allPassed = true;
 
         GIVEN("Case with repeating character sequences") {
-            allPassed &= wildCardMatch_caseSensitive("abcccd", "*ccd");
-            allPassed &= wildCardMatch_caseSensitive("mississipissippi", "*issip*ss*");
-            allPassed &= !wildCardMatch_caseSensitive("xxxx*zzzzzzzzy*f", "xxxx*zzy*fffff");
-            allPassed &= wildCardMatch_caseSensitive("xxxx*zzzzzzzzy*f", "xxx*zzy*f");
-            allPassed &= !wildCardMatch_caseSensitive("xxxxzzzzzzzzyf", "xxxx*zzy*fffff");
-            allPassed &= wildCardMatch_caseSensitive("xxxxzzzzzzzzyf", "xxxx*zzy*f");
-            allPassed &= wildCardMatch_caseSensitive("xyxyxyzyxyz", "xy*z*xyz");
-            allPassed &= wildCardMatch_caseSensitive("mississippi", "*sip*");
-            allPassed &= wildCardMatch_caseSensitive("xyxyxyxyz", "xy*xyz");
-            allPassed &= wildCardMatch_caseSensitive("mississippi", "mi*sip*");
-            allPassed &= wildCardMatch_caseSensitive("ababac", "*abac*");
-            allPassed &= wildCardMatch_caseSensitive("ababac", "*abac*");
-            allPassed &= wildCardMatch_caseSensitive("aaazz", "a*zz*");
-            allPassed &= !wildCardMatch_caseSensitive("a12b12", "*12*23");
-            allPassed &= !wildCardMatch_caseSensitive("a12b12", "a12b");
-            allPassed &= wildCardMatch_caseSensitive("a12b12", "*12*12*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("abcccd", "*ccd");
+            allPassed &= wildcard_match_unsafe_case_sensitive("mississipissippi", "*issip*ss*");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("xxxx*zzzzzzzzy*f",
+                                                               "xxxx*zzy*fffff");
+            allPassed &= wildcard_match_unsafe_case_sensitive("xxxx*zzzzzzzzy*f", "xxx*zzy*f");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("xxxxzzzzzzzzyf", "xxxx*zzy*fffff");
+            allPassed &= wildcard_match_unsafe_case_sensitive("xxxxzzzzzzzzyf", "xxxx*zzy*f");
+            allPassed &= wildcard_match_unsafe_case_sensitive("xyxyxyzyxyz", "xy*z*xyz");
+            allPassed &= wildcard_match_unsafe_case_sensitive("mississippi", "*sip*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("xyxyxyxyz", "xy*xyz");
+            allPassed &= wildcard_match_unsafe_case_sensitive("mississippi", "mi*sip*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("ababac", "*abac*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("ababac", "*abac*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("aaazz", "a*zz*");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("a12b12", "*12*23");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("a12b12", "a12b");
+            allPassed &= wildcard_match_unsafe_case_sensitive("a12b12", "*12*12*");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("Additional cases where the '*' char appears in the tame string") {
-            allPassed &= wildCardMatch_caseSensitive("*", "*");
-            allPassed &= wildCardMatch_caseSensitive("a*abab", "a*b");
-            allPassed &= wildCardMatch_caseSensitive("a*r", "a*");
-            allPassed &= !wildCardMatch_caseSensitive("a*ar", "a*aar");
+            allPassed &= wildcard_match_unsafe_case_sensitive("*", "*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("a*abab", "a*b");
+            allPassed &= wildcard_match_unsafe_case_sensitive("a*r", "a*");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("a*ar", "a*aar");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("More double wildcard scenarios") {
-            allPassed &= wildCardMatch_caseSensitive("XYXYXYZYXYz", "XY*Z*XYz");
-            allPassed &= wildCardMatch_caseSensitive("missisSIPpi", "*SIP*");
-            allPassed &= wildCardMatch_caseSensitive("mississipPI", "*issip*PI");
-            allPassed &= wildCardMatch_caseSensitive("xyxyxyxyz", "xy*xyz");
-            allPassed &= wildCardMatch_caseSensitive("miSsissippi", "mi*sip*");
-            allPassed &= !wildCardMatch_caseSensitive("miSsissippi", "mi*Sip*");
-            allPassed &= wildCardMatch_caseSensitive("abAbac", "*Abac*");
-            allPassed &= wildCardMatch_caseSensitive("abAbac", "*Abac*");
-            allPassed &= wildCardMatch_caseSensitive("aAazz", "a*zz*");
-            allPassed &= !wildCardMatch_caseSensitive("A12b12", "*12*23");
-            allPassed &= wildCardMatch_caseSensitive("a12B12", "*12*12*");
-            allPassed &= wildCardMatch_caseSensitive("oWn", "*oWn*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("XYXYXYZYXYz", "XY*Z*XYz");
+            allPassed &= wildcard_match_unsafe_case_sensitive("missisSIPpi", "*SIP*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("mississipPI", "*issip*PI");
+            allPassed &= wildcard_match_unsafe_case_sensitive("xyxyxyxyz", "xy*xyz");
+            allPassed &= wildcard_match_unsafe_case_sensitive("miSsissippi", "mi*sip*");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("miSsissippi", "mi*Sip*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("abAbac", "*Abac*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("abAbac", "*Abac*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("aAazz", "a*zz*");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("A12b12", "*12*23");
+            allPassed &= wildcard_match_unsafe_case_sensitive("a12B12", "*12*12*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("oWn", "*oWn*");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("Completely tame (no wildcards) cases") {
-            allPassed &= wildCardMatch_caseSensitive("bLah", "bLah");
-            allPassed &= !wildCardMatch_caseSensitive("bLah", "bLaH");
+            allPassed &= wildcard_match_unsafe_case_sensitive("bLah", "bLah");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("bLah", "bLaH");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("Simple mixed wildcard tests suggested by IBMer Marlin Deckert") {
-            allPassed &= wildCardMatch_caseSensitive("a", "*?");
-            allPassed &= wildCardMatch_caseSensitive("ab", "*?");
-            allPassed &= wildCardMatch_caseSensitive("abc", "*?");
+            allPassed &= wildcard_match_unsafe_case_sensitive("a", "*?");
+            allPassed &= wildcard_match_unsafe_case_sensitive("ab", "*?");
+            allPassed &= wildcard_match_unsafe_case_sensitive("abc", "*?");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("More mixed wildcard tests including coverage for false positives") {
-            allPassed &= !wildCardMatch_caseSensitive("a", "??");
-            allPassed &= wildCardMatch_caseSensitive("ab", "?*?");
-            allPassed &= wildCardMatch_caseSensitive("ab", "*?*?*");
-            allPassed &= wildCardMatch_caseSensitive("abc", "?**?*?");
-            allPassed &= !wildCardMatch_caseSensitive("abc", "?**?*&?");
-            allPassed &= wildCardMatch_caseSensitive("abcd", "?b*??");
-            allPassed &= !wildCardMatch_caseSensitive("abcd", "?a*??");
-            allPassed &= wildCardMatch_caseSensitive("abcd", "?**?c?");
-            allPassed &= !wildCardMatch_caseSensitive("abcd", "?**?d?");
-            allPassed &= wildCardMatch_caseSensitive("abcde", "?*b*?*d*?");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("a", "??");
+            allPassed &= wildcard_match_unsafe_case_sensitive("ab", "?*?");
+            allPassed &= wildcard_match_unsafe_case_sensitive("ab", "*?*?*");
+            allPassed &= wildcard_match_unsafe_case_sensitive("abcd", "?b*??");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("abcd", "?a*??");
+            allPassed &= wildcard_match_unsafe_case_sensitive("abcde", "?*b*?*d*?");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("Single-character-match cases") {
-            allPassed &= wildCardMatch_caseSensitive("bLah", "bL?h");
-            allPassed &= !wildCardMatch_caseSensitive("bLaaa", "bLa?");
-            allPassed &= wildCardMatch_caseSensitive("bLah", "bLa?");
-            allPassed &= !wildCardMatch_caseSensitive("bLaH", "?Lah");
-            allPassed &= wildCardMatch_caseSensitive("bLaH", "?LaH");
+            allPassed &= wildcard_match_unsafe_case_sensitive("bLah", "bL?h");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("bLaaa", "bLa?");
+            allPassed &= wildcard_match_unsafe_case_sensitive("bLah", "bLa?");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("bLaH", "?Lah");
+            allPassed &= wildcard_match_unsafe_case_sensitive("bLaH", "?LaH");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("Many-wildcard scenarios") {
-            allPassed &= wildCardMatch_caseSensitive(
+            allPassed &= wildcard_match_unsafe_case_sensitive(
                     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
                     "a*a*a*a*a*a*aa*aaa*a*a*b");
-            allPassed &= wildCardMatch_caseSensitive(
+            allPassed &= wildcard_match_unsafe_case_sensitive(
                     "abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab",
                     "*a*b*ba*ca*a*aa*aaa*fa*ga*b*");
-            allPassed &= !wildCardMatch_caseSensitive(
+            allPassed &= !wildcard_match_unsafe_case_sensitive(
                     "abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab",
                     "*a*b*ba*ca*a*x*aaa*fa*ga*b*");
-            allPassed &= !wildCardMatch_caseSensitive(
+            allPassed &= !wildcard_match_unsafe_case_sensitive(
                     "abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab",
                     "*a*b*ba*ca*aaaa*fa*ga*gggg*b*");
-            allPassed &= wildCardMatch_caseSensitive(
+            allPassed &= wildcard_match_unsafe_case_sensitive(
                     "abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab",
                     "*a*b*ba*ca*aaaa*fa*ga*ggg*b*");
-            allPassed &= wildCardMatch_caseSensitive("aaabbaabbaab", "*aabbaa*a*");
-            allPassed &= wildCardMatch_caseSensitive("a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*",
-                                                     "a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*");
-            allPassed &= wildCardMatch_caseSensitive("aaaaaaaaaaaaaaaaa", "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*");
-            allPassed &= !wildCardMatch_caseSensitive("aaaaaaaaaaaaaaaa", "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*");
-            allPassed &= !wildCardMatch_caseSensitive(
+            allPassed &= wildcard_match_unsafe_case_sensitive("aaabbaabbaab", "*aabbaa*a*");
+            allPassed &= wildcard_match_unsafe_case_sensitive(
+                    "a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*", "a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*");
+            allPassed &= wildcard_match_unsafe_case_sensitive(
+                    "aaaaaaaaaaaaaaaaa", "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*");
+            allPassed &= !wildcard_match_unsafe_case_sensitive(
+                    "aaaaaaaaaaaaaaaa", "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*");
+            allPassed &= !wildcard_match_unsafe_case_sensitive(
                     "abc*abcd*abcde*abcdef*abcdefg*abcdefgh*abcdefghi*abcdefghij*abcdefghijk*abcdefghijkl*abcdefghijklm*abcdefghijklmn",
                     "abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*");
-            allPassed &= wildCardMatch_caseSensitive(
+            allPassed &= wildcard_match_unsafe_case_sensitive(
                     "abc*abcd*abcde*abcdef*abcdefg*abcdefgh*abcdefghi*abcdefghij*abcdefghijk*abcdefghijkl*abcdefghijklm*abcdefghijklmn",
                     "abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*");
-            allPassed &= !wildCardMatch_caseSensitive("abc*abcd*abcd*abc*abcd", "abc*abc*abc*abc*abc");
-            allPassed &= wildCardMatch_caseSensitive("abc*abcd*abcd*abc*abcd*abcd*abc*abcd*abc*abc*abcd",
-                                                     "abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abcd");
-            allPassed &= wildCardMatch_caseSensitive("abc", "********a********b********c********");
-            allPassed &= !wildCardMatch_caseSensitive("********a********b********c********", "abc");
-            allPassed &= !wildCardMatch_caseSensitive("abc", "********a********b********b********");
-            allPassed &= wildCardMatch_caseSensitive("*abc*", "***a*b*c***");
+            allPassed &= !wildcard_match_unsafe_case_sensitive("abc*abcd*abcd*abc*abcd",
+                                                               "abc*abc*abc*abc*abc");
+            allPassed &= wildcard_match_unsafe_case_sensitive(
+                    "abc*abcd*abcd*abc*abcd*abcd*abc*abcd*abc*abc*abcd",
+                    "abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abcd");
             REQUIRE(allPassed == true);
         }
 
         GIVEN("A case-insensitive algorithm test") {
             bool isCaseSensitive = false;
-            allPassed &= wildCardMatch("mississippi", "*issip*PI", isCaseSensitive);
+            allPassed &= wildcard_match_unsafe("mississippi", "*issip*PI", isCaseSensitive);
             REQUIRE(allPassed == true);
         }
     }
@@ -688,8 +625,8 @@ SCENARIO("Test wild card performance", "[wildcard performance]") {
 
     // Typical apache log
     tameVec.push_back("64.242.88.10 - - [07/Mar/2004:16:06:51 -0800] \"GET "
-                              "/twiki/bin/rdiff/TWiki/NewUserTemplate?rev1=1"
-                              ".3&rev2=1.2 HTTP/1.1\" 200 4523");
+                      "/twiki/bin/rdiff/TWiki/NewUserTemplate?rev1=1"
+                      ".3&rev2=1.2 HTTP/1.1\" 200 4523");
     wildVec.push_back("*64.242.88.10*Mar/2004*GET*200*");
 
     /*******************************************************************************************************************
@@ -701,8 +638,9 @@ SCENARIO("Test wild card performance", "[wildcard performance]") {
     t1 = high_resolution_clock::now();
     while (testReps--) {
         BOOST_FOREACH(boost::tie(tameStr, wildStr), boost::combine(tameVec, wildVec)) {
-            allPassed_currentImplementation &= wildCardMatch_caseSensitive(tameStr, wildStr);
-        }
+                        allPassed_currentImplementation &=
+                                wildcard_match_unsafe_case_sensitive(tameStr, wildStr);
+                    }
     }
     t2 = high_resolution_clock::now();
     duration<double> timeSpan_currentImplementation = t2 - t1;
@@ -715,8 +653,9 @@ SCENARIO("Test wild card performance", "[wildcard performance]") {
     while (testReps--) {
         // Replace this part with slow implementation
         BOOST_FOREACH(boost::tie(tameStr, wildStr), boost::combine(tameVec, wildVec)) {
-            allPassed_currentImplementation &= wildCardMatch_caseSensitive(tameStr, wildStr);
-        }
+                        allPassed_currentImplementation &=
+                                wildcard_match_unsafe_case_sensitive(tameStr, wildStr);
+                    }
     }
     t2 = high_resolution_clock::now();
     duration<double> timeSpan_nextBestImplementation = t2 - t1;
@@ -724,8 +663,10 @@ SCENARIO("Test wild card performance", "[wildcard performance]") {
 
 
     if (allPassed_currentImplementation) {
-        cout << "Passed performance test in " << (timeSpan_currentImplementation.count() * 1000) << " milliseconds." << endl;
+        cout << "Passed performance test in " << (timeSpan_currentImplementation.count() * 1000)
+             << " milliseconds." << endl;
     } else {
-        cout << "Failed performance test in " << (timeSpan_currentImplementation.count() * 1000) << " milliseconds." << endl;
+        cout << "Failed performance test in " << (timeSpan_currentImplementation.count() * 1000)
+             << " milliseconds." << endl;
     }
 }


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
When doing wildcard-matching between strings like `"123"` and `"1*3"`, the wildcard matching method would access a character outside the input string buffers. This is a remnant of when we used C-strings which had a terminating null. This bug isn't triggered in production because all current searches are substring matches (i.e., with prefix and suffix `'*'`). 

This PR fixes the issue and achieves a slight performance improvement by omitting some checks which are unnecessary if the caller cleans up the wildcard string. Unnecessary methods and unit tests are also removed.

# Validation performed
<!-- What tests and validation you performed on the change -->
Verified all unit tests (including those with prefix and suffix `'*'`) passed.
