### PR TITLE
Switch from strtoll to C++17's from_chars (fixes #84)

### DIFF
--- a/components/core/src/Utils.cpp
+++ b/components/core/src/Utils.cpp
@@ -7,6 +7,7 @@
 
 // C++ libraries
 #include <algorithm>
+#include <charconv>
 #include <iostream>
 #include <set>
 
@@ -92,23 +93,14 @@ string clean_up_wildcard_search_string (string_view str) {
     return cleaned_str;
 }
 
-bool convert_string_to_int64 (const std::string& raw, int64_t& converted) {
-    if (raw.empty()) {
-        // Can't convert an empty string
+bool convert_string_to_int64 (std::string_view raw, int64_t& converted) {
+    auto raw_end = raw.cend();
+    auto result = std::from_chars(raw.cbegin(), raw_end, converted);
+    if (raw_end != result.ptr) {
         return false;
+    } else {
+        return result.ec == std::errc();
     }
-
-    const char* c_str = raw.c_str();
-    char* endptr;
-    // Reset errno so we can detect if it's been set
-    errno = 0;
-    int64_t raw_as_int = strtoll(c_str, &endptr, 10);
-    if (endptr - c_str != raw.length() || (LLONG_MAX == raw_as_int && ERANGE == errno)) {
-        // Conversion failed
-        return false;
-    }
-    converted = raw_as_int;
-    return true;
 }
 
 bool convert_string_to_double (const std::string& raw, double& converted) {

--- a/components/core/src/Utils.hpp
+++ b/components/core/src/Utils.hpp
@@ -91,7 +91,7 @@ std::string clean_up_wildcard_search_string (std::string_view str);
  * @param converted
  * @return true if the conversion was successful, false otherwise
  */
-bool convert_string_to_int64 (const std::string& raw, int64_t& converted);
+bool convert_string_to_int64 (std::string_view raw, int64_t& converted);
 
 /**
  * Converts the given string to a double if possible

--- a/components/core/tests/test-Utils.cpp
+++ b/components/core/tests/test-Utils.cpp
@@ -51,6 +51,7 @@ TEST_CASE("clean_up_wildcard_search_string", "[clean_up_wildcard_search_string]"
 }
 
 TEST_CASE("convert_string_to_int64", "[convert_string_to_int64]") {
+    int64_t raw_as_int;
     string raw;
     int64_t converted;
 
@@ -59,8 +60,21 @@ TEST_CASE("convert_string_to_int64", "[convert_string_to_int64]") {
     raw = "";
     REQUIRE(false == convert_string_to_int64(raw, converted));
 
-    // Integer that's more than 64-bits
-    raw = "9999999999999999999";
+    // Edges of representable range
+    raw_as_int = INT64_MAX;
+    raw = std::to_string(raw_as_int);
+    REQUIRE(convert_string_to_int64(raw, converted));
+    REQUIRE(raw_as_int == converted);
+
+    raw_as_int = INT64_MIN;
+    raw = std::to_string(raw_as_int);
+    REQUIRE(convert_string_to_int64(raw, converted));
+    REQUIRE(raw_as_int == converted);
+
+    raw = "9223372036854775808";  // INT64_MAX + 1 == 2^63
+    REQUIRE(false == convert_string_to_int64(raw, converted));
+
+    raw = "-9223372036854775809";  // INT64_MIN - 1 == -2^63 - 1
     REQUIRE(false == convert_string_to_int64(raw, converted));
 
     // Non-integers


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#84 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
* The previous use of `strtoll` erroneously checked for a range error only on the positive side.
* Instead of continuing to use `strtoll`, this PR switches to C++17's `from_chars` which allows us to use `string_view`s and achieves better performance.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Verified with a new unit test which tests integers at the boundary and just outside the representable range.
* Verified lossless compression and decompression of logs with integers less than -2^63.
* Verified lossless compression and decompression of logs with integers within the range of int64.


