### PR TITLE
Documentation and Code Corrections

### DIFF
--- a/components/compression-job-handler/README.md
+++ b/components/compression-job-handler/README.md
@@ -6,7 +6,7 @@ This Python module submits compression jobs to the CLP compression scheduler.
 
 ```bash
 pip3 install -r requirements.txt --target <clp-package>/lib/python3/site-packages
-cp -R compression-job-handler <clp-package>/lib/python3/site-packages
+cp -R compression_job_handler <clp-package>/lib/python3/site-packages
 ```
 
 ## Usage

--- a/components/compression-job-handler/README.md
+++ b/components/compression-job-handler/README.md
@@ -6,7 +6,7 @@ This Python module submits compression jobs to the CLP compression scheduler.
 
 ```bash
 pip3 install -r requirements.txt --target <clp-package>/lib/python3/site-packages
-cp -R clp_py_utils <clp-package>/lib/python3/site-packages
+cp -R compression-job-handler <clp-package>/lib/python3/site-packages
 ```
 
 ## Usage

--- a/components/job-orchestration/README.md
+++ b/components/job-orchestration/README.md
@@ -7,7 +7,7 @@ CLP's Compression Job Handler can be used to interface and submit compression jo
 
 ```bash
 pip3 install -r requirements.txt --target <clp-package>/lib/python3/site-packages
-cp -R job-orchestration <clp-package>/lib/python3/site-packages
+cp -R job_orchestration <clp-package>/lib/python3/site-packages
 ```
 
 ## Usage

--- a/components/job-orchestration/README.md
+++ b/components/job-orchestration/README.md
@@ -7,7 +7,7 @@ CLP's Compression Job Handler can be used to interface and submit compression jo
 
 ```bash
 pip3 install -r requirements.txt --target <clp-package>/lib/python3/site-packages
-cp -R clp_py_utils <clp-package>/lib/python3/site-packages
+cp -R job-orchestration <clp-package>/lib/python3/site-packages
 ```
 
 ## Usage


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
- The proposed changes are something I had to make to get CLP up and running on my Ubuntu instance.
- The code in the README.md for copying `compression-job-handler` and ` job-orchestration ` packages is misplaced. 
- I have highlighted line numbers as well as made corrections where necessary. 

# Validation performed
<!-- What tests and validation you performed on the change -->
- I have followed the said steps and got CLP up and running on my Ubuntu box. 
- On the other hand, if someone tries to follow current directions, they'd either get confused or end up copying `clp-py-utils` directory again and again. 
- At the end, they will not be able to run the `start` or `compress` commands as the necessary packages won't be there.
