### PR TITLE
Remove boost dependency from string_utils so that FFI libraries don't depend on it.

### DIFF
--- a/components/core/src/string_utils.cpp
+++ b/components/core/src/string_utils.cpp
@@ -1,11 +1,9 @@
 #include "string_utils.hpp"
 
 // C++ standard libraries
+#include <algorithm>
 #include <charconv>
 #include <cstring>
-
-// Boost libraries
-#include <boost/algorithm/string.hpp>
 
 using std::string;
 using std::string_view;
@@ -68,6 +66,12 @@ string replace_characters (const char* characters_to_replace, const char* replac
         }
     }
     return new_value;
+}
+
+void to_lower (string& str) {
+    std::transform(str.cbegin(), str.cend(), str.begin(), [](unsigned char c) {
+        return std::tolower(c);
+    });
 }
 
 bool is_wildcard (char c) {
@@ -164,9 +168,9 @@ bool wildcard_match_unsafe (string_view tame, string_view wild, bool case_sensit
         // We convert to lowercase (rather than uppercase) anticipating that
         // callers use lowercase more frequently, so little will need to change.
         string lowercase_tame(tame);
-        boost::to_lower(lowercase_tame);
+        to_lower(lowercase_tame);
         string lowercase_wild(wild);
-        boost::to_lower(lowercase_wild);
+        to_lower(lowercase_wild);
         return wildcard_match_unsafe_case_sensitive(lowercase_tame, lowercase_wild);
     }
 }

--- a/components/core/src/string_utils.hpp
+++ b/components/core/src/string_utils.hpp
@@ -46,6 +46,12 @@ std::string replace_characters (const char* characters_to_escape,
                                 bool escape);
 
 /**
+ * Converts a string to lowercase
+ * @param str
+ */
+void to_lower (std::string& str);
+
+/**
  * Cleans wildcard search string
  * <ul>
  *   <li>Removes consecutive '*'</li>

--- a/components/core/tests/test-string_utils.cpp
+++ b/components/core/tests/test-string_utils.cpp
@@ -16,6 +16,12 @@ using std::endl;
 using std::string;
 using std::vector;
 
+TEST_CASE("to_lower", "[to_lower]") {
+    string str = "test123TEST";
+    to_lower(str);
+    REQUIRE(str == "test123test");
+}
+
 TEST_CASE("clean_up_wildcard_search_string", "[clean_up_wildcard_search_string]") {
     string str;
 


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
`string_utils` depends on `boost::to_lower` which forces FFI libraries to depend on it. This PR replaces `boost::to_lower` with our own method.

# Validation performed
<!-- What tests and validation you performed on the change -->
Validated with a unit test.

