### PR TITLE
Move memcpy-based casting (bit_cast) into a method and move type utilities into their own file.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -283,6 +283,7 @@ set(SOURCE_FILES_clp
         src/TimestampPattern.hpp
         src/TraceableException.cpp
         src/TraceableException.hpp
+        src/type_utils.hpp
         src/Utils.cpp
         src/Utils.hpp
         src/VariableDictionaryEntry.cpp
@@ -429,6 +430,7 @@ set(SOURCE_FILES_clg
         src/TimestampPattern.hpp
         src/TraceableException.cpp
         src/TraceableException.hpp
+        src/type_utils.hpp
         src/Utils.cpp
         src/Utils.hpp
         src/VariableDictionaryEntry.cpp
@@ -568,6 +570,7 @@ set(SOURCE_FILES_clo
         src/TimestampPattern.hpp
         src/TraceableException.cpp
         src/TraceableException.hpp
+        src/type_utils.hpp
         src/Utils.cpp
         src/Utils.hpp
         src/VariableDictionaryEntry.cpp
@@ -746,6 +749,7 @@ set(SOURCE_FILES_unitTest
         src/TimestampPattern.hpp
         src/TraceableException.cpp
         src/TraceableException.hpp
+        src/type_utils.hpp
         src/Utils.cpp
         src/Utils.hpp
         src/VariableDictionaryEntry.cpp

--- a/components/core/src/Defs.h
+++ b/components/core/src/Defs.h
@@ -56,15 +56,4 @@ enum LogVerbosity : uint8_t {
 constexpr char cDefaultConfigFilename[] = ".clp.rc";
 constexpr int cMongoDbDuplicateKeyErrorCode = 11000;
 
-/**
- * Gets the underlying type of the given enum
- * @tparam T
- * @param enum_member
- * @return The underlying type of the given enum
- */
-template <typename T>
-constexpr typename std::underlying_type<T>::type enum_to_underlying_type(T enum_member) {
-    return static_cast<typename std::underlying_type<T>::type>(enum_member);
-}
-
 #endif // DEFS_H

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -10,7 +10,7 @@
 // Project headers
 #include "Defs.h"
 #include "string_utils.hpp"
-#include "Utils.hpp"
+#include "type_utils.hpp"
 
 using std::string;
 using std::unordered_set;
@@ -142,18 +142,13 @@ bool EncodedVariableInterpreter::convert_string_to_representable_double_var (con
     encoded_double |= (decimal_point_pos - 1) & 0x0F;
     encoded_double <<= 55;
     encoded_double |= digits & 0x003FFFFFFFFFFFFF;
-    static_assert(sizeof(encoded_var) == sizeof(encoded_double), "sizeof(encoded_var) != sizeof(encoded_double)");
-    // NOTE: We use memcpy rather than reinterpret_cast to avoid violating strict aliasing; a smart compiler should optimize it to a register move
-    std::memcpy(&encoded_var, &encoded_double, sizeof(encoded_double));
+    encoded_var = bit_cast<encoded_variable_t>(encoded_double);
 
     return true;
 }
 
 void EncodedVariableInterpreter::convert_encoded_double_to_string (encoded_variable_t encoded_var, string& value) {
-    uint64_t encoded_double;
-    static_assert(sizeof(encoded_double) == sizeof(encoded_var), "sizeof(encoded_double) != sizeof(encoded_var)");
-    // NOTE: We use memcpy rather than reinterpret_cast to avoid violating strict aliasing; a smart compiler should optimize it to a register move
-    std::memcpy(&encoded_double, &encoded_var, sizeof(encoded_var));
+    auto encoded_double = bit_cast<uint64_t>(encoded_var);
 
     // Decode according to the format described in EncodedVariableInterpreter::convert_string_to_representable_double_var
     uint64_t digits = encoded_double & 0x003FFFFFFFFFFFFF;

--- a/components/core/src/GlobalMySQLMetadataDB.cpp
+++ b/components/core/src/GlobalMySQLMetadataDB.cpp
@@ -6,7 +6,7 @@
 // Project headers
 #include "database_utils.hpp"
 #include "streaming_archive/Constants.hpp"
-#include "Utils.hpp"
+#include "type_utils.hpp"
 
 using std::pair;
 using std::string;

--- a/components/core/src/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.cpp
@@ -12,9 +12,8 @@
 
 // Project headers
 #include "database_utils.hpp"
-#include "Defs.h"
 #include "streaming_archive/Constants.hpp"
-#include "Utils.hpp"
+#include "type_utils.hpp"
 
 // Types
 enum class ArchivesTableFieldIndexes : uint16_t {

--- a/components/core/src/Profiler.cpp
+++ b/components/core/src/Profiler.cpp
@@ -1,5 +1,8 @@
 #include "Profiler.hpp"
 
+// C++ standard libraries
+#include <memory>
+
 using std::unique_ptr;
 using std::vector;
 

--- a/components/core/src/Profiler.hpp
+++ b/components/core/src/Profiler.hpp
@@ -2,11 +2,12 @@
 #define PROFILER_HPP
 
 // C++ libraries
+#include <array>
 #include <vector>
 
 // Project headers
 #include "Stopwatch.hpp"
-#include "Utils.hpp"
+#include "type_utils.hpp"
 
 /**
  * Class to time code.

--- a/components/core/src/ffi/encoding_methods.tpp
+++ b/components/core/src/ffi/encoding_methods.tpp
@@ -3,6 +3,7 @@
 
 // Project headers
 #include "../string_utils.hpp"
+#include "../type_utils.hpp"
 
 namespace ffi {
     template <VariablePlaceholder var_placeholder>

--- a/components/core/src/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/streaming_archive/MetadataDB.cpp
@@ -9,7 +9,7 @@
 // Project headers
 #include "../Defs.h"
 #include "../database_utils.hpp"
-#include "../Utils.hpp"
+#include "../type_utils.hpp"
 #include "Constants.hpp"
 
 // Types

--- a/components/core/src/type_utils.hpp
+++ b/components/core/src/type_utils.hpp
@@ -1,0 +1,39 @@
+#ifndef TYPE_UTILS_HPP
+#define TYPE_UTILS_HPP
+
+// C++ standard libraries
+#include <cstring>
+#include <type_traits>
+
+/**
+ * Gets the underlying type of the given enum
+ * @tparam T
+ * @param enum_member
+ * @return The underlying type of the given enum
+ */
+template <typename T>
+constexpr typename std::underlying_type<T>::type enum_to_underlying_type(T enum_member) {
+    return static_cast<typename std::underlying_type<T>::type>(enum_member);
+}
+
+/**
+ * Cast between types by copying the exact bit representation. This avoids
+ * issues with strict type aliasing. This method should be removed when we
+ * switch to C++20.
+ * @tparam Destination
+ * @tparam Source
+ * @param src
+ * @return
+ */
+template <class Destination, class Source>
+std::enable_if_t<sizeof(Destination) == sizeof(Source) &&
+        std::is_trivially_copyable_v<Destination> &&
+        std::is_trivially_copyable_v<Source> &&
+        std::is_trivially_constructible_v<Destination>, Destination
+> bit_cast (const Source& src) {
+    Destination dst;
+    std::memcpy(&dst, &src, sizeof(Destination));
+    return dst;
+}
+
+#endif // TYPE_UTILS_HPP


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
We're using C++17, so we don't have access to `bit_cast` (C++20) just yet. This PR moves the bit casting logic we were using everywhere into a method. Also, it moves such type utilities into their own file.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Verified that the compiler generated assembly is the same even after moving the code into a method.
* Verified unit tests pass.

