### PR TITLE
FFI: Make variable encoding methods and schema match those of the existing CLP logging libraries; Add a version name for each.

### DIFF
--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -38,6 +38,20 @@ namespace ffi {
     };
 
     // Constants
+    /*
+     * These constants can be used by callers to store the version of the
+     * schemas and encoding methods they're using. At some point, we may update
+     * and/or add built-in schemas/encoding methods. So callers must store the
+     * versions they used for encoding to ensure that they can choose the same
+     * versions for decoding.
+     *
+     * We use versions which look like package names in anticipation of users
+     * writing their own custom schemas and encoding methods.
+     */
+    static constexpr char cVariableEncodingMethodsVersion[] =
+            "com.yscope.clp.VariableEncodingMethodsV1";
+    static constexpr char cVariablesSchemaVersion[] = "com.yscope.clp.VariablesSchemaV1";
+
     static constexpr char cTooFewDictionaryVarsErrorMessage[] =
             "There are fewer dictionary variables than dictionary variable delimiters in the "
             "logtype.";

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -22,6 +22,12 @@ TEST_CASE("ffi::get_bounds_of_next_var", "[ffi::get_bounds_of_next_var]") {
     size_t end_pos;
     bool contains_var_placeholder = false;
 
+    // Since the outputs we use to validate depend on the schema/encoding
+    // methods, we validate the versions
+    REQUIRE(strcmp("com.yscope.clp.VariableEncodingMethodsV1",
+                   ffi::cVariableEncodingMethodsVersion) == 0);
+    REQUIRE(strcmp("com.yscope.clp.VariablesSchemaV1", ffi::cVariablesSchemaVersion) == 0);
+
     // Corner cases
     // Empty string
     str = "";
@@ -77,7 +83,7 @@ TEST_CASE("ffi::get_bounds_of_next_var", "[ffi::get_bounds_of_next_var]") {
     REQUIRE(false == contains_var_placeholder);
 
     REQUIRE(get_bounds_of_next_var(str, begin_pos, end_pos, contains_var_placeholder) == true);
-    REQUIRE("+394" == str.substr(begin_pos, end_pos - begin_pos));
+    REQUIRE("+394/-" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(false == contains_var_placeholder);
 
     REQUIRE(get_bounds_of_next_var(str, begin_pos, end_pos, contains_var_placeholder) == false);


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The existing logging libraries (e.g., [clp-logging](https://pypi.org/project/clp-logging/)) use different delimiters and encoding methods for variables. This commit switches to the same for consistency and assigns version names for bookkeeping. Note that the libraries use the compact variable encoding (4 bytes per encoded variable) whereas the FFI uses the standard variable encoding (8 bytes per encoded variable).

# Validation performed
<!-- What tests and validation you performed on the change -->
Verified the unit tests passed.
