### PR TITLE
FFI: Make '/' a delimiter in the default variables schema to achieve better compression ratio.

### DIFF
--- a/components/core/src/ffi/encoding_methods.cpp
+++ b/components/core/src/ffi/encoding_methods.cpp
@@ -48,8 +48,8 @@ namespace ffi {
      * characters
      */
     static bool is_delim (signed char c) {
-        return !('+' == c || ('-' <= c && c <= '9') || ('A' <= c && c <= 'Z') || '\\' == c ||
-                 '_' == c || ('a' <= c && c <= 'z'));
+        return !('+' == c || ('-' <= c && c <= '.') || ('0' <= c && c <= '9') ||
+                 ('A' <= c && c <= 'Z') || '\\' == c || '_' == c || ('a' <= c && c <= 'z'));
     }
 
     bool is_variable_placeholder (char c) {

--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -50,7 +50,7 @@ namespace ffi {
      */
     static constexpr char cVariableEncodingMethodsVersion[] =
             "com.yscope.clp.VariableEncodingMethodsV1";
-    static constexpr char cVariablesSchemaVersion[] = "com.yscope.clp.VariablesSchemaV1";
+    static constexpr char cVariablesSchemaVersion[] = "com.yscope.clp.VariablesSchemaV2";
 
     static constexpr char cTooFewDictionaryVarsErrorMessage[] =
             "There are fewer dictionary variables than dictionary variable delimiters in the "

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -26,7 +26,7 @@ TEST_CASE("ffi::get_bounds_of_next_var", "[ffi::get_bounds_of_next_var]") {
     // methods, we validate the versions
     REQUIRE(strcmp("com.yscope.clp.VariableEncodingMethodsV1",
                    ffi::cVariableEncodingMethodsVersion) == 0);
-    REQUIRE(strcmp("com.yscope.clp.VariablesSchemaV1", ffi::cVariablesSchemaVersion) == 0);
+    REQUIRE(strcmp("com.yscope.clp.VariablesSchemaV2", ffi::cVariablesSchemaVersion) == 0);
 
     // Corner cases
     // Empty string
@@ -83,7 +83,7 @@ TEST_CASE("ffi::get_bounds_of_next_var", "[ffi::get_bounds_of_next_var]") {
     REQUIRE(false == contains_var_placeholder);
 
     REQUIRE(get_bounds_of_next_var(str, begin_pos, end_pos, contains_var_placeholder) == true);
-    REQUIRE("+394/-" == str.substr(begin_pos, end_pos - begin_pos));
+    REQUIRE("+394" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(false == contains_var_placeholder);
 
     REQUIRE(get_bounds_of_next_var(str, begin_pos, end_pos, contains_var_placeholder) == false);


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
As we evaluate more data sets, we've found that making '/' is a delimiter can sometimes result in a significant increase in compression ratio. In addition, we haven't found any data set where it decreases compression ratio. This commit adds '/' as a delimiter and updates the version name for the default variable schemas.e

# Validation performed
<!-- What tests and validation you performed on the change -->
Verified that the unit tests pass.

