### PR TITLE
Add shim for byteswap.h on macOS.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -660,6 +660,7 @@ set(SOURCE_FILES_unitTest
         src/ffi/encoding_methods.cpp
         src/ffi/encoding_methods.hpp
         src/ffi/encoding_methods.tpp
+        src/ffi/ir_stream/byteswap.hpp
         src/ffi/ir_stream/encoding_methods.cpp
         src/ffi/ir_stream/encoding_methods.hpp
         src/ffi/ir_stream/protocol_constants.hpp

--- a/components/core/src/ffi/ir_stream/byteswap.hpp
+++ b/components/core/src/ffi/ir_stream/byteswap.hpp
@@ -1,0 +1,14 @@
+#ifndef FFI_IR_STREAM_BYTESWAP_HPP
+#define FFI_IR_STREAM_BYTESWAP_HPP
+
+// C standard libraries
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+#else
+#include <byteswap.h>
+#endif
+
+#endif // FFI_IR_STREAM_BYTESWAP_HPP

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -1,12 +1,10 @@
 #include "encoding_methods.hpp"
 
-// C standard libraries
-#include <byteswap.h>
-
 // json
 #include "../../../submodules/json/single_include/nlohmann/json.hpp"
 
 // Project headers
+#include "byteswap.hpp"
 #include "protocol_constants.hpp"
 
 using std::string_view;


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
macOS doesn't have byteswap.h so we need to use macOS-specific macros for swapping bytes.

# Validation performed
<!-- What tests and validation you performed on the change -->
Verified that byteswap.h no longer caused build failures of y-scope/clp-ffi-java#20 on macOS.
