### PR TITLE
Update to msgpackc-cxx 5.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -112,11 +112,11 @@ else()
 endif()
 
 # Find and setup msgpack
-find_package(msgpack 4.1.1 REQUIRED)
-if(msgpack_FOUND)
-    message(STATUS "Found msgpack ${msgpack_VERSION}")
+find_package(msgpackc-cxx 5.0.0 REQUIRED)
+if(msgpackc-cxx_FOUND)
+    message(STATUS "Found msgpackc-cxx ${msgpackc-cxx_VERSION}")
 else()
-    message(FATAL_ERROR "Could not find msgpack")
+    message(FATAL_ERROR "Could not find msgpackc-cxx")
 endif()
 
 # Add yaml-cpp

--- a/components/core/README.md
+++ b/components/core/README.md
@@ -83,7 +83,7 @@ so we've included some scripts to download, compile, and install them:
 ./tools/scripts/lib_install/libarchive.sh 3.5.1
 ./tools/scripts/lib_install/lz4.sh 1.8.2
 ./tools/scripts/lib_install/mariadb-connector-c.sh 3.2.3
-./tools/scripts/lib_install/msgpack.sh 4.1.1
+./tools/scripts/lib_install/msgpack.sh 5.0.0
 ./tools/scripts/lib_install/spdlog.sh 1.9.2
 ./tools/scripts/lib_install/zstandard.sh 1.4.9
 ```

--- a/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-packages-from-source.sh
+++ b/components/core/tools/docker-images/clp-env-base-bionic/setup-scripts/install-packages-from-source.sh
@@ -4,6 +4,6 @@
 ./tools/scripts/lib_install/libarchive.sh 3.5.1
 ./tools/scripts/lib_install/lz4.sh 1.8.2
 ./tools/scripts/lib_install/mariadb-connector-c.sh 3.2.3
-./tools/scripts/lib_install/msgpack.sh 4.1.1
+./tools/scripts/lib_install/msgpack.sh 5.0.0
 ./tools/scripts/lib_install/spdlog.sh 1.9.2
 ./tools/scripts/lib_install/zstandard.sh 1.4.9

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-packages-from-source.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-packages-from-source.sh
@@ -11,6 +11,6 @@ source /opt/rh/devtoolset-7/enable
 ./tools/scripts/lib_install/libarchive.sh 3.5.1
 ./tools/scripts/lib_install/lz4.sh 1.8.2
 ./tools/scripts/lib_install/mariadb-connector-c.sh 3.2.3
-./tools/scripts/lib_install/msgpack.sh 4.1.1
+./tools/scripts/lib_install/msgpack.sh 5.0.0
 ./tools/scripts/lib_install/spdlog.sh 1.9.2
 ./tools/scripts/lib_install/zstandard.sh 1.4.9

--- a/components/core/tools/docker-images/clp-env-base-focal/setup-scripts/install-packages-from-source.sh
+++ b/components/core/tools/docker-images/clp-env-base-focal/setup-scripts/install-packages-from-source.sh
@@ -4,6 +4,6 @@
 ./tools/scripts/lib_install/libarchive.sh 3.5.1
 ./tools/scripts/lib_install/lz4.sh 1.8.2
 ./tools/scripts/lib_install/mariadb-connector-c.sh 3.2.3
-./tools/scripts/lib_install/msgpack.sh 4.1.1
+./tools/scripts/lib_install/msgpack.sh 5.0.0
 ./tools/scripts/lib_install/spdlog.sh 1.9.2
 ./tools/scripts/lib_install/zstandard.sh 1.4.9


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This update is necessary for two reasons:
* v5 is the latest version available from [Homebrew](https://formulae.brew.sh/formula/msgpack-cxx#default), so to build CLP on macOS, we need to support it.
* v5 changes the name of the C++ library from `msgpack` to `msgpackc-cxx`, so it's best to update early to avoid having too many people install older versions.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Installed v5 in the dependency container
* Built the package using the new container
* Compressed some logs using the package
* Validate that search still worked