### PR TITLE
Remove obsolete code for reading columns stored outside a segment.

### DIFF
--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -685,14 +685,8 @@ Grep::get_bounds_of_next_potential_var (const string& value, size_t& begin_pos, 
 }
 
 void Grep::calculate_sub_queries_relevant_to_file (const File& compressed_file, vector<Query>& queries) {
-    if (compressed_file.is_in_segment()) {
-        for (auto& query : queries) {
-            query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
-        }
-    } else {
-        for (auto& query : queries) {
-            query.make_all_sub_queries_relevant();
-        }
+    for (auto& query : queries) {
+        query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
     }
 }
 

--- a/components/core/src/Query.cpp
+++ b/components/core/src/Query.cpp
@@ -161,7 +161,7 @@ void Query::add_sub_query (const SubQuery& sub_query) {
     m_sub_queries.push_back(sub_query);
 
     // Add to relevant sub-queries if necessary
-    if (m_all_subqueries_relevant || sub_query.get_ids_of_matching_segments().count(m_prev_segment_id)) {
+    if (sub_query.get_ids_of_matching_segments().count(m_prev_segment_id)) {
         m_relevant_sub_queries.push_back(&m_sub_queries.back());
     }
 }
@@ -169,24 +169,10 @@ void Query::add_sub_query (const SubQuery& sub_query) {
 void Query::clear_sub_queries() {
     m_sub_queries.clear();
     m_relevant_sub_queries.clear();
-    m_all_subqueries_relevant = true;
-}
-
-void Query::make_all_sub_queries_relevant () {
-    if (m_all_subqueries_relevant) {
-        // All sub-queries already relevant
-        return;
-    }
-
-    m_relevant_sub_queries.clear();
-    for (auto& sub_query : m_sub_queries) {
-        m_relevant_sub_queries.push_back(&sub_query);
-    }
-    m_all_subqueries_relevant = true;
 }
 
 void Query::make_sub_queries_relevant_to_segment (segment_id_t segment_id) {
-    if (false == m_all_subqueries_relevant && segment_id == m_prev_segment_id) {
+    if (segment_id == m_prev_segment_id) {
         // Sub-queries already relevant to segment
         return;
     }
@@ -199,5 +185,4 @@ void Query::make_sub_queries_relevant_to_segment (segment_id_t segment_id) {
         }
     }
     m_prev_segment_id = segment_id;
-    m_all_subqueries_relevant = false;
 }

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -132,7 +132,8 @@ class Query {
 public:
     // Constructors
     Query () : m_search_begin_timestamp(cEpochTimeMin), m_search_end_timestamp(cEpochTimeMax),
-            m_ignore_case(false), m_search_string_matches_all(true) {}
+            m_ignore_case(false), m_search_string_matches_all(true),
+            m_prev_segment_id(cInvalidSegmentId) {}
 
     // Methods
     void set_search_begin_timestamp (epochtime_t timestamp) { m_search_begin_timestamp = timestamp; }

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -131,8 +131,8 @@ private:
 class Query {
 public:
     // Constructors
-    Query () : m_search_begin_timestamp(cEpochTimeMin), m_search_end_timestamp(cEpochTimeMax), m_ignore_case(false), m_search_string_matches_all(true),
-            m_all_subqueries_relevant(true) {}
+    Query () : m_search_begin_timestamp(cEpochTimeMin), m_search_end_timestamp(cEpochTimeMax),
+            m_ignore_case(false), m_search_string_matches_all(true) {}
 
     // Methods
     void set_search_begin_timestamp (epochtime_t timestamp) { m_search_begin_timestamp = timestamp; }
@@ -141,10 +141,6 @@ public:
     void set_search_string (const std::string& search_string);
     void add_sub_query (const SubQuery& sub_query);
     void clear_sub_queries ();
-    /**
-     * Populates the set of relevant sub-queries with all possible sub-queries from the query
-     */
-    void make_all_sub_queries_relevant ();
     /**
      * Populates the set of relevant sub-queries with only those that match the given segment
      * @param segment_id
@@ -186,7 +182,6 @@ private:
     std::vector<SubQuery> m_sub_queries;
     std::vector<const SubQuery*> m_relevant_sub_queries;
     segment_id_t m_prev_segment_id;
-    bool m_all_subqueries_relevant;
 };
 
 

--- a/components/core/src/Utils.hpp
+++ b/components/core/src/Utils.hpp
@@ -100,29 +100,6 @@ bool get_bounds_of_next_var (const std::string& msg, size_t& begin_pos, size_t& 
 std::string get_unambiguous_path (const std::string& path);
 
 /**
- * Maps a given file into memory
- * @param path
- * @param read_ahead Whether to read-ahead in the file
- * @param fd Reference to file descriptor opened for file
- * @param file_size Reference to file size determined for file
- * @param ptr Reference to pointer to mapped region
- * @return ErrorCode_errno on error
- * @return ErrorCode_FileNotFound if file not found
- * @return ErrorCode_Success on success
- */
-ErrorCode memory_map_file (const std::string& path, bool read_ahead, int& fd, size_t& file_size, void*& ptr);
-
-/**
- * Unmaps a memory-mapped file
- * @param fd File's file descriptor
- * @param file_size File's size
- * @param ptr Pointer to mapped region
- * @return ErrorCode_errno on error
- * @return ErrorCode_Success on success
- */
-ErrorCode memory_unmap_file (int fd, size_t file_size, void* ptr);
-
-/**
  * Read a list of paths from a file
  * @param list_path
  * @param paths

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -201,7 +201,7 @@ static bool search (const vector<string>& search_strings, CommandLineArguments& 
 }
 
 static bool open_compressed_file (MetadataDB::FileIterator& file_metadata_ix, Archive& archive, File& compressed_file) {
-    ErrorCode error_code = archive.open_file(compressed_file, file_metadata_ix, false);
+    ErrorCode error_code = archive.open_file(compressed_file, file_metadata_ix);
     if (ErrorCode_Success == error_code) {
         return true;
     }

--- a/components/core/src/clo/clo.cpp
+++ b/components/core/src/clo/clo.cpp
@@ -153,7 +153,7 @@ static SearchFilesResult search_files (Query& query, Archive& archive, MetadataD
 
     // Run query on each file
     for (; file_metadata_ix.has_next(); file_metadata_ix.next()) {
-        ErrorCode error_code = archive.open_file(compressed_file, file_metadata_ix, false);
+        ErrorCode error_code = archive.open_file(compressed_file, file_metadata_ix);
         if (ErrorCode_Success != error_code) {
             string orig_path;
             file_metadata_ix.get_path(orig_path);
@@ -166,11 +166,7 @@ static SearchFilesResult search_files (Query& query, Archive& archive, MetadataD
             continue;
         }
 
-        if (compressed_file.is_in_segment()) {
-            query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
-        } else {
-            query.make_all_sub_queries_relevant();
-        }
+        query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
         while (false == query_cancelled &&
                Grep::search_and_decompress(query, archive, compressed_file, compressed_message, decompressed_message))
         {

--- a/components/core/src/clp/FileDecompressor.cpp
+++ b/components/core/src/clp/FileDecompressor.cpp
@@ -14,7 +14,7 @@ namespace clp {
                                             streaming_archive::reader::Archive& archive_reader, std::unordered_map<string, string>& temp_path_to_final_path)
     {
         // Open compressed file
-        auto error_code = archive_reader.open_file(m_encoded_file, file_metadata_ix, true);
+        auto error_code = archive_reader.open_file(m_encoded_file, file_metadata_ix);
         if (ErrorCode_Success != error_code) {
             if (ErrorCode_errno == error_code) {
                 SPDLOG_ERROR("Failed to open encoded file, errno={}", errno);

--- a/components/core/src/streaming_archive/Constants.hpp
+++ b/components/core/src/streaming_archive/Constants.hpp
@@ -6,7 +6,6 @@
 
 namespace streaming_archive {
     constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevelopmentVersionFlag | 5;
-    constexpr char cLogsDirname[] = "l";
     constexpr char cSegmentsDirname[] = "s";
     constexpr char cSegmentListFilename[] = "segment_list.txt";
     constexpr char cLogTypeDictFilename[] = "logtype.dict";
@@ -15,9 +14,6 @@ namespace streaming_archive {
     constexpr char cVarSegmentIndexFilename[] = "var.segindex";
     constexpr char cMetadataFileName[] = "metadata";
     constexpr char cMetadataDBFileName[] = "metadata.db";
-    constexpr char cTimestampsFileExtension[] = ".tme";
-    constexpr char cLogTypeIdsFileExtension[] = ".lid";
-    constexpr char cVariablesFileExtension[] = ".var";
     constexpr char cSchemaFileName[] = "schema.txt";
 
     namespace cMetadataDB {

--- a/components/core/src/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/streaming_archive/reader/Archive.cpp
@@ -75,12 +75,6 @@ namespace streaming_archive { namespace reader {
         auto metadata_db_path = boost::filesystem::path(path) / cMetadataDBFileName;
         m_metadata_db.open(metadata_db_path.string());
 
-        // Assemble logs directory path
-        m_logs_dir_path = m_path;
-        m_logs_dir_path += '/';
-        m_logs_dir_path += cLogsDirname;
-        m_logs_dir_path += '/';
-
         // Open log-type dictionary
         string logtype_dict_path = m_path;
         logtype_dict_path += '/';
@@ -116,7 +110,6 @@ namespace streaming_archive { namespace reader {
         m_var_dictionary.close();
         m_segment_manager.close();
         m_segments_dir_path.clear();
-        m_logs_dir_path.clear();
         m_metadata_db.close();
         m_path.clear();
     }
@@ -126,8 +119,8 @@ namespace streaming_archive { namespace reader {
         m_var_dictionary.read_new_entries();
     }
 
-    ErrorCode Archive::open_file (File& file, MetadataDB::FileIterator& file_metadata_ix, bool read_ahead) {
-        return file.open_me(m_logtype_dictionary, file_metadata_ix, read_ahead, m_logs_dir_path, m_segment_manager);
+    ErrorCode Archive::open_file (File& file, MetadataDB::FileIterator& file_metadata_ix) {
+        return file.open_me(m_logtype_dictionary, file_metadata_ix, m_segment_manager);
     }
 
     void Archive::close_file (File& file) {

--- a/components/core/src/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/streaming_archive/reader/Archive.hpp
@@ -64,11 +64,9 @@ namespace streaming_archive { namespace reader {
          * Opens file with given path
          * @param file
          * @param file_metadata_ix
-         * @param read_ahead Whether to read-ahead in the file (if possible)
          * @return Same as streaming_archive::reader::File::open_me
-         * @throw Same as streaming_archive::reader::File::open_me
          */
-        ErrorCode open_file (File& file, MetadataDB::FileIterator& file_metadata_ix, bool read_ahead);
+        ErrorCode open_file (File& file, MetadataDB::FileIterator& file_metadata_ix);
         /**
          * Wrapper for streaming_archive::reader::File::close_me
          * @param file
@@ -124,7 +122,6 @@ namespace streaming_archive { namespace reader {
         // Variables
         std::string m_id;
         std::string m_path;
-        std::string m_logs_dir_path;
         std::string m_segments_dir_path;
         LogTypeDictionaryReader m_logtype_dictionary;
         VariableDictionaryReader m_var_dictionary;

--- a/components/core/src/streaming_archive/reader/File.hpp
+++ b/components/core/src/streaming_archive/reader/File.hpp
@@ -16,14 +16,15 @@
 #include "Message.hpp"
 #include "SegmentManager.hpp"
 
-namespace streaming_archive { namespace reader {
+namespace streaming_archive::reader {
     class File {
     public:
         // Types
         class OperationFailed : public TraceableException {
         public:
             // Constructors
-            OperationFailed (ErrorCode error_code, const char* const filename, int line_number) : TraceableException (error_code, filename, line_number) {}
+            OperationFailed (ErrorCode error_code, const char* const filename, int line_number) :
+                    TraceableException(error_code, filename, line_number) {}
 
             // Methods
             const char* what () const noexcept override {
@@ -36,7 +37,6 @@ namespace streaming_archive { namespace reader {
             m_archive_logtype_dict(nullptr),
             m_begin_ts(cEpochTimeMax),
             m_end_ts(cEpochTimeMin),
-            m_is_in_segment(false),
             m_segment_timestamps_decompressed_stream_pos(0),
             m_segment_logtypes_decompressed_stream_pos(0),
             m_segment_variables_decompressed_stream_pos(0),
@@ -46,14 +46,8 @@ namespace streaming_archive { namespace reader {
             m_num_messages(0),
             m_variables_ix(0),
             m_num_variables(0),
-            m_logtypes_fd(-1),
-            m_logtypes_file_size(0),
             m_logtypes(nullptr),
-            m_timestamps_fd(-1),
-            m_timestamps_file_size(0),
             m_timestamps(nullptr),
-            m_variables_fd(-1),
-            m_variables_file_size(0),
             m_variables(nullptr),
             m_current_ts_pattern_ix(0),
             m_current_ts_in_milli(0)
@@ -65,7 +59,6 @@ namespace streaming_archive { namespace reader {
         epochtime_t get_begin_ts () const;
         epochtime_t get_end_ts () const;
         const std::string& get_orig_path () const;
-        bool is_in_segment () const { return m_is_in_segment; }
         segment_id_t get_segment_id () const { return m_segment_id; }
         uint64_t get_num_messages () const { return m_num_messages; }
         bool is_split () const { return m_is_split; }
@@ -78,20 +71,13 @@ namespace streaming_archive { namespace reader {
          * Opens file
          * @param archive_logtype_dict
          * @param file_metadata_ix
-         * @param read_ahead Whether to read-ahead in the file (if possible)
-         * @param archive_logs_dir_path Path to directory where logs are stored on disk in this archive
-         * @param segment_manager Segment manager for when file is stored in a segment
-         * @return FileReader::try_open's error codes on failure to open metadata
-         * @return ErrorCode_Failure_Metadata_Corrupted on metadata loading error
-         * @return ErrorCode_errno on error
-         * @return ErrorCode_FileNotFound if a column's file was not found
-         * @return ErrorCode_Truncated if metadata did not contain all required data or if column in segment was truncated
+         * @param segment_manager
+         * @return Same as SegmentManager::try_read
          * @return ErrorCode_Success on success
-         * @throw FileReader::OperationFailed on any read failure
-         * @throw Same as streaming_archive::reader::SegmentManager::read
          */
-        ErrorCode open_me (const LogTypeDictionaryReader& archive_logtype_dict, MetadataDB::FileIterator& file_metadata_ix, bool read_ahead,
-                const std::string& archive_logs_dir_path, SegmentManager& segment_manager);
+        ErrorCode open_me (const LogTypeDictionaryReader& archive_logtype_dict,
+                           MetadataDB::FileIterator& file_metadata_ix,
+                           SegmentManager& segment_manager);
         /**
          * Closes the file
          */
@@ -114,7 +100,8 @@ namespace streaming_archive { namespace reader {
          * @param msg
          * @return true if a message was found, false otherwise
          */
-        bool find_message_in_time_range (epochtime_t search_begin_timestamp, epochtime_t search_end_timestamp, Message& msg);
+        bool find_message_in_time_range (epochtime_t search_begin_timestamp,
+                                         epochtime_t search_end_timestamp, Message& msg);
         /**
          * Finds message matching the given query
          * @param query
@@ -140,7 +127,6 @@ namespace streaming_archive { namespace reader {
         std::string m_orig_file_id_as_string;
         std::string m_orig_path;
 
-        bool m_is_in_segment;
         segment_id_t m_segment_id;
         uint64_t m_segment_timestamps_decompressed_stream_pos;
         uint64_t m_segment_logtypes_decompressed_stream_pos;
@@ -156,16 +142,8 @@ namespace streaming_archive { namespace reader {
         size_t m_variables_ix;
         uint64_t m_num_variables;
 
-        int m_logtypes_fd;
-        size_t m_logtypes_file_size;
         logtype_dictionary_id_t* m_logtypes;
-
-        int m_timestamps_fd;
-        size_t m_timestamps_file_size;
         epochtime_t* m_timestamps;
-
-        int m_variables_fd;
-        size_t m_variables_file_size;
         encoded_variable_t* m_variables;
 
         size_t m_current_ts_pattern_ix;
@@ -174,6 +152,6 @@ namespace streaming_archive { namespace reader {
         size_t m_split_ix;
         bool m_is_split;
     };
-} }
+}
 
 #endif // STREAMING_ARCHIVE_READER_FILE_HPP

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -69,7 +69,8 @@ namespace streaming_archive { namespace writer {
         std::string m_schema_file_path;
 
         // Constructors
-        Archive () : m_logs_dir_fd(-1), m_segments_dir_fd(-1), m_compression_level(0), m_global_metadata_db(nullptr), old_ts_pattern(), m_schema_file_path() {}
+        Archive () : m_segments_dir_fd(-1), m_compression_level(0), m_global_metadata_db(nullptr),
+                old_ts_pattern(), m_schema_file_path() {}
 
         // Destructor
         ~Archive ();
@@ -252,8 +253,6 @@ namespace streaming_archive { namespace writer {
         size_t m_creation_num;
 
         std::string m_path;
-        std::string m_logs_dir_path;
-        int m_logs_dir_fd;
         std::string m_segments_dir_path;
         int m_segments_dir_fd;
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#39

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

* #39 removed the ability to write encoded files to disk *without* storing them in a segment, but it didn't remove the corresponding read-side of the code. This PR removes the read-side of the code.
* This PR also refactors some line-length violations as a result of updates to code style. Not all violations were corrected to avoid making the PR confusing to read.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Unit tests passed.
* Compressed, decompressed, and searched the [openstack-24hr](https://zenodo.org/record/7094972#.Y-AsKnbMKHt) dataset using `clp`, `clg`, and the `compress` and `search` scripts from the package; validated that the output was the same as before the PR.

