### PR TITLE
Enable GitHub workflows on all branches.

### DIFF
--- a/.github/actions/clp-docker-build-push-action/action.yaml
+++ b/.github/actions/clp-docker-build-push-action/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: "Dockerfile path"
     required: false
     default: ./Dockerfile
+  push_image:
+    description: "Whether to publish the Docker image"
+    required: true
+    default: "false"
 
   token:
     description: "Registry token"
@@ -37,25 +41,12 @@ runs:
       uses: docker/metadata-action@v2
       with:
         images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
-    
-    # Build docker image without pushing on PR
-    - name: Build Docker image
-      uses: docker/build-push-action@v2
-      if: github.event_name == 'pull_request'
-      with:
-        context: ${{inputs.context}}
-        file: ${{inputs.file}}
-        push: false
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
-      if: github.event_name != 'pull_request'
       with:
         context: ${{inputs.context}}
         file: ${{inputs.file}}
-        push: true
+        push: ${{inputs.push_image}}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -2,12 +2,10 @@ name: build-clp-core
 
 on:
   push:
-    branches: [ main ]
     paths:
       - 'components/core/**'
       - '.github/workflows/clp-core-build.yaml'
   pull_request:
-    branches: [ main ]
     paths:
       - 'components/core/**'
       - '.github/workflows/clp-core-build.yaml'
@@ -80,6 +78,7 @@ jobs:
           context: ${{github.workspace}}/binaries
           file: components/core/tools/docker-images/clp-core-focal/Dockerfile
           token: ${{secrets.GITHUB_TOKEN}}
+          push_image: ${{'pull_request' != github.event_name && 'refs/heads/main' == github.ref}}
 
   build-bionic:
     runs-on: ubuntu-latest

--- a/.github/workflows/clp-dependency-image-build.yaml
+++ b/.github/workflows/clp-dependency-image-build.yaml
@@ -2,7 +2,6 @@ name: generate-build-dependency-image
 
 on:
   push:
-    branches: ['main']
     paths:
       - 'components/core/tools/docker-images/**'
       - 'components/core/tools/scripts/lib_install/**'
@@ -35,6 +34,7 @@ jobs:
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-focal/Dockerfile
           token: ${{secrets.GITHUB_TOKEN}}
+          push_image: ${{'pull_request' != github.event_name && 'refs/heads/main' == github.ref}}
 
   build-ubuntu-bionic:
     runs-on: ubuntu-20.04
@@ -55,6 +55,7 @@ jobs:
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
           token: ${{secrets.GITHUB_TOKEN}}
+          push_image: ${{'pull_request' != github.event_name && 'refs/heads/main' == github.ref}}
 
   build-centos:
     runs-on: ubuntu-20.04
@@ -75,3 +76,4 @@ jobs:
           context: components/core/
           file: components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
           token: ${{secrets.GITHUB_TOKEN}}
+          push_image: ${{'pull_request' != github.event_name && 'refs/heads/main' == github.ref}}

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -2,7 +2,6 @@ name: generate-execution-dependency-image
 
 on:
   push:
-    branches: ['main']
     paths:
       - 'tools/docker-images/clp-execution-base-focal/**'
       - 'components/core/tools/scripts/lib_install/**'
@@ -32,3 +31,4 @@ jobs:
           image_name: ${{env.IMAGE_NAME}}
           file: ./tools/docker-images/clp-execution-base-focal/Dockerfile
           token: ${{secrets.GITHUB_TOKEN}}
+          push_image: ${{'pull_request' != github.event_name && 'refs/heads/main' == github.ref}}


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Currently, the GitHub workflows are only enabled for pushes and PRs to the main branch. This is fine for the main repo since we don't use many branches in the main repo. However, it's not very useful for forks: they would need to push/PR to their own main branch to get the workflows to run.

This PR enables workflows to run on all branches while continuing to ensure that the generated Docker images are not pushed to GitHub Packages except when there's a commit to the main branch.

# Validation performed
<!-- What tests and validation you performed on the change -->
The workflows ran [successfully](https://github.com/kirkrodrigues/clp/actions) on the branch that this PR comes from.
