### PR TITLE
Reorganize clp-core's dependency-installation scripts so that users can call them directly.

### DIFF
--- a/components/core/README.md
+++ b/components/core/README.md
@@ -51,42 +51,14 @@ A handful of packages and libraries are required to build CLP. There are two opt
 
 #### Native Environment
 
-*Packages*
+See the relevant README for your OS:
 
-If you're using apt-get, you can use the following command to install all:
-```shell
-sudo apt-get install -y ca-certificates checkinstall cmake curl build-essential \
-libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev \
-libssl-dev pkg-config rsync zlib1g-dev
-```
+* [CentOS 7.4](./tools/scripts/lib_install/centos7.4/README.md)
+* [Ubuntu 18.04](./tools/scripts/lib_install/ubuntu-bionic/README.md)
+* [Ubuntu 20.04](./tools/scripts/lib_install/ubuntu-focal/README.md)
 
-This will download:
-* ca-certificates
-* checkinstall
-* cmake
-* curl
-* build-essential
-* libboost-filesystem-dev
-* libboost-iostreams-dev
-* libboost-program-options-dev
-* libssl-dev
-* pkg-config
-* rsync
-* zlib1g-dev
-
-*Libraries*
-
-The latest versions of some packages are not offered by apt repositories,
-so we've included some scripts to download, compile, and install them:
-```shell
-./tools/scripts/lib_install/fmtlib.sh 8.0.1
-./tools/scripts/lib_install/libarchive.sh 3.5.1
-./tools/scripts/lib_install/lz4.sh 1.8.2
-./tools/scripts/lib_install/mariadb-connector-c.sh 3.2.3
-./tools/scripts/lib_install/msgpack.sh 5.0.0
-./tools/scripts/lib_install/spdlog.sh 1.9.2
-./tools/scripts/lib_install/zstandard.sh 1.4.9
-```
+Want to build natively on an OS not listed here? You can file a [feature request](https://github.com/y-scope/clp/issues/new?assignees=&labels=enhancement&template=feature-request.yml)
+for us to look into.
 
 #### Docker Environment
 

--- a/components/core/README.md
+++ b/components/core/README.md
@@ -57,8 +57,7 @@ See the relevant README for your OS:
 * [Ubuntu 18.04](./tools/scripts/lib_install/ubuntu-bionic/README.md)
 * [Ubuntu 20.04](./tools/scripts/lib_install/ubuntu-focal/README.md)
 
-Want to build natively on an OS not listed here? You can file a [feature request](https://github.com/y-scope/clp/issues/new?assignees=&labels=enhancement&template=feature-request.yml)
-for us to look into.
+Want to build natively on an OS not listed here? You can file a [feature request](https://github.com/y-scope/clp/issues/new?assignees=&labels=enhancement&template=feature-request.yml).
 
 #### Docker Environment
 

--- a/components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-bionic/Dockerfile
@@ -2,14 +2,10 @@ FROM ubuntu:bionic
 
 WORKDIR /root
 
-RUN mkdir -p ./tools/docker-images/clp-env-base-bionic
-ADD ./tools/docker-images/clp-env-base-bionic/setup-scripts ./tools/docker-images/clp-env-base-bionic/setup-scripts
-
 RUN mkdir -p ./tools/scripts/lib_install
 ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
-RUN ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-prebuilt-packages.sh
-RUN ./tools/docker-images/clp-env-base-bionic/setup-scripts/install-packages-from-source.sh
+RUN ./tools/scripts/lib_install/ubuntu-bionic/install-all.sh
 
 # Reset the working directory so that it's accessible by any user who runs the
 # container

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -8,8 +8,7 @@ ADD ./tools/docker-images/clp-env-base-centos7.4/setup-scripts ./tools/docker-im
 RUN mkdir -p ./tools/scripts/lib_install
 ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
-RUN ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-prebuilt-packages.sh
-RUN ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-packages-from-source.sh
+RUN ./tools/scripts/lib_install/centos7.4/install-all.sh
 
 # Set PKG_CONFIG_PATH since CentOS doesn't look in /usr/local by default
 ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig

--- a/components/core/tools/docker-images/clp-env-base-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-focal/Dockerfile
@@ -2,14 +2,10 @@ FROM ubuntu:focal
 
 WORKDIR /root
 
-RUN mkdir -p ./tools/docker-images/clp-env-base-focal
-ADD ./tools/docker-images/clp-env-base-focal/setup-scripts ./tools/docker-images/clp-env-base-focal/setup-scripts
-
 RUN mkdir -p ./tools/scripts/lib_install
 ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
-RUN ./tools/docker-images/clp-env-base-focal/setup-scripts/install-prebuilt-packages.sh
-RUN ./tools/docker-images/clp-env-base-focal/setup-scripts/install-packages-from-source.sh
+RUN ./tools/scripts/lib_install/ubuntu-focal/install-all.sh
 
 # Reset the working directory so that it's accessible by any user who runs the
 # container

--- a/components/core/tools/scripts/lib_install/centos7.4/README.md
+++ b/components/core/tools/scripts/lib_install/centos7.4/README.md
@@ -1,5 +1,5 @@
-These instructions are used to install the dependencies to build CLP. The same 
-steps are used by our Docker containers.
+To install the dependencies required to build clp-core, follow the steps below.
+These same steps are used by our Docker containers.
 
 # Installing dependencies
 
@@ -7,9 +7,9 @@ Before you run any commands below, you should review the scripts to ensure they
 will not install any dependencies you don't expect.
 
 * Install all dependencies:
-  * ⚠ NOTE: The packages built from source are installed (`make install`) 
-    without using a packager, so they need to be manually uninstalled if 
-    necessary.
+  * ⚠ NOTE: The packages built from source (`install-packages-from-source.sh`) 
+    are installed without using a packager. So if you ever need to uninstall 
+    them, you will need to do so manually.
 
   ```bash
   ./install-all.sh

--- a/components/core/tools/scripts/lib_install/centos7.4/README.md
+++ b/components/core/tools/scripts/lib_install/centos7.4/README.md
@@ -1,0 +1,35 @@
+These instructions are used to install the dependencies to build CLP. The same 
+steps are used by our Docker containers.
+
+# Installing dependencies
+
+Before you run any commands below, you should review the scripts to ensure they
+will not install any dependencies you don't expect.
+
+* Install all dependencies:
+  * ⚠ NOTE: The packages built from source are installed (`make install`) 
+    without using a packager, so they need to be manually uninstalled if 
+    necessary.
+
+  ```bash
+  ./install-all.sh
+  ```
+
+# Setup dependencies
+
+* Enable gcc 8
+
+  ```bash
+  ln -s /opt/rh/devtoolset-8/enable /etc/profile.d/devtoolset.sh
+  ```
+
+* Set PKG_CONFIG_PATH since CentOS doesn't look in `/usr/local` by default.
+  You should add this to your shell's profile/startup file (e.g., `.bashrc`).
+
+  ```bash
+  export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
+  ```
+
+# Building CLP
+
+* See the instructions in the [main README](../../../../README.md#build)

--- a/components/core/tools/scripts/lib_install/centos7.4/install-all.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+"$script_dir"/install-prebuilt-packages.sh
+"$script_dir"/install-packages-from-source.sh

--- a/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
@@ -1,4 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Enable gcc 7
+source /opt/rh/devtoolset-7/enable
+
+# NOTE: cmake and boost must be installed first since the remaining packages depend on them
+./tools/scripts/lib_install/install-cmake.sh 3.21.2
+./tools/scripts/lib_install/install-boost.sh 1.76.0
 
 ./tools/scripts/lib_install/fmtlib.sh 8.0.1
 ./tools/scripts/lib_install/libarchive.sh 3.5.1

--- a/components/core/tools/scripts/lib_install/centos7.4/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-prebuilt-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 yum install -y \
   bzip2 \

--- a/components/core/tools/scripts/lib_install/install-boost.sh
+++ b/components/core/tools/scripts/lib_install/install-boost.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error
 set -e

--- a/components/core/tools/scripts/lib_install/install-cmake.sh
+++ b/components/core/tools/scripts/lib_install/install-cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error
 set -e

--- a/components/core/tools/scripts/lib_install/ubuntu-bionic/README.md
+++ b/components/core/tools/scripts/lib_install/ubuntu-bionic/README.md
@@ -1,0 +1,17 @@
+These instructions are used to install the dependencies to build CLP. The same
+steps are used by our Docker containers.
+
+# Installing dependencies
+
+Before you run any commands below, you should review the scripts to ensure they
+will not install any dependencies you don't expect.
+
+* Install all dependencies:
+
+  ```bash
+  ./install-all.sh
+  ```
+
+# Building CLP
+
+* See the instructions in the [main README](../../../../README.md#build)

--- a/components/core/tools/scripts/lib_install/ubuntu-bionic/README.md
+++ b/components/core/tools/scripts/lib_install/ubuntu-bionic/README.md
@@ -1,5 +1,5 @@
-These instructions are used to install the dependencies to build CLP. The same
-steps are used by our Docker containers.
+To install the dependencies required to build clp-core, follow the steps below.
+These same steps are used by our Docker containers.
 
 # Installing dependencies
 

--- a/components/core/tools/scripts/lib_install/ubuntu-bionic/install-all.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-bionic/install-all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+"$script_dir"/install-prebuilt-packages.sh
+"$script_dir"/install-packages-from-source.sh

--- a/components/core/tools/scripts/lib_install/ubuntu-bionic/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-bionic/install-packages-from-source.sh
@@ -1,11 +1,4 @@
-#!/bin/bash
-
-# Enable gcc 7
-source /opt/rh/devtoolset-7/enable
-
-# NOTE: cmake and boost must be installed first since the remaining packages depend on them
-./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-cmake.sh 3.21.2
-./tools/docker-images/clp-env-base-centos7.4/setup-scripts/install-boost.sh 1.76.0
+#!/usr/bin/env bash
 
 ./tools/scripts/lib_install/fmtlib.sh 8.0.1
 ./tools/scripts/lib_install/libarchive.sh 3.5.1

--- a/components/core/tools/scripts/lib_install/ubuntu-bionic/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-bionic/install-prebuilt-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/README.md
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/README.md
@@ -1,0 +1,17 @@
+These instructions are used to install the dependencies to build CLP. The same
+steps are used by our Docker containers.
+
+# Installing dependencies
+
+Before you run any commands below, you should review the scripts to ensure they
+will not install any dependencies you don't expect.
+
+* Install all dependencies:
+
+  ```bash
+  ./install-all.sh
+  ```
+
+# Building CLP
+
+* See the instructions in the [main README](../../../../README.md#build)

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/README.md
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/README.md
@@ -1,5 +1,5 @@
-These instructions are used to install the dependencies to build CLP. The same
-steps are used by our Docker containers.
+To install the dependencies required to build clp-core, follow the steps below.
+These same steps are used by our Docker containers.
 
 # Installing dependencies
 

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+"$script_dir"/install-prebuilt-packages.sh
+"$script_dir"/install-packages-from-source.sh

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./tools/scripts/lib_install/fmtlib.sh 8.0.1
 ./tools/scripts/lib_install/libarchive.sh 3.5.1

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
As we support building clp-core on more platforms, the instructions for installing dependencies are starting starting to clutter the README. This PR instead moves the instructions into platform-specific folders.

In addition, the containers currently use scripts to install the dependencies that have to be kept in-sync with the READMEs. This PR also changes the READMEs to simply ask the users to run the scripts directly.

# Validation performed
<!-- What tests and validation you performed on the change -->
Container images built successfully.