### PR TITLE
Add support for building clp-core on macOS

### DIFF
--- a/.github/actions/clp-core-build/action.yaml
+++ b/.github/actions/clp-core-build/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: "CLP CMake Build Type: Debug, Release, RelWithDebInfo and MinSizeRel"
     required: false
     default: Release
+  cmake_config_extra_args:
+    description: "Extra args to pass to CMake during configuration"
+    required: false
+    default: ""
   
 runs:
   using: "composite"
@@ -17,9 +21,10 @@ runs:
       shell: bash
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=${{inputs.build_type}}
+      # Configure CMake in a 'build' subdirectory
+      run: cmake -B $GITHUB_WORKSPACE/build
+                 -DCMAKE_BUILD_TYPE=${{inputs.build_type}} 
+                 ${{inputs.cmake_config_extra_args}}
       working-directory: ./components/core
       shell: bash
 

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -109,3 +109,21 @@ jobs:
 
       - name: Build CLP Core
         uses: ./.github/actions/clp-core-build
+
+  build-macos:
+    runs-on: macos-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+            submodules: recursive
+
+      - name: Install dependencies
+        run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh
+
+      - name: Build CLP Core
+        uses: ./.github/actions/clp-core-build
+        with:
+          # libarchive is a keg-only package on macOS since macOS has a built-in 
+          # version. So we need to point CMake at the keg installation path.
+          cmake_config_extra_args: "-DCMAKE_PREFIX_PATH=/usr/local/opt/libarchive"

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -23,7 +23,8 @@ endif()
 # Add local CMake module directory to CMake's modules path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-# Macro providing the length of the absolute source directory path so we can create a relative (rather than absolute) __FILE__ macro
+# Macro providing the length of the absolute source directory path so we can
+# create a relative (rather than absolute) __FILE__ macro
 string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
@@ -48,12 +49,29 @@ endif()
 
 # Detect linking mode (static or shared); Default to static.
 set(CLP_USE_STATIC_LIBS ON CACHE BOOL "Whether to link against static libraries")
+if (CLP_USE_STATIC_LIBS AND APPLE)
+    message(AUTHOR_WARNING "Building with static libraries is unsupported on macOS."
+            " Switching to shared libraries.")
+    set(CLP_USE_STATIC_LIBS OFF)
+endif ()
 if(CLP_USE_STATIC_LIBS)
     set(CLP_LIBS_STRING "static")
 else()
     set(CLP_LIBS_STRING "shared")
 endif()
 message(STATUS "Building using ${CLP_LIBS_STRING} libraries")
+
+# Link against c++fs if required by the compiler being used
+set(STD_FS_LIBS "")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.1.0")
+        set(STD_FS_LIBS "stdc++fs")
+    endif ()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0.0")
+        set(STD_FS_LIBS "c++fs")
+    endif ()
+endif ()
 
 # Find and setup Boost Library
 if(CLP_USE_STATIC_LIBS)
@@ -309,7 +327,7 @@ target_link_libraries(clp
         ${sqlite_LIBRARY_DEPENDENCIES}
         LibArchive::LibArchive
         MariaDBClient::MariaDBClient
-        stdc++fs
+        ${STD_FS_LIBS}
         yaml-cpp::yaml-cpp
         ZStd::ZStd
         )
@@ -455,7 +473,7 @@ target_link_libraries(clg
         MariaDBClient::MariaDBClient
         spdlog::spdlog
         ${sqlite_LIBRARY_DEPENDENCIES}
-        stdc++fs
+        ${STD_FS_LIBS}
         yaml-cpp::yaml-cpp
         ZStd::ZStd
         )
@@ -595,7 +613,7 @@ target_link_libraries(clo
         msgpackc-cxx
         spdlog::spdlog
         ${sqlite_LIBRARY_DEPENDENCIES}
-        stdc++fs
+        ${STD_FS_LIBS}
         ZStd::ZStd
         )
 target_compile_features(clo
@@ -793,7 +811,7 @@ target_link_libraries(unitTest
         MariaDBClient::MariaDBClient
         spdlog::spdlog
         ${sqlite_LIBRARY_DEPENDENCIES}
-        stdc++fs
+        ${STD_FS_LIBS}
         yaml-cpp::yaml-cpp
         ZStd::ZStd
         )

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -248,6 +248,7 @@ set(SOURCE_FILES_clp
         src/PageAllocatedVector.hpp
         src/ParsedMessage.cpp
         src/ParsedMessage.hpp
+        src/Platform.hpp
         src/Profiler.cpp
         src/Profiler.hpp
         src/Query.cpp
@@ -399,6 +400,7 @@ set(SOURCE_FILES_clg
         src/PageAllocatedVector.hpp
         src/ParsedMessage.cpp
         src/ParsedMessage.hpp
+        src/Platform.hpp
         src/Profiler.cpp
         src/Profiler.hpp
         src/Query.cpp
@@ -537,6 +539,7 @@ set(SOURCE_FILES_clo
         src/PageAllocatedVector.hpp
         src/ParsedMessage.cpp
         src/ParsedMessage.hpp
+        src/Platform.hpp
         src/Profiler.cpp
         src/Profiler.hpp
         src/Query.cpp
@@ -718,6 +721,7 @@ set(SOURCE_FILES_unitTest
         src/PageAllocatedVector.hpp
         src/ParsedMessage.cpp
         src/ParsedMessage.hpp
+        src/Platform.hpp
         src/Profiler.cpp
         src/Profiler.hpp
         src/Query.cpp

--- a/components/core/cmake/Modules/FindLZ4.cmake
+++ b/components/core/cmake/Modules/FindLZ4.cmake
@@ -13,6 +13,8 @@
 
 set(lz4_LIBNAME "lz4")
 
+include(cmake/Modules/FindLibraryDependencies.cmake)
+
 # Run pkg-config
 find_package(PkgConfig)
 pkg_check_modules(lz4_PKGCONF QUIET "lib${lz4_LIBNAME}")
@@ -43,10 +45,9 @@ if (LZ4_LIBRARY)
     set(LZ4_FOUND ON)
 endif()
 
-include(cmake/Modules/FindLibraryDependencies.cmake)
-FindStaticLibraryDependencies(${lz4_LIBNAME} lz4 "${lz4_PKGCONF_STATIC_LIBRARIES}")
-
 if(LZ4_USE_STATIC_LIBS)
+    FindStaticLibraryDependencies(${lz4_LIBNAME} lz4 "${lz4_PKGCONF_STATIC_LIBRARIES}")
+
     # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${lz4_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
     unset(lz4_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
@@ -69,7 +70,8 @@ if(NOT TARGET LZ4::LZ4)
         if (LZ4_USE_STATIC_LIBS)
             add_library(LZ4::LZ4 STATIC IMPORTED)
         else()
-            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED libraries installed, we can still use the STATIC libraries
+            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
+            # libraries installed, we can still use the STATIC libraries
             add_library(LZ4::LZ4 UNKNOWN IMPORTED)
         endif()
     endif()

--- a/components/core/cmake/Modules/FindLibArchive.cmake
+++ b/components/core/cmake/Modules/FindLibArchive.cmake
@@ -14,6 +14,8 @@
 
 set(libarchive_LIBNAME "archive")
 
+include(cmake/Modules/FindLibraryDependencies.cmake)
+
 # Run pkg-config
 find_package(PkgConfig)
 pkg_check_modules(libarchive_PKGCONF QUIET "lib${libarchive_LIBNAME}")
@@ -44,10 +46,10 @@ if (LibArchive_LIBRARY)
     set(LibArchive_FOUND ON)
 endif()
 
-include(cmake/Modules/FindLibraryDependencies.cmake)
-FindStaticLibraryDependencies(${libarchive_LIBNAME} libarchive "${libarchive_PKGCONF_STATIC_LIBRARIES}")
-
 if(LibArchive_USE_STATIC_LIBS)
+    FindStaticLibraryDependencies(${libarchive_LIBNAME} libarchive
+                                  "${libarchive_PKGCONF_STATIC_LIBRARIES}")
+
     # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${libarchive_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
     unset(libarchive_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
@@ -70,7 +72,8 @@ if(NOT TARGET LibArchive::LibArchive)
         if (LibArchive_USE_STATIC_LIBS)
             add_library(LibArchive::LibArchive STATIC IMPORTED)
         else()
-            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED libraries installed, we can still use the STATIC libraries
+            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
+            # libraries installed, we can still use the STATIC libraries
             add_library(LibArchive::LibArchive UNKNOWN IMPORTED)
         endif()
     endif()

--- a/components/core/cmake/Modules/FindLibraryDependencies.cmake
+++ b/components/core/cmake/Modules/FindLibraryDependencies.cmake
@@ -29,7 +29,8 @@ macro(FindStaticLibraryDependencies fld_LIBNAME fld_PREFIX fld_STATIC_LIBS)
                 PATH_SUFFIXES lib
                 )
         if(${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY)
-            list(APPEND ${fld_PREFIX}_LIBRARY_DEPENDENCIES "${${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY}")
+            list(APPEND ${fld_PREFIX}_LIBRARY_DEPENDENCIES
+                 "${${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY}")
         else()
             message(SEND_ERROR "Static ${fld_DEP_LIB} library not found")
         endif()
@@ -39,7 +40,7 @@ endmacro()
 # Find the given libraries
 # Params:
 #   fld_PREFIX - Prefix for created variables
-#   fld_STATIC_LIBS - List of libraries to find
+#   fld_DYNAMIC_LIBS - List of libraries to find
 # Returns:
 #   ${fld_PREFIX}_LIBRARY_DEPENDENCIES - Found libraries
 macro(FindDynamicLibraryDependencies fld_PREFIX fld_DYNAMIC_LIBS)

--- a/components/core/cmake/Modules/FindMariaDBClient.cmake
+++ b/components/core/cmake/Modules/FindMariaDBClient.cmake
@@ -14,6 +14,8 @@
 
 set(mariadbclient_LIBNAME "mariadb")
 
+include(cmake/Modules/FindLibraryDependencies.cmake)
+
 # Run pkg-config
 find_package(PkgConfig)
 pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
@@ -44,10 +46,10 @@ if (MariaDBClient_LIBRARY)
     set(MariaDBClient_FOUND ON)
 endif()
 
-include(cmake/Modules/FindLibraryDependencies.cmake)
-FindStaticLibraryDependencies(${mariadbclient_LIBNAME} mariadbclient "${mariadbclient_PKGCONF_STATIC_LIBRARIES}")
-
 if(MariaDBClient_USE_STATIC_LIBS)
+    FindStaticLibraryDependencies(${mariadbclient_LIBNAME} mariadbclient
+                                  "${mariadbclient_PKGCONF_STATIC_LIBRARIES}")
+
     # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${mariadbclient_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
     unset(mariadbclient_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
@@ -70,7 +72,8 @@ if(NOT TARGET MariaDBClient::MariaDBClient)
         if (MariaDBClient_USE_STATIC_LIBS)
             add_library(MariaDBClient::MariaDBClient STATIC IMPORTED)
         else()
-            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED libraries installed, we can still use the STATIC libraries
+            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
+            # libraries installed, we can still use the STATIC libraries
             add_library(MariaDBClient::MariaDBClient UNKNOWN IMPORTED)
         endif()
     endif()

--- a/components/core/cmake/Modules/FindZStd.cmake
+++ b/components/core/cmake/Modules/FindZStd.cmake
@@ -13,6 +13,8 @@
 
 set(zstd_LIBNAME "zstd")
 
+include(cmake/Modules/FindLibraryDependencies.cmake)
+
 # Run pkg-config
 find_package(PkgConfig)
 pkg_check_modules(zstd_PKGCONF QUIET lib${zstd_LIBNAME})
@@ -43,10 +45,9 @@ if (ZStd_LIBRARY)
     set(ZStd_FOUND ON)
 endif()
 
-include(cmake/Modules/FindLibraryDependencies.cmake)
-FindStaticLibraryDependencies(${zstd_LIBNAME} zstd "${zstd_PKGCONF_STATIC_LIBRARIES}")
-
 if(ZStd_USE_STATIC_LIBS)
+    FindStaticLibraryDependencies(${zstd_LIBNAME} zstd "${zstd_PKGCONF_STATIC_LIBRARIES}")
+
     # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${zstd_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
     unset(zstd_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
@@ -72,7 +73,8 @@ if(NOT TARGET ZStd::ZStd)
         if (ZStd_USE_STATIC_LIBS)
             add_library(ZStd::ZStd STATIC IMPORTED)
         else()
-            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED libraries installed, we can still use the STATIC libraries
+            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
+            # libraries installed, we can still use the STATIC libraries
             add_library(ZStd::ZStd UNKNOWN IMPORTED)
         endif()
     endif()

--- a/components/core/src/GlobalMetadataDB.hpp
+++ b/components/core/src/GlobalMetadataDB.hpp
@@ -49,14 +49,16 @@ public:
      * @param creator_id
      * @param creation_num
      */
-    virtual void add_archive (const std::string& id, size_t uncompressed_size, size_t size, const std::string& creator_id, size_t creation_num) = 0;
+    virtual void add_archive (const std::string& id, uint64_t uncompressed_size, uint64_t size,
+                              const std::string& creator_id, uint64_t creation_num) = 0;
     /**
      * Updates the size of the archive identified by the given ID in the global metadata database
      * @param archive_id
      * @param uncompressed_size
      * @param size
      */
-    virtual void update_archive_size (const std::string& archive_id, size_t uncompressed_size, size_t size) = 0;
+    virtual void update_archive_size (const std::string& archive_id, uint64_t uncompressed_size,
+                                      uint64_t size) = 0;
     /**
      * Updates the metadata of the given files in the global metadata database
      * @param archive_id

--- a/components/core/src/GlobalMySQLMetadataDB.cpp
+++ b/components/core/src/GlobalMySQLMetadataDB.cpp
@@ -107,7 +107,10 @@ void GlobalMySQLMetadataDB::close () {
     m_is_open = false;
 }
 
-void GlobalMySQLMetadataDB::add_archive (const string& id, size_t uncompressed_size, size_t size, const string& creator_id, size_t creation_num) {
+void GlobalMySQLMetadataDB::add_archive (const string& id, uint64_t uncompressed_size,
+                                         uint64_t size, const string& creator_id,
+                                         uint64_t creation_num)
+{
     if (false == m_is_open) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
@@ -123,7 +126,9 @@ void GlobalMySQLMetadataDB::add_archive (const string& id, size_t uncompressed_s
     }
 }
 
-void GlobalMySQLMetadataDB::update_archive_size (const std::string& archive_id, size_t uncompressed_size, size_t size) {
+void GlobalMySQLMetadataDB::update_archive_size (const std::string& archive_id,
+                                                 uint64_t uncompressed_size, uint64_t size)
+{
     if (false == m_is_open) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }

--- a/components/core/src/GlobalMySQLMetadataDB.hpp
+++ b/components/core/src/GlobalMySQLMetadataDB.hpp
@@ -60,8 +60,10 @@ public:
     void open () override;
     void close () override;
 
-    void add_archive (const std::string& id, size_t uncompressed_size, size_t size, const std::string& creator_id, size_t creation_num) override;
-    void update_archive_size (const std::string& archive_id, size_t uncompressed_size, size_t size) override;
+    void add_archive (const std::string& id, uint64_t uncompressed_size, uint64_t size,
+                      const std::string& creator_id, uint64_t creation_num) override;
+    void update_archive_size (const std::string& archive_id, uint64_t uncompressed_size,
+                              uint64_t size) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override;

--- a/components/core/src/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.cpp
@@ -235,7 +235,10 @@ void GlobalSQLiteMetadataDB::close () {
     m_is_open = false;
 }
 
-void GlobalSQLiteMetadataDB::add_archive (const string& id, size_t uncompressed_size, size_t size, const string& creator_id, size_t creation_num) {
+void GlobalSQLiteMetadataDB::add_archive (const string& id, uint64_t uncompressed_size,
+                                          uint64_t size, const string& creator_id,
+                                          uint64_t creation_num)
+{
     if (false == m_is_open) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
@@ -249,7 +252,9 @@ void GlobalSQLiteMetadataDB::add_archive (const string& id, size_t uncompressed_
     m_insert_archive_statement->reset();
 }
 
-void GlobalSQLiteMetadataDB::update_archive_size (const string& archive_id, size_t uncompressed_size, size_t size) {
+void GlobalSQLiteMetadataDB::update_archive_size (const string& archive_id,
+                                                  uint64_t uncompressed_size, uint64_t size)
+{
     if (false == m_is_open) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }

--- a/components/core/src/GlobalSQLiteMetadataDB.hpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.hpp
@@ -65,8 +65,10 @@ public:
     void open () override;
     void close () override;
 
-    void add_archive (const std::string& id, size_t uncompressed_size, size_t size, const std::string& creator_id, size_t creation_num) override;
-    void update_archive_size (const std::string& archive_id, size_t uncompressed_size, size_t size) override;
+    void add_archive (const std::string& id, uint64_t uncompressed_size, uint64_t size,
+                      const std::string& creator_id, uint64_t creation_num) override;
+    void update_archive_size (const std::string& archive_id, uint64_t uncompressed_size,
+                              uint64_t size) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override { return new ArchiveIterator(m_db); }

--- a/components/core/src/Platform.hpp
+++ b/components/core/src/Platform.hpp
@@ -1,0 +1,52 @@
+#ifndef PLATFORM_HPP
+#define PLATFORM_HPP
+
+#include <cstdint>
+
+/**
+ * Enum defining the supported platforms. This allows us to use C++ constants
+ * instead of macros when defining code that's platform-dependent. Using
+ * constants is generally cleaner than using macros everywhere since the code
+ * isn't completely invisible to the compiler when a macro is not set.
+ * However, it does mean that we have to define shims for symbols that exist on
+ * one platform and not the others. Luckily, defining shims can generally be
+ * done in headers rather than being interspersed in functions. Moreover, by
+ * defining these shims, it makes it very clear what symbols are missing on
+ * different platforms.
+ *
+ * For example, if we define some code conditionally for macOS:
+ * - With macros:
+ *
+ *   #if defined(__APPLE__) || defined(__MACH__)
+ *   method(MACOS_SPECIFIC_MACRO);
+ *   #else
+ *   method(LINUX_SPECIFIC_MACRO);
+ *   #endif
+ *
+ * - With C++ constants
+ *
+ *   if constexpr (Platforms::MacOs == cCurrentPlatform) {
+ *       method(MACOS_SPECIFIC_MACRO);
+ *   } else {
+ *       method(LINUX_SPECIFIC_MACRO);
+ *   }
+ *
+ * When using C++ constants, this code is more readable and in case we make a
+ * mistake like forgetting a semicolon, the compiler will warn us no matter
+ * what platform we're building on. The price we pay is that we have to write a
+ * shim for MACOS_SPECIFIC_MACRO and LINUX_SPECIFIC_MACRO.
+ */
+enum class Platform {
+    MacOs = 0,
+    Linux,
+};
+
+// Define the current platform based on which platform macros exist and are
+// supported.
+#if defined(__APPLE__) || defined(__MACH__)
+constexpr Platform cCurrentPlatform = Platform::MacOs;
+#else
+constexpr Platform cCurrentPlatform = Platform::Linux;
+#endif
+
+#endif // PLATFORM_HPP

--- a/components/core/src/Utils.cpp
+++ b/components/core/src/Utils.cpp
@@ -24,7 +24,7 @@ using std::list;
 using std::string;
 using std::vector;
 
-ErrorCode create_directory (const string& path, __mode_t mode, bool exist_ok) {
+ErrorCode create_directory (const string& path, mode_t mode, bool exist_ok) {
     int retval = mkdir(path.c_str(), mode);
     if (0 != retval ) {
         if (EEXIST != errno) {
@@ -37,7 +37,7 @@ ErrorCode create_directory (const string& path, __mode_t mode, bool exist_ok) {
     return ErrorCode_Success;
 }
 
-ErrorCode create_directory_structure (const string& path, __mode_t mode) {
+ErrorCode create_directory_structure (const string& path, mode_t mode) {
     assert(!path.empty());
 
     // Check if entire path already exists

--- a/components/core/src/Utils.hpp
+++ b/components/core/src/Utils.hpp
@@ -56,7 +56,7 @@ inline bool is_delim (char c) {
  * @return ErrorCode_errno on error
  * @return ErrorCode_FileExists if exist_ok was false and the path already existed
  */
-ErrorCode create_directory (const std::string& path, __mode_t mode, bool exist_ok);
+ErrorCode create_directory (const std::string& path, mode_t mode, bool exist_ok);
 
 /**
  * Creates every directory in the given path (if they don't exist)
@@ -65,7 +65,7 @@ ErrorCode create_directory (const std::string& path, __mode_t mode, bool exist_o
  * @param mode Permission bits for structure
  * @return ErrorCode_Success on success, ErrorCode_errno otherwise
  */
-ErrorCode create_directory_structure (const std::string& path, __mode_t mode);
+ErrorCode create_directory_structure (const std::string& path, mode_t mode);
 
 /**
  * Gets the parent directory path for a given path

--- a/components/core/src/streaming_archive/writer/File.hpp
+++ b/components/core/src/streaming_archive/writer/File.hpp
@@ -98,7 +98,7 @@ namespace streaming_archive { namespace writer {
          * Gets the file's uncompressed size
          * @return File's uncompressed size in bytes
          */
-        size_t get_num_uncompressed_bytes () const { return m_num_uncompressed_bytes; }
+        uint64_t get_num_uncompressed_bytes () const { return m_num_uncompressed_bytes; }
 
         /**
          * Gets the file's encoded size in bytes
@@ -148,8 +148,8 @@ namespace streaming_archive { namespace writer {
         epochtime_t get_end_ts () const { return m_end_ts; }
         const std::vector<std::pair<int64_t, TimestampPattern>>& get_timestamp_patterns () const { return m_timestamp_patterns; }
         std::string get_encoded_timestamp_patterns () const;
-        size_t get_num_messages () const { return m_num_messages; }
-        size_t get_num_variables () const { return m_num_variables; }
+        uint64_t get_num_messages () const { return m_num_messages; }
+        uint64_t get_num_variables () const { return m_num_variables; }
 
         bool is_in_segment () const { return SegmentationState_InSegment == m_segmentation_state; }
         segment_id_t get_segment_id () const { return m_segment_id; }

--- a/components/core/tests/test-Segment.cpp
+++ b/components/core/tests/test-Segment.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Test writing and reading a segment", "[Segment]") {
     auto segment_id = writer_segment.get_id();
 
     // Fill segment
-    size_t offset = 0;
+    uint64_t offset = 0;
     writer_segment.append(uncompressed_data, uncompressed_data_size, offset);
     writer_segment.close();
 

--- a/components/core/tools/scripts/lib_install/macos-12/README.md
+++ b/components/core/tools/scripts/lib_install/macos-12/README.md
@@ -1,0 +1,18 @@
+To install the dependencies required to build clp-core, follow the steps below.
+These same steps are used by our 
+[GitHub workflow](../../../../../../.github/workflows/clp-core-build.yaml).
+
+# Installing dependencies
+
+Before you run any commands below, you should review the scripts to ensure they
+will not install any dependencies you don't expect.
+
+* Install all dependencies:
+
+  ```bash
+  ./install-all.sh
+  ```
+
+# Building CLP
+
+* See the instructions in the [main README](../../../../README.md#build)

--- a/components/core/tools/scripts/lib_install/macos-12/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos-12/install-all.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+brew install \
+  boost \
+  cmake \
+  fmt \
+  gcc \
+  libarchive \
+  lz4 \
+  mariadb-connector-c \
+  msgpack-cxx \
+  spdlog \
+  pkg-config \
+  zstd


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR adds some compilation fixes and platform-specific code to build CLP's core on macOS; in addition, it adds a GitHub workflow job to test building CLP's core on macOS 12.

Each step is split up into a different commit.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Built all CLP core executables on macOS.
* Validated compression, decompression, and search of the [openstack-24hr](https://zenodo.org/record/7094972#.Y-AsKnbMKHt) dataset.