### PR TITLE
ffi: Escape escape characters when encoding the logtype for IR streams (fixes #109).

### DIFF
--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -56,6 +56,8 @@ namespace ffi {
             "com.yscope.clp.VariableEncodingMethodsV1";
     static constexpr char cVariablesSchemaVersion[] = "com.yscope.clp.VariablesSchemaV2";
 
+    constexpr char cVariablePlaceholderEscapeCharacter = '\\';
+
     static constexpr char cTooFewDictionaryVarsErrorMessage[] =
             "There are fewer dictionary variables than dictionary variable delimiters in the "
             "logtype.";

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -176,16 +176,15 @@ namespace ffi::ir_stream {
     {
         size_t begin_pos = 0;
         auto constant_len = constant.length();
-        if (contains_variable_placeholder) {
-            for (size_t i = 0; i < constant_len; ++i) {
-                if (is_variable_placeholder(constant[i])) {
-                    logtype.append(constant, begin_pos, i - begin_pos);
-                    logtype += '\\';
-                    // NOTE: We don't need to append the variable placeholder
-                    // immediately since the next constant copy operation will
-                    // get it
-                    begin_pos = i;
-                }
+        for (size_t i = 0; i < constant_len; ++i) {
+            auto c = constant[i];
+            if (cVariablePlaceholderEscapeCharacter == c || is_variable_placeholder(c)) {
+                logtype.append(constant, begin_pos, i - begin_pos);
+                logtype += cVariablePlaceholderEscapeCharacter;
+                // NOTE: We don't need to append the character of interest
+                // immediately since the next constant copy operation will
+                // get it
+                begin_pos = i;
             }
         }
         logtype.append(constant, begin_pos, constant_len - begin_pos);


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#109

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The IR encoding of logtypes mistakenly only escaped variable placeholders. This is an overoptimization that the existing decoders don't expect. This PR fixes it.

# Validation performed
<!-- What tests and validation you performed on the change -->
Followed the reproduction steps in #109 and verified that backslashes were no longer gobbled up. Unit tests will cover this case once we have support for IR decoding in this repo.