### PR TITLE
Support decoding IR in ffi::clp 

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -811,7 +811,7 @@ set(SOURCE_FILES_unitTest
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp
         tests/test-Grep.cpp
-        tests/test-ir-encoding_methods.cpp
+        tests/test-ir_encoding_methods.cpp
         tests/test-main.cpp
         tests/test-ParserWithUserSchema.cpp
         tests/test-query_methods.cpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -682,6 +682,8 @@ set(SOURCE_FILES_unitTest
         src/ffi/encoding_methods.hpp
         src/ffi/encoding_methods.tpp
         src/ffi/ir_stream/byteswap.hpp
+        src/ffi/ir_stream/decoding_methods.cpp
+        src/ffi/ir_stream/decoding_methods.hpp
         src/ffi/ir_stream/encoding_methods.cpp
         src/ffi/ir_stream/encoding_methods.hpp
         src/ffi/ir_stream/protocol_constants.hpp
@@ -809,6 +811,7 @@ set(SOURCE_FILES_unitTest
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp
         tests/test-Grep.cpp
+        tests/test-ir-encoding_methods.cpp
         tests/test-main.cpp
         tests/test-ParserWithUserSchema.cpp
         tests/test-query_methods.cpp

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -14,10 +14,10 @@ using std::vector;
 
 namespace ffi::ir_stream {
     /**
-     * Checks if the tag is a variable encoding tag
      * @tparam encoded_variable_t Type of the encoded variable
      * @param tag
-     * @param is_encoded_var Returns whether the tag is for an encoded variable
+     * @param is_encoded_var Returns true if tag is for an encoded variable (as
+     * opposed to a dictionary variable)
      * @return Whether the tag is a variable tag
      */
     template <typename encoded_variable_t>
@@ -38,7 +38,7 @@ namespace ffi::ir_stream {
      * Decodes the next logtype string from ir_buf
      * @param ir_buf
      * @param encoded_tag
-     * @param logtype Returns logtype string
+     * @param logtype Returns the logtype string
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
@@ -51,7 +51,7 @@ namespace ffi::ir_stream {
      * Decodes the next dictionary-type variable string from ir_buf
      * @param ir_buf
      * @param encoded_tag
-     * @param dict_var Returns dictionary variable
+     * @param dict_var Returns the dictionary variable
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain enough
@@ -61,14 +61,13 @@ namespace ffi::ir_stream {
                                              string_view& dict_var);
 
     /**
-     * Parses the next timestamp from ir_buf. Returns the
-     * timestamp delta if encoded_variable_t == four_byte_encoded_variable_t or
-     * the actual timestamp if encoded_variable_t ==
-     * eight_byte_encoded_variable_t.
+     * Parses the next timestamp from ir_buf
      * @tparam encoded_variable_t Type of the encoded variable
      * @param ir_buf
      * @param encoded_tag
-     * @param ts Returns the next timestamp
+     * @param ts Returns the timestamp delta if
+     * encoded_variable_t == four_byte_encoded_variable_t or the actual
+     * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
@@ -78,20 +77,24 @@ namespace ffi::ir_stream {
     IRErrorCode parse_timestamp (IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
 
     /**
-     * Extracts timestamp info from json metadata and stores into ts_info
-     * @param metadata_json Returns the json metadata
-     * @param ts_info Returns timestamp info
+     * Extracts timestamp info from the JSON metadata and stores it into ts_info
+     * @param metadata_json The JSON metadata
+     * @param ts_info Returns the timestamp info
      */
     static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info);
 
     /**
-     * Decodes a message from ir_buf
+     * Decodes the next encoded message from ir_buf
      * @tparam encoded_variable_t Type of the encoded variable
      * @param ir_buf
      * @param message Returns the decoded message
-     * @param timestamp
+     * @param timestamp Returns the timestamp delta if
+     * encoded_variable_t == four_byte_encoded_variable_t or the actual
+     * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+     * @return IRErrorCode_Decode_Error if the encoded message cannot be
+     * properly decoded
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
      * to decode
      */
@@ -102,7 +105,7 @@ namespace ffi::ir_stream {
     /**
      * Decodes the JSON metadata from the ir_buf
      * @param ir_buf
-     * @param json_metadata Returns JSON metadata
+     * @param json_metadata Returns the JSON metadata
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -232,8 +232,7 @@ namespace ffi::ir_stream {
      * @return true on success, false otherwise
      */
     template <typename encoded_variable_t>
-    static IR_ErrorCode decode_next_message_general (const TimestampInfo& ts_info,
-                                                     const std::vector<int8_t>& ir_buf,
+    static IR_ErrorCode decode_next_message_general (const std::vector<int8_t>& ir_buf,
                                                      std::string& message,
                                                      epoch_time_ms_t& timestamp,
                                                      size_t& ending_pos) {
@@ -304,13 +303,11 @@ namespace ffi::ir_stream {
     }
 
     namespace four_byte_encoding {
-        IR_ErrorCode decode_next_message (const TimestampInfo& ts_info,
-                                          const std::vector<int8_t>& ir_buf,
+        IR_ErrorCode decode_next_message (const std::vector<int8_t>& ir_buf,
                                           std::string& message,
                                           epoch_time_ms_t& ts_delta,
                                           size_t& ending_pos) {
-            return decode_next_message_general<four_byte_encoded_variable_t>(ts_info,
-                                                                             ir_buf,
+            return decode_next_message_general<four_byte_encoded_variable_t>(ir_buf,
                                                                              message,
                                                                              ts_delta,
                                                                              ending_pos);
@@ -380,14 +377,12 @@ namespace ffi::ir_stream {
             return ErrorCode_Success;
         }
 
-        IR_ErrorCode decode_next_message (const TimestampInfo& ts_info,
-                                          const std::vector<int8_t>& ir_buf,
+        IR_ErrorCode decode_next_message (const std::vector<int8_t>& ir_buf,
                                           std::string& message,
                                           epoch_time_ms_t& timestamp,
                                           size_t& ending_pos) {
 
-            return decode_next_message_general<eight_byte_encoded_variable_t>(ts_info,
-                                                                              ir_buf,
+            return decode_next_message_general<eight_byte_encoded_variable_t>(ir_buf,
                                                                               message,
                                                                               timestamp,
                                                                               ending_pos);

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -178,18 +178,23 @@ namespace ffi::ir_stream {
         return ErrorCode_Success;
     }
 
-    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, bool& is_4bytes_encoding) {
+    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, size_t& cursor_pos, bool& is_4bytes_encoding) {
+        bool header_match = false;
         if (ir_buf.size() < cProtocol::MagicNumberLength) {
             return ErrorCode_InComplete_IR;
         }
         if (0 == memcmp(ir_buf.data(), cProtocol::FourByteEncodingMagicNumber, cProtocol::MagicNumberLength)) {
             is_4bytes_encoding = true;
-            return ErrorCode_Success;
+            header_match = true;
         } else if (0 == memcmp(ir_buf.data(), cProtocol::EightByteEncodingMagicNumber, cProtocol::MagicNumberLength)) {
             is_4bytes_encoding = false;
-            return ErrorCode_Success;
+            header_match = true;
         }
-        return ErrorCode_Corrupted_IR;
+        if (false == header_match) {
+            return ErrorCode_Corrupted_IR;
+        }
+        cursor_pos += cProtocol::MagicNumberLength;
+        return ErrorCode_Success;
     }
 
     namespace eight_byte_encoding {

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -1,0 +1,340 @@
+#include "decoding_methods.hpp"
+
+// json
+#include "../../../submodules/json/single_include/nlohmann/json.hpp"
+
+// logging library
+
+// Project headers
+#include "byteswap.hpp"
+#include "protocol_constants.hpp"
+
+using std::string_view;
+using std::string;
+using std::vector;
+
+#include <spdlog/spdlog.h>
+
+namespace ffi::ir_stream {
+
+    template <typename encoded_variable_t>
+    static bool is_encoding_variable_tag(encoded_tag_t tag) {
+        static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                      std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+        if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+            if (tag == cProtocol::Payload::VarEightByteEncoding ||
+                tag == cProtocol::Payload::VarStrLenUByte ||
+                tag == cProtocol::Payload::VarStrLenUShort ||
+                tag == cProtocol::Payload::VarStrLenInt) {
+                return true;
+            }
+        } else {
+            if (tag == cProtocol::Payload::VarFourByteEncoding ||
+                tag == cProtocol::Payload::VarStrLenUByte ||
+                tag == cProtocol::Payload::VarStrLenUShort ||
+                tag == cProtocol::Payload::VarStrLenInt) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // read next tag byte and increment read_pos by size of tag
+    static bool try_read_tag (const std::vector<int8_t>& ir_buf, size_t& cursor_pos, encoded_tag_t& tag_byte) {
+        // In case we have different tag size in the future
+        constexpr size_t read_pos_incr = sizeof(encoded_tag_t) / sizeof(int8_t);
+        if (cursor_pos >= ir_buf.size()) {
+            return false;
+        }
+        tag_byte = ir_buf.at(cursor_pos);
+        cursor_pos += read_pos_incr;
+        return true;
+    }
+
+    static bool try_read_string (const std::vector<int8_t>& ir_buf, size_t& cursor_pos, std::string& str_data, size_t read_size) {
+        if (ir_buf.size() < cursor_pos + read_size) {
+            return false;
+        }
+        str_data = std::string((char*)(ir_buf.data() + cursor_pos), read_size);
+        cursor_pos += read_size;
+        return true;
+    }
+
+    template <typename integer_t>
+    static bool read_data_big_endian (const std::vector<int8_t>& ir_buf, integer_t& data, size_t& cursor_pos) {
+        constexpr size_t read_size = sizeof(integer_t);
+        static_assert(read_size == 1 || read_size == 2 || read_size == 4 || read_size == 8);
+
+        integer_t value_small_endian;
+        if(ir_buf.size() < cursor_pos + read_size) {
+            return false;
+        }
+
+        memcpy(&value_small_endian, ir_buf.data() + cursor_pos, read_size);
+
+        if constexpr (read_size == 1) {
+            data = value_small_endian;
+        } else if constexpr (read_size == 2) {
+            data = bswap_16(value_small_endian);
+        } else if constexpr (read_size == 4) {
+            data = bswap_32(value_small_endian);
+        } else if constexpr (read_size == 8) {
+            data = bswap_64(value_small_endian);
+        }
+        cursor_pos += read_size;
+        return true;
+    }
+
+    static IR_ErrorCode get_logtype_length (const std::vector<int8_t>& ir_buf, encoded_tag_t encoded_tag, size_t& logtype_length, size_t& cursor_pos) {
+        if(encoded_tag == ffi::ir_stream::cProtocol::Payload::LogtypeStrLenUByte) {
+            uint8_t length;
+            if (false == read_data_big_endian(ir_buf, length, cursor_pos)) {
+                return ErrorCode_InComplete_IR;
+            }
+            logtype_length = length;
+        } else if (encoded_tag == ffi::ir_stream::cProtocol::Payload::LogtypeStrLenUShort) {
+            uint16_t length;
+            if (false == read_data_big_endian(ir_buf, length, cursor_pos)) {
+                return ErrorCode_InComplete_IR;
+            }
+            logtype_length = length;
+        } else if (encoded_tag == ffi::ir_stream::cProtocol::Payload::LogtypeStrLenInt) {
+            int32_t length;
+            if (false == read_data_big_endian(ir_buf, length, cursor_pos)) {
+                return ErrorCode_InComplete_IR;
+            }
+            logtype_length = length;
+        } else {
+            SPDLOG_ERROR("Unexpected tag byte {}\n", encoded_tag);
+            return ErrorCode_Corrupted_IR;
+        }
+        return ErrorCode_Success;
+    }
+
+    static IR_ErrorCode parse_log_type(const std::vector<int8_t>& ir_buf, encoded_tag_t encoded_tag, std::string& logtype, size_t& cursor_pos) {
+
+        size_t log_length;
+        IR_ErrorCode error_code = get_logtype_length(ir_buf, encoded_tag, log_length, cursor_pos);
+        if (ErrorCode_Success != error_code) {
+            return error_code;
+        }
+        if (false == try_read_string(ir_buf, cursor_pos, logtype, log_length)) {
+            return ErrorCode_InComplete_IR;
+        }
+        return ErrorCode_Success;
+    }
+
+    IR_ErrorCode parse_dictionary_var(const std::vector<int8_t>& ir_buf, encoded_tag_t encoded_tag, std::string& dict_var, size_t& cursor_pos) {
+        size_t var_length;
+        if (cProtocol::Payload::VarStrLenUByte == encoded_tag) {
+            uint8_t length;
+            if (false == read_data_big_endian(ir_buf, length, cursor_pos)) {
+                return ErrorCode_InComplete_IR;
+            }
+            var_length = length;
+        } else if (cProtocol::Payload::VarStrLenUShort == encoded_tag) {
+            uint16_t length;
+            if (false == read_data_big_endian(ir_buf, length, cursor_pos)) {
+                return ErrorCode_InComplete_IR;
+            }
+            var_length = length;
+        } else if (cProtocol::Payload::VarStrLenInt == encoded_tag) {
+            int32_t length;
+            if (false == read_data_big_endian(ir_buf, length, cursor_pos)) {
+                return ErrorCode_InComplete_IR;
+            }
+            var_length = length;
+        } else {
+            SPDLOG_ERROR("Unexpected tag byte {}", encoded_tag);
+            return ErrorCode_Corrupted_IR;
+        }
+
+        if (false == try_read_string(ir_buf, cursor_pos, dict_var, var_length)) {
+            return ErrorCode_InComplete_IR;
+        }
+
+        return ErrorCode_Success;
+    }
+
+    // Need to think about how to handle reference timestamp later
+    template <typename encoded_variable_t>
+    IR_ErrorCode parse_timestamp(const std::vector<int8_t>& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts, size_t& cursor_pos) {
+        static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                      std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+        if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+            if(cProtocol::Payload::TimestampVal != encoded_tag) {
+                SPDLOG_ERROR("Unexpected timestamp tag {}", encoded_tag);
+                return ErrorCode_Corrupted_IR;
+            }
+            if (!read_data_big_endian(ir_buf, ts, cursor_pos)) {
+                return ErrorCode_InComplete_IR;
+            }
+        } else {
+            SPDLOG_ERROR("Too lazy to support 4 bytes IR atm");
+            throw;
+        }
+        return ErrorCode_Success;
+    }
+
+    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, bool& is_4bytes_encoding) {
+        if (ir_buf.size() < cProtocol::MagicNumberLength) {
+            return ErrorCode_InComplete_IR;
+        }
+        if (0 == memcmp(ir_buf.data(), cProtocol::FourByteEncodingMagicNumber, cProtocol::MagicNumberLength)) {
+            is_4bytes_encoding = true;
+            return ErrorCode_Success;
+        } else if (0 == memcmp(ir_buf.data(), cProtocol::EightByteEncodingMagicNumber, cProtocol::MagicNumberLength)) {
+            is_4bytes_encoding = false;
+            return ErrorCode_Success;
+        }
+        return ErrorCode_Corrupted_IR;
+    }
+
+    namespace eight_byte_encoding {
+        IR_ErrorCode decode_preamble (std::vector<int8_t>& ir_buf,
+                                      TimestampInfo& ts_info,
+                                      size_t& ending_pos) {
+
+            size_t cursor_pos = ending_pos;
+            encoded_tag_t encoded_tag;
+            if (false == try_read_tag(ir_buf, cursor_pos, encoded_tag)) {
+                return ErrorCode_InComplete_IR;
+            }
+            if (encoded_tag != cProtocol::Metadata::EncodingJson) {
+                SPDLOG_ERROR("Unexpected encoding tag {}", encoded_tag);
+                return ErrorCode_Corrupted_IR;
+            }
+
+            // read length
+            if(false == try_read_tag(ir_buf, cursor_pos, encoded_tag)) {
+                return ErrorCode_InComplete_IR;
+            }
+            unsigned int metadata_length;
+            switch(encoded_tag) {
+                case cProtocol::Metadata::LengthUByte:
+                    uint8_t ubyte_res;
+                    if (false == read_data_big_endian(ir_buf, ubyte_res, cursor_pos)) {
+                        return ErrorCode_InComplete_IR;
+                    }
+                    metadata_length = ubyte_res;
+                    break;
+                case cProtocol::Metadata::LengthUShort:
+                    uint16_t ushort_res;
+                    if (false == read_data_big_endian(ir_buf, ushort_res, cursor_pos)) {
+                        return ErrorCode_InComplete_IR;
+                    }
+                    metadata_length = ushort_res;
+                    break;
+                default:
+                    SPDLOG_ERROR("Invalid Length Tag {}", encoded_tag);
+                    return ErrorCode_Corrupted_IR;
+            }
+
+            // read the json contents
+            std::string json_string;
+            if (false == try_read_string(ir_buf, cursor_pos, json_string, metadata_length)) {
+                return ErrorCode_InComplete_IR;
+            }
+
+            // TODO: should we do a try & catch to handle a corrupted json?
+            auto metadata_json = nlohmann::json::parse(json_string);
+
+            // Only here is the non-generic part
+            ts_info.time_zone_id = metadata_json.at(ffi::ir_stream::cProtocol::Metadata::TimeZoneIdKey);
+            ts_info.timestamp_pattern = metadata_json.at(ffi::ir_stream::cProtocol::Metadata::TimestampPatternKey);
+            ts_info.timestamp_pattern_syntax = metadata_json.at(ffi::ir_stream::cProtocol::Metadata::TimestampPatternSyntaxKey);
+            std::string version = metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey);
+            if (version != ffi::ir_stream::cProtocol::Metadata::VersionValue) {
+                SPDLOG_ERROR("Deprecated version: {}", version);
+                return ErrorCode_Unsupported_Version;
+            }
+            ending_pos = cursor_pos;
+
+            return ErrorCode_Success;
+        }
+
+        /**
+         * decodes the first message in the given eight-byte encoding IR stream.
+         * if the IR stream is incomplete, return false.
+         * else, return the ending position of the IR stream.
+         * @param ts_info
+         * @param ir_buf
+         * @param message
+         * @param timestamp
+         * @param ending_pos
+         * @return true on success, false otherwise
+         */
+        IR_ErrorCode decode_next_message (const TimestampInfo& ts_info,
+                                          const std::vector<int8_t>& ir_buf,
+                                          std::string& message,
+                                          epoch_time_ms_t& timestamp,
+                                          size_t& ending_pos) {
+            size_t cursor_pos = ending_pos;
+            encoded_tag_t encoded_tag;
+
+            if (false == try_read_tag(ir_buf, cursor_pos, encoded_tag)) {
+                return ErrorCode_InComplete_IR;
+            }
+
+            if (cProtocol::Eof == encoded_tag) {
+                // TODO: do we want to sanity check if the current tag is the last byte of ir_buf
+                return ErrorCode_End_of_IR;
+            }
+
+            std::vector<eight_byte_encoded_variable_t> encoded_vars;
+            std::string all_dict_var_strings;
+            vector<int32_t> dictionary_var_end_offsets;
+            IR_ErrorCode error_code;
+            // handle variables
+            while (is_encoding_variable_tag<eight_byte_encoded_variable_t>(encoded_tag)) {
+                // Variable handle will be slightly different between 4 bytes and 8 bytes
+                if (cProtocol::Payload::VarEightByteEncoding == encoded_tag) {
+                    eight_byte_encoded_variable_t encoded_variable;
+                    if (false == read_data_big_endian(ir_buf, encoded_variable, cursor_pos)) {
+                        return ErrorCode_InComplete_IR;
+                    }
+                    encoded_vars.push_back(encoded_variable);
+                } else {
+                    std::string var_str;
+                    error_code = parse_dictionary_var(ir_buf, encoded_tag, var_str, cursor_pos);
+                    if (ErrorCode_Success != error_code) {
+                        return error_code;
+                    }
+                    all_dict_var_strings.append(var_str);
+                    dictionary_var_end_offsets.push_back(all_dict_var_strings.length());
+                }
+                if (false == try_read_tag(ir_buf, cursor_pos, encoded_tag)) {
+                    return ErrorCode_InComplete_IR;
+                }
+            }
+
+            // now handle logtype
+            std::string logtype;
+            error_code = parse_log_type(ir_buf, encoded_tag, logtype, cursor_pos);
+            if (ErrorCode_Success != error_code) {
+                return error_code;
+            }
+
+            // now handle timestamp
+            // this is different between 8 bytes and 4 bytes
+            if (false == try_read_tag(ir_buf, cursor_pos, encoded_tag)) {
+                return ErrorCode_InComplete_IR;
+            }
+            error_code = parse_timestamp<eight_byte_encoded_variable_t>(ir_buf, encoded_tag, timestamp, cursor_pos);
+            if (ErrorCode_Success != error_code) {
+                return error_code;
+            }
+            // now decode message
+            message = decode_message(logtype, encoded_vars.data(),
+                                     encoded_vars.size(), all_dict_var_strings,
+                                     dictionary_var_end_offsets.data(),
+                                     dictionary_var_end_offsets.size());
+
+            ending_pos = cursor_pos;
+
+            return ErrorCode_Success;
+        }
+    }
+}

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -14,29 +14,29 @@ using std::vector;
 
 namespace ffi::ir_stream {
     /**
-     * Decodes size(integer_t) from ir_buf and return the data by reference
+     * Decodes an integer from ir_buf and returns it by reference
      * @tparam integer_t
      * @param ir_buf
      * @param data
-     * @return true on success, false if the ir_buf doesn't
-     * contain enough data
+     * @return true on success, false if the ir_buf doesn't contain enough data
+     * to decode
      */
     template <typename integer_t>
-    static bool read_data_big_endian (IRBuffer& ir_buf, integer_t& data);
+    static bool decode_int (IRBuffer& ir_buf, integer_t& data);
 
     /**
-     * Decodes the length of next logtype from the ir_buf and returns
-     * the logtype_length by reference
+     * Decodes the length of the next logtype from ir_buf and returns it by
+     * reference
      * @param ir_buf
      * @param encoded_tag
      * @param logtype_length
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
-     * enough data for decoding
+     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
+     * data to decode
      */
-    static IRErrorCode
-    get_logtype_length (IRBuffer& ir_buf, encoded_tag_t encoded_tag, size_t& logtype_length);
+    static IRErrorCode get_logtype_length (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
+                                           size_t& logtype_length);
 
     /**
      * Decodes the next logtype string from ir_buf and returns as a string view
@@ -46,11 +46,11 @@ namespace ffi::ir_stream {
      * @param logtype
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
-     * enough data for decoding
+     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+     * to decode
      */
-    static IRErrorCode
-    parse_logtype (IRBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& logtype);
+    static IRErrorCode parse_logtype (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
+                                      string_view& logtype);
 
     /**
      * Decodes the next dictionary type variable string from ir_buf and returns as a string view
@@ -60,35 +60,35 @@ namespace ffi::ir_stream {
      * @param dict_var
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
-     * enough data for decoding
+     * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain
+     * enough data to decode
      */
     static IRErrorCode parse_dictionary_var (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
                                              string_view& dict_var);
 
     /**
-     * Parses the next timestamp from the IR. Returns the timestamp delta for
-     * four_byte_encoded_variable_t and actual timestamp for
-     * eight_byte_encoded_variable_t by reference.
+     * Parses the next timestamp from the IR. Returns, by reference, the
+     * timestamp delta if encoded_variable_t == four_byte_encoded_variable_t or
+     * the actual timestamp if encoded_variable_t ==
+     * eight_byte_encoded_variable_t.
      * @tparam encoded_variable_t Type of the encoded variable
      * @param ir_buf
      * @param encoded_tag
      * @param ts
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
-     * enough data for decoding
+     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+     * to decode
      */
     template <typename encoded_variable_t>
-    IRErrorCode
-    parse_timestamp (IRBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
+    IRErrorCode parse_timestamp (IRBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
 
     /**
      * Extracts timestamp info from json metadata and stores into ts_info
      * @param metadata_json
      * @param ts_info
      */
-    static void setTsInfo (const nlohmann::json& metadata_json, TimestampInfo& ts_info);
+    static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info);
 
     /**
      * Templated function for decoding IR message
@@ -98,7 +98,7 @@ namespace ffi::ir_stream {
      * @param timestamp
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
+     * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain
      * enough data for decoding
      */
     template <typename encoded_variable_t>
@@ -113,17 +113,16 @@ namespace ffi::ir_stream {
      * @param json_metadata
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
+     * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain
      * enough data for decoding
      */
-    static IRErrorCode extract_json_metadata (IRBuffer& ir_buf,
-                                              string_view& json_metadata);
+    static IRErrorCode read_json_metadata (IRBuffer& ir_buf, string_view& json_metadata);
 
-    bool IRBuffer::try_read_string (string_view& str_data, size_t read_size) {
-        if (will_read_overflow(read_size)) {
+    bool IRBuffer::try_read (string_view& str_view, size_t read_size) {
+        if (read_will_overflow(read_size)) {
             return false;
         }
-        str_data = string_view(reinterpret_cast<const char*>(m_data + m_internal_cursor_pos),
+        str_view = string_view(reinterpret_cast<const char*>(m_data + m_internal_cursor_pos),
                                read_size);
         m_internal_cursor_pos += read_size;
         return true;
@@ -131,12 +130,11 @@ namespace ffi::ir_stream {
 
     template <typename integer_t>
     bool IRBuffer::try_read (integer_t& data) {
-        constexpr auto read_size = sizeof(integer_t);
-        return try_read(&data, read_size);
+        return try_read(&data, sizeof(data));
     }
 
     bool IRBuffer::try_read (void* dest, size_t read_size) {
-        if (will_read_overflow(read_size)) {
+        if (read_will_overflow(read_size)) {
             return false;
         }
         memcpy(dest, (m_data + m_internal_cursor_pos), read_size);
@@ -171,15 +169,14 @@ namespace ffi::ir_stream {
     }
 
     template <typename integer_t>
-    static bool read_data_big_endian (IRBuffer& ir_buf, integer_t& data) {
-        constexpr auto read_size = sizeof(integer_t);
-        static_assert(read_size == 1 || read_size == 2 || read_size == 4 || read_size == 8);
-
+    static bool decode_int (IRBuffer& ir_buf, integer_t& data) {
         integer_t value_small_endian;
         if (ir_buf.try_read(value_small_endian) == false) {
             return false;
         }
 
+        constexpr auto read_size = sizeof(integer_t);
+        static_assert(read_size == 1 || read_size == 2 || read_size == 4 || read_size == 8);
         if constexpr (read_size == 1) {
             data = value_small_endian;
         } else if constexpr (read_size == 2) {
@@ -196,20 +193,20 @@ namespace ffi::ir_stream {
     get_logtype_length (IRBuffer& ir_buf, encoded_tag_t encoded_tag, size_t& logtype_length) {
         if (encoded_tag == cProtocol::Payload::LogtypeStrLenUByte) {
             uint8_t length;
-            if (false == read_data_big_endian(ir_buf, length)) {
-                return IRErrorCode_InComplete_IR;
+            if (false == decode_int(ir_buf, length)) {
+                return IRErrorCode_Incomplete_IR;
             }
             logtype_length = length;
         } else if (encoded_tag == cProtocol::Payload::LogtypeStrLenUShort) {
             uint16_t length;
-            if (false == read_data_big_endian(ir_buf, length)) {
-                return IRErrorCode_InComplete_IR;
+            if (false == decode_int(ir_buf, length)) {
+                return IRErrorCode_Incomplete_IR;
             }
             logtype_length = length;
         } else if (encoded_tag == cProtocol::Payload::LogtypeStrLenInt) {
             int32_t length;
-            if (false == read_data_big_endian(ir_buf, length)) {
-                return IRErrorCode_InComplete_IR;
+            if (false == decode_int(ir_buf, length)) {
+                return IRErrorCode_Incomplete_IR;
             }
             logtype_length = length;
         } else {
@@ -218,56 +215,58 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    static IRErrorCode
-    parse_logtype (IRBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& logtype) {
+    static IRErrorCode parse_logtype (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
+                                      string_view& logtype)
+    {
         size_t log_length;
-        if (IRErrorCode error_code = get_logtype_length(ir_buf, encoded_tag, log_length);
-                IRErrorCode_Success != error_code) {
+        if (auto error_code = get_logtype_length(ir_buf, encoded_tag, log_length);
+                IRErrorCode_Success != error_code)
+        {
             return error_code;
         }
-        if (ir_buf.try_read_string(logtype, log_length) == false) {
-            return IRErrorCode_InComplete_IR;
+        if (ir_buf.try_read(logtype, log_length) == false) {
+            return IRErrorCode_Incomplete_IR;
         }
         return IRErrorCode_Success;
     }
 
     static IRErrorCode parse_dictionary_var (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
                                              string_view& dict_var) {
-        // decode the length of the variable from IR
+        // Decode variable's length
         size_t var_length;
         if (cProtocol::Payload::VarStrLenUByte == encoded_tag) {
             uint8_t length;
-            if (false == read_data_big_endian(ir_buf, length)) {
-                return IRErrorCode_InComplete_IR;
+            if (false == decode_int(ir_buf, length)) {
+                return IRErrorCode_Incomplete_IR;
             }
             var_length = length;
         } else if (cProtocol::Payload::VarStrLenUShort == encoded_tag) {
             uint16_t length;
-            if (false == read_data_big_endian(ir_buf, length)) {
-                return IRErrorCode_InComplete_IR;
+            if (false == decode_int(ir_buf, length)) {
+                return IRErrorCode_Incomplete_IR;
             }
             var_length = length;
         } else if (cProtocol::Payload::VarStrLenInt == encoded_tag) {
             int32_t length;
-            if (false == read_data_big_endian(ir_buf, length)) {
-                return IRErrorCode_InComplete_IR;
+            if (false == decode_int(ir_buf, length)) {
+                return IRErrorCode_Incomplete_IR;
             }
             var_length = length;
         } else {
             return IRErrorCode_Corrupted_IR;
         }
 
-        // parse out the variable string
-        if (false == ir_buf.try_read_string(dict_var, var_length)) {
-            return IRErrorCode_InComplete_IR;
+        // Read the dictionary variable
+        if (false == ir_buf.try_read(dict_var, var_length)) {
+            return IRErrorCode_Incomplete_IR;
         }
 
         return IRErrorCode_Success;
     }
 
     template <typename encoded_variable_t>
-    IRErrorCode
-    parse_timestamp (IRBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts) {
+    IRErrorCode parse_timestamp (IRBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts)
+    {
         static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                       is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
@@ -275,26 +274,26 @@ namespace ffi::ir_stream {
             if (cProtocol::Payload::TimestampVal != encoded_tag) {
                 return IRErrorCode_Corrupted_IR;
             }
-            if (!read_data_big_endian(ir_buf, ts)) {
-                return IRErrorCode_InComplete_IR;
+            if (false == decode_int(ir_buf, ts)) {
+                return IRErrorCode_Incomplete_IR;
             }
         } else {
             if (cProtocol::Payload::TimestampDeltaByte == encoded_tag) {
                 int8_t ts_delta;
-                if (!read_data_big_endian(ir_buf, ts_delta)) {
-                    return IRErrorCode_InComplete_IR;
+                if (false == decode_int(ir_buf, ts_delta)) {
+                    return IRErrorCode_Incomplete_IR;
                 }
                 ts = ts_delta;
             } else if (cProtocol::Payload::TimestampDeltaShort == encoded_tag) {
                 int16_t ts_delta;
-                if (!read_data_big_endian(ir_buf, ts_delta)) {
-                    return IRErrorCode_InComplete_IR;
+                if (false == decode_int(ir_buf, ts_delta)) {
+                    return IRErrorCode_Incomplete_IR;
                 }
                 ts = ts_delta;
             } else if (cProtocol::Payload::TimestampDeltaInt == encoded_tag) {
                 int32_t ts_delta;
-                if (!read_data_big_endian(ir_buf, ts_delta)) {
-                    return IRErrorCode_InComplete_IR;
+                if (false == decode_int(ir_buf, ts_delta)) {
+                    return IRErrorCode_Incomplete_IR;
                 }
                 ts = ts_delta;
             } else {
@@ -304,7 +303,7 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    static void setTsInfo (const nlohmann::json& metadata_json, TimestampInfo& ts_info) {
+    static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info) {
         ts_info.time_zone_id = metadata_json.at(cProtocol::Metadata::TimeZoneIdKey);
         ts_info.timestamp_pattern = metadata_json.at(cProtocol::Metadata::TimestampPatternKey);
         ts_info.timestamp_pattern_syntax =
@@ -312,59 +311,61 @@ namespace ffi::ir_stream {
     }
 
     template <typename encoded_variable_t>
-    static IRErrorCode decode_next_message_general (IRBuffer& ir_buf,
-                                                    string& message,
-                                                    epoch_time_ms_t& timestamp) {
+    static IRErrorCode decode_next_message_general (IRBuffer& ir_buf, string& message,
+                                                    epoch_time_ms_t& timestamp)
+    {
         ir_buf.init_internal_pos();
-        encoded_tag_t encoded_tag;
 
+        encoded_tag_t encoded_tag;
         if (false == ir_buf.try_read(encoded_tag)) {
-            return IRErrorCode_InComplete_IR;
+            return IRErrorCode_Incomplete_IR;
         }
         if (cProtocol::Eof == encoded_tag) {
             return IRErrorCode_Eof;
         }
 
+        // Handle variables
         vector<encoded_variable_t> encoded_vars;
         string all_dict_var_strings;
         vector<int32_t> dictionary_var_end_offsets;
         bool is_encoded_var;
-        // handle variables
         while (is_variable_tag<encoded_variable_t>(encoded_tag, is_encoded_var)) {
             if (is_encoded_var) {
                 encoded_variable_t encoded_variable;
-                if (false == read_data_big_endian(ir_buf, encoded_variable)) {
-                    return IRErrorCode_InComplete_IR;
+                if (false == decode_int(ir_buf, encoded_variable)) {
+                    return IRErrorCode_Incomplete_IR;
                 }
                 encoded_vars.push_back(encoded_variable);
             } else {
                 string_view var_str;
-                if (IRErrorCode error_code = parse_dictionary_var(ir_buf, encoded_tag, var_str);
-                        IRErrorCode_Success != error_code) {
+                if (auto error_code = parse_dictionary_var(ir_buf, encoded_tag, var_str);
+                        IRErrorCode_Success != error_code)
+                {
                     return error_code;
                 }
                 all_dict_var_strings.append(var_str);
                 dictionary_var_end_offsets.push_back(all_dict_var_strings.length());
             }
             if (false == ir_buf.try_read(encoded_tag)) {
-                return IRErrorCode_InComplete_IR;
+                return IRErrorCode_Incomplete_IR;
             }
         }
 
-        // Handles logtype
+        // Handle logtype
         string_view logtype;
-        if (IRErrorCode error_code = parse_logtype(ir_buf, encoded_tag, logtype);
-                IRErrorCode_Success != error_code) {
+        if (auto error_code = parse_logtype(ir_buf, encoded_tag, logtype);
+                IRErrorCode_Success != error_code)
+        {
             return error_code;
         }
 
-        // Note, for 8-bytes encoding, the timestamp is the actual timestamp;
-        // for 4-bytes encoding, the timestamp is the timestamp_delta
+        // NOTE: for the eight-byte encoding, the timestamp is the actual
+        // timestamp; for the four-byte encoding, the timestamp is a
+        // timestamp delta
         if (false == ir_buf.try_read(encoded_tag)) {
-            return IRErrorCode_InComplete_IR;
+            return IRErrorCode_Incomplete_IR;
         }
-        if (IRErrorCode error_code = parse_timestamp<encoded_variable_t>(ir_buf, encoded_tag,
-                                                                         timestamp);
+        if (auto error_code = parse_timestamp<encoded_variable_t>(ir_buf, encoded_tag, timestamp);
                 IRErrorCode_Success != error_code) {
             return error_code;
         }
@@ -378,33 +379,32 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    static IRErrorCode extract_json_metadata (IRBuffer& ir_buf,
-                                              string_view& json_metadata) {
+    static IRErrorCode read_json_metadata (IRBuffer& ir_buf, string_view& json_metadata) {
         encoded_tag_t encoded_tag;
         if (false == ir_buf.try_read(encoded_tag)) {
-            return IRErrorCode_InComplete_IR;
+            return IRErrorCode_Incomplete_IR;
         }
         if (encoded_tag != cProtocol::Metadata::EncodingJson) {
             return IRErrorCode_Corrupted_IR;
         }
 
-        // read length
+        // Read metadata length
         if (false == ir_buf.try_read(encoded_tag)) {
-            return IRErrorCode_InComplete_IR;
+            return IRErrorCode_Incomplete_IR;
         }
         unsigned int metadata_length;
         switch (encoded_tag) {
             case cProtocol::Metadata::LengthUByte:
                 uint8_t ubyte_res;
-                if (false == read_data_big_endian(ir_buf, ubyte_res)) {
-                    return IRErrorCode_InComplete_IR;
+                if (false == decode_int(ir_buf, ubyte_res)) {
+                    return IRErrorCode_Incomplete_IR;
                 }
                 metadata_length = ubyte_res;
                 break;
             case cProtocol::Metadata::LengthUShort:
                 uint16_t ushort_res;
-                if (false == read_data_big_endian(ir_buf, ushort_res)) {
-                    return IRErrorCode_InComplete_IR;
+                if (false == decode_int(ir_buf, ushort_res)) {
+                    return IRErrorCode_Incomplete_IR;
                 }
                 metadata_length = ushort_res;
                 break;
@@ -412,9 +412,9 @@ namespace ffi::ir_stream {
                 return IRErrorCode_Corrupted_IR;
         }
 
-        // extract the json contents
-        if (false == ir_buf.try_read_string(json_metadata, metadata_length)) {
-            return IRErrorCode_InComplete_IR;
+        // Read the serialized metadata
+        if (false == ir_buf.try_read(json_metadata, metadata_length)) {
+            return IRErrorCode_Incomplete_IR;
         }
         return IRErrorCode_Success;
     }
@@ -422,21 +422,17 @@ namespace ffi::ir_stream {
     IRErrorCode get_encoding_type (IRBuffer& ir_buf, bool& is_four_bytes_encoding) {
         ir_buf.init_internal_pos();
 
-        bool header_match = false;
         int8_t buffer[cProtocol::MagicNumberLength];
         if (false == ir_buf.try_read(buffer, cProtocol::MagicNumberLength)) {
-            return IRErrorCode_InComplete_IR;
+            return IRErrorCode_Incomplete_IR;
         }
         if (0 == memcmp(buffer, cProtocol::FourByteEncodingMagicNumber,
                         cProtocol::MagicNumberLength)) {
             is_four_bytes_encoding = true;
-            header_match = true;
         } else if (0 == memcmp(buffer, cProtocol::EightByteEncodingMagicNumber,
                                cProtocol::MagicNumberLength)) {
             is_four_bytes_encoding = false;
-            header_match = true;
-        }
-        if (false == header_match) {
+        } else {
             return IRErrorCode_Corrupted_IR;
         }
         ir_buf.commit_internal_pos();
@@ -444,25 +440,26 @@ namespace ffi::ir_stream {
     }
 
     namespace four_byte_encoding {
-        IRErrorCode decode_preamble (IRBuffer& ir_buf,
-                                     TimestampInfo& ts_info,
-                                     epoch_time_ms_t& reference_ts) {
+        IRErrorCode decode_preamble (IRBuffer& ir_buf, TimestampInfo& ts_info,
+                                     epoch_time_ms_t& reference_ts)
+        {
             ir_buf.init_internal_pos();
 
             string_view json_metadata;
-            if (IRErrorCode error_code = extract_json_metadata(ir_buf, json_metadata);
-                    error_code != IRErrorCode_Success) {
+            if (auto error_code = read_json_metadata(ir_buf, json_metadata);
+                    error_code != IRErrorCode_Success)
+            {
                 return error_code;
             }
 
             try {
                 auto metadata_json = nlohmann::json::parse(json_metadata);
-                string version = metadata_json.at(cProtocol::Metadata::VersionKey);
+                const auto& version = metadata_json.at(cProtocol::Metadata::VersionKey);
                 if (version != cProtocol::Metadata::VersionValue) {
                     return IRErrorCode_Unsupported_Version;
                 }
 
-                setTsInfo(metadata_json, ts_info);
+                set_timestamp_info(metadata_json, ts_info);
                 reference_ts = std::stoll(metadata_json.at(
                         cProtocol::Metadata::ReferenceTimestampKey).get<string>());
             } catch (const nlohmann::json::parse_error& e) {
@@ -483,23 +480,23 @@ namespace ffi::ir_stream {
     }
 
     namespace eight_byte_encoding {
-        IRErrorCode decode_preamble (IRBuffer& ir_buf,
-                                     TimestampInfo& ts_info) {
+        IRErrorCode decode_preamble (IRBuffer& ir_buf, TimestampInfo& ts_info) {
             ir_buf.init_internal_pos();
 
             string_view json_metadata;
-            if (IRErrorCode error_code = extract_json_metadata(ir_buf, json_metadata);
-                    error_code != IRErrorCode_Success) {
+            if (auto error_code = read_json_metadata(ir_buf, json_metadata);
+                    error_code != IRErrorCode_Success)
+            {
                 return error_code;
             }
             try {
                 auto metadata_json = nlohmann::json::parse(json_metadata);
-                string version = metadata_json.at(cProtocol::Metadata::VersionKey);
+                const auto& version = metadata_json.at(cProtocol::Metadata::VersionKey);
                 if (version != cProtocol::Metadata::VersionValue) {
                     return IRErrorCode_Unsupported_Version;
                 }
 
-                setTsInfo(metadata_json, ts_info);
+                set_timestamp_info(metadata_json, ts_info);
             } catch (const nlohmann::json::parse_error& e) {
                 return IRErrorCode_Corrupted_Metadata;
             }

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -55,11 +55,11 @@ namespace ffi::ir_stream {
         return true;
     }
 
-    static bool try_read_string (IRBuffer& ir_buf, std::string& str_data, size_t read_size) {
+    static bool try_read_string (IRBuffer& ir_buf, std::string_view& str_data, size_t read_size) {
         if (ir_buf.size_overflow(read_size)) {
             return false;
         }
-        str_data = std::string((char*)ir_buf.internal_head(), read_size);
+        str_data = std::string_view((char*)ir_buf.internal_head(), read_size);
         ir_buf.increment_internal_pos(read_size);
         return true;
     }
@@ -115,7 +115,7 @@ namespace ffi::ir_stream {
         return ErrorCode_Success;
     }
 
-    static IR_ErrorCode parse_log_type(IRBuffer& ir_buf, encoded_tag_t encoded_tag, std::string& logtype) {
+    static IR_ErrorCode parse_log_type(IRBuffer& ir_buf, encoded_tag_t encoded_tag, std::string_view& logtype) {
 
         size_t log_length;
         IR_ErrorCode error_code = get_logtype_length(ir_buf, encoded_tag, log_length);
@@ -128,7 +128,7 @@ namespace ffi::ir_stream {
         return ErrorCode_Success;
     }
 
-    IR_ErrorCode parse_dictionary_var(IRBuffer& ir_buf, encoded_tag_t encoded_tag, std::string& dict_var) {
+    IR_ErrorCode parse_dictionary_var(IRBuffer& ir_buf, encoded_tag_t encoded_tag, std::string_view& dict_var) {
         size_t var_length;
         if (cProtocol::Payload::VarStrLenUByte == encoded_tag) {
             uint8_t length;
@@ -265,7 +265,7 @@ namespace ffi::ir_stream {
                 }
                 encoded_vars.push_back(encoded_variable);
             } else {
-                std::string var_str;
+                std::string_view var_str;
                 error_code = parse_dictionary_var(ir_buf, encoded_tag, var_str);
                 if (ErrorCode_Success != error_code) {
                     return error_code;
@@ -279,7 +279,7 @@ namespace ffi::ir_stream {
         }
 
         // now handle logtype
-        std::string logtype;
+        std::string_view logtype;
         error_code = parse_log_type(ir_buf, encoded_tag, logtype);
         if (ErrorCode_Success != error_code) {
             return error_code;
@@ -305,7 +305,7 @@ namespace ffi::ir_stream {
     }
 
     IR_ErrorCode extract_json_metadata(IRBuffer& ir_buf,
-                                       std::string& json_metadata) {
+                                       std::string_view& json_metadata) {
 
         encoded_tag_t encoded_tag;
         if (false == try_read_tag(ir_buf, encoded_tag)) {
@@ -355,7 +355,7 @@ namespace ffi::ir_stream {
                                       epoch_time_ms_t& reference_ts) {
 
             ir_buf.init_internal_pos();
-            std::string json_metadata;
+            std::string_view json_metadata;
             if (IR_ErrorCode error_code = extract_json_metadata(ir_buf, json_metadata); error_code != ErrorCode_Success) {
                 return error_code;
             }
@@ -391,7 +391,7 @@ namespace ffi::ir_stream {
                                       TimestampInfo& ts_info) {
 
             ir_buf.init_internal_pos();
-            std::string json_metadata;
+            std::string_view json_metadata;
             if (IR_ErrorCode error_code = extract_json_metadata(ir_buf, json_metadata); error_code != ErrorCode_Success) {
                 return error_code;
             }

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -14,7 +14,8 @@ using std::vector;
 
 namespace ffi::ir_stream {
     /**
-     * @tparam encoded_variable_t
+     * Checks if the tag is a variable encoding tag
+     * @tparam encoded_variable_t Type of the encoded variable
      * @param tag
      * @param is_encoded_var Returns whether the tag is for an encoded variable
      * @return Whether the tag is a variable tag
@@ -23,73 +24,71 @@ namespace ffi::ir_stream {
     static bool is_variable_tag (encoded_tag_t tag, bool& is_encoded_var);
 
     /**
-     * Decodes an integer from ir_buf and returns it by reference
-     * @tparam integer_t
+     * Decodes an integer from ir_buf
+     * @tparam integer_t Type of the integer to decode
      * @param ir_buf
-     * @param value
+     * @param value Returns the decoded integer
      * @return true on success, false if the ir_buf doesn't contain enough data
      * to decode
      */
     template <typename integer_t>
-    static bool decode_int (IRBuffer& ir_buf, integer_t& value);
+    static bool decode_int (IrBuffer& ir_buf, integer_t& value);
 
     /**
-     * Decodes the next logtype string from ir_buf and returns as a string view
-     * by reference
+     * Decodes the next logtype string from ir_buf
      * @param ir_buf
      * @param encoded_tag
-     * @param logtype
+     * @param logtype Returns logtype string
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
      * to decode
      */
-    static IRErrorCode parse_logtype (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
+    static IRErrorCode parse_logtype (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
                                       string_view& logtype);
 
     /**
      * Decodes the next dictionary-type variable string from ir_buf
-     * and returns as a string view by reference
      * @param ir_buf
      * @param encoded_tag
-     * @param dict_var
+     * @param dict_var Returns dictionary variable
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain enough
      * data to decode
      */
-    static IRErrorCode parse_dictionary_var (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
+    static IRErrorCode parse_dictionary_var (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
                                              string_view& dict_var);
 
     /**
-     * Parses the next timestamp from ir_buf. Returns, by reference, the
+     * Parses the next timestamp from ir_buf. Returns the
      * timestamp delta if encoded_variable_t == four_byte_encoded_variable_t or
      * the actual timestamp if encoded_variable_t ==
      * eight_byte_encoded_variable_t.
      * @tparam encoded_variable_t Type of the encoded variable
      * @param ir_buf
      * @param encoded_tag
-     * @param ts
+     * @param ts Returns the next timestamp
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
      * to decode
      */
     template <typename encoded_variable_t>
-    IRErrorCode parse_timestamp (IRBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
+    IRErrorCode parse_timestamp (IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
 
     /**
      * Extracts timestamp info from json metadata and stores into ts_info
-     * @param metadata_json
-     * @param ts_info
+     * @param metadata_json Returns the json metadata
+     * @param ts_info Returns timestamp info
      */
     static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info);
 
     /**
      * Decodes a message from ir_buf
-     * @tparam encoded_variable_t
+     * @tparam encoded_variable_t Type of the encoded variable
      * @param ir_buf
-     * @param message
+     * @param message Returns the decoded message
      * @param timestamp
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
@@ -97,22 +96,21 @@ namespace ffi::ir_stream {
      * to decode
      */
     template <typename encoded_variable_t>
-    static IRErrorCode generic_decode_next_message (IRBuffer& ir_buf, string& message,
+    static IRErrorCode generic_decode_next_message (IrBuffer& ir_buf, string& message,
                                                     epoch_time_ms_t& timestamp);
 
     /**
-     * Decodes the JSON metadata from the ir_buf and return the metadata as
-     * as string_view by reference
+     * Decodes the JSON metadata from the ir_buf
      * @param ir_buf
-     * @param json_metadata
+     * @param json_metadata Returns JSON metadata
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
      * to decode
      */
-    static IRErrorCode read_json_metadata (IRBuffer& ir_buf, string_view& json_metadata);
+    static IRErrorCode read_json_metadata (IrBuffer& ir_buf, string_view& json_metadata);
 
-    bool IRBuffer::try_read (string_view& str_view, size_t read_size) {
+    bool IrBuffer::try_read (string_view& str_view, size_t read_size) {
         if (read_will_overflow(read_size)) {
             return false;
         }
@@ -123,11 +121,11 @@ namespace ffi::ir_stream {
     }
 
     template <typename integer_t>
-    bool IRBuffer::try_read (integer_t& data) {
+    bool IrBuffer::try_read (integer_t& data) {
         return try_read(&data, sizeof(data));
     }
 
-    bool IRBuffer::try_read (void* dest, size_t read_size) {
+    bool IrBuffer::try_read (void* dest, size_t read_size) {
         if (read_will_overflow(read_size)) {
             return false;
         }
@@ -163,7 +161,7 @@ namespace ffi::ir_stream {
     }
 
     template <typename integer_t>
-    static bool decode_int (IRBuffer& ir_buf, integer_t& value) {
+    static bool decode_int (IrBuffer& ir_buf, integer_t& value) {
         integer_t value_small_endian;
         if (ir_buf.try_read(value_small_endian) == false) {
             return false;
@@ -183,7 +181,7 @@ namespace ffi::ir_stream {
         return true;
     }
 
-    static IRErrorCode parse_logtype (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
+    static IRErrorCode parse_logtype (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
                                       string_view& logtype)
     {
         size_t logtype_length;
@@ -215,7 +213,7 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    static IRErrorCode parse_dictionary_var (IRBuffer& ir_buf, encoded_tag_t encoded_tag,
+    static IRErrorCode parse_dictionary_var (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
                                              string_view& dict_var) {
         // Decode variable's length
         size_t var_length;
@@ -250,7 +248,7 @@ namespace ffi::ir_stream {
     }
 
     template <typename encoded_variable_t>
-    IRErrorCode parse_timestamp (IRBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts)
+    IRErrorCode parse_timestamp (IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts)
     {
         static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                       is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
@@ -296,7 +294,7 @@ namespace ffi::ir_stream {
     }
 
     template <typename encoded_variable_t>
-    static IRErrorCode generic_decode_next_message (IRBuffer& ir_buf, string& message,
+    static IRErrorCode generic_decode_next_message (IrBuffer& ir_buf, string& message,
                                                     epoch_time_ms_t& timestamp)
     {
         ir_buf.init_internal_pos();
@@ -368,7 +366,7 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    static IRErrorCode read_json_metadata (IRBuffer& ir_buf, string_view& json_metadata) {
+    static IRErrorCode read_json_metadata (IrBuffer& ir_buf, string_view& json_metadata) {
         encoded_tag_t encoded_tag;
         if (false == ir_buf.try_read(encoded_tag)) {
             return IRErrorCode_Incomplete_IR;
@@ -408,7 +406,7 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    IRErrorCode get_encoding_type (IRBuffer& ir_buf, bool& is_four_bytes_encoding) {
+    IRErrorCode get_encoding_type (IrBuffer& ir_buf, bool& is_four_bytes_encoding) {
         ir_buf.init_internal_pos();
 
         int8_t buffer[cProtocol::MagicNumberLength];
@@ -429,7 +427,7 @@ namespace ffi::ir_stream {
     }
 
     namespace four_byte_encoding {
-        IRErrorCode decode_preamble (IRBuffer& ir_buf, TimestampInfo& ts_info,
+        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info,
                                      epoch_time_ms_t& reference_ts)
         {
             ir_buf.init_internal_pos();
@@ -459,7 +457,7 @@ namespace ffi::ir_stream {
             return IRErrorCode_Success;
         }
 
-        IRErrorCode decode_next_message (IRBuffer& ir_buf, string& message,
+        IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message,
                                          epoch_time_ms_t& timestamp_delta)
         {
             return generic_decode_next_message<four_byte_encoded_variable_t>(
@@ -469,7 +467,7 @@ namespace ffi::ir_stream {
     }
 
     namespace eight_byte_encoding {
-        IRErrorCode decode_preamble (IRBuffer& ir_buf, TimestampInfo& ts_info) {
+        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info) {
             ir_buf.init_internal_pos();
 
             string_view json_metadata;
@@ -494,7 +492,7 @@ namespace ffi::ir_stream {
             return IRErrorCode_Success;
         }
 
-        IRErrorCode decode_next_message (IRBuffer& ir_buf, string& message,
+        IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message,
                                          epoch_time_ms_t& timestamp)
         {
             return generic_decode_next_message<eight_byte_encoded_variable_t>(

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -54,8 +54,7 @@ namespace ffi::ir_stream {
          * @param ending_pos
          * @return true on success, false otherwise
          */
-        IR_ErrorCode decode_next_message (const TimestampInfo& ts_info,
-                                          const std::vector<int8_t>& ir_buf,
+        IR_ErrorCode decode_next_message (const std::vector<int8_t>& ir_buf,
                                           std::string& message,
                                           epoch_time_ms_t& timestamp,
                                           size_t& ending_pos);
@@ -88,8 +87,7 @@ namespace ffi::ir_stream {
          * @param ir_buf
          * @return true on success, false otherwise
          */
-        IR_ErrorCode decode_next_message (const TimestampInfo& ts_info,
-                                          const std::vector<int8_t>& ir_buf,
+        IR_ErrorCode decode_next_message (const std::vector<int8_t>& ir_buf,
                                           std::string& message,
                                           epoch_time_ms_t& ts_delta,
                                           size_t& ending_pos);

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -12,6 +12,12 @@
 namespace ffi::ir_stream {
     using encoded_tag_t = uint8_t;
 
+    typedef struct {
+        std::string timestamp_pattern;
+        std::string timestamp_pattern_syntax;
+        std::string time_zone_id;
+    } TimestampInfo;
+
     typedef enum {
         ErrorCode_Success,
         ErrorCode_Corrupted_IR,
@@ -20,14 +26,9 @@ namespace ffi::ir_stream {
         ErrorCode_End_of_IR
     } IR_ErrorCode;
 
-    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, size_t& cursor_pos, bool& is_compact);
+    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, size_t& cursor_pos, bool& is_four_bytes_encoding);
 
     namespace eight_byte_encoding {
-        typedef struct {
-            std::string timestamp_pattern;
-            std::string timestamp_pattern_syntax;
-            std::string time_zone_id;
-        } TimestampInfo;
 
         /**
          * decodes the preamble for the eight-byte encoding IR stream
@@ -63,12 +64,6 @@ namespace ffi::ir_stream {
 
     namespace four_byte_encoding {
 
-        typedef struct {
-            std::string timestamp_pattern;
-            std::string timestamp_pattern_syntax;
-            std::string time_zone_id;
-        } TimestampInfo;
-
         /**
          * decodes the preamble for the eight-byte encoding IR stream
          * @param timestamp_pattern
@@ -93,13 +88,12 @@ namespace ffi::ir_stream {
          * @param ir_buf
          * @return true on success, false otherwise
          */
-        bool decode_message (const TimestampInfo& ts_info,
-                             const std::vector<int8_t>& ir_buf,
-                             epoch_time_ms_t& reference_ts,
-                             std::string& message,
-                             epoch_time_ms_t& timestamp,
-                             size_t& ending_pos);
+        IR_ErrorCode decode_next_message (const TimestampInfo& ts_info,
+                                          const std::vector<int8_t>& ir_buf,
+                                          std::string& message,
+                                          epoch_time_ms_t& ts_delta,
+                                          size_t& ending_pos);
     }
 }
 
-#endif //DECODING_METHODS_HPP
+#endif //FFI_IR_STREAM_DECODING_METHODS_HPP

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -87,6 +87,7 @@ namespace ffi::ir_stream {
 
     typedef enum {
         IRErrorCode_Success,
+        IRErrorCode_Decode_Error,
         IRErrorCode_Eof,
         IRErrorCode_Corrupted_IR,
         IRErrorCode_Corrupted_Metadata,
@@ -131,6 +132,8 @@ namespace ffi::ir_stream {
          * @param timestamp
          * @return ErrorCode_Success on success
          * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return ErrorCode_Decode_Error if the encoded message can not be
+         * properly decoded
          * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
          * to decode
          * @return ErrorCode_End_of_IR if the IR ends
@@ -168,6 +171,8 @@ namespace ffi::ir_stream {
          * @param timestamp_delta
          * @return ErrorCode_Success on success
          * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return ErrorCode_Decode_Error if the encoded message can not be
+         * properly decoded
          * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
          * to decode
          * @return ErrorCode_End_of_IR if the IR ends

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -33,8 +33,7 @@ namespace ffi::ir_stream {
 
         /**
          * Tries reading a string view of size = read_size from the ir_buf.
-         * On success, returns the string as string_view by reference.
-         * @param str_view
+         * @param str_view Returns the string view
          * @param read_size
          * @return true on success, false if the ir_buf doesn't contain enough
          * data to decode
@@ -107,7 +106,7 @@ namespace ffi::ir_stream {
      * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
      * decode
      */
-    IRErrorCode get_encoding_type (IrBuffer & ir_buf, bool & is_four_bytes_encoding);
+    IRErrorCode get_encoding_type (IrBuffer& ir_buf, bool& is_four_bytes_encoding);
 
     namespace eight_byte_encoding {
         /**
@@ -123,14 +122,13 @@ namespace ffi::ir_stream {
          * @return IRErrorCode_Corrupted_Metadata if the metadata cannot be
          * decoded
          */
-        IRErrorCode decode_preamble (IrBuffer & ir_buf, TimestampInfo & ts_info);
+        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info);
 
         /**
          * Decodes the next message for the eight-byte encoding IR stream.
-         * On success, returns message and timestamp by reference
          * @param ir_buf
-         * @param message
-         * @param timestamp
+         * @param message Returns the decoded message
+         * @param timestamp Returns the decoded timestamp
          * @return ErrorCode_Success on success
          * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
          * @return ErrorCode_Decode_Error if the encoded message cannot be
@@ -139,17 +137,16 @@ namespace ffi::ir_stream {
          * to decode
          * @return ErrorCode_End_of_IR if the IR ends
          */
-        IRErrorCode decode_next_message (IrBuffer & ir_buf, std::string & message,
+        IRErrorCode decode_next_message (IrBuffer& ir_buf, std::string& message,
                                          epoch_time_ms_t& timestamp);
     }
 
     namespace four_byte_encoding {
         /**
          * Decodes the preamble for the four-byte encoding IR stream.
-         * On success, returns ts_info and reference_ts by reference
          * @param ir_buf
-         * @param ts_info
-         * @param reference_ts
+         * @param ts_info Returns the decoded timestamp info
+         * @param reference_ts Returns the decoded reference timestamp
          * @return IRErrorCode_Success on success
          * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
          * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
@@ -159,17 +156,14 @@ namespace ffi::ir_stream {
          * @return IRErrorCode_Corrupted_Metadata if the metadata cannot be
          * decoded
          */
-        IRErrorCode decode_preamble (IrBuffer & ir_buf,
-                                     TimestampInfo& ts_info,
+        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info,
                                      epoch_time_ms_t& reference_ts);
 
         /**
          * Decodes the next message for the four-byte encoding IR stream.
-         * On success, returns message and ts_delta by reference and sets
-         * get_cursor_pos in ir_buf to be the end of decoded message
          * @param ir_buf
-         * @param message
-         * @param timestamp_delta
+         * @param message Returns the decoded message
+         * @param timestamp_delta Returns the decoded timestamp delta
          * @return ErrorCode_Success on success
          * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
          * @return ErrorCode_Decode_Error if the encoded message cannot be
@@ -178,7 +172,7 @@ namespace ffi::ir_stream {
          * to decode
          * @return ErrorCode_End_of_IR if the IR ends
          */
-        IRErrorCode decode_next_message (IrBuffer & ir_buf, std::string & message,
+        IRErrorCode decode_next_message (IrBuffer& ir_buf, std::string& message,
                                          epoch_time_ms_t& timestamp_delta);
     }
 }

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -72,10 +72,10 @@ namespace ffi::ir_stream {
          * @return true on success, false otherwise
          * Also return the ending position of preamble
          */
-        bool decode_preamble (std::vector<int8_t>& ir_buf,
-                              TimestampInfo& ts_info,
-                              epoch_time_ms_t& reference_ts,
-                              size_t& ending_pos);
+        IR_ErrorCode decode_preamble (std::vector<int8_t>& ir_buf,
+                                      TimestampInfo& ts_info,
+                                      size_t& ending_pos,
+                                      epoch_time_ms_t& reference_ts);
 
         /**
          * decodes the first message in the given eight-byte encoding IR stream.

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -8,12 +8,13 @@
 // Project headers
 #include "../encoding_methods.hpp"
 
-
 namespace ffi::ir_stream {
     using encoded_tag_t = uint8_t;
 
+    // Class representing the IR buffer passed in by users
     class IRBuffer {
     public:
+
         IRBuffer (const int8_t* data, size_t size) : m_data(data),
                   m_size(size),
                   m_cursor_pos(0),
@@ -24,21 +25,22 @@ namespace ffi::ir_stream {
         void set_cursor_pos (size_t cursor_pos) { m_cursor_pos = cursor_pos; }
 
         // the following functions are only supposed to be used by the decoder
-        void commit_internal_pos () { m_cursor_pos = m_internal_cursor_pos; }
         void increment_internal_pos (size_t val) { m_internal_cursor_pos += val; }
         void init_internal_pos () { m_internal_cursor_pos = m_cursor_pos; }
+        void commit_internal_pos () { m_cursor_pos = m_internal_cursor_pos; }
+        const int8_t* internal_head() { return m_data + m_internal_cursor_pos; }
 
         bool size_overflow (size_t read_size) {
             return (m_internal_cursor_pos + read_size) > m_size;
         }
-
-        const int8_t* internal_head() { return m_data + m_internal_cursor_pos; }
 
 
     private:
         const int8_t* const m_data;
         const size_t m_size;
         size_t m_cursor_pos;
+        // Internal cursor position to help keeping
+        // cursor pos on a decoding failure.
         size_t m_internal_cursor_pos;
     };
 
@@ -56,32 +58,44 @@ namespace ffi::ir_stream {
         ErrorCode_End_of_IR
     } IR_ErrorCode;
 
+    /**
+     * Decodes the encoding type for the encoded IR stream.
+     * On success, return the encoding type by reference
+     * @param ir_buf
+     * @param is_four_bytes_encoding
+     * @return ErrorCode_Success on success
+     * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+     * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
+     */
     IR_ErrorCode get_encoding_type(IRBuffer& ir_buf, bool& is_four_bytes_encoding);
 
     namespace eight_byte_encoding {
 
         /**
-         * decodes the preamble for the eight-byte encoding IR stream
-         * @param timestamp_pattern
-         * @param timestamp_pattern_syntax
-         * @param time_zone_id
+         * decodes the preamble for the eight-byte encoding IR stream.
+         * On success, returns ts_info by reference and sets the cursor_pos
+         * in ir_buf to be the end of preamble
          * @param ir_buf
-         * @return true on success, false otherwise
-         * Also return the ending position of preamble
+         * @param ts_info
+         * @return ErrorCode_Success on success
+         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
+         * @return ErrorCode_Unsupported_Version is the IR has a version that is not supported
          */
         IR_ErrorCode decode_preamble (IRBuffer& ir_buf,
                                       TimestampInfo& ts_info);
 
         /**
-         * decodes the first message in the given eight-byte encoding IR stream.
-         * if the IR stream is incomplete, return false.
-         * else, return the ending position of the IR stream.
-         * @param ts_info
+         * decodes the next message for the eight-byte encoding IR stream.
+         * On success, returns message and timestamp by reference and sets the
+         * cursor_pos in ir_buf to be end of decoded message
          * @param ir_buf
          * @param message
          * @param timestamp
-         * @param ending_pos
-         * @return true on success, false otherwise
+         * @return ErrorCode_Success on success
+         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
+         * @return ErrorCode_End_of_IR if the IR ends
          */
         IR_ErrorCode decode_next_message (IRBuffer& ir_buf,
                                           std::string& message,
@@ -92,27 +106,31 @@ namespace ffi::ir_stream {
     namespace four_byte_encoding {
 
         /**
-         * decodes the preamble for the eight-byte encoding IR stream
-         * @param timestamp_pattern
-         * @param timestamp_pattern_syntax
-         * @param time_zone_id
+         * decodes the preamble for the four-byte encoding IR stream.
+         * On success, returns ts_info and reference_ts by reference
+         * and sets cursor_pos in ir_buf to the be end of preamble
          * @param ir_buf
-         * @return true on success, false otherwise
-         * Also return the ending position of preamble
+         * @param ts_info
+         * @return ErrorCode_Success on success
+         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
+         * @return ErrorCode_Unsupported_Version is the IR has a version that is not supported
          */
         IR_ErrorCode decode_preamble (IRBuffer& ir_buf,
                                       TimestampInfo& ts_info,
                                       epoch_time_ms_t& reference_ts);
 
         /**
-         * decodes the first message in the given eight-byte encoding IR stream.
-         * if the IR stream is incomplete, return false.
-         * else, return the ending position of the IR stream.
-         * @param timestamp
-         * @param message
-         * @param logtype
+         * decodes the next message for the four-byte encoding IR stream.
+         * On success, returns message and ts_delta by reference and sets
+         * cursor_pos in ir_buf to be the end of decoded message
          * @param ir_buf
-         * @return true on success, false otherwise
+         * @param message
+         * @param ts_delta
+         * @return ErrorCode_Success on success
+         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
+         * @return ErrorCode_End_of_IR if the IR ends
          */
         IR_ErrorCode decode_next_message (IRBuffer& ir_buf,
                                           std::string& message,

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -16,9 +16,9 @@ namespace ffi::ir_stream {
      * The class maintains an internal cursor such that every successful read
      * increments the cursor.
      */
-    class IRBuffer {
+    class IrBuffer {
     public:
-        IRBuffer (const int8_t* data, size_t size) :
+        IrBuffer (const int8_t* data, size_t size) :
                 m_data(data),
                 m_size(size),
                 m_cursor_pos(0),
@@ -42,10 +42,9 @@ namespace ffi::ir_stream {
         [[nodiscard]] bool try_read (std::string_view& str_view, size_t read_size);
 
         /**
-         * Tries reading an integer of size = sizeof(integer_t) from the ir_buf.
-         * On success, returns the value by reference.
+         * Tries reading an integer of size = sizeof(integer_t) from the ir_buf
          * @tparam integer_t
-         * @param data
+         * @param data Returns the integer
          * @return true on success, false if the ir_buf doesn't contain enough
          * data to decode
          */
@@ -100,23 +99,21 @@ namespace ffi::ir_stream {
     } IRErrorCode;
 
     /**
-     * Decodes the encoding type for the encoded IR stream.
-     * On success, return the encoding type by reference
+     * Decodes the encoding type for the encoded IR stream
      * @param ir_buf
-     * @param is_four_bytes_encoding
+     * @param is_four_bytes_encoding Returns the encoding type
      * @return ErrorCode_Success on success
      * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
      * decode
      */
-    IRErrorCode get_encoding_type (IRBuffer& ir_buf, bool& is_four_bytes_encoding);
+    IRErrorCode get_encoding_type (IrBuffer & ir_buf, bool & is_four_bytes_encoding);
 
     namespace eight_byte_encoding {
         /**
          * Decodes the preamble for the eight-byte encoding IR stream.
-         * On success, returns ts_info by reference
          * @param ir_buf
-         * @param ts_info
+         * @param ts_info Returns the timestamp info on success
          * @return IRErrorCode_Success on success
          * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
          * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
@@ -126,7 +123,7 @@ namespace ffi::ir_stream {
          * @return IRErrorCode_Corrupted_Metadata if the metadata cannot be
          * decoded
          */
-        IRErrorCode decode_preamble (IRBuffer& ir_buf, TimestampInfo& ts_info);
+        IRErrorCode decode_preamble (IrBuffer & ir_buf, TimestampInfo & ts_info);
 
         /**
          * Decodes the next message for the eight-byte encoding IR stream.
@@ -142,7 +139,7 @@ namespace ffi::ir_stream {
          * to decode
          * @return ErrorCode_End_of_IR if the IR ends
          */
-        IRErrorCode decode_next_message (IRBuffer& ir_buf, std::string& message,
+        IRErrorCode decode_next_message (IrBuffer & ir_buf, std::string & message,
                                          epoch_time_ms_t& timestamp);
     }
 
@@ -162,7 +159,7 @@ namespace ffi::ir_stream {
          * @return IRErrorCode_Corrupted_Metadata if the metadata cannot be
          * decoded
          */
-        IRErrorCode decode_preamble (IRBuffer& ir_buf,
+        IRErrorCode decode_preamble (IrBuffer & ir_buf,
                                      TimestampInfo& ts_info,
                                      epoch_time_ms_t& reference_ts);
 
@@ -181,7 +178,7 @@ namespace ffi::ir_stream {
          * to decode
          * @return ErrorCode_End_of_IR if the IR ends
          */
-        IRErrorCode decode_next_message (IRBuffer& ir_buf, std::string& message,
+        IRErrorCode decode_next_message (IrBuffer & ir_buf, std::string & message,
                                          epoch_time_ms_t& timestamp_delta);
     }
 }

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -11,31 +11,62 @@
 namespace ffi::ir_stream {
     using encoded_tag_t = uint8_t;
 
-    // Class representing the IR buffer passed in by users
+    /**
+     * Class representing an ir buffer that decoder sequentially reads from
+     */
     class IRBuffer {
     public:
+        IRBuffer (const int8_t* data, size_t size) :
+                m_data(data),
+                m_size(size),
+                m_cursor_pos(0),
+                m_internal_cursor_pos(0) {}
 
-        IRBuffer (const int8_t* data, size_t size) : m_data(data),
-                  m_size(size),
-                  m_cursor_pos(0),
-                  m_internal_cursor_pos(0)
-        {}
-
-        size_t cursor_pos () const { return m_cursor_pos; }
+        [[nodiscard]] size_t get_cursor_pos () const { return m_cursor_pos; }
         void set_cursor_pos (size_t cursor_pos) { m_cursor_pos = cursor_pos; }
 
         // the following functions are only supposed to be used by the decoder
-        void increment_internal_pos (size_t val) { m_internal_cursor_pos += val; }
         void init_internal_pos () { m_internal_cursor_pos = m_cursor_pos; }
         void commit_internal_pos () { m_cursor_pos = m_internal_cursor_pos; }
-        const int8_t* internal_head() { return m_data + m_internal_cursor_pos; }
+        /**
+         * Tries reading a string view of size = read_size from the ir_buf
+         * On success, returns the string as string_view by reference
+         * and increments the internal cursor of if_buf
+         * @param str_data
+         * @param read_size
+         * @return true on success, false if the ir_buf doesn't
+         * contain enough data
+         **/
+        [[nodiscard]] bool try_read_string(std::string_view& str_data, size_t read_size);
 
-        bool size_overflow (size_t read_size) {
+        /**
+         * Tries reading data of size = sizeof(integer_t) from
+         * the ir_buf. On success, returns the value by reference
+         * and increments the internal cursor of if_buf
+         * @tparam integer_t
+         * @param data
+         * @return true on success, false if the ir_buf doesn't
+         * contain enough data
+         */
+        template <typename integer_t>
+        [[nodiscard]] bool try_read(integer_t& data);
+
+        /**
+         * Tries reading data of size = read_size from the ir_buf.
+         * On success, stores the data into dest and increments the internal
+         * cursor of if_buf
+         * @param dest
+         * @param read_size
+         * @return true on success, false if the ir_buf doesn't
+         * contain enough data
+         */
+        [[nodiscard]] bool try_read(void* dest, size_t read_size);
+
+    private:
+        [[nodiscard]] bool will_read_overflow (size_t read_size) const {
             return (m_internal_cursor_pos + read_size) > m_size;
         }
 
-
-    private:
         const int8_t* const m_data;
         const size_t m_size;
         size_t m_cursor_pos;
@@ -44,19 +75,20 @@ namespace ffi::ir_stream {
         size_t m_internal_cursor_pos;
     };
 
-    typedef struct {
+    struct TimestampInfo {
         std::string timestamp_pattern;
         std::string timestamp_pattern_syntax;
         std::string time_zone_id;
-    } TimestampInfo;
+    };
 
     typedef enum {
-        ErrorCode_Success,
-        ErrorCode_Corrupted_IR,
-        ErrorCode_InComplete_IR,
-        ErrorCode_Unsupported_Version,
-        ErrorCode_End_of_IR
-    } IR_ErrorCode;
+        IRErrorCode_Success,
+        IRErrorCode_Eof,
+        IRErrorCode_Corrupted_IR,
+        IRErrorCode_Corrupted_Metadata,
+        IRErrorCode_InComplete_IR,
+        IRErrorCode_Unsupported_Version,
+    } IRErrorCode;
 
     /**
      * Decodes the encoding type for the encoded IR stream.
@@ -67,28 +99,30 @@ namespace ffi::ir_stream {
      * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
      */
-    IR_ErrorCode get_encoding_type(IRBuffer& ir_buf, bool& is_four_bytes_encoding);
+    IRErrorCode get_encoding_type (IRBuffer& ir_buf, bool& is_four_bytes_encoding);
 
     namespace eight_byte_encoding {
-
         /**
          * decodes the preamble for the eight-byte encoding IR stream.
-         * On success, returns ts_info by reference and sets the cursor_pos
+         * On success, returns ts_info by reference and sets the get_cursor_pos
          * in ir_buf to be the end of preamble
          * @param ir_buf
          * @param ts_info
-         * @return ErrorCode_Success on success
-         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
-         * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
-         * @return ErrorCode_Unsupported_Version is the IR has a version that is not supported
+         * @return IRErrorCode_Success on success
+         * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
+         * enough data for decoding
+         * @return IRErrorCode_Unsupported_Version if the IR has a version that
+         * is not supported
+         * @return IRErrorCode_Corrupted_Metadata if the metadata can not be
+         * decoded not supported
          */
-        IR_ErrorCode decode_preamble (IRBuffer& ir_buf,
-                                      TimestampInfo& ts_info);
+        IRErrorCode decode_preamble (IRBuffer& ir_buf, TimestampInfo& ts_info);
 
         /**
          * decodes the next message for the eight-byte encoding IR stream.
          * On success, returns message and timestamp by reference and sets the
-         * cursor_pos in ir_buf to be end of decoded message
+         * get_cursor_pos in ir_buf to be end of decoded message
          * @param ir_buf
          * @param message
          * @param timestamp
@@ -97,44 +131,45 @@ namespace ffi::ir_stream {
          * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
          * @return ErrorCode_End_of_IR if the IR ends
          */
-        IR_ErrorCode decode_next_message (IRBuffer& ir_buf,
-                                          std::string& message,
-                                          epoch_time_ms_t& timestamp);
-
+        IRErrorCode decode_next_message (IRBuffer& ir_buf, std::string& message,
+                                         epoch_time_ms_t& timestamp);
     }
 
     namespace four_byte_encoding {
-
         /**
          * decodes the preamble for the four-byte encoding IR stream.
          * On success, returns ts_info and reference_ts by reference
-         * and sets cursor_pos in ir_buf to the be end of preamble
+         * and sets get_cursor_pos in ir_buf to the be end of preamble
          * @param ir_buf
          * @param ts_info
-         * @return ErrorCode_Success on success
-         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
-         * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
-         * @return ErrorCode_Unsupported_Version is the IR has a version that is not supported
+         * @param reference_ts
+         * @return IRErrorCode_Success on success
+         * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+         * @return IRErrorCode_InComplete_IR if input buffer doesn't contain
+         * enough data for decoding
+         * @return IRErrorCode_Unsupported_Version if the IR has a version that
+         * is not supported
+         * @return IRErrorCode_Corrupted_Metadata if the metadata can not be
+         * decoded not supported
          */
-        IR_ErrorCode decode_preamble (IRBuffer& ir_buf,
-                                      TimestampInfo& ts_info,
-                                      epoch_time_ms_t& reference_ts);
+        IRErrorCode decode_preamble (IRBuffer& ir_buf,
+                                     TimestampInfo& ts_info,
+                                     epoch_time_ms_t& reference_ts);
 
         /**
          * decodes the next message for the four-byte encoding IR stream.
          * On success, returns message and ts_delta by reference and sets
-         * cursor_pos in ir_buf to be the end of decoded message
+         * get_cursor_pos in ir_buf to be the end of decoded message
          * @param ir_buf
          * @param message
-         * @param ts_delta
+         * @param timestamp_delta
          * @return ErrorCode_Success on success
          * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
          * @return ErrorCode_InComplete_IR if input buffer doesn't contain enough data for decoding
          * @return ErrorCode_End_of_IR if the IR ends
          */
-        IR_ErrorCode decode_next_message (IRBuffer& ir_buf,
-                                          std::string& message,
-                                          epoch_time_ms_t& ts_delta);
+        IRErrorCode decode_next_message (IRBuffer& ir_buf, std::string& message,
+                                         epoch_time_ms_t& timestamp_delta);
     }
 }
 

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -12,6 +12,16 @@
 namespace ffi::ir_stream {
     using encoded_tag_t = uint8_t;
 
+    struct IRBuffer {
+        const int8_t* const data;
+        const size_t length;
+        size_t cursor_pos;
+        IRBuffer(const int8_t* _data, size_t _length) : data(_data),
+                                                        length(_length),
+                                                        cursor_pos(0)
+                                                        {}
+    };
+
     typedef struct {
         std::string timestamp_pattern;
         std::string timestamp_pattern_syntax;
@@ -26,7 +36,7 @@ namespace ffi::ir_stream {
         ErrorCode_End_of_IR
     } IR_ErrorCode;
 
-    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, size_t& cursor_pos, bool& is_four_bytes_encoding);
+    IR_ErrorCode get_encoding_type(IRBuffer& ir_buf, bool& is_four_bytes_encoding);
 
     namespace eight_byte_encoding {
 
@@ -39,9 +49,8 @@ namespace ffi::ir_stream {
          * @return true on success, false otherwise
          * Also return the ending position of preamble
          */
-        IR_ErrorCode decode_preamble (std::vector<int8_t>& ir_buf,
-                                      TimestampInfo& ts_info,
-                                      size_t& ending_pos);
+        IR_ErrorCode decode_preamble (IRBuffer& ir_buf,
+                                      TimestampInfo& ts_info);
 
         /**
          * decodes the first message in the given eight-byte encoding IR stream.
@@ -54,10 +63,9 @@ namespace ffi::ir_stream {
          * @param ending_pos
          * @return true on success, false otherwise
          */
-        IR_ErrorCode decode_next_message (const std::vector<int8_t>& ir_buf,
+        IR_ErrorCode decode_next_message (IRBuffer& ir_buf,
                                           std::string& message,
-                                          epoch_time_ms_t& timestamp,
-                                          size_t& ending_pos);
+                                          epoch_time_ms_t& timestamp);
 
     }
 
@@ -72,9 +80,8 @@ namespace ffi::ir_stream {
          * @return true on success, false otherwise
          * Also return the ending position of preamble
          */
-        IR_ErrorCode decode_preamble (std::vector<int8_t>& ir_buf,
+        IR_ErrorCode decode_preamble (IRBuffer& ir_buf,
                                       TimestampInfo& ts_info,
-                                      size_t& ending_pos,
                                       epoch_time_ms_t& reference_ts);
 
         /**
@@ -87,10 +94,9 @@ namespace ffi::ir_stream {
          * @param ir_buf
          * @return true on success, false otherwise
          */
-        IR_ErrorCode decode_next_message (const std::vector<int8_t>& ir_buf,
+        IR_ErrorCode decode_next_message (IRBuffer& ir_buf,
                                           std::string& message,
-                                          epoch_time_ms_t& ts_delta,
-                                          size_t& ending_pos);
+                                          epoch_time_ms_t& ts_delta);
     }
 }
 

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -1,0 +1,105 @@
+#ifndef FFI_IR_STREAM_DECODING_METHODS_HPP
+#define FFI_IR_STREAM_DECODING_METHODS_HPP
+
+// C++ standard libraries
+#include <string_view>
+#include <vector>
+
+// Project headers
+#include "../encoding_methods.hpp"
+
+
+namespace ffi::ir_stream {
+    using encoded_tag_t = uint8_t;
+
+    typedef enum {
+        ErrorCode_Success,
+        ErrorCode_Corrupted_IR,
+        ErrorCode_InComplete_IR,
+        ErrorCode_Unsupported_Version,
+        ErrorCode_End_of_IR
+    } IR_ErrorCode;
+
+    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, bool& is_compact);
+    namespace eight_byte_encoding {
+
+        typedef struct {
+            std::string timestamp_pattern;
+            std::string timestamp_pattern_syntax;
+            std::string time_zone_id;
+        } TimestampInfo;
+
+        /**
+         * decodes the preamble for the eight-byte encoding IR stream
+         * @param timestamp_pattern
+         * @param timestamp_pattern_syntax
+         * @param time_zone_id
+         * @param ir_buf
+         * @return true on success, false otherwise
+         * Also return the ending position of preamble
+         */
+        IR_ErrorCode decode_preamble (std::vector<int8_t>& ir_buf,
+                                      TimestampInfo& ts_info,
+                                      size_t& ending_pos);
+
+        /**
+         * decodes the first message in the given eight-byte encoding IR stream.
+         * if the IR stream is incomplete, return false.
+         * else, return the ending position of the IR stream.
+         * @param ts_info
+         * @param ir_buf
+         * @param message
+         * @param timestamp
+         * @param ending_pos
+         * @return true on success, false otherwise
+         */
+        IR_ErrorCode decode_next_message (const TimestampInfo& ts_info,
+                                          const std::vector<int8_t>& ir_buf,
+                                          std::string& message,
+                                          epoch_time_ms_t& timestamp,
+                                          size_t& ending_pos);
+
+    }
+
+    namespace four_byte_encoding {
+
+        typedef struct {
+            std::string timestamp_pattern;
+            std::string timestamp_pattern_syntax;
+            std::string time_zone_id;
+        } TimestampInfo;
+
+        /**
+         * decodes the preamble for the eight-byte encoding IR stream
+         * @param timestamp_pattern
+         * @param timestamp_pattern_syntax
+         * @param time_zone_id
+         * @param ir_buf
+         * @return true on success, false otherwise
+         * Also return the ending position of preamble
+         */
+        bool decode_preamble (std::vector<int8_t>& ir_buf,
+                              TimestampInfo& ts_info,
+                              epoch_time_ms_t& reference_ts,
+                              size_t& ending_pos);
+
+        /**
+         * decodes the first message in the given eight-byte encoding IR stream.
+         * if the IR stream is incomplete, return false.
+         * else, return the ending position of the IR stream.
+         * @param timestamp
+         * @param message
+         * @param logtype
+         * @param ir_buf
+         * @return true on success, false otherwise
+         */
+        bool decode_message (const TimestampInfo& ts_info,
+                             const std::vector<int8_t>& ir_buf,
+                             epoch_time_ms_t& reference_ts,
+                             std::string& message,
+                             epoch_time_ms_t& timestamp,
+                             size_t& ending_pos);
+    }
+}
+
+#endif //DECODING_METHODS_HPP

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -12,14 +12,34 @@
 namespace ffi::ir_stream {
     using encoded_tag_t = uint8_t;
 
-    struct IRBuffer {
-        const int8_t* const data;
-        const size_t length;
-        size_t cursor_pos;
-        IRBuffer(const int8_t* _data, size_t _length) : data(_data),
-                                                        length(_length),
-                                                        cursor_pos(0)
-                                                        {}
+    class IRBuffer {
+    public:
+        IRBuffer (const int8_t* data, size_t size) : m_data(data),
+                  m_size(size),
+                  m_cursor_pos(0),
+                  m_internal_cursor_pos(0)
+        {}
+
+        size_t cursor_pos () const { return m_cursor_pos; }
+        void set_cursor_pos (size_t cursor_pos) { m_cursor_pos = cursor_pos; }
+
+        // the following functions are only supposed to be used by the decoder
+        void commit_internal_pos () { m_cursor_pos = m_internal_cursor_pos; }
+        void increment_internal_pos (size_t val) { m_internal_cursor_pos += val; }
+        void init_internal_pos () { m_internal_cursor_pos = m_cursor_pos; }
+
+        bool size_overflow (size_t read_size) {
+            return (m_internal_cursor_pos + read_size) > m_size;
+        }
+
+        const int8_t* internal_head() { return m_data + m_internal_cursor_pos; }
+
+
+    private:
+        const int8_t* const m_data;
+        const size_t m_size;
+        size_t m_cursor_pos;
+        size_t m_internal_cursor_pos;
     };
 
     typedef struct {

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -20,9 +20,9 @@ namespace ffi::ir_stream {
         ErrorCode_End_of_IR
     } IR_ErrorCode;
 
-    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, bool& is_compact);
-    namespace eight_byte_encoding {
+    IR_ErrorCode get_encoding_type(const std::vector<int8_t>& ir_buf, size_t& cursor_pos, bool& is_compact);
 
+    namespace eight_byte_encoding {
         typedef struct {
             std::string timestamp_pattern;
             std::string timestamp_pattern_syntax;

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -5,14 +5,16 @@
 #include <cstdint>
 
 namespace ffi::ir_stream::cProtocol {
-    constexpr size_t MagicNumberLength = 4;
     constexpr int8_t FourByteEncodingMagicNumber[] = {
             static_cast<int8_t>(0xFD), 0x2F, static_cast<int8_t>(0xB5), 0x29
     };
     constexpr int8_t EightByteEncodingMagicNumber[] = {
             static_cast<int8_t>(0xFD), 0x2F, static_cast<int8_t>(0xB5), 0x30
     };
-
+    constexpr std::enable_if<
+            sizeof(EightByteEncodingMagicNumber) == sizeof(FourByteEncodingMagicNumber),
+            size_t
+    >::type MagicNumberLength = sizeof(EightByteEncodingMagicNumber);
     namespace Metadata {
         constexpr int8_t EncodingJson = 0x1;
         constexpr int8_t LengthUByte = 0x11;

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 namespace ffi::ir_stream::cProtocol {
+    constexpr size_t MagicNumberLength = 4;
     constexpr int8_t FourByteEncodingMagicNumber[] = {
             static_cast<int8_t>(0xFD), 0x2F, static_cast<int8_t>(0xB5), 0x29
     };

--- a/components/core/tests/test-ir-encoding_methods.cpp
+++ b/components/core/tests/test-ir-encoding_methods.cpp
@@ -173,14 +173,14 @@ TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]", four_byt
     bool is_four_bytes_encoding;
     REQUIRE(ffi::ir_stream::get_encoding_type(preamble_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(match_encoding_type<TestType>(is_four_bytes_encoding));
-    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == preamble_buffer.cursor_pos);
+    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == preamble_buffer.cursor_pos());
 
     // Test if preamble can be decoded correctly
     REQUIRE(decode_preamble<TestType>(preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-    REQUIRE(encoded_preamble_end_pos == preamble_buffer.cursor_pos);
+    REQUIRE(encoded_preamble_end_pos == preamble_buffer.cursor_pos());
     if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
         REQUIRE(reference_ts == decoded_ts);
     }
@@ -188,13 +188,13 @@ TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]", four_byt
     // Test if incomplete IR can be detected.
     ir_buf.resize(encoded_preamble_end_pos - 1);
     ffi::ir_stream::IRBuffer incomplete_preamble_buffer (ir_buf.data(), ir_buf.size());
-    incomplete_preamble_buffer.cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+    incomplete_preamble_buffer.set_cursor_pos(ffi::ir_stream::cProtocol::MagicNumberLength);
     REQUIRE(decode_preamble<TestType>(incomplete_preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_InComplete_IR);
 
     // Test if corrupted IR can be detected.
     ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
     ffi::ir_stream::IRBuffer corrupted_preamble_buffer (ir_buf.data(), ir_buf.size());
-    incomplete_preamble_buffer.cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+    incomplete_preamble_buffer.set_cursor_pos(ffi::ir_stream::cProtocol::MagicNumberLength);
     REQUIRE(decode_preamble<TestType>(corrupted_preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_Corrupted_IR);
 }
 
@@ -217,9 +217,9 @@ TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]", 
     REQUIRE(ffi::ir_stream::ErrorCode_Success == decode_next_message<TestType>(encoded_message_buffer, decoded_message, timestamp));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
-    REQUIRE(encoded_message_buffer.cursor_pos == encoded_message_end_pos);
+    REQUIRE(encoded_message_buffer.cursor_pos() == encoded_message_end_pos);
 
-    encoded_message_buffer.cursor_pos = encoded_message_start_pos + 1;
+    encoded_message_buffer.set_cursor_pos(encoded_message_start_pos + 1);
     REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == decode_next_message<TestType>(encoded_message_buffer, message, timestamp));
 
     ir_buf.resize(encoded_message_end_pos - 4);
@@ -296,5 +296,5 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]", four_byte
         REQUIRE(decoded_message == reference_messages[ix]);
         REQUIRE(timestamp == reference_timestamps[ix]);
     }
-    REQUIRE(complete_encoding_buffer.cursor_pos == encoded_message_end_pos);
+    REQUIRE(complete_encoding_buffer.cursor_pos() == encoded_message_end_pos);
 }

--- a/components/core/tests/test-ir-encoding_methods.cpp
+++ b/components/core/tests/test-ir-encoding_methods.cpp
@@ -1,0 +1,114 @@
+// Catch2
+#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+
+// Project headers
+#include "../src/ffi/encoding_methods.hpp"
+#include "../src/ffi/ir_stream/encoding_methods.hpp"
+#include "../src/ffi/ir_stream/decoding_methods.hpp"
+#include "../src/ffi/ir_stream/protocol_constants.hpp"
+
+using ffi::decode_float_var;
+using ffi::decode_integer_var;
+using ffi::decode_message;
+using ffi::eight_byte_encoded_variable_t;
+using ffi::four_byte_encoded_variable_t;
+using ffi::encode_float_string;
+using ffi::encode_integer_string;
+using ffi::encode_message;
+using ffi::get_bounds_of_next_var;
+using ffi::VariablePlaceholder;
+using ffi::wildcard_query_matches_any_encoded_var;
+using std::string;
+using std::vector;
+using ffi::ir_stream::IR_ErrorCode;
+
+TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
+
+    std::vector<int8_t> empty_ir_buf;
+    bool is_four_bytes_encoding;
+    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
+
+    std::vector<int8_t> invalid_ir_buf{0x02,0x43,0x24,0x34};
+    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+
+    std::vector<int8_t> ir_buf;
+    ir_buf.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
+    memcpy(ir_buf.data(), ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(false == is_four_bytes_encoding);
+
+    memcpy(ir_buf.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(is_four_bytes_encoding);
+
+    // add some random values
+    ir_buf.push_back(0x04);
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(is_four_bytes_encoding);
+}
+
+TEST_CASE("decode_preamble", "[ffi][check_encoding_type]") {
+
+    string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
+
+    std::vector<int8_t> ir_buf;
+    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+    const std::string time_zone_id = "Asia/Tokyo";
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf));
+    const size_t encoded_preamble_end_pos = ir_buf.size();
+    const size_t encoded_preamble_start_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+    ir_buf.push_back(0x34);
+
+    ffi::ir_stream::eight_byte_encoding::TimestampInfo ts_info;
+    bool is_four_bytes_encoding;
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(false == is_four_bytes_encoding);
+
+    size_t cursor_pos = encoded_preamble_start_pos;
+
+    // Test if preamble can be properly decoded
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Success);
+
+    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+    REQUIRE(time_zone_id == ts_info.time_zone_id);
+    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+    REQUIRE(encoded_preamble_end_pos == cursor_pos);
+
+    // Test if incomplete IR can be detected.
+    ir_buf.resize(encoded_preamble_end_pos - 1);
+    cursor_pos = encoded_preamble_start_pos;
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_InComplete_IR);
+
+    // Test if corruped IR can be detected.
+    ir_buf.at(encoded_preamble_start_pos) = 0x23;
+    cursor_pos = encoded_preamble_start_pos;
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+}
+
+TEST_CASE("decode_message", "[ffi][check_encoding_type]") {
+
+    string message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
+
+    std::vector<int8_t> ir_buf;
+    std::string logtype;
+    ffi::ir_stream::eight_byte_encoding::TimestampInfo ts_info;
+    ffi::epoch_time_ms_t reference_timestamp = 1234567;
+    REQUIRE(true == ffi::ir_stream::eight_byte_encoding::encode_message(reference_timestamp, message, logtype, ir_buf));
+    const size_t encoded_message_end_pos = ir_buf.size();
+    const size_t encoded_message_start_pos = 0;
+
+    size_t cursor_pos = encoded_message_start_pos;
+    string decoded_message;
+    ffi::epoch_time_ms_t timestamp;
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, decoded_message, timestamp, cursor_pos));
+    REQUIRE(message == decoded_message);
+    REQUIRE(timestamp == reference_timestamp);
+
+    cursor_pos = encoded_message_start_pos + 1;
+    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
+
+    cursor_pos = encoded_message_start_pos;
+    ir_buf.resize(encoded_message_end_pos - 4);
+    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
+}

--- a/components/core/tests/test-ir-encoding_methods.cpp
+++ b/components/core/tests/test-ir-encoding_methods.cpp
@@ -54,7 +54,7 @@ TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
     REQUIRE(is_four_bytes_encoding);
 }
 
-TEST_CASE("decode_preamble", "[ffi][check_encoding_type]") {
+TEST_CASE("decode_preamble-8bytes", "[ffi][check_encoding_type]") {
 
     string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
 
@@ -92,7 +92,48 @@ TEST_CASE("decode_preamble", "[ffi][check_encoding_type]") {
     REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Corrupted_IR);
 }
 
-TEST_CASE("decode_next_message", "[ffi][decode_next_message]") {
+TEST_CASE("decode_preamble-4bytes", "[ffi][check_encoding_type]") {
+
+    string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
+
+    std::vector<int8_t> ir_buf;
+    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+    const std::string time_zone_id = "Asia/Tokyo";
+    const ffi::epoch_time_ms_t reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_ts, ir_buf));
+    const size_t encoded_preamble_end_pos = ir_buf.size();
+    ir_buf.push_back(0x34);
+
+    ffi::ir_stream::TimestampInfo ts_info;
+    ffi::epoch_time_ms_t decoded_ts;
+    size_t cursor_pos = 0;
+    bool is_four_bytes_encoding;
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(true == is_four_bytes_encoding);
+    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == cursor_pos);
+
+    // Test if preamble can be properly decoded
+    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Success);
+
+    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+    REQUIRE(time_zone_id == ts_info.time_zone_id);
+    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+    REQUIRE(reference_ts == decoded_ts);
+    REQUIRE(encoded_preamble_end_pos == cursor_pos);
+
+    // Test if incomplete IR can be detected.
+    ir_buf.resize(encoded_preamble_end_pos - 1);
+    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_InComplete_IR);
+
+    // Test if corrupted IR can be detected.
+    ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
+    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+}
+
+TEST_CASE("decode_next_message-8bytes", "[ffi][decode_next_message]") {
 
     string message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
 
@@ -125,31 +166,38 @@ TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
 
     std::vector<int8_t> ir_buf;
     std::string logtype;
-    ffi::epoch_time_ms_t reference_timestamp = -5;
-    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_timestamp, message, logtype, ir_buf));
+    // ensure that decoder can handle negative ts_delta
+    ffi::epoch_time_ms_t reference_delta_ts_negative = -5;
+    ffi::epoch_time_ms_t reference_delta_ts = 23453;
+    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts_negative, message, logtype, ir_buf));
+    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts, message, logtype, ir_buf));
     const size_t encoded_message_end_pos = ir_buf.size();
     const size_t encoded_message_start_pos = 0;
 
     size_t cursor_pos = encoded_message_start_pos;
     string decoded_message;
-    ffi::epoch_time_ms_t timestamp;
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
+    ffi::epoch_time_ms_t delta_ts;
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
     REQUIRE(message == decoded_message);
-    REQUIRE(timestamp == reference_timestamp);
+    REQUIRE(delta_ts == reference_delta_ts_negative);
+
+    size_t first_msg_end_pos = cursor_pos;
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
+    REQUIRE(delta_ts == reference_delta_ts);
     REQUIRE(cursor_pos == encoded_message_end_pos);
 
-    cursor_pos = encoded_message_start_pos + 1;
-    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
 
-    cursor_pos = encoded_message_start_pos;
+    cursor_pos = encoded_message_start_pos + 1;
+    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
+
+    cursor_pos = first_msg_end_pos;
     ir_buf.resize(encoded_message_end_pos - 4);
-    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
+    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
 }
 
-
-TEST_CASE("complete_test", "[ffi][decode_next_message]") {
+TEST_CASE("complete_test-8bytes", "[ffi][decode_next_message]") {
     string message;
-    uint64_t ts;
+    ffi::epoch_time_ms_t ts;
     std::vector<int8_t> ir_buf;
     std::string logtype;
     std::vector<std::string> reference_messages;
@@ -194,6 +242,66 @@ TEST_CASE("complete_test", "[ffi][decode_next_message]") {
     ffi::epoch_time_ms_t timestamp;
     for (size_t ix = 0; ix < reference_messages.size(); ix++) {
         REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
+        REQUIRE(decoded_message == reference_messages[ix]);
+        REQUIRE(timestamp == reference_timestamps[ix]);
+    }
+    REQUIRE(cursor_pos == encoded_message_end_pos);
+}
+
+TEST_CASE("complete_test-4bytes", "[ffi][decode_next_message]") {
+    string message;
+    ffi::epoch_time_ms_t ts;
+    ffi::epoch_time_ms_t ts_delta;
+    std::vector<int8_t> ir_buf;
+    std::string logtype;
+    std::vector<std::string> reference_messages;
+    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
+    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+    const std::string time_zone_id = "Asia/Tokyo";
+    const ffi::epoch_time_ms_t base_reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+
+    ts = base_reference_ts;
+    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, base_reference_ts, ir_buf));
+
+
+    // First message:
+    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
+    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
+    ts += ts_delta;
+    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
+    reference_messages.push_back(message);
+    reference_timestamps.push_back(ts_delta);
+
+    // Second message:
+    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
+    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
+    ts += ts_delta;
+    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
+    reference_messages.push_back(message);
+    reference_timestamps.push_back(ts_delta);
+
+    const size_t encoded_message_end_pos = ir_buf.size();
+    const size_t encoded_message_start_pos = 0;
+    size_t cursor_pos = encoded_message_start_pos;
+
+
+    bool is_four_bytes_encoding;
+    ffi::ir_stream::TimestampInfo ts_info;
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(true == is_four_bytes_encoding);
+
+    // Test if preamble can be properly decoded
+    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, ts) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+    REQUIRE(time_zone_id == ts_info.time_zone_id);
+    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+    REQUIRE(base_reference_ts == ts);
+
+    string decoded_message;
+    ffi::epoch_time_ms_t timestamp;
+    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
+        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
         REQUIRE(decoded_message == reference_messages[ix]);
         REQUIRE(timestamp == reference_timestamps[ix]);
     }

--- a/components/core/tests/test-ir-encoding_methods.cpp
+++ b/components/core/tests/test-ir-encoding_methods.cpp
@@ -24,18 +24,101 @@ using ffi::ir_stream::IR_ErrorCode;
 using std::chrono::milliseconds;
 using std::chrono::system_clock;
 
+static ffi::epoch_time_ms_t get_current_ts() {
+    return std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+}
+
+template <typename encoded_variable_t>
+bool match_encoding_type(bool is_four_bytes_encoding) {
+    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        return false == is_four_bytes_encoding;
+    } else {
+        return is_four_bytes_encoding;
+    }
+}
+
+template <typename encoded_variable_t>
+ffi::epoch_time_ms_t get_next_timestamp_for_test() {
+    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    // we return complete timestamp for 8-bytes encoding and a faked-up delta_ts for 4-bytes encoding
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        return get_current_ts();
+    } else {
+        ffi::epoch_time_ms_t ts1 = get_current_ts();
+        ffi::epoch_time_ms_t ts2 = get_current_ts();
+        return ts2 - ts1;
+    }
+}
+
+// A helper function to generalize the testing caller interface.
+// The reference_timestamp is only used by four bytes encoding
+template <typename encoded_variable_t>
+bool encode_preamble(std::string_view timestamp_pattern, std::string_view timestamp_pattern_syntax,
+                     std::string_view time_zone_id, ffi::epoch_time_ms_t reference_timestamp,
+                     std::vector<int8_t>& ir_buf)
+{
+    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        return ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf);
+    } else {
+        return ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_timestamp, ir_buf);
+    }
+}
+
+template <typename encoded_variable_t>
+IR_ErrorCode decode_preamble(ffi::ir_stream::IRBuffer& ir_buf,
+                             ffi::ir_stream::TimestampInfo& ts_info,
+                             ffi::epoch_time_ms_t& reference_ts)
+{
+    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        return ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info);
+    } else {
+        return ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, reference_ts);
+    }
+}
+
+template <typename encoded_variable_t>
+bool encode_message(ffi::epoch_time_ms_t timestamp, std::string_view message, string& logtype,
+                            vector<int8_t>& ir_buf)
+{
+    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        return ffi::ir_stream::eight_byte_encoding::encode_message(timestamp, message, logtype, ir_buf);
+    } else {
+        return ffi::ir_stream::four_byte_encoding::encode_message(timestamp, message, logtype, ir_buf);
+    }
+}
+
+template <typename encoded_variable_t>
+IR_ErrorCode decode_next_message(ffi::ir_stream::IRBuffer& ir_buf,
+                                 std::string& message,
+                                 ffi::epoch_time_ms_t& decoded_ts)
+{
+    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        return ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message, decoded_ts);
+    } else {
+        return ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, decoded_ts);
+    }
+}
+
 TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
 
-    const std::vector<int8_t> empty_ir_vec;
-    ffi::ir_stream::IRBuffer empty_ir_buffer(empty_ir_vec.data(), empty_ir_vec.size());
-
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
-
-    const std::vector<int8_t> invalid_ir_vec{0x02,0x43,0x24,0x34};
-    ffi::ir_stream::IRBuffer invalid_ir_buffer(invalid_ir_vec.data(), invalid_ir_vec.size());
-
-    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
 
     // Test eight bytes encoding
     std::vector<int8_t> eight_byte_encoding_vec;
@@ -44,19 +127,34 @@ TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
 
     ffi::ir_stream::IRBuffer eight_byte_ir_buffer(eight_byte_encoding_vec.data(), eight_byte_encoding_vec.size());
     REQUIRE(ffi::ir_stream::get_encoding_type(eight_byte_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(false == is_four_bytes_encoding);
+    REQUIRE(match_encoding_type<eight_byte_encoded_variable_t>);
 
 
+    // Test four bytes encoding
     std::vector<int8_t> four_byte_encoding_vec;
     four_byte_encoding_vec.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
     memcpy(four_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
 
     ffi::ir_stream::IRBuffer four_byte_ir_buffer(four_byte_encoding_vec.data(), four_byte_encoding_vec.size());
     REQUIRE(ffi::ir_stream::get_encoding_type(four_byte_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(is_four_bytes_encoding);
+    REQUIRE(match_encoding_type<four_byte_encoded_variable_t>);
+
+    // Test error on empty and incomplete ir_buffer
+    const std::vector<int8_t> empty_ir_vec;
+    ffi::ir_stream::IRBuffer empty_ir_buffer(empty_ir_vec.data(), empty_ir_vec.size());
+    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
+
+    ffi::ir_stream::IRBuffer incomplete_ir_buffer(four_byte_encoding_vec.data(), four_byte_encoding_vec.size() - 1);
+    REQUIRE(ffi::ir_stream::get_encoding_type(incomplete_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
+
+    // Test error on invalid encoding.
+    const std::vector<int8_t> invalid_ir_vec{0x02,0x43,0x24,0x34};
+    ffi::ir_stream::IRBuffer invalid_ir_buffer(invalid_ir_vec.data(), invalid_ir_vec.size());
+    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+
 }
 
-TEST_CASE("decode_preamble-8bytes", "[ffi][check_encoding_type]") {
+TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]", four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
 
     string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
 
@@ -64,89 +162,51 @@ TEST_CASE("decode_preamble-8bytes", "[ffi][check_encoding_type]") {
     const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
     const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
     const std::string time_zone_id = "Asia/Tokyo";
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf));
+    const ffi::epoch_time_ms_t reference_ts = get_current_ts();
+    REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_ts, ir_buf));
     const size_t encoded_preamble_end_pos = ir_buf.size();
-    ir_buf.push_back(0x34);
 
+    // Check if encoding type is propely readed.
     ffi::ir_stream::TimestampInfo ts_info;
-    ffi::ir_stream::IRBuffer eight_bytes_preamble_buffer(ir_buf.data(), ir_buf.size());
+    ffi::ir_stream::IRBuffer preamble_buffer(ir_buf.data(), ir_buf.size());
+    ffi::epoch_time_ms_t decoded_ts;
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(eight_bytes_preamble_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(false == is_four_bytes_encoding);
-    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == eight_bytes_preamble_buffer.cursor_pos);
+    REQUIRE(ffi::ir_stream::get_encoding_type(preamble_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(match_encoding_type<TestType>(is_four_bytes_encoding));
+    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == preamble_buffer.cursor_pos);
 
-    // Test if preamble can be properly decoded
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(eight_bytes_preamble_buffer, ts_info) == IR_ErrorCode::ErrorCode_Success);
-
+    // Test if preamble can be decoded correctly
+    REQUIRE(decode_preamble<TestType>(preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-    REQUIRE(encoded_preamble_end_pos == eight_bytes_preamble_buffer.cursor_pos);
+    REQUIRE(encoded_preamble_end_pos == preamble_buffer.cursor_pos);
+    if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
+        REQUIRE(reference_ts == decoded_ts);
+    }
 
     // Test if incomplete IR can be detected.
     ir_buf.resize(encoded_preamble_end_pos - 1);
     ffi::ir_stream::IRBuffer incomplete_preamble_buffer (ir_buf.data(), ir_buf.size());
     incomplete_preamble_buffer.cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(incomplete_preamble_buffer, ts_info) == IR_ErrorCode::ErrorCode_InComplete_IR);
+    REQUIRE(decode_preamble<TestType>(incomplete_preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_InComplete_IR);
 
     // Test if corrupted IR can be detected.
     ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
     ffi::ir_stream::IRBuffer corrupted_preamble_buffer (ir_buf.data(), ir_buf.size());
     incomplete_preamble_buffer.cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(corrupted_preamble_buffer, ts_info) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+    REQUIRE(decode_preamble<TestType>(corrupted_preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_Corrupted_IR);
 }
 
-//TEST_CASE("decode_preamble-4bytes", "[ffi][check_encoding_type]") {
-//
-//    string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
-//
-//    std::vector<int8_t> ir_buf;
-//    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-//    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-//    const std::string time_zone_id = "Asia/Tokyo";
-//    const ffi::epoch_time_ms_t reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-//    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_ts, ir_buf));
-//    const size_t encoded_preamble_end_pos = ir_buf.size();
-//    ir_buf.push_back(0x34);
-//
-//    ffi::ir_stream::TimestampInfo ts_info;
-//    ffi::epoch_time_ms_t decoded_ts;
-//    size_t cursor_pos = 0;
-//    bool is_four_bytes_encoding;
-//    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-//    REQUIRE(true == is_four_bytes_encoding);
-//    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == cursor_pos);
-//
-//    // Test if preamble can be properly decoded
-//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Success);
-//
-//    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
-//    REQUIRE(time_zone_id == ts_info.time_zone_id);
-//    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-//    REQUIRE(reference_ts == decoded_ts);
-//    REQUIRE(encoded_preamble_end_pos == cursor_pos);
-//
-//    // Test if incomplete IR can be detected.
-//    ir_buf.resize(encoded_preamble_end_pos - 1);
-//    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_InComplete_IR);
-//
-//    // Test if corrupted IR can be detected.
-//    ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
-//    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Corrupted_IR);
-//}
 
-TEST_CASE("decode_next_message-8bytes", "[ffi][decode_next_message]") {
+TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]", four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
 
     string message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
 
     std::vector<int8_t> ir_buf;
     std::string logtype;
-    ffi::epoch_time_ms_t reference_timestamp = 1234567;
-    REQUIRE(true == ffi::ir_stream::eight_byte_encoding::encode_message(reference_timestamp, message, logtype, ir_buf));
+    ffi::epoch_time_ms_t reference_timestamp = get_next_timestamp_for_test<TestType>();
+    REQUIRE(true == encode_message<TestType>(reference_timestamp, message, logtype, ir_buf));
     const size_t encoded_message_end_pos = ir_buf.size();
     const size_t encoded_message_start_pos = 0;
 
@@ -154,163 +214,87 @@ TEST_CASE("decode_next_message-8bytes", "[ffi][decode_next_message]") {
     ffi::epoch_time_ms_t timestamp;
     ffi::ir_stream::IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
 
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(encoded_message_buffer, decoded_message, timestamp));
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == decode_next_message<TestType>(encoded_message_buffer, decoded_message, timestamp));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
     REQUIRE(encoded_message_buffer.cursor_pos == encoded_message_end_pos);
 
     encoded_message_buffer.cursor_pos = encoded_message_start_pos + 1;
-    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(encoded_message_buffer, message, timestamp));
+    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == decode_next_message<TestType>(encoded_message_buffer, message, timestamp));
 
     ir_buf.resize(encoded_message_end_pos - 4);
     ffi::ir_stream::IRBuffer incomplete_message_buffer(ir_buf.data(), ir_buf.size());
-    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(incomplete_message_buffer, message, timestamp));
+    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == decode_next_message<TestType>(incomplete_message_buffer, message, timestamp));
 }
 
-//TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
-//
-//    string message = "Static <\text>, dictVar1, 123, 456345232.7234223, dictVar2, 987, 654.3, end of static text";
-//
-//    std::vector<int8_t> ir_buf;
-//    std::string logtype;
-//    // ensure that decoder can handle negative ts_delta
-//    ffi::epoch_time_ms_t reference_delta_ts_negative = -5;
-//    ffi::epoch_time_ms_t reference_delta_ts = 23453;
-//    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts_negative, message, logtype, ir_buf));
-//    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts, message, logtype, ir_buf));
-//    const size_t encoded_message_end_pos = ir_buf.size();
-//    const size_t encoded_message_start_pos = 0;
-//
-//    size_t cursor_pos = encoded_message_start_pos;
-//    string decoded_message;
-//    ffi::epoch_time_ms_t delta_ts;
-//    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
-//    REQUIRE(message == decoded_message);
-//    REQUIRE(delta_ts == reference_delta_ts_negative);
-//
-//    size_t first_msg_end_pos = cursor_pos;
-//    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
-//    REQUIRE(delta_ts == reference_delta_ts);
-//    REQUIRE(cursor_pos == encoded_message_end_pos);
-//
-//
-//    cursor_pos = encoded_message_start_pos + 1;
-//    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
-//
-//    cursor_pos = first_msg_end_pos;
-//    ir_buf.resize(encoded_message_end_pos - 4);
-//    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
-//}
-//
-//TEST_CASE("complete_test-8bytes", "[ffi][decode_next_message]") {
-//    string message;
-//    ffi::epoch_time_ms_t ts;
-//    std::vector<int8_t> ir_buf;
-//    std::string logtype;
-//    std::vector<std::string> reference_messages;
-//    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
-//    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-//    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-//    const std::string time_zone_id = "Asia/Tokyo";
-//    REQUIRE(ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf));
-//
-//
-//    // First message:
-//    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
-//    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-//    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
-//    reference_messages.push_back(message);
-//    reference_timestamps.push_back(ts);
-//
-//    // Second message:
-//    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
-//    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-//    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
-//    reference_messages.push_back(message);
-//    reference_timestamps.push_back(ts);
-//
-//    const size_t encoded_message_end_pos = ir_buf.size();
-//    const size_t encoded_message_start_pos = 0;
-//    size_t cursor_pos = encoded_message_start_pos;
-//
-//
-//    bool is_four_bytes_encoding;
-//    ffi::ir_stream::TimestampInfo ts_info;
-//    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-//    REQUIRE(false == is_four_bytes_encoding);
-//
-//    // Test if preamble can be properly decoded
-//    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Success);
-//    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
-//    REQUIRE(time_zone_id == ts_info.time_zone_id);
-//    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-//
-//    string decoded_message;
-//    ffi::epoch_time_ms_t timestamp;
-//    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
-//        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
-//        REQUIRE(decoded_message == reference_messages[ix]);
-//        REQUIRE(timestamp == reference_timestamps[ix]);
-//    }
-//    REQUIRE(cursor_pos == encoded_message_end_pos);
-//}
-//
-//TEST_CASE("complete_test-4bytes", "[ffi][decode_next_message]") {
-//    string message;
-//    ffi::epoch_time_ms_t ts;
-//    ffi::epoch_time_ms_t ts_delta;
-//    std::vector<int8_t> ir_buf;
-//    std::string logtype;
-//    std::vector<std::string> reference_messages;
-//    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
-//    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-//    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-//    const std::string time_zone_id = "Asia/Tokyo";
-//    const ffi::epoch_time_ms_t base_reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-//
-//    ts = base_reference_ts;
-//    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, base_reference_ts, ir_buf));
-//
-//
-//    // First message:
-//    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
-//    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
-//    ts += ts_delta;
-//    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
-//    reference_messages.push_back(message);
-//    reference_timestamps.push_back(ts_delta);
-//
-//    // Second message:
-//    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
-//    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
-//    ts += ts_delta;
-//    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
-//    reference_messages.push_back(message);
-//    reference_timestamps.push_back(ts_delta);
-//
-//    const size_t encoded_message_end_pos = ir_buf.size();
-//    const size_t encoded_message_start_pos = 0;
-//    size_t cursor_pos = encoded_message_start_pos;
-//
-//
-//    bool is_four_bytes_encoding;
-//    ffi::ir_stream::TimestampInfo ts_info;
-//    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-//    REQUIRE(true == is_four_bytes_encoding);
-//
-//    // Test if preamble can be properly decoded
-//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, ts) == IR_ErrorCode::ErrorCode_Success);
-//    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
-//    REQUIRE(time_zone_id == ts_info.time_zone_id);
-//    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-//    REQUIRE(base_reference_ts == ts);
-//
-//    string decoded_message;
-//    ffi::epoch_time_ms_t timestamp;
-//    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
-//        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
-//        REQUIRE(decoded_message == reference_messages[ix]);
-//        REQUIRE(timestamp == reference_timestamps[ix]);
-//    }
-//    REQUIRE(cursor_pos == encoded_message_end_pos);
-//}
+// Corner case for 4-bytes encoding
+TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
+    string message = "Static <\text>, dictVar1, 123, 456345232.7234223, dictVar2, 987, 654.3, end of static text";
+    std::vector<int8_t> ir_buf;
+    std::string logtype;
+    // ensure that decoder can handle negative ts_delta
+    ffi::epoch_time_ms_t reference_delta_ts_negative = -5;
+    REQUIRE(true == encode_message<four_byte_encoded_variable_t>(reference_delta_ts_negative, message, logtype, ir_buf));
+
+    ffi::ir_stream::IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
+    string decoded_message;
+    ffi::epoch_time_ms_t delta_ts;
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == decode_next_message<four_byte_encoded_variable_t>(encoded_message_buffer, decoded_message, delta_ts));
+    REQUIRE(message == decoded_message);
+    REQUIRE(delta_ts == reference_delta_ts_negative);
+}
+
+TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]", four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
+    string message;
+    ffi::epoch_time_ms_t ts;
+    ffi::epoch_time_ms_t preamble_ts = get_current_ts();
+    std::vector<int8_t> ir_buf;
+    std::string logtype;
+    std::vector<std::string> reference_messages;
+    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
+    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+    const std::string time_zone_id = "Asia/Tokyo";
+
+    REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, preamble_ts, ir_buf));
+
+    // First message:
+    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
+    ts = get_next_timestamp_for_test<TestType>();
+    REQUIRE(encode_message<TestType>(ts, message, logtype, ir_buf));
+    reference_messages.push_back(message);
+    reference_timestamps.push_back(ts);
+
+    // Second message:
+    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
+    ts = get_next_timestamp_for_test<TestType>();
+    REQUIRE(encode_message<TestType>(ts, message, logtype, ir_buf));
+    reference_messages.push_back(message);
+    reference_timestamps.push_back(ts);
+
+    const size_t encoded_message_end_pos = ir_buf.size();
+    const size_t encoded_message_start_pos = 0;
+
+    ffi::ir_stream::IRBuffer complete_encoding_buffer(ir_buf.data(), ir_buf.size());
+
+
+    bool is_four_bytes_encoding;
+    ffi::ir_stream::TimestampInfo ts_info;
+    REQUIRE(ffi::ir_stream::get_encoding_type(complete_encoding_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(match_encoding_type<TestType>(is_four_bytes_encoding));
+
+    // Test if preamble can be properly decoded
+    REQUIRE(decode_preamble<TestType>(complete_encoding_buffer, ts_info, preamble_ts) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+    REQUIRE(time_zone_id == ts_info.time_zone_id);
+    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+
+    string decoded_message;
+    ffi::epoch_time_ms_t timestamp;
+    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
+        REQUIRE(ffi::ir_stream::ErrorCode_Success == decode_next_message<TestType>(complete_encoding_buffer, decoded_message, timestamp));
+        REQUIRE(decoded_message == reference_messages[ix]);
+        REQUIRE(timestamp == reference_timestamps[ix]);
+    }
+    REQUIRE(complete_encoding_buffer.cursor_pos == encoded_message_end_pos);
+}

--- a/components/core/tests/test-ir-encoding_methods.cpp
+++ b/components/core/tests/test-ir-encoding_methods.cpp
@@ -21,29 +21,36 @@ using ffi::wildcard_query_matches_any_encoded_var;
 using std::string;
 using std::vector;
 using ffi::ir_stream::IR_ErrorCode;
+using std::chrono::milliseconds;
+using std::chrono::system_clock;
 
 TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
 
     std::vector<int8_t> empty_ir_buf;
+    size_t cursor = 0;
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
+    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
 
     std::vector<int8_t> invalid_ir_buf{0x02,0x43,0x24,0x34};
-    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+    cursor = 0;
+    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
 
     std::vector<int8_t> ir_buf;
     ir_buf.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
     memcpy(ir_buf.data(), ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    cursor = 0;
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(false == is_four_bytes_encoding);
 
     memcpy(ir_buf.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    cursor = 0;
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(is_four_bytes_encoding);
 
     // add some random values
     ir_buf.push_back(0x04);
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    cursor = 0;
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(is_four_bytes_encoding);
 }
 
@@ -57,15 +64,14 @@ TEST_CASE("decode_preamble", "[ffi][check_encoding_type]") {
     const std::string time_zone_id = "Asia/Tokyo";
     REQUIRE(ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf));
     const size_t encoded_preamble_end_pos = ir_buf.size();
-    const size_t encoded_preamble_start_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
     ir_buf.push_back(0x34);
 
     ffi::ir_stream::eight_byte_encoding::TimestampInfo ts_info;
+    size_t cursor_pos = 0;
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(false == is_four_bytes_encoding);
-
-    size_t cursor_pos = encoded_preamble_start_pos;
+    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == cursor_pos);
 
     // Test if preamble can be properly decoded
     REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Success);
@@ -77,16 +83,16 @@ TEST_CASE("decode_preamble", "[ffi][check_encoding_type]") {
 
     // Test if incomplete IR can be detected.
     ir_buf.resize(encoded_preamble_end_pos - 1);
-    cursor_pos = encoded_preamble_start_pos;
+    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
     REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_InComplete_IR);
 
-    // Test if corruped IR can be detected.
-    ir_buf.at(encoded_preamble_start_pos) = 0x23;
-    cursor_pos = encoded_preamble_start_pos;
+    // Test if corrupted IR can be detected.
+    ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
+    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
     REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Corrupted_IR);
 }
 
-TEST_CASE("decode_message", "[ffi][check_encoding_type]") {
+TEST_CASE("decode_next_message", "[ffi][decode_next_message]") {
 
     string message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
 
@@ -104,6 +110,7 @@ TEST_CASE("decode_message", "[ffi][check_encoding_type]") {
     REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, decoded_message, timestamp, cursor_pos));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
+    REQUIRE(cursor_pos == encoded_message_end_pos);
 
     cursor_pos = encoded_message_start_pos + 1;
     REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
@@ -111,4 +118,57 @@ TEST_CASE("decode_message", "[ffi][check_encoding_type]") {
     cursor_pos = encoded_message_start_pos;
     ir_buf.resize(encoded_message_end_pos - 4);
     REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
+}
+
+TEST_CASE("complete_test", "[ffi][decode_next_message]") {
+    string message;
+    uint64_t ts;
+    std::vector<int8_t> ir_buf;
+    std::string logtype;
+    std::vector<std::string> reference_messages;
+    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
+    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+    const std::string time_zone_id = "Asia/Tokyo";
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf));
+
+
+    // First message:
+    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
+    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
+    reference_messages.push_back(message);
+    reference_timestamps.push_back(ts);
+
+    // Second message:
+    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
+    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
+    reference_messages.push_back(message);
+    reference_timestamps.push_back(ts);
+
+    const size_t encoded_message_end_pos = ir_buf.size();
+    const size_t encoded_message_start_pos = 0;
+    size_t cursor_pos = encoded_message_start_pos;
+
+
+    bool is_four_bytes_encoding;
+    ffi::ir_stream::eight_byte_encoding::TimestampInfo ts_info;
+    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(false == is_four_bytes_encoding);
+
+    // Test if preamble can be properly decoded
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+    REQUIRE(time_zone_id == ts_info.time_zone_id);
+    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+
+    string decoded_message;
+    ffi::epoch_time_ms_t timestamp;
+    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
+        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, decoded_message, timestamp, cursor_pos));
+        REQUIRE(decoded_message == reference_messages[ix]);
+        REQUIRE(timestamp == reference_timestamps[ix]);
+    }
+    REQUIRE(cursor_pos == encoded_message_end_pos);
 }

--- a/components/core/tests/test-ir-encoding_methods.cpp
+++ b/components/core/tests/test-ir-encoding_methods.cpp
@@ -98,7 +98,6 @@ TEST_CASE("decode_next_message", "[ffi][decode_next_message]") {
 
     std::vector<int8_t> ir_buf;
     std::string logtype;
-    ffi::ir_stream::TimestampInfo ts_info;
     ffi::epoch_time_ms_t reference_timestamp = 1234567;
     REQUIRE(true == ffi::ir_stream::eight_byte_encoding::encode_message(reference_timestamp, message, logtype, ir_buf));
     const size_t encoded_message_end_pos = ir_buf.size();
@@ -107,17 +106,17 @@ TEST_CASE("decode_next_message", "[ffi][decode_next_message]") {
     size_t cursor_pos = encoded_message_start_pos;
     string decoded_message;
     ffi::epoch_time_ms_t timestamp;
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, decoded_message, timestamp, cursor_pos));
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
     REQUIRE(cursor_pos == encoded_message_end_pos);
 
     cursor_pos = encoded_message_start_pos + 1;
-    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
+    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
 
     cursor_pos = encoded_message_start_pos;
     ir_buf.resize(encoded_message_end_pos - 4);
-    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
+    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
 }
 
 TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
@@ -126,7 +125,6 @@ TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
 
     std::vector<int8_t> ir_buf;
     std::string logtype;
-    ffi::ir_stream::TimestampInfo ts_info;
     ffi::epoch_time_ms_t reference_timestamp = -5;
     REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_timestamp, message, logtype, ir_buf));
     const size_t encoded_message_end_pos = ir_buf.size();
@@ -135,17 +133,17 @@ TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
     size_t cursor_pos = encoded_message_start_pos;
     string decoded_message;
     ffi::epoch_time_ms_t timestamp;
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ts_info, ir_buf, decoded_message, timestamp, cursor_pos));
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
     REQUIRE(cursor_pos == encoded_message_end_pos);
 
     cursor_pos = encoded_message_start_pos + 1;
-    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
+    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
 
     cursor_pos = encoded_message_start_pos;
     ir_buf.resize(encoded_message_end_pos - 4);
-    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ts_info, ir_buf, message, timestamp, cursor_pos));
+    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
 }
 
 
@@ -195,7 +193,7 @@ TEST_CASE("complete_test", "[ffi][decode_next_message]") {
     string decoded_message;
     ffi::epoch_time_ms_t timestamp;
     for (size_t ix = 0; ix < reference_messages.size(); ix++) {
-        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ts_info, ir_buf, decoded_message, timestamp, cursor_pos));
+        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
         REQUIRE(decoded_message == reference_messages[ix]);
         REQUIRE(timestamp == reference_timestamps[ix]);
     }

--- a/components/core/tests/test-ir-encoding_methods.cpp
+++ b/components/core/tests/test-ir-encoding_methods.cpp
@@ -26,31 +26,33 @@ using std::chrono::system_clock;
 
 TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
 
-    std::vector<int8_t> empty_ir_buf;
-    size_t cursor = 0;
+    const std::vector<int8_t> empty_ir_vec;
+    ffi::ir_stream::IRBuffer empty_ir_buffer(empty_ir_vec.data(), empty_ir_vec.size());
+
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
+    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
 
-    std::vector<int8_t> invalid_ir_buf{0x02,0x43,0x24,0x34};
-    cursor = 0;
-    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+    const std::vector<int8_t> invalid_ir_vec{0x02,0x43,0x24,0x34};
+    ffi::ir_stream::IRBuffer invalid_ir_buffer(invalid_ir_vec.data(), invalid_ir_vec.size());
 
-    std::vector<int8_t> ir_buf;
-    ir_buf.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
-    memcpy(ir_buf.data(), ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
-    cursor = 0;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+
+    // Test eight bytes encoding
+    std::vector<int8_t> eight_byte_encoding_vec;
+    eight_byte_encoding_vec.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
+    memcpy(eight_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
+
+    ffi::ir_stream::IRBuffer eight_byte_ir_buffer(eight_byte_encoding_vec.data(), eight_byte_encoding_vec.size());
+    REQUIRE(ffi::ir_stream::get_encoding_type(eight_byte_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(false == is_four_bytes_encoding);
 
-    memcpy(ir_buf.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
-    cursor = 0;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(is_four_bytes_encoding);
 
-    // add some random values
-    ir_buf.push_back(0x04);
-    cursor = 0;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    std::vector<int8_t> four_byte_encoding_vec;
+    four_byte_encoding_vec.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
+    memcpy(four_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
+
+    ffi::ir_stream::IRBuffer four_byte_ir_buffer(four_byte_encoding_vec.data(), four_byte_encoding_vec.size());
+    REQUIRE(ffi::ir_stream::get_encoding_type(four_byte_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(is_four_bytes_encoding);
 }
 
@@ -67,71 +69,75 @@ TEST_CASE("decode_preamble-8bytes", "[ffi][check_encoding_type]") {
     ir_buf.push_back(0x34);
 
     ffi::ir_stream::TimestampInfo ts_info;
-    size_t cursor_pos = 0;
+    ffi::ir_stream::IRBuffer eight_bytes_preamble_buffer(ir_buf.data(), ir_buf.size());
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(ffi::ir_stream::get_encoding_type(eight_bytes_preamble_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
     REQUIRE(false == is_four_bytes_encoding);
-    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == cursor_pos);
+    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == eight_bytes_preamble_buffer.cursor_pos);
 
     // Test if preamble can be properly decoded
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(eight_bytes_preamble_buffer, ts_info) == IR_ErrorCode::ErrorCode_Success);
 
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-    REQUIRE(encoded_preamble_end_pos == cursor_pos);
+    REQUIRE(encoded_preamble_end_pos == eight_bytes_preamble_buffer.cursor_pos);
 
     // Test if incomplete IR can be detected.
     ir_buf.resize(encoded_preamble_end_pos - 1);
-    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_InComplete_IR);
+    ffi::ir_stream::IRBuffer incomplete_preamble_buffer (ir_buf.data(), ir_buf.size());
+    incomplete_preamble_buffer.cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(incomplete_preamble_buffer, ts_info) == IR_ErrorCode::ErrorCode_InComplete_IR);
 
     // Test if corrupted IR can be detected.
     ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
-    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+    ffi::ir_stream::IRBuffer corrupted_preamble_buffer (ir_buf.data(), ir_buf.size());
+    incomplete_preamble_buffer.cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+
+    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(corrupted_preamble_buffer, ts_info) == IR_ErrorCode::ErrorCode_Corrupted_IR);
 }
 
-TEST_CASE("decode_preamble-4bytes", "[ffi][check_encoding_type]") {
-
-    string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
-
-    std::vector<int8_t> ir_buf;
-    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-    const std::string time_zone_id = "Asia/Tokyo";
-    const ffi::epoch_time_ms_t reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_ts, ir_buf));
-    const size_t encoded_preamble_end_pos = ir_buf.size();
-    ir_buf.push_back(0x34);
-
-    ffi::ir_stream::TimestampInfo ts_info;
-    ffi::epoch_time_ms_t decoded_ts;
-    size_t cursor_pos = 0;
-    bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(true == is_four_bytes_encoding);
-    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == cursor_pos);
-
-    // Test if preamble can be properly decoded
-    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Success);
-
-    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
-    REQUIRE(time_zone_id == ts_info.time_zone_id);
-    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-    REQUIRE(reference_ts == decoded_ts);
-    REQUIRE(encoded_preamble_end_pos == cursor_pos);
-
-    // Test if incomplete IR can be detected.
-    ir_buf.resize(encoded_preamble_end_pos - 1);
-    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_InComplete_IR);
-
-    // Test if corrupted IR can be detected.
-    ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
-    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
-    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Corrupted_IR);
-}
+//TEST_CASE("decode_preamble-4bytes", "[ffi][check_encoding_type]") {
+//
+//    string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
+//
+//    std::vector<int8_t> ir_buf;
+//    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+//    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+//    const std::string time_zone_id = "Asia/Tokyo";
+//    const ffi::epoch_time_ms_t reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+//    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_ts, ir_buf));
+//    const size_t encoded_preamble_end_pos = ir_buf.size();
+//    ir_buf.push_back(0x34);
+//
+//    ffi::ir_stream::TimestampInfo ts_info;
+//    ffi::epoch_time_ms_t decoded_ts;
+//    size_t cursor_pos = 0;
+//    bool is_four_bytes_encoding;
+//    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+//    REQUIRE(true == is_four_bytes_encoding);
+//    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == cursor_pos);
+//
+//    // Test if preamble can be properly decoded
+//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Success);
+//
+//    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+//    REQUIRE(time_zone_id == ts_info.time_zone_id);
+//    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+//    REQUIRE(reference_ts == decoded_ts);
+//    REQUIRE(encoded_preamble_end_pos == cursor_pos);
+//
+//    // Test if incomplete IR can be detected.
+//    ir_buf.resize(encoded_preamble_end_pos - 1);
+//    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_InComplete_IR);
+//
+//    // Test if corrupted IR can be detected.
+//    ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
+//    cursor_pos = ffi::ir_stream::cProtocol::MagicNumberLength;
+//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, decoded_ts) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+//}
 
 TEST_CASE("decode_next_message-8bytes", "[ffi][decode_next_message]") {
 
@@ -144,166 +150,167 @@ TEST_CASE("decode_next_message-8bytes", "[ffi][decode_next_message]") {
     const size_t encoded_message_end_pos = ir_buf.size();
     const size_t encoded_message_start_pos = 0;
 
-    size_t cursor_pos = encoded_message_start_pos;
     string decoded_message;
     ffi::epoch_time_ms_t timestamp;
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
+    ffi::ir_stream::IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
+
+    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(encoded_message_buffer, decoded_message, timestamp));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
-    REQUIRE(cursor_pos == encoded_message_end_pos);
+    REQUIRE(encoded_message_buffer.cursor_pos == encoded_message_end_pos);
 
-    cursor_pos = encoded_message_start_pos + 1;
-    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
+    encoded_message_buffer.cursor_pos = encoded_message_start_pos + 1;
+    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(encoded_message_buffer, message, timestamp));
 
-    cursor_pos = encoded_message_start_pos;
     ir_buf.resize(encoded_message_end_pos - 4);
-    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message, timestamp, cursor_pos));
+    ffi::ir_stream::IRBuffer incomplete_message_buffer(ir_buf.data(), ir_buf.size());
+    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::eight_byte_encoding::decode_next_message(incomplete_message_buffer, message, timestamp));
 }
 
-TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
-
-    string message = "Static <\text>, dictVar1, 123, 456345232.7234223, dictVar2, 987, 654.3, end of static text";
-
-    std::vector<int8_t> ir_buf;
-    std::string logtype;
-    // ensure that decoder can handle negative ts_delta
-    ffi::epoch_time_ms_t reference_delta_ts_negative = -5;
-    ffi::epoch_time_ms_t reference_delta_ts = 23453;
-    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts_negative, message, logtype, ir_buf));
-    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts, message, logtype, ir_buf));
-    const size_t encoded_message_end_pos = ir_buf.size();
-    const size_t encoded_message_start_pos = 0;
-
-    size_t cursor_pos = encoded_message_start_pos;
-    string decoded_message;
-    ffi::epoch_time_ms_t delta_ts;
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
-    REQUIRE(message == decoded_message);
-    REQUIRE(delta_ts == reference_delta_ts_negative);
-
-    size_t first_msg_end_pos = cursor_pos;
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
-    REQUIRE(delta_ts == reference_delta_ts);
-    REQUIRE(cursor_pos == encoded_message_end_pos);
-
-
-    cursor_pos = encoded_message_start_pos + 1;
-    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
-
-    cursor_pos = first_msg_end_pos;
-    ir_buf.resize(encoded_message_end_pos - 4);
-    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
-}
-
-TEST_CASE("complete_test-8bytes", "[ffi][decode_next_message]") {
-    string message;
-    ffi::epoch_time_ms_t ts;
-    std::vector<int8_t> ir_buf;
-    std::string logtype;
-    std::vector<std::string> reference_messages;
-    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
-    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-    const std::string time_zone_id = "Asia/Tokyo";
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf));
-
-
-    // First message:
-    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
-    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
-    reference_messages.push_back(message);
-    reference_timestamps.push_back(ts);
-
-    // Second message:
-    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
-    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
-    reference_messages.push_back(message);
-    reference_timestamps.push_back(ts);
-
-    const size_t encoded_message_end_pos = ir_buf.size();
-    const size_t encoded_message_start_pos = 0;
-    size_t cursor_pos = encoded_message_start_pos;
-
-
-    bool is_four_bytes_encoding;
-    ffi::ir_stream::TimestampInfo ts_info;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(false == is_four_bytes_encoding);
-
-    // Test if preamble can be properly decoded
-    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
-    REQUIRE(time_zone_id == ts_info.time_zone_id);
-    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-
-    string decoded_message;
-    ffi::epoch_time_ms_t timestamp;
-    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
-        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
-        REQUIRE(decoded_message == reference_messages[ix]);
-        REQUIRE(timestamp == reference_timestamps[ix]);
-    }
-    REQUIRE(cursor_pos == encoded_message_end_pos);
-}
-
-TEST_CASE("complete_test-4bytes", "[ffi][decode_next_message]") {
-    string message;
-    ffi::epoch_time_ms_t ts;
-    ffi::epoch_time_ms_t ts_delta;
-    std::vector<int8_t> ir_buf;
-    std::string logtype;
-    std::vector<std::string> reference_messages;
-    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
-    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-    const std::string time_zone_id = "Asia/Tokyo";
-    const ffi::epoch_time_ms_t base_reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-
-    ts = base_reference_ts;
-    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, base_reference_ts, ir_buf));
-
-
-    // First message:
-    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
-    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
-    ts += ts_delta;
-    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
-    reference_messages.push_back(message);
-    reference_timestamps.push_back(ts_delta);
-
-    // Second message:
-    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
-    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
-    ts += ts_delta;
-    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
-    reference_messages.push_back(message);
-    reference_timestamps.push_back(ts_delta);
-
-    const size_t encoded_message_end_pos = ir_buf.size();
-    const size_t encoded_message_start_pos = 0;
-    size_t cursor_pos = encoded_message_start_pos;
-
-
-    bool is_four_bytes_encoding;
-    ffi::ir_stream::TimestampInfo ts_info;
-    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(true == is_four_bytes_encoding);
-
-    // Test if preamble can be properly decoded
-    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, ts) == IR_ErrorCode::ErrorCode_Success);
-    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
-    REQUIRE(time_zone_id == ts_info.time_zone_id);
-    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-    REQUIRE(base_reference_ts == ts);
-
-    string decoded_message;
-    ffi::epoch_time_ms_t timestamp;
-    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
-        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
-        REQUIRE(decoded_message == reference_messages[ix]);
-        REQUIRE(timestamp == reference_timestamps[ix]);
-    }
-    REQUIRE(cursor_pos == encoded_message_end_pos);
-}
+//TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
+//
+//    string message = "Static <\text>, dictVar1, 123, 456345232.7234223, dictVar2, 987, 654.3, end of static text";
+//
+//    std::vector<int8_t> ir_buf;
+//    std::string logtype;
+//    // ensure that decoder can handle negative ts_delta
+//    ffi::epoch_time_ms_t reference_delta_ts_negative = -5;
+//    ffi::epoch_time_ms_t reference_delta_ts = 23453;
+//    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts_negative, message, logtype, ir_buf));
+//    REQUIRE(true == ffi::ir_stream::four_byte_encoding::encode_message(reference_delta_ts, message, logtype, ir_buf));
+//    const size_t encoded_message_end_pos = ir_buf.size();
+//    const size_t encoded_message_start_pos = 0;
+//
+//    size_t cursor_pos = encoded_message_start_pos;
+//    string decoded_message;
+//    ffi::epoch_time_ms_t delta_ts;
+//    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
+//    REQUIRE(message == decoded_message);
+//    REQUIRE(delta_ts == reference_delta_ts_negative);
+//
+//    size_t first_msg_end_pos = cursor_pos;
+//    REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, delta_ts, cursor_pos));
+//    REQUIRE(delta_ts == reference_delta_ts);
+//    REQUIRE(cursor_pos == encoded_message_end_pos);
+//
+//
+//    cursor_pos = encoded_message_start_pos + 1;
+//    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
+//
+//    cursor_pos = first_msg_end_pos;
+//    ir_buf.resize(encoded_message_end_pos - 4);
+//    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, delta_ts, cursor_pos));
+//}
+//
+//TEST_CASE("complete_test-8bytes", "[ffi][decode_next_message]") {
+//    string message;
+//    ffi::epoch_time_ms_t ts;
+//    std::vector<int8_t> ir_buf;
+//    std::string logtype;
+//    std::vector<std::string> reference_messages;
+//    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
+//    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+//    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+//    const std::string time_zone_id = "Asia/Tokyo";
+//    REQUIRE(ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf));
+//
+//
+//    // First message:
+//    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
+//    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+//    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
+//    reference_messages.push_back(message);
+//    reference_timestamps.push_back(ts);
+//
+//    // Second message:
+//    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
+//    ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+//    ffi::ir_stream::eight_byte_encoding::encode_message(ts, message, logtype, ir_buf);
+//    reference_messages.push_back(message);
+//    reference_timestamps.push_back(ts);
+//
+//    const size_t encoded_message_end_pos = ir_buf.size();
+//    const size_t encoded_message_start_pos = 0;
+//    size_t cursor_pos = encoded_message_start_pos;
+//
+//
+//    bool is_four_bytes_encoding;
+//    ffi::ir_stream::TimestampInfo ts_info;
+//    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+//    REQUIRE(false == is_four_bytes_encoding);
+//
+//    // Test if preamble can be properly decoded
+//    REQUIRE(ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos) == IR_ErrorCode::ErrorCode_Success);
+//    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+//    REQUIRE(time_zone_id == ts_info.time_zone_id);
+//    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+//
+//    string decoded_message;
+//    ffi::epoch_time_ms_t timestamp;
+//    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
+//        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
+//        REQUIRE(decoded_message == reference_messages[ix]);
+//        REQUIRE(timestamp == reference_timestamps[ix]);
+//    }
+//    REQUIRE(cursor_pos == encoded_message_end_pos);
+//}
+//
+//TEST_CASE("complete_test-4bytes", "[ffi][decode_next_message]") {
+//    string message;
+//    ffi::epoch_time_ms_t ts;
+//    ffi::epoch_time_ms_t ts_delta;
+//    std::vector<int8_t> ir_buf;
+//    std::string logtype;
+//    std::vector<std::string> reference_messages;
+//    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
+//    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+//    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+//    const std::string time_zone_id = "Asia/Tokyo";
+//    const ffi::epoch_time_ms_t base_reference_ts = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+//
+//    ts = base_reference_ts;
+//    REQUIRE(ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, base_reference_ts, ir_buf));
+//
+//
+//    // First message:
+//    message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
+//    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
+//    ts += ts_delta;
+//    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
+//    reference_messages.push_back(message);
+//    reference_timestamps.push_back(ts_delta);
+//
+//    // Second message:
+//    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
+//    ts_delta = std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - ts;
+//    ts += ts_delta;
+//    ffi::ir_stream::four_byte_encoding::encode_message(ts_delta, message, logtype, ir_buf);
+//    reference_messages.push_back(message);
+//    reference_timestamps.push_back(ts_delta);
+//
+//    const size_t encoded_message_end_pos = ir_buf.size();
+//    const size_t encoded_message_start_pos = 0;
+//    size_t cursor_pos = encoded_message_start_pos;
+//
+//
+//    bool is_four_bytes_encoding;
+//    ffi::ir_stream::TimestampInfo ts_info;
+//    REQUIRE(ffi::ir_stream::get_encoding_type(ir_buf, cursor_pos, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+//    REQUIRE(true == is_four_bytes_encoding);
+//
+//    // Test if preamble can be properly decoded
+//    REQUIRE(ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, cursor_pos, ts) == IR_ErrorCode::ErrorCode_Success);
+//    REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
+//    REQUIRE(time_zone_id == ts_info.time_zone_id);
+//    REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
+//    REQUIRE(base_reference_ts == ts);
+//
+//    string decoded_message;
+//    ffi::epoch_time_ms_t timestamp;
+//    for (size_t ix = 0; ix < reference_messages.size(); ix++) {
+//        REQUIRE(ffi::ir_stream::ErrorCode_Success == ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, decoded_message, timestamp, cursor_pos));
+//        REQUIRE(decoded_message == reference_messages[ix]);
+//        REQUIRE(timestamp == reference_timestamps[ix]);
+//    }
+//    REQUIRE(cursor_pos == encoded_message_end_pos);
+//}

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -20,16 +20,17 @@ using ffi::VariablePlaceholder;
 using ffi::wildcard_query_matches_any_encoded_var;
 using std::string;
 using std::vector;
-using ffi::ir_stream::IR_ErrorCode;
+using ffi::ir_stream::IRErrorCode;
 using std::chrono::milliseconds;
 using std::chrono::system_clock;
 
-static ffi::epoch_time_ms_t get_current_ts() {
-    return std::chrono::duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+static ffi::epoch_time_ms_t get_current_ts () {
+    return std::chrono::duration_cast<milliseconds>(
+            system_clock::now().time_since_epoch()).count();
 }
 
 template <typename encoded_variable_t>
-bool match_encoding_type(bool is_four_bytes_encoding) {
+bool match_encoding_type (bool is_four_bytes_encoding) {
     static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                   std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
@@ -41,7 +42,7 @@ bool match_encoding_type(bool is_four_bytes_encoding) {
 }
 
 template <typename encoded_variable_t>
-ffi::epoch_time_ms_t get_next_timestamp_for_test() {
+ffi::epoch_time_ms_t get_next_timestamp_for_test () {
     static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                   std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
@@ -58,25 +59,29 @@ ffi::epoch_time_ms_t get_next_timestamp_for_test() {
 // A helper function to generalize the testing caller interface.
 // The reference_timestamp is only used by four bytes encoding
 template <typename encoded_variable_t>
-bool encode_preamble(std::string_view timestamp_pattern, std::string_view timestamp_pattern_syntax,
-                     std::string_view time_zone_id, ffi::epoch_time_ms_t reference_timestamp,
-                     std::vector<int8_t>& ir_buf)
-{
+bool
+encode_preamble (std::string_view timestamp_pattern, std::string_view timestamp_pattern_syntax,
+                 std::string_view time_zone_id, ffi::epoch_time_ms_t reference_timestamp,
+                 std::vector<int8_t>& ir_buf) {
     static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                   std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-        return ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buf);
+        return ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern,
+                                                                    timestamp_pattern_syntax,
+                                                                    time_zone_id, ir_buf);
     } else {
-        return ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_timestamp, ir_buf);
+        return ffi::ir_stream::four_byte_encoding::encode_preamble(timestamp_pattern,
+                                                                   timestamp_pattern_syntax,
+                                                                   time_zone_id,
+                                                                   reference_timestamp, ir_buf);
     }
 }
 
 template <typename encoded_variable_t>
-IR_ErrorCode decode_preamble(ffi::ir_stream::IRBuffer& ir_buf,
+IRErrorCode decode_preamble (ffi::ir_stream::IRBuffer& ir_buf,
                              ffi::ir_stream::TimestampInfo& ts_info,
-                             ffi::epoch_time_ms_t& reference_ts)
-{
+                             ffi::epoch_time_ms_t& reference_ts) {
     static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                   std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
@@ -88,31 +93,33 @@ IR_ErrorCode decode_preamble(ffi::ir_stream::IRBuffer& ir_buf,
 }
 
 template <typename encoded_variable_t>
-bool encode_message(ffi::epoch_time_ms_t timestamp, std::string_view message, string& logtype,
-                            vector<int8_t>& ir_buf)
-{
+bool encode_message (ffi::epoch_time_ms_t timestamp, std::string_view message, string& logtype,
+                     vector<int8_t>& ir_buf) {
     static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                   std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-        return ffi::ir_stream::eight_byte_encoding::encode_message(timestamp, message, logtype, ir_buf);
+        return ffi::ir_stream::eight_byte_encoding::encode_message(timestamp, message, logtype,
+                                                                   ir_buf);
     } else {
-        return ffi::ir_stream::four_byte_encoding::encode_message(timestamp, message, logtype, ir_buf);
+        return ffi::ir_stream::four_byte_encoding::encode_message(timestamp, message, logtype,
+                                                                  ir_buf);
     }
 }
 
 template <typename encoded_variable_t>
-IR_ErrorCode decode_next_message(ffi::ir_stream::IRBuffer& ir_buf,
+IRErrorCode decode_next_message (ffi::ir_stream::IRBuffer& ir_buf,
                                  std::string& message,
-                                 ffi::epoch_time_ms_t& decoded_ts)
-{
+                                 ffi::epoch_time_ms_t& decoded_ts) {
     static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
                   std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-        return ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message, decoded_ts);
+        return ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message,
+                                                                        decoded_ts);
     } else {
-        return ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message, decoded_ts);
+        return ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message,
+                                                                       decoded_ts);
     }
 }
 
@@ -123,38 +130,49 @@ TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
     // Test eight bytes encoding
     std::vector<int8_t> eight_byte_encoding_vec;
     eight_byte_encoding_vec.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
-    memcpy(eight_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
+    memcpy(eight_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber,
+           ffi::ir_stream::cProtocol::MagicNumberLength);
 
-    ffi::ir_stream::IRBuffer eight_byte_ir_buffer(eight_byte_encoding_vec.data(), eight_byte_encoding_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(eight_byte_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    ffi::ir_stream::IRBuffer eight_byte_ir_buffer(eight_byte_encoding_vec.data(),
+                                                  eight_byte_encoding_vec.size());
+    REQUIRE(ffi::ir_stream::get_encoding_type(eight_byte_ir_buffer, is_four_bytes_encoding) ==
+            IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<eight_byte_encoded_variable_t>);
 
 
     // Test four bytes encoding
     std::vector<int8_t> four_byte_encoding_vec;
     four_byte_encoding_vec.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
-    memcpy(four_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber, ffi::ir_stream::cProtocol::MagicNumberLength);
+    memcpy(four_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber,
+           ffi::ir_stream::cProtocol::MagicNumberLength);
 
-    ffi::ir_stream::IRBuffer four_byte_ir_buffer(four_byte_encoding_vec.data(), four_byte_encoding_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(four_byte_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    ffi::ir_stream::IRBuffer four_byte_ir_buffer(four_byte_encoding_vec.data(),
+                                                 four_byte_encoding_vec.size());
+    REQUIRE(ffi::ir_stream::get_encoding_type(four_byte_ir_buffer, is_four_bytes_encoding) ==
+            IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<four_byte_encoded_variable_t>);
 
     // Test error on empty and incomplete ir_buffer
     const std::vector<int8_t> empty_ir_vec;
     ffi::ir_stream::IRBuffer empty_ir_buffer(empty_ir_vec.data(), empty_ir_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
+    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buffer, is_four_bytes_encoding) ==
+            IRErrorCode::IRErrorCode_InComplete_IR);
 
-    ffi::ir_stream::IRBuffer incomplete_ir_buffer(four_byte_encoding_vec.data(), four_byte_encoding_vec.size() - 1);
-    REQUIRE(ffi::ir_stream::get_encoding_type(incomplete_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_InComplete_IR);
+    ffi::ir_stream::IRBuffer incomplete_ir_buffer(four_byte_encoding_vec.data(),
+                                                  four_byte_encoding_vec.size() - 1);
+    REQUIRE(ffi::ir_stream::get_encoding_type(incomplete_ir_buffer, is_four_bytes_encoding) ==
+            IRErrorCode::IRErrorCode_InComplete_IR);
 
     // Test error on invalid encoding.
-    const std::vector<int8_t> invalid_ir_vec{0x02,0x43,0x24,0x34};
+    const std::vector<int8_t> invalid_ir_vec{0x02, 0x43, 0x24, 0x34};
     ffi::ir_stream::IRBuffer invalid_ir_buffer(invalid_ir_vec.data(), invalid_ir_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding) ==
+            IRErrorCode::IRErrorCode_Corrupted_IR);
 
 }
 
-TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]", four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
+TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]",
+                   four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
 
     string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
 
@@ -163,7 +181,8 @@ TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]", four_byt
     const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
     const std::string time_zone_id = "Asia/Tokyo";
     const ffi::epoch_time_ms_t reference_ts = get_current_ts();
-    REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, reference_ts, ir_buf));
+    REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id,
+                                      reference_ts, ir_buf));
     const size_t encoded_preamble_end_pos = ir_buf.size();
 
     // Check if encoding type is propely readed.
@@ -171,37 +190,43 @@ TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]", four_byt
     ffi::ir_stream::IRBuffer preamble_buffer(ir_buf.data(), ir_buf.size());
     ffi::epoch_time_ms_t decoded_ts;
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(preamble_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(ffi::ir_stream::get_encoding_type(preamble_buffer, is_four_bytes_encoding) ==
+            IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<TestType>(is_four_bytes_encoding));
-    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == preamble_buffer.cursor_pos());
+    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == preamble_buffer.get_cursor_pos());
 
     // Test if preamble can be decoded correctly
-    REQUIRE(decode_preamble<TestType>(preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(decode_preamble<TestType>(preamble_buffer, ts_info, decoded_ts) ==
+            IRErrorCode::IRErrorCode_Success);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-    REQUIRE(encoded_preamble_end_pos == preamble_buffer.cursor_pos());
+    REQUIRE(encoded_preamble_end_pos == preamble_buffer.get_cursor_pos());
     if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
         REQUIRE(reference_ts == decoded_ts);
     }
 
     // Test if incomplete IR can be detected.
     ir_buf.resize(encoded_preamble_end_pos - 1);
-    ffi::ir_stream::IRBuffer incomplete_preamble_buffer (ir_buf.data(), ir_buf.size());
+    ffi::ir_stream::IRBuffer incomplete_preamble_buffer(ir_buf.data(), ir_buf.size());
     incomplete_preamble_buffer.set_cursor_pos(ffi::ir_stream::cProtocol::MagicNumberLength);
-    REQUIRE(decode_preamble<TestType>(incomplete_preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_InComplete_IR);
+    REQUIRE(decode_preamble<TestType>(incomplete_preamble_buffer, ts_info, decoded_ts) ==
+            IRErrorCode::IRErrorCode_InComplete_IR);
 
     // Test if corrupted IR can be detected.
     ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
-    ffi::ir_stream::IRBuffer corrupted_preamble_buffer (ir_buf.data(), ir_buf.size());
+    ffi::ir_stream::IRBuffer corrupted_preamble_buffer(ir_buf.data(), ir_buf.size());
     incomplete_preamble_buffer.set_cursor_pos(ffi::ir_stream::cProtocol::MagicNumberLength);
-    REQUIRE(decode_preamble<TestType>(corrupted_preamble_buffer, ts_info, decoded_ts) == IR_ErrorCode::ErrorCode_Corrupted_IR);
+    REQUIRE(decode_preamble<TestType>(corrupted_preamble_buffer, ts_info, decoded_ts) ==
+            IRErrorCode::IRErrorCode_Corrupted_IR);
 }
 
 
-TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]", four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
+TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]",
+                   four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
 
-    string message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
+    string message = "Static <\text>, dictVar1, 123, 456.7, "
+                     "dictVar2, 987, 654.3, end of static text";
 
     std::vector<int8_t> ir_buf;
     std::string logtype;
@@ -214,37 +239,46 @@ TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]", 
     ffi::epoch_time_ms_t timestamp;
     ffi::ir_stream::IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
 
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == decode_next_message<TestType>(encoded_message_buffer, decoded_message, timestamp));
+    REQUIRE(ffi::ir_stream::IRErrorCode_Success ==
+            decode_next_message<TestType>(encoded_message_buffer, decoded_message, timestamp));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
-    REQUIRE(encoded_message_buffer.cursor_pos() == encoded_message_end_pos);
+    REQUIRE(encoded_message_buffer.get_cursor_pos() == encoded_message_end_pos);
 
     encoded_message_buffer.set_cursor_pos(encoded_message_start_pos + 1);
-    REQUIRE(ffi::ir_stream::ErrorCode_Corrupted_IR == decode_next_message<TestType>(encoded_message_buffer, message, timestamp));
+    REQUIRE(ffi::ir_stream::IRErrorCode_Corrupted_IR ==
+            decode_next_message<TestType>(encoded_message_buffer, message, timestamp));
 
     ir_buf.resize(encoded_message_end_pos - 4);
     ffi::ir_stream::IRBuffer incomplete_message_buffer(ir_buf.data(), ir_buf.size());
-    REQUIRE(ffi::ir_stream::ErrorCode_InComplete_IR == decode_next_message<TestType>(incomplete_message_buffer, message, timestamp));
+    REQUIRE(ffi::ir_stream::IRErrorCode_InComplete_IR ==
+            decode_next_message<TestType>(incomplete_message_buffer, message, timestamp));
 }
 
 // Corner case for 4-bytes encoding
 TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
-    string message = "Static <\text>, dictVar1, 123, 456345232.7234223, dictVar2, 987, 654.3, end of static text";
+    string message = "Static <\text>, dictVar1, 123, 456345232.7234223, "
+                     "dictVar2, 987, 654.3, end of static text";
     std::vector<int8_t> ir_buf;
     std::string logtype;
     // ensure that decoder can handle negative ts_delta
     ffi::epoch_time_ms_t reference_delta_ts_negative = -5;
-    REQUIRE(true == encode_message<four_byte_encoded_variable_t>(reference_delta_ts_negative, message, logtype, ir_buf));
+    REQUIRE(true ==
+            encode_message<four_byte_encoded_variable_t>(reference_delta_ts_negative, message,
+                                                         logtype, ir_buf));
 
     ffi::ir_stream::IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
     string decoded_message;
     ffi::epoch_time_ms_t delta_ts;
-    REQUIRE(ffi::ir_stream::ErrorCode_Success == decode_next_message<four_byte_encoded_variable_t>(encoded_message_buffer, decoded_message, delta_ts));
+    REQUIRE(ffi::ir_stream::IRErrorCode_Success ==
+            decode_next_message<four_byte_encoded_variable_t>(encoded_message_buffer,
+                                                              decoded_message, delta_ts));
     REQUIRE(message == decoded_message);
     REQUIRE(delta_ts == reference_delta_ts_negative);
 }
 
-TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]", four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
+TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]",
+                   four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
     string message;
     ffi::epoch_time_ms_t ts;
     ffi::epoch_time_ms_t preamble_ts = get_current_ts();
@@ -256,7 +290,8 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]", four_byte
     const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
     const std::string time_zone_id = "Asia/Tokyo";
 
-    REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id, preamble_ts, ir_buf));
+    REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id,
+                                      preamble_ts, ir_buf));
 
     // First message:
     message = "Static <\text>, dictVar1, 123, 456.7, dictVar2, 987, 654.3, end of static text";
@@ -266,7 +301,8 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]", four_byte
     reference_timestamps.push_back(ts);
 
     // Second message:
-    message = "Static <\text>, dictVar3, 355.2352512, 23953324532112, python3.4.6, end of static text";
+    message = "Static <\text>, dictVar3, 355.2352512, "
+              "23953324532112, python3.4.6, end of static text";
     ts = get_next_timestamp_for_test<TestType>();
     REQUIRE(encode_message<TestType>(ts, message, logtype, ir_buf));
     reference_messages.push_back(message);
@@ -280,11 +316,13 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]", four_byte
 
     bool is_four_bytes_encoding;
     ffi::ir_stream::TimestampInfo ts_info;
-    REQUIRE(ffi::ir_stream::get_encoding_type(complete_encoding_buffer, is_four_bytes_encoding) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(ffi::ir_stream::get_encoding_type(complete_encoding_buffer, is_four_bytes_encoding) ==
+            IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<TestType>(is_four_bytes_encoding));
 
     // Test if preamble can be properly decoded
-    REQUIRE(decode_preamble<TestType>(complete_encoding_buffer, ts_info, preamble_ts) == IR_ErrorCode::ErrorCode_Success);
+    REQUIRE(decode_preamble<TestType>(complete_encoding_buffer, ts_info, preamble_ts) ==
+            IRErrorCode::IRErrorCode_Success);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
@@ -292,9 +330,11 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]", four_byte
     string decoded_message;
     ffi::epoch_time_ms_t timestamp;
     for (size_t ix = 0; ix < reference_messages.size(); ix++) {
-        REQUIRE(ffi::ir_stream::ErrorCode_Success == decode_next_message<TestType>(complete_encoding_buffer, decoded_message, timestamp));
+        REQUIRE(ffi::ir_stream::IRErrorCode_Success ==
+                decode_next_message<TestType>(complete_encoding_buffer, decoded_message,
+                                              timestamp));
         REQUIRE(decoded_message == reference_messages[ix]);
         REQUIRE(timestamp == reference_timestamps[ix]);
     }
-    REQUIRE(complete_encoding_buffer.cursor_pos() == encoded_message_end_pos);
+    REQUIRE(complete_encoding_buffer.get_cursor_pos() == encoded_message_end_pos);
 }

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -15,26 +15,35 @@ using ffi::four_byte_encoded_variable_t;
 using ffi::encode_float_string;
 using ffi::encode_integer_string;
 using ffi::encode_message;
+using ffi::epoch_time_ms_t;
 using ffi::get_bounds_of_next_var;
 using ffi::VariablePlaceholder;
 using ffi::wildcard_query_matches_any_encoded_var;
-using std::string;
-using std::vector;
+using ffi::ir_stream::get_encoding_type;
+using ffi::ir_stream::IRBuffer;
 using ffi::ir_stream::IRErrorCode;
+using ffi::ir_stream::TimestampInfo;
+using ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber;
+using ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber;
+using ffi::ir_stream::cProtocol::MagicNumberLength;
+using std::chrono::duration_cast;
 using std::chrono::milliseconds;
 using std::chrono::system_clock;
+using std::is_same_v;
+using std::string;
+using std::string_view;
+using std::vector;
 
-static ffi::epoch_time_ms_t get_current_ts () {
-    return std::chrono::duration_cast<milliseconds>(
-            system_clock::now().time_since_epoch()).count();
+static epoch_time_ms_t get_current_ts () {
+    return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
 
 template <typename encoded_variable_t>
 bool match_encoding_type (bool is_four_bytes_encoding) {
-    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
-    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return false == is_four_bytes_encoding;
     } else {
         return is_four_bytes_encoding;
@@ -42,16 +51,17 @@ bool match_encoding_type (bool is_four_bytes_encoding) {
 }
 
 template <typename encoded_variable_t>
-ffi::epoch_time_ms_t get_next_timestamp_for_test () {
-    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+epoch_time_ms_t get_next_timestamp_for_test () {
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
-    // we return complete timestamp for 8-bytes encoding and a faked-up delta_ts for 4-bytes encoding
-    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+    // we return complete timestamp for 8-bytes encoding and
+    // a faked-up delta_ts for 4-bytes encoding
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return get_current_ts();
     } else {
-        ffi::epoch_time_ms_t ts1 = get_current_ts();
-        ffi::epoch_time_ms_t ts2 = get_current_ts();
+        epoch_time_ms_t ts1 = get_current_ts();
+        epoch_time_ms_t ts2 = get_current_ts();
         return ts2 - ts1;
     }
 }
@@ -59,14 +69,13 @@ ffi::epoch_time_ms_t get_next_timestamp_for_test () {
 // A helper function to generalize the testing caller interface.
 // The reference_timestamp is only used by four bytes encoding
 template <typename encoded_variable_t>
-bool encode_preamble (std::string_view timestamp_pattern,
-                      std::string_view timestamp_pattern_syntax, std::string_view time_zone_id,
-                      ffi::epoch_time_ms_t reference_timestamp, std::vector<int8_t>& ir_buf)
-{
-    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+bool encode_preamble (string_view timestamp_pattern,
+                      string_view timestamp_pattern_syntax, string_view time_zone_id,
+                      epoch_time_ms_t reference_timestamp, vector<int8_t>& ir_buf) {
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
-    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::encode_preamble(timestamp_pattern,
                                                                     timestamp_pattern_syntax,
                                                                     time_zone_id, ir_buf);
@@ -79,13 +88,13 @@ bool encode_preamble (std::string_view timestamp_pattern,
 }
 
 template <typename encoded_variable_t>
-IRErrorCode decode_preamble (ffi::ir_stream::IRBuffer& ir_buf,
-                             ffi::ir_stream::TimestampInfo& ts_info,
-                             ffi::epoch_time_ms_t& reference_ts) {
-    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+IRErrorCode decode_preamble (IRBuffer& ir_buf,
+                             TimestampInfo& ts_info,
+                             epoch_time_ms_t& reference_ts) {
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
-    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info);
     } else {
         return ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, reference_ts);
@@ -93,12 +102,12 @@ IRErrorCode decode_preamble (ffi::ir_stream::IRBuffer& ir_buf,
 }
 
 template <typename encoded_variable_t>
-bool encode_message (ffi::epoch_time_ms_t timestamp, std::string_view message, string& logtype,
+bool encode_message (epoch_time_ms_t timestamp, string_view message, string& logtype,
                      vector<int8_t>& ir_buf) {
-    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
-    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::encode_message(timestamp, message, logtype,
                                                                    ir_buf);
     } else {
@@ -108,13 +117,13 @@ bool encode_message (ffi::epoch_time_ms_t timestamp, std::string_view message, s
 }
 
 template <typename encoded_variable_t>
-IRErrorCode decode_next_message (ffi::ir_stream::IRBuffer& ir_buf,
-                                 std::string& message,
-                                 ffi::epoch_time_ms_t& decoded_ts) {
-    static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+IRErrorCode decode_next_message (IRBuffer& ir_buf,
+                                 string& message,
+                                 epoch_time_ms_t& decoded_ts) {
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
+                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
-    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::decode_next_message(ir_buf, message,
                                                                         decoded_ts);
     } else {
@@ -127,44 +136,40 @@ TEST_CASE("check_encoding_type", "[ffi][check_encoding_type]") {
     bool is_four_bytes_encoding;
 
     // Test eight-byte encoding
-    std::vector<int8_t> eight_byte_encoding_vec;
-    eight_byte_encoding_vec.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
-    memcpy(eight_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::EightByteEncodingMagicNumber,
-           ffi::ir_stream::cProtocol::MagicNumberLength);
+    vector<int8_t> eight_byte_encoding_vec{EightByteEncodingMagicNumber,
+                                           EightByteEncodingMagicNumber + MagicNumberLength};
 
-    ffi::ir_stream::IRBuffer eight_byte_ir_buffer(eight_byte_encoding_vec.data(),
-                                                  eight_byte_encoding_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(eight_byte_ir_buffer, is_four_bytes_encoding) ==
+    IRBuffer eight_byte_ir_buffer(eight_byte_encoding_vec.data(),
+                                  eight_byte_encoding_vec.size());
+    REQUIRE(get_encoding_type(eight_byte_ir_buffer, is_four_bytes_encoding) ==
             IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<eight_byte_encoded_variable_t>(is_four_bytes_encoding));
 
     // Test four-byte encoding
-    std::vector<int8_t> four_byte_encoding_vec;
-    four_byte_encoding_vec.resize(ffi::ir_stream::cProtocol::MagicNumberLength);
-    memcpy(four_byte_encoding_vec.data(), ffi::ir_stream::cProtocol::FourByteEncodingMagicNumber,
-           ffi::ir_stream::cProtocol::MagicNumberLength);
+    vector<int8_t> four_byte_encoding_vec{FourByteEncodingMagicNumber,
+                                          FourByteEncodingMagicNumber + MagicNumberLength};
 
-    ffi::ir_stream::IRBuffer four_byte_ir_buffer(four_byte_encoding_vec.data(),
-                                                 four_byte_encoding_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(four_byte_ir_buffer, is_four_bytes_encoding) ==
+    IRBuffer four_byte_ir_buffer(four_byte_encoding_vec.data(),
+                                 four_byte_encoding_vec.size());
+    REQUIRE(get_encoding_type(four_byte_ir_buffer, is_four_bytes_encoding) ==
             IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<four_byte_encoded_variable_t>(is_four_bytes_encoding));
 
     // Test error on empty and incomplete ir_buffer
-    const std::vector<int8_t> empty_ir_vec;
-    ffi::ir_stream::IRBuffer empty_ir_buffer(empty_ir_vec.data(), empty_ir_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(empty_ir_buffer, is_four_bytes_encoding) ==
+    const vector<int8_t> empty_ir_vec;
+    IRBuffer empty_ir_buffer(empty_ir_vec.data(), empty_ir_vec.size());
+    REQUIRE(get_encoding_type(empty_ir_buffer, is_four_bytes_encoding) ==
             IRErrorCode::IRErrorCode_Incomplete_IR);
 
-    ffi::ir_stream::IRBuffer incomplete_ir_buffer(four_byte_encoding_vec.data(),
-                                                  four_byte_encoding_vec.size() - 1);
-    REQUIRE(ffi::ir_stream::get_encoding_type(incomplete_ir_buffer, is_four_bytes_encoding) ==
+    IRBuffer incomplete_ir_buffer(four_byte_encoding_vec.data(),
+                                  four_byte_encoding_vec.size() - 1);
+    REQUIRE(get_encoding_type(incomplete_ir_buffer, is_four_bytes_encoding) ==
             IRErrorCode::IRErrorCode_Incomplete_IR);
 
     // Test error on invalid encoding.
-    const std::vector<int8_t> invalid_ir_vec{0x02, 0x43, 0x24, 0x34};
-    ffi::ir_stream::IRBuffer invalid_ir_buffer(invalid_ir_vec.data(), invalid_ir_vec.size());
-    REQUIRE(ffi::ir_stream::get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding) ==
+    const vector<int8_t> invalid_ir_vec{0x02, 0x43, 0x24, 0x34};
+    IRBuffer invalid_ir_buffer(invalid_ir_vec.data(), invalid_ir_vec.size());
+    REQUIRE(get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding) ==
             IRErrorCode::IRErrorCode_Corrupted_IR);
 
 }
@@ -174,24 +179,24 @@ TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]",
 {
     string message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
 
-    std::vector<int8_t> ir_buf;
-    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-    const std::string time_zone_id = "Asia/Tokyo";
-    const ffi::epoch_time_ms_t reference_ts = get_current_ts();
+    vector<int8_t> ir_buf;
+    const string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+    const string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+    const string time_zone_id = "Asia/Tokyo";
+    const epoch_time_ms_t reference_ts = get_current_ts();
     REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id,
                                       reference_ts, ir_buf));
     const size_t encoded_preamble_end_pos = ir_buf.size();
 
     // Check if encoding type is properly read
-    ffi::ir_stream::TimestampInfo ts_info;
-    ffi::ir_stream::IRBuffer preamble_buffer(ir_buf.data(), ir_buf.size());
-    ffi::epoch_time_ms_t decoded_ts;
+    TimestampInfo ts_info;
+    IRBuffer preamble_buffer(ir_buf.data(), ir_buf.size());
+    epoch_time_ms_t decoded_ts;
     bool is_four_bytes_encoding;
-    REQUIRE(ffi::ir_stream::get_encoding_type(preamble_buffer, is_four_bytes_encoding) ==
+    REQUIRE(get_encoding_type(preamble_buffer, is_four_bytes_encoding) ==
             IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<TestType>(is_four_bytes_encoding));
-    REQUIRE(ffi::ir_stream::cProtocol::MagicNumberLength == preamble_buffer.get_cursor_pos());
+    REQUIRE(MagicNumberLength == preamble_buffer.get_cursor_pos());
 
     // Test if preamble can be decoded correctly
     REQUIRE(decode_preamble<TestType>(preamble_buffer, ts_info, decoded_ts) ==
@@ -200,21 +205,21 @@ TEMPLATE_TEST_CASE("decode_preamble_general", "[ffi][decode_preamble]",
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
     REQUIRE(encoded_preamble_end_pos == preamble_buffer.get_cursor_pos());
-    if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
+    if constexpr (is_same_v<TestType, four_byte_encoded_variable_t>) {
         REQUIRE(reference_ts == decoded_ts);
     }
 
     // Test if incomplete IR can be detected.
     ir_buf.resize(encoded_preamble_end_pos - 1);
-    ffi::ir_stream::IRBuffer incomplete_preamble_buffer(ir_buf.data(), ir_buf.size());
-    incomplete_preamble_buffer.set_cursor_pos(ffi::ir_stream::cProtocol::MagicNumberLength);
+    IRBuffer incomplete_preamble_buffer(ir_buf.data(), ir_buf.size());
+    incomplete_preamble_buffer.set_cursor_pos(MagicNumberLength);
     REQUIRE(decode_preamble<TestType>(incomplete_preamble_buffer, ts_info, decoded_ts) ==
             IRErrorCode::IRErrorCode_Incomplete_IR);
 
     // Test if corrupted IR can be detected.
-    ir_buf.at(ffi::ir_stream::cProtocol::MagicNumberLength) = 0x23;
-    ffi::ir_stream::IRBuffer corrupted_preamble_buffer(ir_buf.data(), ir_buf.size());
-    incomplete_preamble_buffer.set_cursor_pos(ffi::ir_stream::cProtocol::MagicNumberLength);
+    ir_buf.at(MagicNumberLength) = 0x23;
+    IRBuffer corrupted_preamble_buffer(ir_buf.data(), ir_buf.size());
+    incomplete_preamble_buffer.set_cursor_pos(MagicNumberLength);
     REQUIRE(decode_preamble<TestType>(corrupted_preamble_buffer, ts_info, decoded_ts) ==
             IRErrorCode::IRErrorCode_Corrupted_IR);
 }
@@ -225,30 +230,30 @@ TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]",
     string message = "Static <\text>, dictVar1, 123, 456.7, "
                      "dictVar2, 987, 654.3, end of static text";
 
-    std::vector<int8_t> ir_buf;
-    std::string logtype;
-    ffi::epoch_time_ms_t reference_timestamp = get_next_timestamp_for_test<TestType>();
+    vector<int8_t> ir_buf;
+    string logtype;
+    epoch_time_ms_t reference_timestamp = get_next_timestamp_for_test<TestType>();
     REQUIRE(true == encode_message<TestType>(reference_timestamp, message, logtype, ir_buf));
     const size_t encoded_message_end_pos = ir_buf.size();
     const size_t encoded_message_start_pos = 0;
 
     string decoded_message;
-    ffi::epoch_time_ms_t timestamp;
-    ffi::ir_stream::IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
+    epoch_time_ms_t timestamp;
+    IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
 
-    REQUIRE(ffi::ir_stream::IRErrorCode_Success ==
+    REQUIRE(IRErrorCode::IRErrorCode_Success ==
             decode_next_message<TestType>(encoded_message_buffer, decoded_message, timestamp));
     REQUIRE(message == decoded_message);
     REQUIRE(timestamp == reference_timestamp);
     REQUIRE(encoded_message_buffer.get_cursor_pos() == encoded_message_end_pos);
 
     encoded_message_buffer.set_cursor_pos(encoded_message_start_pos + 1);
-    REQUIRE(ffi::ir_stream::IRErrorCode_Corrupted_IR ==
+    REQUIRE(IRErrorCode::IRErrorCode_Corrupted_IR ==
             decode_next_message<TestType>(encoded_message_buffer, message, timestamp));
 
     ir_buf.resize(encoded_message_end_pos - 4);
-    ffi::ir_stream::IRBuffer incomplete_message_buffer(ir_buf.data(), ir_buf.size());
-    REQUIRE(ffi::ir_stream::IRErrorCode_Incomplete_IR ==
+    IRBuffer incomplete_message_buffer(ir_buf.data(), ir_buf.size());
+    REQUIRE(IRErrorCode::IRErrorCode_Incomplete_IR ==
             decode_next_message<TestType>(incomplete_message_buffer, message, timestamp));
 }
 
@@ -256,18 +261,18 @@ TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]",
 TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
     string message = "Static <\text>, dictVar1, 123, 456345232.7234223, "
                      "dictVar2, 987, 654.3, end of static text";
-    std::vector<int8_t> ir_buf;
-    std::string logtype;
+    vector<int8_t> ir_buf;
+    string logtype;
     // ensure that decoder can handle negative ts_delta
-    ffi::epoch_time_ms_t reference_delta_ts_negative = -5;
+    epoch_time_ms_t reference_delta_ts_negative = -5;
     REQUIRE(true ==
             encode_message<four_byte_encoded_variable_t>(reference_delta_ts_negative, message,
                                                          logtype, ir_buf));
 
-    ffi::ir_stream::IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
+    IRBuffer encoded_message_buffer(ir_buf.data(), ir_buf.size());
     string decoded_message;
-    ffi::epoch_time_ms_t delta_ts;
-    REQUIRE(ffi::ir_stream::IRErrorCode_Success ==
+    epoch_time_ms_t delta_ts;
+    REQUIRE(IRErrorCode::IRErrorCode_Success ==
             decode_next_message<four_byte_encoded_variable_t>(encoded_message_buffer,
                                                               decoded_message, delta_ts));
     REQUIRE(message == decoded_message);
@@ -277,15 +282,15 @@ TEST_CASE("decode_next_message-4bytes", "[ffi][decode_next_message]") {
 TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]",
                    four_byte_encoded_variable_t, eight_byte_encoded_variable_t) {
     string message;
-    ffi::epoch_time_ms_t ts;
-    ffi::epoch_time_ms_t preamble_ts = get_current_ts();
-    std::vector<int8_t> ir_buf;
-    std::string logtype;
-    std::vector<std::string> reference_messages;
-    std::vector<ffi::epoch_time_ms_t> reference_timestamps;
-    const std::string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
-    const std::string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
-    const std::string time_zone_id = "Asia/Tokyo";
+    epoch_time_ms_t ts;
+    epoch_time_ms_t preamble_ts = get_current_ts();
+    vector<int8_t> ir_buf;
+    string logtype;
+    vector<string> reference_messages;
+    vector<epoch_time_ms_t> reference_timestamps;
+    const string timestamp_pattern = "%Y-%m-%d %H:%M:%S,%3";
+    const string timestamp_pattern_syntax = "yyyy-MM-dd HH:mm:ss";
+    const string time_zone_id = "Asia/Tokyo";
 
     REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id,
                                       preamble_ts, ir_buf));
@@ -308,11 +313,11 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]",
     const size_t encoded_message_end_pos = ir_buf.size();
     const size_t encoded_message_start_pos = 0;
 
-    ffi::ir_stream::IRBuffer complete_encoding_buffer(ir_buf.data(), ir_buf.size());
+    IRBuffer complete_encoding_buffer(ir_buf.data(), ir_buf.size());
 
     bool is_four_bytes_encoding;
-    ffi::ir_stream::TimestampInfo ts_info;
-    REQUIRE(ffi::ir_stream::get_encoding_type(complete_encoding_buffer, is_four_bytes_encoding) ==
+    TimestampInfo ts_info;
+    REQUIRE(get_encoding_type(complete_encoding_buffer, is_four_bytes_encoding) ==
             IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<TestType>(is_four_bytes_encoding));
 
@@ -324,9 +329,9 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]",
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
 
     string decoded_message;
-    ffi::epoch_time_ms_t timestamp;
+    epoch_time_ms_t timestamp;
     for (size_t ix = 0; ix < reference_messages.size(); ix++) {
-        REQUIRE(ffi::ir_stream::IRErrorCode_Success ==
+        REQUIRE(IRErrorCode::IRErrorCode_Success ==
                 decode_next_message<TestType>(complete_encoding_buffer, decoded_message,
                                               timestamp));
         REQUIRE(decoded_message == reference_messages[ix]);


### PR DESCRIPTION
# Description

Added decoding support to ffi library.

# Validation performed

Added Unit-tests for both 8-bytes and 4-bytes encoding.

