### PR TITLE
Install zstd on execution image for libarchive and update error message

### DIFF
--- a/components/core/src/clp/FileCompressor.cpp
+++ b/components/core/src/clp/FileCompressor.cpp
@@ -215,7 +215,7 @@ namespace clp {
         // Check if it's an archive
         auto error_code = m_libarchive_reader.try_open(m_utf8_validation_buf_length, m_utf8_validation_buf, m_file_reader, filename_if_compressed);
         if (ErrorCode_Success != error_code) {
-            SPDLOG_ERROR("Cannot compress {} - not UTF-8 encoded.", file_to_compress.get_path().c_str());
+            SPDLOG_ERROR("Cannot compress {} - failed to open with libarchive.", file_to_compress.get_path().c_str());
             return false;
         }
 

--- a/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
@@ -5,4 +5,5 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   checkinstall \
   curl \
   python3 \
-  rsync
+  rsync \
+  zstd


### PR DESCRIPTION
# References
https://github.com/y-scope/clp/issues/113

# Description
Added Zstd to clp-execution image so libarchive can decompress zstd input

# Validation performed
Built the image locally and modified a package to use the local image. Confirmed that zstd files can be compressed by the package.

