### PR TITLE
Aligns variable placeholder and float encoding with IR format specification

### DIFF
--- a/components/core/src/Defs.h
+++ b/components/core/src/Defs.h
@@ -18,10 +18,13 @@ typedef int64_t logtype_dictionary_id_t;
 static const logtype_dictionary_id_t cLogtypeDictionaryIdMax = INT64_MAX;
 
 typedef uint16_t archive_format_version_t;
-// This flag is used to maintain two separate streams of archive format versions:
-// - Development versions (which can change frequently as necessary) which should have the flag
-// - Production versions (which should be changed with care and as infrequently as possible) which should not have the flag
-constexpr archive_format_version_t cArchiveFormatDevelopmentVersionFlag = 0x8000;
+// This flag is used to maintain two separate streams of archive format
+// versions:
+// - Development versions (which can change frequently as necessary) which
+//   should have the flag
+// - Production versions (which should be changed with care and as infrequently
+//   as possible) which should not have the flag
+constexpr archive_format_version_t cArchiveFormatDevVersionFlag = 0x8000;
 
 typedef uint64_t file_id_t;
 typedef uint64_t segment_id_t;

--- a/components/core/src/Defs.h
+++ b/components/core/src/Defs.h
@@ -8,17 +8,17 @@
 
 // Types
 typedef int64_t epochtime_t;
-static const epochtime_t cEpochTimeMin = std::numeric_limits<epochtime_t>::min();
-static const epochtime_t cEpochTimeMax = std::numeric_limits<epochtime_t>::max();
+constexpr epochtime_t cEpochTimeMin = std::numeric_limits<epochtime_t>::min();
+constexpr epochtime_t cEpochTimeMax = std::numeric_limits<epochtime_t>::max();
 #define SECONDS_TO_EPOCHTIME(x) x*1000
 #define MICROSECONDS_TO_EPOCHTIME(x) 0
 
 typedef uint64_t variable_dictionary_id_t;
-static const variable_dictionary_id_t cVariableDictionaryIdMax =
+constexpr variable_dictionary_id_t cVariableDictionaryIdMax =
         std::numeric_limits<variable_dictionary_id_t>::max();
 
 typedef int64_t logtype_dictionary_id_t;
-static const logtype_dictionary_id_t cLogtypeDictionaryIdMax =
+constexpr logtype_dictionary_id_t cLogtypeDictionaryIdMax =
         std::numeric_limits<logtype_dictionary_id_t>::max();
 
 typedef uint16_t archive_format_version_t;

--- a/components/core/src/Defs.h
+++ b/components/core/src/Defs.h
@@ -4,18 +4,22 @@
 // C++ libraries
 #include <atomic>
 #include <cstdint>
+#include <limits>
 
 // Types
 typedef int64_t epochtime_t;
-static const epochtime_t cEpochTimeMin = INT64_MIN;
-static const epochtime_t cEpochTimeMax = INT64_MAX;
+static const epochtime_t cEpochTimeMin = std::numeric_limits<epochtime_t>::min();
+static const epochtime_t cEpochTimeMax = std::numeric_limits<epochtime_t>::max();
 #define SECONDS_TO_EPOCHTIME(x) x*1000
 #define MICROSECONDS_TO_EPOCHTIME(x) 0
 
 typedef uint64_t variable_dictionary_id_t;
-static const variable_dictionary_id_t cVariableDictionaryIdMax = UINT64_MAX;
+static const variable_dictionary_id_t cVariableDictionaryIdMax =
+        std::numeric_limits<variable_dictionary_id_t>::max();
+
 typedef int64_t logtype_dictionary_id_t;
-static const logtype_dictionary_id_t cLogtypeDictionaryIdMax = INT64_MAX;
+static const logtype_dictionary_id_t cLogtypeDictionaryIdMax =
+        std::numeric_limits<logtype_dictionary_id_t>::max();
 
 typedef uint16_t archive_format_version_t;
 // This flag is used to maintain two separate streams of archive format
@@ -28,14 +32,14 @@ constexpr archive_format_version_t cArchiveFormatDevVersionFlag = 0x8000;
 
 typedef uint64_t file_id_t;
 typedef uint64_t segment_id_t;
-constexpr segment_id_t cInvalidSegmentId = UINT64_MAX;
+constexpr segment_id_t cInvalidSegmentId = std::numeric_limits<segment_id_t>::max();
 
 typedef int64_t encoded_variable_t;
 
 typedef uint64_t group_id_t;
 
 typedef uint64_t pipeline_id_t;
-constexpr pipeline_id_t cPipelineIdMax = UINT64_MAX;
+constexpr pipeline_id_t cPipelineIdMax = std::numeric_limits<pipeline_id_t>::max();
 typedef std::atomic_uint64_t atomic_pipeline_id_t;
 
 enum LogVerbosity : uint8_t {

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -259,7 +259,8 @@ bool EncodedVariableInterpreter::decode_variables_into_message (const LogTypeDic
         size_t var_position = logtype_dict_entry.get_var_info(i, var_delim);
 
         // Add the constant that's between the last variable and this one
-        decompressed_msg.append(logtype_value, constant_begin_pos, var_position - constant_begin_pos);
+        decompressed_msg.append(logtype_value, constant_begin_pos,
+                                var_position - constant_begin_pos);
 
         if (LogTypeDictionaryEntry::VarDelim::Integer == var_delim) {
             decompressed_msg += std::to_string(encoded_vars[i]);

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -18,10 +18,6 @@ using std::string;
 using std::unordered_set;
 using std::vector;
 
-encoded_variable_t EncodedVariableInterpreter::get_var_dict_id_max () {
-    return m_var_dict_id_max;
-}
-
 variable_dictionary_id_t EncodedVariableInterpreter::decode_var_dict_id (encoded_variable_t encoded_var) {
     return bit_cast<variable_dictionary_id_t>(encoded_var);
 }

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -9,28 +9,21 @@
 
 // Project headers
 #include "Defs.h"
+#include "ffi/encoding_methods.hpp"
 #include "string_utils.hpp"
 #include "type_utils.hpp"
 
+using ffi::cEightByteEncodedFloatDigitsBitMask;
 using std::string;
 using std::unordered_set;
 using std::vector;
 
-encoded_variable_t EncodedVariableInterpreter::get_var_dict_id_range_begin () {
-    return m_var_dict_id_range_begin;
-}
-
-encoded_variable_t EncodedVariableInterpreter::get_var_dict_id_range_end () {
-    return m_var_dict_id_range_end;
-}
-
-bool EncodedVariableInterpreter::is_var_dict_id (encoded_variable_t encoded_var) {
-    return (m_var_dict_id_range_begin <= encoded_var && encoded_var < m_var_dict_id_range_end);
+encoded_variable_t EncodedVariableInterpreter::get_var_dict_id_max () {
+    return m_var_dict_id_max;
 }
 
 variable_dictionary_id_t EncodedVariableInterpreter::decode_var_dict_id (encoded_variable_t encoded_var) {
-    variable_dictionary_id_t id = encoded_var - m_var_dict_id_range_begin;
-    return id;
+    return bit_cast<variable_dictionary_id_t>(encoded_var);
 }
 
 bool EncodedVariableInterpreter::convert_string_to_representable_integer_var (const string& value, encoded_variable_t& encoded_var) {
@@ -62,9 +55,6 @@ bool EncodedVariableInterpreter::convert_string_to_representable_integer_var (co
     if (false == convert_string_to_int(value, result)) {
         // Conversion failed
         return false;
-    } else if (result >= m_var_dict_id_range_begin) {
-        // Value is in dictionary variable range, so cannot be converted
-        return false;
     } else {
         encoded_var = result;
     }
@@ -72,16 +62,18 @@ bool EncodedVariableInterpreter::convert_string_to_representable_integer_var (co
     return true;
 }
 
-bool EncodedVariableInterpreter::convert_string_to_representable_double_var (const string& value, encoded_variable_t& encoded_var) {
+bool EncodedVariableInterpreter::convert_string_to_representable_float_var (
+        const string& value, encoded_variable_t& encoded_var)
+{
     if (value.empty()) {
         // Can't convert an empty string
         return false;
     }
 
     size_t pos = 0;
-    constexpr size_t cMaxDigitsInRepresentableDoubleVar = 16;
+    constexpr size_t cMaxDigitsInRepresentableFloatVar = 16;
     // +1 for decimal point
-    size_t max_length = cMaxDigitsInRepresentableDoubleVar + 1;
+    size_t max_length = cMaxDigitsInRepresentableFloatVar + 1;
 
     // Check for a negative sign
     bool is_negative = false;
@@ -141,32 +133,34 @@ bool EncodedVariableInterpreter::convert_string_to_representable_double_var (con
     //           range from 0 to 16 because of the negative sign. Whereas
     //           from the right, the negative sign is inconsequential.
     //     - Thus, we use 4 bits and map the range [1, 16] to [0x0, 0xF].
-    uint64_t encoded_double = 0;
+    uint64_t encoded_float = 0;
     if (is_negative) {
-        encoded_double = 1;
+        encoded_float = 1;
     }
-    encoded_double <<= 55;  // 1 unused + 54 for digits of the float
-    encoded_double |= digits & 0x003FFFFFFFFFFFFF;
-    encoded_double <<= 4;
-    encoded_double |= (num_digits - 1) & 0x0F;
-    encoded_double <<= 4;
-    encoded_double |= (decimal_point_pos - 1) & 0x0F;
-    encoded_var = bit_cast<encoded_variable_t>(encoded_double);
+    encoded_float <<= 55;  // 1 unused + 54 for digits of the float
+    encoded_float |= digits & cEightByteEncodedFloatDigitsBitMask;
+    encoded_float <<= 4;
+    encoded_float |= (num_digits - 1) & 0x0F;
+    encoded_float <<= 4;
+    encoded_float |= (decimal_point_pos - 1) & 0x0F;
+    encoded_var = bit_cast<encoded_variable_t>(encoded_float);
 
     return true;
 }
 
-void EncodedVariableInterpreter::convert_encoded_double_to_string (encoded_variable_t encoded_var, string& value) {
-    auto encoded_double = bit_cast<uint64_t>(encoded_var);
+void EncodedVariableInterpreter::convert_encoded_float_to_string (encoded_variable_t encoded_var,
+                                                                  string& value) {
+    auto encoded_float = bit_cast<uint64_t>(encoded_var);
 
-    // Decode according to the format described in EncodedVariableInterpreter::convert_string_to_representable_double_var
-    uint8_t decimal_pos = (encoded_double & 0x0F) + 1;
-    encoded_double >>= 4;
-    uint8_t num_digits = (encoded_double & 0x0F) + 1;
-    encoded_double >>= 4;
-    uint64_t digits = encoded_double & 0x003FFFFFFFFFFFFF;
-    encoded_double >>= 55;
-    bool is_negative = encoded_double > 0;
+    // Decode according to the format described in
+    // EncodedVariableInterpreter::convert_string_to_representable_float_var
+    uint8_t decimal_pos = (encoded_float & 0x0F) + 1;
+    encoded_float >>= 4;
+    uint8_t num_digits = (encoded_float & 0x0F) + 1;
+    encoded_float >>= 4;
+    uint64_t digits = encoded_float & cEightByteEncodedFloatDigitsBitMask;
+    encoded_float >>= 55;
+    bool is_negative = encoded_float > 0;
 
     size_t value_length = num_digits + 1 + is_negative;
     value.resize(value_length);
@@ -223,7 +217,7 @@ void EncodedVariableInterpreter::encode_and_add_to_dictionary (const string& mes
         encoded_variable_t encoded_var;
         if (convert_string_to_representable_integer_var(var_str, encoded_var)) {
             logtype_dict_entry.add_int_var();
-        } else if (convert_string_to_representable_double_var(var_str, encoded_var)) {
+        } else if (convert_string_to_representable_float_var(var_str, encoded_var)) {
             logtype_dict_entry.add_float_var();
         } else {
             // Variable string looks like a dictionary variable, so encode it as so
@@ -254,8 +248,8 @@ bool EncodedVariableInterpreter::decode_variables_into_message (const LogTypeDic
 
     LogTypeDictionaryEntry::VarDelim var_delim;
     size_t constant_begin_pos = 0;
-    string double_str;
-    encoded_variable_t var_dict_id;
+    string float_str;
+    variable_dictionary_id_t var_dict_id;
     for (size_t i = 0; i < num_vars_in_logtype; ++i) {
         size_t var_position = logtype_dict_entry.get_var_info(i, var_delim);
 
@@ -267,8 +261,8 @@ bool EncodedVariableInterpreter::decode_variables_into_message (const LogTypeDic
                 decompressed_msg += std::to_string(encoded_vars[i]);
                 break;
             case LogTypeDictionaryEntry::VarDelim::Float:
-                convert_encoded_double_to_string(encoded_vars[i], double_str);
-                decompressed_msg += double_str;
+                convert_encoded_float_to_string(encoded_vars[i], float_str);
+                decompressed_msg += float_str;
                 break;
             case LogTypeDictionaryEntry::VarDelim::Dictionary:
                 var_dict_id = decode_var_dict_id(encoded_vars[i]);
@@ -278,7 +272,7 @@ bool EncodedVariableInterpreter::decode_variables_into_message (const LogTypeDic
                 SPDLOG_ERROR(
                     "EncodedVariableInterpreter: Logtype '{}' contains "
                     "unexpected variable placeholder {}",
-                    logtype_value.c_str(),
+                    logtype_value,
                     enum_to_underlying_type(var_delim));
                 return false;
         }
@@ -305,7 +299,7 @@ bool EncodedVariableInterpreter::encode_and_search_dictionary (const string& var
     if (convert_string_to_representable_integer_var(var_str, encoded_var)) {
         LogTypeDictionaryEntry::add_int_var(logtype);
         sub_query.add_non_dict_var(encoded_var);
-    } else if (convert_string_to_representable_double_var(var_str, encoded_var)) {
+    } else if (convert_string_to_representable_float_var(var_str, encoded_var)) {
         LogTypeDictionaryEntry::add_float_var(logtype);
         sub_query.add_non_dict_var(encoded_var);
     } else {
@@ -347,5 +341,5 @@ bool EncodedVariableInterpreter::wildcard_search_dictionary_and_get_encoded_matc
 }
 
 encoded_variable_t EncodedVariableInterpreter::encode_var_dict_id (variable_dictionary_id_t id) {
-    return (encoded_variable_t)id + m_var_dict_id_range_begin;
+    return bit_cast<encoded_variable_t>(id);
 }

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -279,7 +279,7 @@ bool EncodedVariableInterpreter::decode_variables_into_message (const LogTypeDic
                     "EncodedVariableInterpreter: Logtype '{}' contains "
                     "unexpected variable placeholder {}",
                     logtype_value.c_str(),
-                    var_delim);
+                    enum_to_underlying_type(var_delim));
                 return false;
         }
         // Move past the variable delimiter

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -271,7 +271,7 @@ bool EncodedVariableInterpreter::decode_variables_into_message (const LogTypeDic
             default:
                 SPDLOG_ERROR(
                     "EncodedVariableInterpreter: Logtype '{}' contains "
-                    "unexpected variable placeholder {}",
+                    "unexpected variable placeholder 0x{:x}",
                     logtype_value,
                     enum_to_underlying_type(var_delim));
                 return false;

--- a/components/core/src/EncodedVariableInterpreter.hpp
+++ b/components/core/src/EncodedVariableInterpreter.hpp
@@ -40,7 +40,6 @@ public:
     };
 
     // Methods
-    static encoded_variable_t get_var_dict_id_max ();
     static encoded_variable_t encode_var_dict_id (variable_dictionary_id_t id);
     static variable_dictionary_id_t decode_var_dict_id (encoded_variable_t encoded_var);
     /**
@@ -51,18 +50,14 @@ public:
      */
     static bool convert_string_to_representable_integer_var (const std::string& value, encoded_variable_t& encoded_var);
     /**
-     * Converts the given string into a representable double variable if possible
-     * A representable double:
-     * - is base-10
-     * - has 16-digits with a decimal point, where at least one digit is after the decimal point
-     * - has an optional negative sign
+     * Converts the given string into a representable float variable if possible
      * @param value
      * @param encoded_var
      * @return true if was successfully converted, false otherwise
      */
     static bool convert_string_to_representable_float_var (const std::string& value, encoded_variable_t& encoded_var);
     /**
-     * Converts the given encoded double into a string
+     * Converts the given encoded float into a string
      * @param encoded_var
      * @param value
      */
@@ -111,12 +106,6 @@ public:
      */
     static bool wildcard_search_dictionary_and_get_encoded_matches (const std::string& var_wildcard_str, const VariableDictionaryReader& var_dict,
                                                                     bool ignore_case, SubQuery& sub_query);
-
-private:
-    // Variables
-    // The maximum value for encoding variable dictionary IDs
-    static constexpr encoded_variable_t m_var_dict_id_max =
-            std::numeric_limits<variable_dictionary_id_t>::max();
 };
 
 #endif // ENCODEDVARIABLEINTERPRETER_HPP

--- a/components/core/src/EncodedVariableInterpreter.hpp
+++ b/components/core/src/EncodedVariableInterpreter.hpp
@@ -40,9 +40,7 @@ public:
     };
 
     // Methods
-    static encoded_variable_t get_var_dict_id_range_begin ();
-    static encoded_variable_t get_var_dict_id_range_end ();
-    static bool is_var_dict_id (encoded_variable_t encoded_var);
+    static encoded_variable_t get_var_dict_id_max ();
     static encoded_variable_t encode_var_dict_id (variable_dictionary_id_t id);
     static variable_dictionary_id_t decode_var_dict_id (encoded_variable_t encoded_var);
     /**
@@ -62,13 +60,13 @@ public:
      * @param encoded_var
      * @return true if was successfully converted, false otherwise
      */
-    static bool convert_string_to_representable_double_var (const std::string& value, encoded_variable_t& encoded_var);
+    static bool convert_string_to_representable_float_var (const std::string& value, encoded_variable_t& encoded_var);
     /**
      * Converts the given encoded double into a string
      * @param encoded_var
      * @param value
      */
-    static void convert_encoded_double_to_string (encoded_variable_t encoded_var, std::string& value);
+    static void convert_encoded_float_to_string (encoded_variable_t encoded_var, std::string& value);
 
     /**
      * Parses all variables from a message (while constructing the logtype) and encodes them (adding them to the variable dictionary if necessary)
@@ -116,10 +114,9 @@ public:
 
 private:
     // Variables
-    // The beginning of the range used for encoding variable dictionary IDs
-    static constexpr encoded_variable_t m_var_dict_id_range_begin = 1LL << 62;
-    // The end (exclusive) of the range used for encoding variable dictionary IDs
-    static constexpr encoded_variable_t m_var_dict_id_range_end = (1ULL << 63) - 1;
+    // The maximum value for encoding variable dictionary IDs
+    static constexpr encoded_variable_t m_var_dict_id_max =
+            std::numeric_limits<variable_dictionary_id_t>::max();
 };
 
 #endif // ENCODEDVARIABLEINTERPRETER_HPP

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -144,6 +144,7 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
                 m_type = Type::Ambiguous;
                 m_possible_types.push_back(Type::IntVar);
                 m_possible_types.push_back(Type::FloatVar);
+                m_possible_types.push_back(Type::DictionaryVar);
                 m_cannot_convert_to_non_dict_var = false;
             }
         }

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -35,7 +35,8 @@ public:
     bool has_prefix_greedy_wildcard () const;
     bool has_suffix_greedy_wildcard () const;
     bool is_ambiguous_token () const;
-    bool is_double_var () const;
+    bool is_float_var () const;
+    bool is_int_var () const;
     bool is_var () const;
     bool is_wildcard () const;
 
@@ -54,8 +55,9 @@ private:
         // Ambiguous indicates the token can be more than one of the types listed below
         Ambiguous,
         Logtype,
-        DictOrIntVar,
-        DoubleVar
+        DictionaryVar,
+        FloatVar,
+        IntVar
     };
 
     // Variables
@@ -109,8 +111,12 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
             } else {
                 m_type = Type::Ambiguous;
                 m_possible_types.push_back(Type::Logtype);
-                m_possible_types.push_back(Type::DictOrIntVar);
-                m_possible_types.push_back(Type::DoubleVar);
+                m_possible_types.push_back(Type::DictionaryVar);
+                // For myself's reasoning and for code review
+                // If a token is not var, it must not have any number in it.
+                // the only case it be can be a double is if the non-wilcard is "-" or "."
+                m_possible_types.push_back(Type::FloatVar);
+                m_possible_types.push_back(Type::IntVar);
             }
         } else {
             string value_without_wildcards = m_value;
@@ -131,12 +137,18 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
 
             if (!converts_to_non_dict_var) {
                 // Dictionary variable
-                m_type = Type::DictOrIntVar;
+                // This seems to be incorrect? what if a wildcard is at the middle?
+                // in that case it can still be a int or a float
+                m_type = Type::DictionaryVar;
                 m_cannot_convert_to_non_dict_var = true;
             } else {
                 m_type = Type::Ambiguous;
-                m_possible_types.push_back(Type::DictOrIntVar);
-                m_possible_types.push_back(Type::DoubleVar);
+                m_possible_types.push_back(Type::IntVar);
+                m_possible_types.push_back(Type::FloatVar);
+                // For myself's reasoning and for code review
+                // Ideally, here still needs to consider Dict var
+                // It's possible that the non-wildcard matches a dictionary value
+                 m_possible_types.push_back(Type::DictionaryVar);
                 m_cannot_convert_to_non_dict_var = false;
             }
         }
@@ -167,14 +179,24 @@ bool QueryToken::is_ambiguous_token () const {
     return Type::Ambiguous == m_type;
 }
 
-bool QueryToken::is_double_var () const {
+bool QueryToken::is_float_var () const {
     Type type;
     if (Type::Ambiguous == m_type) {
         type = m_possible_types[m_current_possible_type_ix];
     } else {
         type = m_type;
     }
-    return Type::DoubleVar == type;
+    return Type::FloatVar == type;
+}
+
+bool QueryToken::is_int_var () const {
+    Type type;
+    if (Type::Ambiguous == m_type) {
+        type = m_possible_types[m_current_possible_type_ix];
+    } else {
+        type = m_type;
+    }
+    return Type::IntVar == type;
 }
 
 bool QueryToken::is_var () const {
@@ -184,7 +206,7 @@ bool QueryToken::is_var () const {
     } else {
         type = m_type;
     }
-    return (Type::DictOrIntVar == type || Type::DoubleVar == type);
+    return (Type::IntVar == type || Type::FloatVar == type || Type::DictionaryVar == type);
 }
 
 bool QueryToken::is_wildcard () const {
@@ -265,10 +287,12 @@ static bool process_var_token (const QueryToken& query_token, const Archive& arc
             logtype += '*';
         }
 
-        if (query_token.is_double_var()) {
-            LogTypeDictionaryEntry::add_double_var(logtype);
+        if (query_token.is_float_var()) {
+            LogTypeDictionaryEntry::add_float_var(logtype);
+        } else if (query_token.is_int_var()) {
+            LogTypeDictionaryEntry::add_int_var(logtype);
         } else {
-            LogTypeDictionaryEntry::add_non_double_var(logtype);
+            LogTypeDictionaryEntry::add_dict_var(logtype);
 
             if (query_token.cannot_convert_to_non_dict_var()) {
                 // Must be a dictionary variable, so search variable dictionary
@@ -331,7 +355,7 @@ SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery (const Archiv
                 logtype += '*';
             } else {
                 logtype += '*';
-                LogTypeDictionaryEntry::add_non_double_var(logtype);
+                LogTypeDictionaryEntry::add_dict_var(logtype);
                 logtype += '*';
             }
         } else {

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -131,7 +131,7 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
             bool converts_to_non_dict_var = false;
             if (EncodedVariableInterpreter::convert_string_to_representable_integer_var(
                     value_without_wildcards, encoded_var) ||
-                EncodedVariableInterpreter::convert_string_to_representable_double_var(
+                EncodedVariableInterpreter::convert_string_to_representable_float_var(
                         value_without_wildcards, encoded_var)) {
                 converts_to_non_dict_var = true;
             }

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -80,7 +80,8 @@ private:
 };
 
 QueryToken::QueryToken (const string& query_string, const size_t begin_pos, const size_t end_pos,
-                        const bool is_var) : m_current_possible_type_ix(0) {
+                        const bool is_var) : m_current_possible_type_ix(0)
+{
     m_begin_pos = begin_pos;
     m_end_pos = end_pos;
     m_value.assign(query_string, m_begin_pos, m_end_pos - m_begin_pos);

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -79,7 +79,8 @@ private:
     size_t m_current_possible_type_ix;
 };
 
-QueryToken::QueryToken (const string& query_string, const size_t begin_pos, const size_t end_pos, const bool is_var) : m_current_possible_type_ix(0) {
+QueryToken::QueryToken (const string& query_string, const size_t begin_pos, const size_t end_pos,
+                        const bool is_var) : m_current_possible_type_ix(0) {
     m_begin_pos = begin_pos;
     m_end_pos = end_pos;
     m_value.assign(query_string, m_begin_pos, m_end_pos - m_begin_pos);
@@ -103,7 +104,8 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
             }
         }
 
-        m_contains_wildcards = (m_has_prefix_greedy_wildcard || m_has_suffix_greedy_wildcard || m_has_greedy_wildcard_in_middle);
+        m_contains_wildcards = (m_has_prefix_greedy_wildcard || m_has_suffix_greedy_wildcard ||
+                                m_has_greedy_wildcard_in_middle);
 
         if (!is_var) {
             if (!m_contains_wildcards) {
@@ -126,9 +128,10 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
 
             encoded_variable_t encoded_var;
             bool converts_to_non_dict_var = false;
-            if (EncodedVariableInterpreter::convert_string_to_representable_integer_var(value_without_wildcards, encoded_var) ||
-                EncodedVariableInterpreter::convert_string_to_representable_double_var(value_without_wildcards, encoded_var))
-            {
+            if (EncodedVariableInterpreter::convert_string_to_representable_integer_var(
+                    value_without_wildcards, encoded_var) ||
+                EncodedVariableInterpreter::convert_string_to_representable_double_var(
+                        value_without_wildcards, encoded_var)) {
                 converts_to_non_dict_var = true;
             }
 

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -111,12 +111,9 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
             } else {
                 m_type = Type::Ambiguous;
                 m_possible_types.push_back(Type::Logtype);
-                m_possible_types.push_back(Type::DictionaryVar);
-                // For myself's reasoning and for code review
-                // If a token is not var, it must not have any number in it.
-                // the only case it be can be a double is if the non-wilcard is "-" or "."
-                m_possible_types.push_back(Type::FloatVar);
                 m_possible_types.push_back(Type::IntVar);
+                m_possible_types.push_back(Type::FloatVar);
+                m_possible_types.push_back(Type::DictionaryVar);
             }
         } else {
             string value_without_wildcards = m_value;
@@ -137,18 +134,12 @@ QueryToken::QueryToken (const string& query_string, const size_t begin_pos, cons
 
             if (!converts_to_non_dict_var) {
                 // Dictionary variable
-                // This seems to be incorrect? what if a wildcard is at the middle?
-                // in that case it can still be a int or a float
                 m_type = Type::DictionaryVar;
                 m_cannot_convert_to_non_dict_var = true;
             } else {
                 m_type = Type::Ambiguous;
                 m_possible_types.push_back(Type::IntVar);
                 m_possible_types.push_back(Type::FloatVar);
-                // For myself's reasoning and for code review
-                // Ideally, here still needs to consider Dict var
-                // It's possible that the non-wildcard matches a dictionary value
-                 m_possible_types.push_back(Type::DictionaryVar);
                 m_cannot_convert_to_non_dict_var = false;
             }
         }

--- a/components/core/src/LogTypeDictionaryEntry.cpp
+++ b/components/core/src/LogTypeDictionaryEntry.cpp
@@ -23,7 +23,10 @@ static void escape_variable_delimiters (const string& value, size_t begin_ix, si
         auto c = value[i];
 
         // Add escape character if necessary
-        if ((char)LogTypeDictionaryEntry::VarDelim::NonDouble == c || (char)LogTypeDictionaryEntry::VarDelim::Double == c || cEscapeChar == c) {
+        if ((char)LogTypeDictionaryEntry::VarDelim::Integer == c ||
+            (char)LogTypeDictionaryEntry::VarDelim::Float == c ||
+            (char)LogTypeDictionaryEntry::VarDelim::Dictionary == c ||
+            cEscapeChar == c) {
             escaped_value += cEscapeChar;
         }
 
@@ -43,28 +46,6 @@ size_t LogTypeDictionaryEntry::get_var_info (size_t var_ix, VarDelim& var_delim)
     return m_var_positions[var_ix];
 }
 
-LogTypeDictionaryEntry::VarDelim LogTypeDictionaryEntry::get_var_delim (size_t var_ix) const {
-    if (var_ix >= m_var_positions.size()) {
-        return VarDelim::Length;
-    }
-
-    auto var_position = m_var_positions[var_ix];
-    return (VarDelim)m_value[var_position];
-}
-
-size_t LogTypeDictionaryEntry::get_var_length_in_logtype (size_t var_ix) const {
-    auto var_delim = get_var_delim(var_ix);
-    switch (var_delim) {
-        case VarDelim::NonDouble:
-            return 1;
-        case VarDelim::Double:
-            return 2;
-        case VarDelim::Length:
-        default:
-            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-}
-
 size_t LogTypeDictionaryEntry::get_data_size () const {
     // NOTE: sizeof(vector[0]) is executed at compile time so there's no risk of an exception at runtime
     return sizeof(m_id) + sizeof(m_verbosity) + m_value.length() + m_var_positions.size() * sizeof(m_var_positions[0]) +
@@ -75,14 +56,19 @@ void LogTypeDictionaryEntry::add_constant (const string& value_containing_consta
     m_value.append(value_containing_constant, begin_pos, length);
 }
 
-void LogTypeDictionaryEntry::add_non_double_var () {
+void LogTypeDictionaryEntry::add_dictionary_var () {
     m_var_positions.push_back(m_value.length());
-    add_non_double_var(m_value);
+    add_dict_var(m_value);
 }
 
-void LogTypeDictionaryEntry::add_double_var () {
+void LogTypeDictionaryEntry::add_int_var () {
     m_var_positions.push_back(m_value.length());
-    add_double_var(m_value);
+    add_int_var(m_value);
+}
+
+void LogTypeDictionaryEntry::add_float_var () {
+    m_var_positions.push_back(m_value.length());
+    add_float_var(m_value);
 }
 
 bool LogTypeDictionaryEntry::parse_next_var (const string& msg, size_t& var_begin_pos, size_t& var_end_pos, string& var) {
@@ -158,16 +144,18 @@ ErrorCode LogTypeDictionaryEntry::try_read_from_file (streaming_compression::Dec
         } else if (cEscapeChar == c) {
             is_escaped = true;
         } else {
-            if ((char)LogTypeDictionaryEntry::VarDelim::NonDouble == c) {
+            if ((char)LogTypeDictionaryEntry::VarDelim::Integer == c) {
                 add_constant(constant, 0, constant.length());
                 constant.clear();
-
-                add_non_double_var();
-            } else if ((char)LogTypeDictionaryEntry::VarDelim::Double == c) {
+                add_int_var();
+            } else if ((char)LogTypeDictionaryEntry::VarDelim::Float == c) {
                 add_constant(constant, 0, constant.length());
                 constant.clear();
-
-                add_double_var();
+                add_float_var();
+            } else if ((char)LogTypeDictionaryEntry::VarDelim::Dictionary == c) {
+                add_constant(constant, 0, constant.length());
+                constant.clear();
+                add_dictionary_var();
             } else {
                 constant += c;
             }

--- a/components/core/src/LogTypeDictionaryEntry.cpp
+++ b/components/core/src/LogTypeDictionaryEntry.cpp
@@ -3,6 +3,7 @@
 // Project headers
 #include "type_utils.hpp"
 #include "Utils.hpp"
+
 using std::string;
 
 // Constants
@@ -148,13 +149,12 @@ ErrorCode LogTypeDictionaryEntry::try_read_from_file (streaming_compression::Dec
                 add_constant(constant, 0, constant.length());
                 constant.clear();
                 add_int_var();
-            }
-            else if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Float) == c) {
+            } else if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Float) == c) {
                 add_constant(constant, 0, constant.length());
                 constant.clear();
                 add_float_var();
-            }
-            else if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Dictionary) == c) {
+            } else if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Dictionary) == c)
+            {
                 add_constant(constant, 0, constant.length());
                 constant.clear();
                 add_dictionary_var();

--- a/components/core/src/LogTypeDictionaryEntry.cpp
+++ b/components/core/src/LogTypeDictionaryEntry.cpp
@@ -1,8 +1,8 @@
 #include "LogTypeDictionaryEntry.hpp"
 
 // Project headers
+#include "type_utils.hpp"
 #include "Utils.hpp"
-
 using std::string;
 
 // Constants
@@ -23,9 +23,9 @@ static void escape_variable_delimiters (const string& value, size_t begin_ix, si
         auto c = value[i];
 
         // Add escape character if necessary
-        if ((char)LogTypeDictionaryEntry::VarDelim::Integer == c ||
-            (char)LogTypeDictionaryEntry::VarDelim::Float == c ||
-            (char)LogTypeDictionaryEntry::VarDelim::Dictionary == c ||
+        if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Integer) == c ||
+            enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Float) == c ||
+            enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Dictionary) == c ||
             cEscapeChar == c) {
             escaped_value += cEscapeChar;
         }
@@ -144,19 +144,22 @@ ErrorCode LogTypeDictionaryEntry::try_read_from_file (streaming_compression::Dec
         } else if (cEscapeChar == c) {
             is_escaped = true;
         } else {
-            if ((char)LogTypeDictionaryEntry::VarDelim::Integer == c) {
+            if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Integer) == c) {
                 add_constant(constant, 0, constant.length());
                 constant.clear();
                 add_int_var();
-            } else if ((char)LogTypeDictionaryEntry::VarDelim::Float == c) {
+            }
+            else if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Float) == c) {
                 add_constant(constant, 0, constant.length());
                 constant.clear();
                 add_float_var();
-            } else if ((char)LogTypeDictionaryEntry::VarDelim::Dictionary == c) {
+            }
+            else if (enum_to_underlying_type(LogTypeDictionaryEntry::VarDelim::Dictionary) == c) {
                 add_constant(constant, 0, constant.length());
                 constant.clear();
                 add_dictionary_var();
-            } else {
+            }
+            else {
                 constant += c;
             }
         }

--- a/components/core/src/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/LogTypeDictionaryEntry.hpp
@@ -35,7 +35,8 @@ public:
         // NOTE: These values are used within logtypes to denote variables, so care must be taken when changing them
         Integer = 0x11,
         Dictionary = 0x12,
-        Float = 0x13
+        Float = 0x13,
+        Length = 3
     };
 
     // Constructors

--- a/components/core/src/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/LogTypeDictionaryEntry.hpp
@@ -33,9 +33,9 @@ public:
     // Constants
     enum class VarDelim {
         // NOTE: These values are used within logtypes to denote variables, so care must be taken when changing them
-        NonDouble = 17,
-        Double = 18,
-        Length = 2,
+        Integer = 0x11,
+        Dictionary = 0x12,
+        Float = 0x13
     };
 
     // Constructors
@@ -49,15 +49,20 @@ public:
 
     // Methods
     /**
-     * Adds a non-double variable delimiter to the given logtype
+     * Adds a dictionary variable delimiter to the given logtype
      * @param logtype
      */
-    static void add_non_double_var (std::string& logtype) { logtype += (char)VarDelim::NonDouble; }
+    static void add_dict_var (std::string& logtype) { logtype += (char)VarDelim::Dictionary; }
+    /**
+     * Adds a integer variable delimiter to the given logtype
+     * @param logtype
+     */
+    static void add_int_var (std::string& logtype) { logtype += (char)VarDelim::Integer; }
     /**
      * Adds a double variable delimiter to the given logtype
      * @param logtype
      */
-    static void add_double_var (std::string& logtype) { logtype += (char)VarDelim::Double; }
+    static void add_float_var (std::string& logtype) { logtype += (char)VarDelim::Float; }
 
     size_t get_num_vars () const { return m_var_positions.size(); }
     /**
@@ -67,18 +72,6 @@ public:
      * @return The variable's position in the logtype, or SIZE_MAX if var_ix is out of bounds
      */
     size_t get_var_info (size_t var_ix, VarDelim& var_delim) const;
-    /**
-     * Gets the variable delimiter at the given index
-     * @param var_ix The index of the variable delimiter to get
-     * @return The variable delimiter, or LogTypeDictionaryEntry::VarDelim::Length if var_ix is out of bounds
-     */
-    VarDelim get_var_delim (size_t var_ix) const;
-    /**
-     * Gets the length of the specified variable's representation in the logtype
-     * @param var_ix The index of the variable
-     * @return The length
-     */
-    size_t get_var_length_in_logtype (size_t var_ix) const;
 
     /**
      * Gets the size (in-memory) of the data contained in this entry
@@ -94,13 +87,17 @@ public:
      */
     void add_constant (const std::string& value_containing_constant, size_t begin_pos, size_t length);
     /**
-     * Adds a non-double variable delimiter
+     * Adds an int variable delimiter
      */
-    void add_non_double_var ();
+    void add_int_var ();
     /**
-     * Adds a double variable delimiter
+     * Adds a float variable delimiter
      */
-    void add_double_var ();
+    void add_float_var ();
+    /**
+     * Adds a dictionary variable delimiter
+     */
+    void add_dictionary_var ();
 
     /**
      * Parses next variable from a message, constructing the constant part of the message's logtype as well

--- a/components/core/src/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/LogTypeDictionaryEntry.hpp
@@ -55,7 +55,7 @@ public:
      */
     static void add_dict_var (std::string& logtype) { logtype += (char)VarDelim::Dictionary; }
     /**
-     * Adds a integer variable delimiter to the given logtype
+     * Adds an integer variable delimiter to the given logtype
      * @param logtype
      */
     static void add_int_var (std::string& logtype) { logtype += (char)VarDelim::Integer; }

--- a/components/core/src/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/LogTypeDictionaryEntry.hpp
@@ -12,6 +12,7 @@
 #include "streaming_compression/zstd/Compressor.hpp"
 #include "streaming_compression/zstd/Decompressor.hpp"
 #include "TraceableException.hpp"
+#include "type_utils.hpp"
 
 /**
  * Class representing a logtype dictionary entry
@@ -31,7 +32,7 @@ public:
     };
 
     // Constants
-    enum class VarDelim {
+    enum class VarDelim : char {
         // NOTE: These values are used within logtypes to denote variables, so care must be taken when changing them
         Integer = 0x11,
         Dictionary = 0x12,
@@ -53,17 +54,23 @@ public:
      * Adds a dictionary variable delimiter to the given logtype
      * @param logtype
      */
-    static void add_dict_var (std::string& logtype) { logtype += (char)VarDelim::Dictionary; }
+    static void add_dict_var (std::string& logtype) {
+        logtype += enum_to_underlying_type(VarDelim::Dictionary);
+    }
     /**
      * Adds an integer variable delimiter to the given logtype
      * @param logtype
      */
-    static void add_int_var (std::string& logtype) { logtype += (char)VarDelim::Integer; }
+    static void add_int_var (std::string& logtype) {
+        logtype += enum_to_underlying_type(VarDelim::Integer);
+    }
     /**
-     * Adds a double variable delimiter to the given logtype
+     * Adds a float variable delimiter to the given logtype
      * @param logtype
      */
-    static void add_float_var (std::string& logtype) { logtype += (char)VarDelim::Float; }
+    static void add_float_var (std::string& logtype) {
+        logtype += enum_to_underlying_type(VarDelim::Float);
+    }
 
     size_t get_num_vars () const { return m_var_positions.size(); }
     /**

--- a/components/core/src/compressor_frontend/Constants.hpp
+++ b/components/core/src/compressor_frontend/Constants.hpp
@@ -16,7 +16,7 @@ namespace compressor_frontend {
         TokenEndID,
         TokenUncaughtStringID,
         TokenIntId,
-        TokenDoubleId,
+        TokenFloatId,
         TokenFirstTimestampId,
         TokenNewlineTimestampId,
         TokenNewlineId
@@ -25,7 +25,7 @@ namespace compressor_frontend {
     constexpr char cTokenEnd[] = "$end";
     constexpr char cTokenUncaughtString[] = "$UncaughtString";
     constexpr char cTokenInt[] = "int";
-    constexpr char cTokenDouble[] = "double";
+    constexpr char cTokenFloat[] = "float";
     constexpr char cTokenFirstTimestamp[] = "firstTimestamp";
     constexpr char cTokenNewlineTimestamp[] = "newLineTimestamp";
     constexpr char cTokenNewline[] = "newLine";

--- a/components/core/src/compressor_frontend/LALR1Parser.tpp
+++ b/components/core/src/compressor_frontend/LALR1Parser.tpp
@@ -38,7 +38,7 @@ namespace compressor_frontend {
         m_lexer.m_symbol_id[cTokenEnd] = (int) SymbolID::TokenEndID;
         m_lexer.m_symbol_id[cTokenUncaughtString] = (int) SymbolID::TokenUncaughtStringID;
         m_lexer.m_symbol_id[cTokenInt] = (int) SymbolID::TokenIntId;
-        m_lexer.m_symbol_id[cTokenDouble] = (int) SymbolID::TokenDoubleId;
+        m_lexer.m_symbol_id[cTokenFloat] = (int) SymbolID::TokenFloatId;
         m_lexer.m_symbol_id[cTokenFirstTimestamp] = (int) SymbolID::TokenFirstTimestampId;
         m_lexer.m_symbol_id[cTokenNewlineTimestamp] = (int) SymbolID::TokenNewlineTimestampId;
         m_lexer.m_symbol_id[cTokenNewline] = (int) SymbolID::TokenNewlineId;
@@ -46,7 +46,7 @@ namespace compressor_frontend {
         m_lexer.m_id_symbol[(int) SymbolID::TokenEndID] = cTokenEnd;
         m_lexer.m_id_symbol[(int) SymbolID::TokenUncaughtStringID] = cTokenUncaughtString;
         m_lexer.m_id_symbol[(int) SymbolID::TokenIntId] = cTokenInt;
-        m_lexer.m_id_symbol[(int) SymbolID::TokenDoubleId] = cTokenDouble;
+        m_lexer.m_id_symbol[(int) SymbolID::TokenFloatId] = cTokenFloat;
         m_lexer.m_id_symbol[(int) SymbolID::TokenFirstTimestampId] = cTokenFirstTimestamp;
         m_lexer.m_id_symbol[(int) SymbolID::TokenNewlineTimestampId] = cTokenNewlineTimestamp;
         m_lexer.m_id_symbol[(int) SymbolID::TokenNewlineId] = cTokenNewline;
@@ -54,7 +54,7 @@ namespace compressor_frontend {
         m_terminals.insert((int) SymbolID::TokenEndID);
         m_terminals.insert((int) SymbolID::TokenUncaughtStringID);
         m_terminals.insert((int) SymbolID::TokenIntId);
-        m_terminals.insert((int) SymbolID::TokenDoubleId);
+        m_terminals.insert((int) SymbolID::TokenFloatId);
         m_terminals.insert((int) SymbolID::TokenFirstTimestampId);
         m_terminals.insert((int) SymbolID::TokenNewlineTimestampId);
         m_terminals.insert((int) SymbolID::TokenNewlineId);

--- a/components/core/src/compressor_frontend/utils.cpp
+++ b/components/core/src/compressor_frontend/utils.cpp
@@ -28,7 +28,7 @@ namespace compressor_frontend {
         lexer.m_symbol_id[cTokenEnd] = (int) SymbolID::TokenEndID;
         lexer.m_symbol_id[cTokenUncaughtString] = (int) SymbolID::TokenUncaughtStringID;
         lexer.m_symbol_id[cTokenInt] = (int) SymbolID::TokenIntId;
-        lexer.m_symbol_id[cTokenDouble] = (int) SymbolID::TokenDoubleId;
+        lexer.m_symbol_id[cTokenFloat] = (int) SymbolID::TokenFloatId;
         lexer.m_symbol_id[cTokenFirstTimestamp] = (int) SymbolID::TokenFirstTimestampId;
         lexer.m_symbol_id[cTokenNewlineTimestamp] = (int) SymbolID::TokenNewlineTimestampId;
         lexer.m_symbol_id[cTokenNewline] = (int) SymbolID::TokenNewlineId;
@@ -36,7 +36,7 @@ namespace compressor_frontend {
         lexer.m_id_symbol[(int) SymbolID::TokenEndID] = cTokenEnd;
         lexer.m_id_symbol[(int) SymbolID::TokenUncaughtStringID] = cTokenUncaughtString;
         lexer.m_id_symbol[(int) SymbolID::TokenIntId] = cTokenInt;
-        lexer.m_id_symbol[(int) SymbolID::TokenDoubleId] = cTokenDouble;
+        lexer.m_id_symbol[(int) SymbolID::TokenFloatId] = cTokenFloat;
         lexer.m_id_symbol[(int) SymbolID::TokenFirstTimestampId] = cTokenFirstTimestamp;
         lexer.m_id_symbol[(int) SymbolID::TokenNewlineTimestampId] = cTokenNewlineTimestamp;
         lexer.m_id_symbol[(int) SymbolID::TokenNewlineId] = cTokenNewline;

--- a/components/core/src/streaming_archive/Constants.hpp
+++ b/components/core/src/streaming_archive/Constants.hpp
@@ -5,7 +5,7 @@
 #define STREAMING_ARCHIVE_CONSTANTS_HPP
 
 namespace streaming_archive {
-    constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevelopmentVersionFlag | 5;
+    constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevVersionFlag | 6;
     constexpr char cSegmentsDirname[] = "s";
     constexpr char cSegmentListFilename[] = "segment_list.txt";
     constexpr char cLogTypeDictFilename[] = "logtype.dict";

--- a/components/core/src/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/streaming_archive/writer/Archive.cpp
@@ -159,8 +159,7 @@ namespace streaming_archive::writer {
         // Open variable dictionary
         string var_dict_path = archive_path_string + '/' + cVarDictFilename;
         string var_dict_segment_index_path = archive_path_string + '/' + cVarSegmentIndexFilename;
-        m_var_dict.open(var_dict_path, var_dict_segment_index_path,
-                        EncodedVariableInterpreter::get_var_dict_id_max());
+        m_var_dict.open(var_dict_path, var_dict_segment_index_path, cVariableDictionaryIdMax);
 
         #if FLUSH_TO_DISK_ENABLED
             // fsync archive directory now that everything in the archive directory has been created

--- a/components/core/src/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/streaming_archive/writer/Archive.cpp
@@ -342,8 +342,10 @@ namespace streaming_archive::writer {
                         variable_dictionary_id_t id;
                         m_var_dict.add_entry(token.get_string(), id);
                         encoded_var = EncodedVariableInterpreter::encode_var_dict_id(id);
+                        m_logtype_dict_entry.add_dictionary_var();
+                    } else {
+                        m_logtype_dict_entry.add_int_var();
                     }
-                    m_logtype_dict_entry.add_non_double_var();
                     m_encoded_vars.push_back(encoded_var);
                     break;
                 }
@@ -353,9 +355,9 @@ namespace streaming_archive::writer {
                         variable_dictionary_id_t id;
                         m_var_dict.add_entry(token.get_string(), id);
                         encoded_var = EncodedVariableInterpreter::encode_var_dict_id(id);
-                        m_logtype_dict_entry.add_non_double_var();
+                        m_logtype_dict_entry.add_dictionary_var();
                     } else {
-                        m_logtype_dict_entry.add_double_var();
+                        m_logtype_dict_entry.add_float_var();
                     }
                     m_encoded_vars.push_back(encoded_var);
                     break;
@@ -368,7 +370,7 @@ namespace streaming_archive::writer {
                     encoded_var = EncodedVariableInterpreter::encode_var_dict_id(id);
                     m_var_ids.push_back(id);
 
-                    m_logtype_dict_entry.add_non_double_var();
+                    m_logtype_dict_entry.add_dictionary_var();
                     m_encoded_vars.push_back(encoded_var);
                     break;
                 }

--- a/components/core/src/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/streaming_archive/writer/Archive.cpp
@@ -160,7 +160,7 @@ namespace streaming_archive::writer {
         string var_dict_path = archive_path_string + '/' + cVarDictFilename;
         string var_dict_segment_index_path = archive_path_string + '/' + cVarSegmentIndexFilename;
         m_var_dict.open(var_dict_path, var_dict_segment_index_path,
-                        EncodedVariableInterpreter::get_var_dict_id_range_end() - EncodedVariableInterpreter::get_var_dict_id_range_begin());
+                        EncodedVariableInterpreter::get_var_dict_id_max());
 
         #if FLUSH_TO_DISK_ENABLED
             // fsync archive directory now that everything in the archive directory has been created
@@ -349,9 +349,10 @@ namespace streaming_archive::writer {
                     m_encoded_vars.push_back(encoded_var);
                     break;
                 }
-                case (int) compressor_frontend::SymbolID::TokenDoubleId: {
+                case (int) compressor_frontend::SymbolID::TokenFloatId: {
                     encoded_variable_t encoded_var;
-                    if (!EncodedVariableInterpreter::convert_string_to_representable_double_var(token.get_string(), encoded_var)) {
+                    if (!EncodedVariableInterpreter::convert_string_to_representable_float_var(
+                            token.get_string(), encoded_var)) {
                         variable_dictionary_id_t id;
                         m_var_dict.add_entry(token.get_string(), id);
                         encoded_var = EncodedVariableInterpreter::encode_var_dict_id(id);

--- a/components/core/src/utils/make_dictionaries_readable/README.md
+++ b/components/core/src/utils/make_dictionaries_readable/README.md
@@ -4,6 +4,6 @@ For a dictionary, `make-dictionaries-readable` prints one entry per line.
 For log type dictionary entries, this requires making some characters printable:
 
 * Newlines are replaced with `\n`
-* Dictionary variable delimiters are replaced with `\v`
-* Non-dictionary integer variable delimiters are replaced with `\v`
-* Non-dictionary float variable delimiters are replaced with `\ff`
+* Dictionary variable delimiters are replaced with `\d`
+* Non-dictionary integer variable delimiters are replaced with `\i`
+* Non-dictionary float variable delimiters are replaced with `\f`

--- a/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
+++ b/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
@@ -14,6 +14,7 @@
 #include "../../LogTypeDictionaryReader.hpp"
 #include "../../VariableDictionaryReader.hpp"
 #include "../../streaming_archive/Constants.hpp"
+#include "../../type_utils.hpp"
 #include "CommandLineArguments.hpp"
 
 using std::string;
@@ -82,8 +83,8 @@ int main (int argc, const char* argv[]) {
                     human_readable_value += "\\d";
                     break;
                 default:
-                    SPDLOG_ERROR("Logtype '{}' contains ""unexpected variable placeholder {}",
-                                 value, var_delim);
+                    SPDLOG_ERROR("Logtype '{}' contains unexpected variable placeholder 0x{:x}",
+                                 value, enum_to_underlying_type(var_delim));
                     return -1;
             }
             // Move past the variable delimiter

--- a/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
+++ b/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
@@ -71,10 +71,12 @@ int main (int argc, const char* argv[]) {
             // Add the constant that's between the last variable and this one, with newlines escaped
             human_readable_value.append(value, constant_begin_pos, var_pos - constant_begin_pos);
 
-            if (LogTypeDictionaryEntry::VarDelim::NonDouble == var_delim) {
-                human_readable_value += "\\v";
-            } else { // LogTypeDictionaryEntry::VarDelim::Double == var_delim
+            if (LogTypeDictionaryEntry::VarDelim::Integer == var_delim) {
+                human_readable_value += "\\i";
+            } else if (LogTypeDictionaryEntry::VarDelim::Float == var_delim) {
                 human_readable_value += "\\f";
+            } else { // LogTypeDictionaryEntry::VarDelim::Dictionary == var_delim
+                human_readable_value += "\\d";
             }
             // Move past the variable delimiter
             constant_begin_pos = var_pos + 1;

--- a/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
+++ b/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
@@ -71,12 +71,20 @@ int main (int argc, const char* argv[]) {
             // Add the constant that's between the last variable and this one, with newlines escaped
             human_readable_value.append(value, constant_begin_pos, var_pos - constant_begin_pos);
 
-            if (LogTypeDictionaryEntry::VarDelim::Integer == var_delim) {
-                human_readable_value += "\\i";
-            } else if (LogTypeDictionaryEntry::VarDelim::Float == var_delim) {
-                human_readable_value += "\\f";
-            } else { // LogTypeDictionaryEntry::VarDelim::Dictionary == var_delim
-                human_readable_value += "\\d";
+            switch (var_delim) {
+                case LogTypeDictionaryEntry::VarDelim::Integer:
+                    human_readable_value += "\\i";
+                    break;
+                case LogTypeDictionaryEntry::VarDelim::Float:
+                    human_readable_value += "\\f";
+                    break;
+                case LogTypeDictionaryEntry::VarDelim::Dictionary:
+                    human_readable_value += "\\d";
+                    break;
+                default:
+                    SPDLOG_ERROR("Logtype '{}' contains ""unexpected variable placeholder {}",
+                                 value, var_delim);
+                    return -1;
             }
             // Move past the variable delimiter
             constant_begin_pos = var_pos + 1;

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -13,10 +13,6 @@ using std::to_string;
 using std::vector;
 
 TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
-    SECTION("Test range of variable dictionary IDs") {
-        // Ensure range of variable dictionary IDs goes from begin to end and is not empty
-        REQUIRE(EncodedVariableInterpreter::get_var_dict_id_range_begin() < EncodedVariableInterpreter::get_var_dict_id_range_end());
-    }
 
     SECTION("Test convert_string_to_representable_integer_var") {
         string value;
@@ -36,7 +32,7 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
         REQUIRE(1 == encoded_var);
 
         // Test edges of representable range
-        encoded_variable_t representable_int_range_begin = EncodedVariableInterpreter::get_var_dict_id_range_begin() - 1;
+        encoded_variable_t representable_int_range_begin = INT64_MAX;
         value = to_string(representable_int_range_begin);
         REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_integer_var(value, encoded_var));
         REQUIRE(representable_int_range_begin == encoded_var);
@@ -110,122 +106,113 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
 
         value = "-0";
         REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_integer_var(value, encoded_var));
-
-        value = to_string(EncodedVariableInterpreter::get_var_dict_id_range_begin());
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_integer_var(value, encoded_var));
-
-        value = to_string(EncodedVariableInterpreter::get_var_dict_id_range_end());
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_integer_var(value, encoded_var));
     }
 
-    SECTION("Test convert_string_to_representable_double_var") {
+    SECTION("Test convert_string_to_representable_float_var") {
         string value;
         encoded_variable_t encoded_var;
         double var_as_double;
 
         // Test basic conversions
         value = "0.0";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE("0.0" == value);
 
         value = "-1.0";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE("-1.0" == value);
 
         value = "1.0";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE("1.0" == value);
 
         value = ".1";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE(".1" == value);
 
         value = "-00.00";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE("-00.00" == value);
 
         // Test edges of representable range
         value = "-999999999999999.9";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE("-999999999999999.9" == value);
 
         value = "-.9999999999999999";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE("-.9999999999999999" == value);
 
         value = ".9999999999999999";
-        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-        EncodedVariableInterpreter::convert_encoded_double_to_string(encoded_var, value);
+        REQUIRE(EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
+        EncodedVariableInterpreter::convert_encoded_float_to_string(encoded_var, value);
         REQUIRE(".9999999999999999" == value);
 
         // Test non-doubles
         value = "";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "a";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "-";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "+";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "-a";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "+a";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "--";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "++";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         // Test unrepresentable values
         value = ".";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "1.";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = " 1.0";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "- 1.0";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "1.0 ";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "+1.0";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "1.0f";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "1.0F";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "1.0l";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
         value = "1.0L";
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
 
-        value = to_string(EncodedVariableInterpreter::get_var_dict_id_range_begin());
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
-
-        value = to_string(EncodedVariableInterpreter::get_var_dict_id_range_end());
-        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_double_var(value, encoded_var));
+        value = to_string(UINT64_MAX);
+        REQUIRE(!EncodedVariableInterpreter::convert_string_to_representable_float_var(value, encoded_var));
     }
 
     SECTION("Test encoding and decoding") {
@@ -237,25 +224,37 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
         // Open writer
         VariableDictionaryWriter var_dict_writer;
         var_dict_writer.open(cVarDictPath, cVarSegmentIndexPath,
-                             EncodedVariableInterpreter::get_var_dict_id_range_end() - EncodedVariableInterpreter::get_var_dict_id_range_begin());
+                             EncodedVariableInterpreter::get_var_dict_id_max());
 
         // Test encoding
         vector<encoded_variable_t> encoded_vars;
         vector<variable_dictionary_id_t> var_ids;
-        vector<string> var_strs = {"4938", to_string(EncodedVariableInterpreter::get_var_dict_id_range_begin()),
-                                   "-25.5196868642755", "-00.00", "bin/python2.7.3"};
-        msg = "here is a string with a small int " + var_strs[0] + " and a very large int " + var_strs[1] + " and a double " + var_strs[2] +
-              " and a weird double " + var_strs[3] + " and a str with numbers " + var_strs[4];
+
+        string large_val_str = to_string(EncodedVariableInterpreter::get_var_dict_id_max()) + "0";
+        vector<string> var_strs = {"4938", large_val_str, "-25.5196868642755",
+                                   "-00.00", "bin/python2.7.3"};
+        msg = "here is a string with a small int " + var_strs[0] +
+                " and a very large int " + var_strs[1] +
+                " and a double " + var_strs[2] +
+                " and a weird double " + var_strs[3] +
+                " and a str with numbers " + var_strs[4];
+
         LogTypeDictionaryEntry logtype_dict_entry;
-        EncodedVariableInterpreter::encode_and_add_to_dictionary(msg, logtype_dict_entry, var_dict_writer, encoded_vars, var_ids);
+        EncodedVariableInterpreter::encode_and_add_to_dictionary(msg, logtype_dict_entry,
+                                                                 var_dict_writer, encoded_vars,
+                                                                 var_ids);
         var_dict_writer.close();
 
         // Test var_ids is correctly populated
         size_t encoded_var_id_ix = 0;
-        for (const auto& var : encoded_vars) {
-            if(EncodedVariableInterpreter::is_var_dict_id(var)){
+        LogTypeDictionaryEntry::VarDelim var_placeholder;
+        for (auto var_ix = 0; var_ix < logtype_dict_entry.get_num_vars(); var_ix++) {
+            static_cast<void>(logtype_dict_entry.get_var_info(var_ix, var_placeholder));
+            if(LogTypeDictionaryEntry::VarDelim::Dictionary == var_placeholder){
+                encoded_variable_t var = encoded_vars[var_ix];
                 REQUIRE(var_ids.size() > encoded_var_id_ix);
-                REQUIRE(EncodedVariableInterpreter::decode_var_dict_id(var) == var_ids[encoded_var_id_ix]);
+                REQUIRE(EncodedVariableInterpreter::decode_var_dict_id(var) ==
+                        var_ids[encoded_var_id_ix]);
                 encoded_var_id_ix++;
             }
         }

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -13,7 +13,6 @@ using std::to_string;
 using std::vector;
 
 TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
-
     SECTION("Test convert_string_to_representable_integer_var") {
         string value;
         encoded_variable_t encoded_var;
@@ -223,14 +222,13 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
 
         // Open writer
         VariableDictionaryWriter var_dict_writer;
-        var_dict_writer.open(cVarDictPath, cVarSegmentIndexPath,
-                             EncodedVariableInterpreter::get_var_dict_id_max());
+        var_dict_writer.open(cVarDictPath, cVarSegmentIndexPath, cVariableDictionaryIdMax);
 
         // Test encoding
         vector<encoded_variable_t> encoded_vars;
         vector<variable_dictionary_id_t> var_ids;
 
-        string large_val_str = to_string(EncodedVariableInterpreter::get_var_dict_id_max()) + "0";
+        string large_val_str = to_string(cVariableDictionaryIdMax) + "0";
         vector<string> var_strs = {"4938", large_val_str, "-25.5196868642755",
                                    "-00.00", "bin/python2.7.3"};
         msg = "here is a string with a small int " + var_strs[0] +
@@ -249,9 +247,9 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
         size_t encoded_var_id_ix = 0;
         LogTypeDictionaryEntry::VarDelim var_placeholder;
         for (auto var_ix = 0; var_ix < logtype_dict_entry.get_num_vars(); var_ix++) {
-            static_cast<void>(logtype_dict_entry.get_var_info(var_ix, var_placeholder));
-            if(LogTypeDictionaryEntry::VarDelim::Dictionary == var_placeholder){
-                encoded_variable_t var = encoded_vars[var_ix];
+            std::ignore = logtype_dict_entry.get_var_info(var_ix, var_placeholder);
+            if (LogTypeDictionaryEntry::VarDelim::Dictionary == var_placeholder) {
+                auto var = encoded_vars[var_ix];
                 REQUIRE(var_ids.size() > encoded_var_id_ix);
                 REQUIRE(EncodedVariableInterpreter::decode_var_dict_id(var) ==
                         var_ids[encoded_var_id_ix]);

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -332,7 +332,7 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     decoded_value = decode_float_var(encoded_var);
     REQUIRE(decoded_value == value);
 
-    // Test non-doubles
+    // Test non-floats
     value = "";
     REQUIRE(!encode_float_string(value, encoded_var));
 
@@ -405,9 +405,9 @@ TEMPLATE_TEST_CASE("Encoding messages", "[ffi][encode-message]", eight_byte_enco
     message = "here is a string with a small int " + var_strs[var_ix++];
     message += " and a medium int " + var_strs[var_ix++];
     message += " and a very large int " + var_strs[var_ix++];
-    message += " and a small double " + var_strs[var_ix++];
-    message += " and a medium double " + var_strs[var_ix++];
-    message += " and a weird double " + var_strs[var_ix++];
+    message += " and a small float " + var_strs[var_ix++];
+    message += " and a medium float " + var_strs[var_ix++];
+    message += " and a weird float " + var_strs[var_ix++];
     message += " and a string with numbers " + var_strs[var_ix++];
     message += " and another string with numbers " + var_strs[var_ix++];
     REQUIRE(encode_message(message, logtype, encoded_vars, dictionary_var_bounds));


### PR DESCRIPTION
# References

# Description
Use IR format for CLP message encoding and floating number

# Validation performed
Compression ratio delta:
hadoop-24hrs. +0.5%
hadoop-30gb. < -0.01%
openstacks-24hr. -0.2%
spark. -0.3%
var-logs. -2%


