### PR TITLE
Add temporary decode_message for ir_decoder to handle escaped placehold in the logtype

### DIFF
--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -63,7 +63,8 @@ namespace ffi {
             "logtype.";
     static constexpr char cTooFewEncodedVarsErrorMessage[] =
             "There are fewer encoded variables than encoded variable delimiters in the logtype.";
-
+    static constexpr char cUnexpectedEscapeCharacterMessage[] =
+            "Unexpected escape character without escaped value at the end of logtype.";
     constexpr size_t cMaxDigitsInRepresentableEightByteFloatVar = 16;
     constexpr size_t cMaxDigitsInRepresentableFourByteFloatVar = 8;
 

--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -65,6 +65,7 @@ namespace ffi {
             "There are fewer encoded variables than encoded variable delimiters in the logtype.";
     static constexpr char cUnexpectedEscapeCharacterMessage[] =
             "Unexpected escape character without escaped value at the end of logtype.";
+
     constexpr size_t cMaxDigitsInRepresentableEightByteFloatVar = 16;
     constexpr size_t cMaxDigitsInRepresentableFourByteFloatVar = 8;
 

--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -64,7 +64,7 @@ namespace ffi {
     static constexpr char cTooFewEncodedVarsErrorMessage[] =
             "There are fewer encoded variables than encoded variable delimiters in the logtype.";
     static constexpr char cUnexpectedEscapeCharacterMessage[] =
-            "Unexpected escape character without escaped value at the end of logtype.";
+            "Unexpected escape character without escaped value at the end of the logtype.";
 
     constexpr size_t cMaxDigitsInRepresentableEightByteFloatVar = 16;
     constexpr size_t cMaxDigitsInRepresentableFourByteFloatVar = 8;

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -332,10 +332,9 @@ TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]",
             decode_next_message<TestType>(incomplete_message_buffer, message, timestamp));
 }
 
-// The test case only tests eight_byte_encoded_variable_t. Because the timestamp
-// size is fixed, it is easier to reverse engineer the last index of logtype in
-// the ir_buffer. The test makes modification to the logtype in the ir_buf
-// to trigger a mocked IRErrorCode_Decode_Error.
+// NOTE: This test only tests eight_byte_encoded_variable_t because we trigger
+// IRErrorCode_Decode_Error by manually modifying the logtype within the IR, and
+// this is easier for the eight_byte_encoded_variable_t case.
 TEST_CASE("message_decode_error", "[ffi][decode_next_message]")
 {
     vector<int8_t> ir_buf;
@@ -345,36 +344,35 @@ TEST_CASE("message_decode_error", "[ffi][decode_next_message]")
     string message = "Static <\text>, dictVar1, 123, 456.7 dictVar2, 987, 654.3," +
                      placeholder_as_string + " end of static text";
     epoch_time_ms_t reference_ts = get_next_timestamp_for_test<eight_byte_encoded_variable_t>();
-    REQUIRE(true ==
-            encode_message<eight_byte_encoded_variable_t>(reference_ts, message, logtype,
-                                                          ir_buf));
+    REQUIRE(true == encode_message<eight_byte_encoded_variable_t>(reference_ts, message,
+                                                                  logtype, ir_buf));
 
-    // Timestamp is encoded as tagbyte + eight_byte_encoded_variable_t
+    // Find the end of the encoded logtype which is before the encoded timestamp
+    // The timestamp is encoded as tagbyte + eight_byte_encoded_variable_t
     size_t timestamp_encoding_size = sizeof(ffi::ir_stream::cProtocol::Payload::TimestampVal) +
                                      sizeof(eight_byte_encoded_variable_t);
-    const size_t logtype_end_index = (ir_buf.size() - 1) - timestamp_encoding_size;
+    const size_t logtype_end_pos = ir_buf.size() - timestamp_encoding_size;
 
     string decoded_message;
     epoch_time_ms_t timestamp;
 
     // Test if a trailing escape triggers a decoder error
     auto ir_with_extra_escape{ir_buf};
-    ir_with_extra_escape.at(logtype_end_index) = ffi::cVariablePlaceholderEscapeCharacter;
+    ir_with_extra_escape.at(logtype_end_pos - 1) = ffi::cVariablePlaceholderEscapeCharacter;
     IrBuffer ir_buffer_with_extra_escape(ir_with_extra_escape.data(), ir_with_extra_escape.size());
     REQUIRE(IRErrorCode::IRErrorCode_Decode_Error ==
             decode_next_message<eight_byte_encoded_variable_t>(ir_buffer_with_extra_escape,
-                                                               message, timestamp));
-
+                                                               decoded_message, timestamp));
 
     // Test if an extra placeholder triggers a decoder error
     auto ir_with_extra_placeholder{ir_buf};
-    ir_with_extra_placeholder.at(logtype_end_index) = enum_to_underlying_type(
-            VariablePlaceholder::Dictionary);
+    ir_with_extra_placeholder.at(logtype_end_pos - 1) =
+            enum_to_underlying_type(VariablePlaceholder::Dictionary);
     IrBuffer ir_buffer_with_extra_placeholder(ir_with_extra_escape.data(),
                                               ir_with_extra_escape.size());
     REQUIRE(IRErrorCode::IRErrorCode_Decode_Error ==
             decode_next_message<eight_byte_encoded_variable_t>(ir_buffer_with_extra_placeholder,
-                                                               message, timestamp));
+                                                               decoded_message, timestamp));
 }
 
 TEST_CASE("decode_next_message_four_byte_negative_delta", "[ffi][decode_next_message]") {

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -304,8 +304,9 @@ TEMPLATE_TEST_CASE("decode_next_message_general", "[ffi][decode_next_message]",
     vector<int8_t> ir_buf;
     string logtype;
 
-    string message = "Static <\text>, dictVar1, 123, 456.7, "
-                     "dictVar2, 987, 654.3, end of static text";
+    string placeholder_as_string {enum_to_underlying_type(ffi::VariablePlaceholder::Dictionary)};
+    string message = "Static <\text>, dictVar1, 123, 456.7 dictVar2, 987, 654.3," +
+                     placeholder_as_string + " end of static text";
     epoch_time_ms_t reference_timestamp = get_next_timestamp_for_test<TestType>();
     REQUIRE(true == encode_message<TestType>(reference_timestamp, message, logtype, ir_buf));
     const size_t encoded_message_end_pos = ir_buf.size();

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -352,7 +352,7 @@ TEST_CASE("message_decode_error", "[ffi][decode_next_message]")
     // Timestamp is encoded as tagbyte + eight_byte_encoded_variable_t
     size_t timestamp_encoding_size = sizeof(ffi::ir_stream::cProtocol::Payload::TimestampVal) +
                                      sizeof(eight_byte_encoded_variable_t);
-    const size_t logtype_end_index = (ir_buf.size() - 1) - encoded_timestamp_size;
+    const size_t logtype_end_index = (ir_buf.size() - 1) - timestamp_encoding_size;
 
     string decoded_message;
     epoch_time_ms_t timestamp;


### PR DESCRIPTION
# References
N/A

# Description
Let the ir decoder use a temporary version of decode message that properly handles escaped placeholder.

# Validation performed
Updated the unit test to cover escaped placeholder in the logtype
