### PR TITLE
Additional 4-byte encoding methods

### DIFF
--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -268,20 +268,18 @@ namespace ffi::ir_stream {
         bool encode_message (epoch_time_ms_t timestamp_delta, string_view message, string& logtype,
                              vector<int8_t>& ir_buf)
         {
-            if (!encode_message(message, logtype, ir_buf)) {
+            if (false == encode_message(message, logtype, ir_buf)) {
                 return false;
             }
 
-            if (!encode_timestamp(timestamp_delta, ir_buf)) {
+            if (false == encode_timestamp(timestamp_delta, ir_buf)) {
                 return false;
             }
 
             return true;
         }
 
-        bool encode_message (std::string_view message, std::string& logtype,
-                             std::vector<int8_t>& ir_buf)
-        {
+        bool encode_message (string_view message, string& logtype, vector<int8_t>& ir_buf) {
             auto encoded_var_handler = [&ir_buf] (four_byte_encoded_variable_t encoded_var) {
                 ir_buf.push_back(cProtocol::Payload::VarFourByteEncoding);
                 encode_int(encoded_var, ir_buf);

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -268,6 +268,20 @@ namespace ffi::ir_stream {
         bool encode_message (epoch_time_ms_t timestamp_delta, string_view message, string& logtype,
                              vector<int8_t>& ir_buf)
         {
+            if (!encode_message(message, logtype, ir_buf)) {
+                return false;
+            }
+
+            if (!encode_timestamp(timestamp_delta, ir_buf)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        bool encode_message (std::string_view message, std::string& logtype,
+                             std::vector<int8_t>& ir_buf)
+        {
             auto encoded_var_handler = [&ir_buf] (four_byte_encoded_variable_t encoded_var) {
                 ir_buf.push_back(cProtocol::Payload::VarFourByteEncoding);
                 encode_int(encoded_var, ir_buf);
@@ -284,7 +298,10 @@ namespace ffi::ir_stream {
                 return false;
             }
 
-            // Encode timestamp delta
+            return true;
+        }
+
+        bool encode_timestamp (epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf) {
             if (INT8_MIN <= timestamp_delta && timestamp_delta <= INT8_MAX) {
                 ir_buf.push_back(cProtocol::Payload::TimestampDeltaByte);
                 ir_buf.push_back(static_cast<int8_t>(timestamp_delta));

--- a/components/core/src/ffi/ir_stream/encoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.hpp
@@ -59,6 +59,25 @@ namespace ffi::ir_stream {
          */
         bool encode_message (epoch_time_ms_t timestamp_delta, std::string_view message,
                              std::string& logtype, std::vector<int8_t>& ir_buf);
+
+        /**
+         * Encodes the given message into the four-byte encoding IR stream
+         * without encoding timestamp delta
+         * @param message
+         * @param logtype
+         * @param ir_buf
+         * @return true on success, false otherwise
+         */
+        bool encode_message (std::string_view message, std::string& logtype,
+                             std::vector<int8_t>& ir_buf);
+
+        /**
+         * Encodes the given timestamp delta into the four-byte encoding IR stream
+         * @param timestamp_delta
+         * @param ir_buf
+         * @return true on success, false otherwise
+         */
+        bool encode_timestamp (epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf);
     }
 }
 

--- a/components/core/src/ffi/ir_stream/encoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.hpp
@@ -72,7 +72,8 @@ namespace ffi::ir_stream {
                              std::vector<int8_t>& ir_buf);
 
         /**
-         * Encodes the given timestamp delta into the four-byte encoding IR stream
+         * Encodes the given timestamp delta into the four-byte encoding IR
+         * stream
          * @param timestamp_delta
          * @param ir_buf
          * @return true on success, false otherwise


### PR DESCRIPTION
# Description
Adding two 4-byte encoding methods, which separate message encoding and timestamp encoding. The Python logging library needs to encode messages separately in some cases. This PR is to accommodate Python logging library needs without breaking existing functionalities.

# Validation performed
Tested with Python logging libraries and had the correctness verified.

