### PR TITLE
ffi: Return metadata position, size, and type from decode_preamble for upper layer to parse.

### DIFF
--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -374,9 +374,6 @@ namespace ffi::ir_stream {
         if (false == ir_buf.try_read(metadata_type)) {
             return IRErrorCode_Incomplete_IR;
         }
-        if (metadata_type != cProtocol::Metadata::EncodingJson) {
-            return IRErrorCode_Corrupted_IR;
-        }
 
         // Read metadata length
         encoded_tag_t encoded_tag;

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -1,8 +1,5 @@
 #include "decoding_methods.hpp"
 
-// json
-#include "../../../submodules/json/single_include/nlohmann/json.hpp"
-
 // Project headers
 #include "byteswap.hpp"
 #include "protocol_constants.hpp"
@@ -77,13 +74,6 @@ namespace ffi::ir_stream {
     IRErrorCode parse_timestamp (IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
 
     /**
-     * Extracts timestamp info from the JSON metadata and stores it into ts_info
-     * @param metadata_json The JSON metadata
-     * @param ts_info Returns the timestamp info
-     */
-    static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info);
-
-    /**
      * Decodes the next encoded message from ir_buf
      * @tparam encoded_variable_t Type of the encoded variable
      * @param ir_buf
@@ -103,15 +93,18 @@ namespace ffi::ir_stream {
                                                     epoch_time_ms_t& timestamp);
 
     /**
-     * Decodes the JSON metadata from the ir_buf
+     * Reads metadata information from the ir_buf
      * @param ir_buf
-     * @param json_metadata Returns the JSON metadata
+     * @param metadata_type Returns the type of the metadata found in the IR
+     * @param metadata_pos Returns the starting position of the metadata in ir_buf
+     * @param metadata_size Returns the size of the metadata written in the IR
      * @return IRErrorCode_Success on success
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
      * to decode
      */
-    static IRErrorCode read_json_metadata (IrBuffer& ir_buf, string_view& json_metadata);
+    static IRErrorCode read_metadata_info (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
+                                           uint16_t& metadata_size);
 
     /**
      * Decodes the message from the given logtype, encoded variables, and
@@ -308,13 +301,6 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info) {
-        ts_info.time_zone_id = metadata_json.at(cProtocol::Metadata::TimeZoneIdKey);
-        ts_info.timestamp_pattern = metadata_json.at(cProtocol::Metadata::TimestampPatternKey);
-        ts_info.timestamp_pattern_syntax =
-                metadata_json.at(cProtocol::Metadata::TimestampPatternSyntaxKey);
-    }
-
     template <typename encoded_variable_t>
     static IRErrorCode generic_decode_next_message (IrBuffer& ir_buf, string& message,
                                                     epoch_time_ms_t& timestamp)
@@ -383,42 +369,37 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    static IRErrorCode read_json_metadata (IrBuffer& ir_buf, string_view& json_metadata) {
-        encoded_tag_t encoded_tag;
-        if (false == ir_buf.try_read(encoded_tag)) {
+    static IRErrorCode read_metadata_info (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
+                                           uint16_t& metadata_size) {
+        if (false == ir_buf.try_read(metadata_type)) {
             return IRErrorCode_Incomplete_IR;
         }
-        if (encoded_tag != cProtocol::Metadata::EncodingJson) {
+        if (metadata_type != cProtocol::Metadata::EncodingJson) {
             return IRErrorCode_Corrupted_IR;
         }
 
         // Read metadata length
+        encoded_tag_t encoded_tag;
         if (false == ir_buf.try_read(encoded_tag)) {
             return IRErrorCode_Incomplete_IR;
         }
-        unsigned int metadata_length;
         switch (encoded_tag) {
             case cProtocol::Metadata::LengthUByte:
                 uint8_t ubyte_res;
                 if (false == decode_int(ir_buf, ubyte_res)) {
                     return IRErrorCode_Incomplete_IR;
                 }
-                metadata_length = ubyte_res;
+                metadata_size = ubyte_res;
                 break;
             case cProtocol::Metadata::LengthUShort:
                 uint16_t ushort_res;
                 if (false == decode_int(ir_buf, ushort_res)) {
                     return IRErrorCode_Incomplete_IR;
                 }
-                metadata_length = ushort_res;
+                metadata_size = ushort_res;
                 break;
             default:
                 return IRErrorCode_Corrupted_IR;
-        }
-
-        // Read the serialized metadata
-        if (false == ir_buf.try_read(json_metadata, metadata_length)) {
-            return IRErrorCode_Incomplete_IR;
         }
         return IRErrorCode_Success;
     }
@@ -532,37 +513,28 @@ namespace ffi::ir_stream {
         return IRErrorCode_Success;
     }
 
-    namespace four_byte_encoding {
-        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info,
-                                     epoch_time_ms_t& reference_ts)
-        {
-            ir_buf.init_internal_pos();
+    IRErrorCode decode_preamble (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
+                                 size_t& metadata_pos, uint16_t& metadata_size)
+    {
+        ir_buf.init_internal_pos();
 
-            string_view json_metadata;
-            if (auto error_code = read_json_metadata(ir_buf, json_metadata);
-                    error_code != IRErrorCode_Success)
-            {
-                return error_code;
-            }
-
-            try {
-                auto metadata_json = nlohmann::json::parse(json_metadata);
-                const auto& version = metadata_json.at(cProtocol::Metadata::VersionKey);
-                if (version != cProtocol::Metadata::VersionValue) {
-                    return IRErrorCode_Unsupported_Version;
-                }
-
-                set_timestamp_info(metadata_json, ts_info);
-                reference_ts = std::stoll(metadata_json.at(
-                        cProtocol::Metadata::ReferenceTimestampKey).get<string>());
-            } catch (const nlohmann::json::parse_error& e) {
-                return IRErrorCode_Corrupted_Metadata;
-            }
-
-            ir_buf.commit_internal_pos();
-            return IRErrorCode_Success;
+        if (auto error_code = read_metadata_info(ir_buf, metadata_type, metadata_size);
+                error_code != IRErrorCode_Success) {
+            return error_code;
         }
 
+        size_t pos{ir_buf.get_cursor_pos()};
+        ir_buf.commit_internal_pos();
+        metadata_pos = ir_buf.get_cursor_pos();
+        if (ir_buf.size() < metadata_pos + metadata_size) {
+            ir_buf.set_cursor_pos(pos);
+            return IRErrorCode_Incomplete_IR;
+        }
+        ir_buf.set_cursor_pos(metadata_pos + metadata_size);
+        return IRErrorCode_Success;
+    }
+
+    namespace four_byte_encoding {
         IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message,
                                          epoch_time_ms_t& timestamp_delta)
         {
@@ -573,31 +545,6 @@ namespace ffi::ir_stream {
     }
 
     namespace eight_byte_encoding {
-        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info) {
-            ir_buf.init_internal_pos();
-
-            string_view json_metadata;
-            if (auto error_code = read_json_metadata(ir_buf, json_metadata);
-                    error_code != IRErrorCode_Success)
-            {
-                return error_code;
-            }
-            try {
-                auto metadata_json = nlohmann::json::parse(json_metadata);
-                const auto& version = metadata_json.at(cProtocol::Metadata::VersionKey);
-                if (version != cProtocol::Metadata::VersionValue) {
-                    return IRErrorCode_Unsupported_Version;
-                }
-
-                set_timestamp_info(metadata_json, ts_info);
-            } catch (const nlohmann::json::parse_error& e) {
-                return IRErrorCode_Corrupted_Metadata;
-            }
-
-            ir_buf.commit_internal_pos();
-            return IRErrorCode_Success;
-        }
-
         IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message,
                                          epoch_time_ms_t& timestamp)
         {

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -30,7 +30,7 @@ namespace ffi::ir_stream {
         // The following methods should only be used by the decoder
         void init_internal_pos () { m_internal_cursor_pos = m_cursor_pos; }
         void commit_internal_pos () { m_cursor_pos = m_internal_cursor_pos; }
-        size_t const size () const { return m_size; }
+        size_t size () const { return m_size; }
 
         /**
          * Tries reading a string view of size = read_size from the ir_buf.
@@ -79,15 +79,6 @@ namespace ffi::ir_stream {
         size_t m_internal_cursor_pos;
     };
 
-    /**
-     * Struct to hold the timestamp info from the IR stream's metadata
-     */
-    struct TimestampInfo {
-        std::string timestamp_pattern;
-        std::string timestamp_pattern_syntax;
-        std::string time_zone_id;
-    };
-
     typedef enum {
         IRErrorCode_Success,
         IRErrorCode_Decode_Error,
@@ -110,7 +101,7 @@ namespace ffi::ir_stream {
     IRErrorCode get_encoding_type (IrBuffer& ir_buf, bool& is_four_bytes_encoding);
 
     /**
-     * Decodes the preamble for the eight-byte encoding IR stream.
+     * Decodes the preamble for an IR stream.
      * @param ir_buf
      * @param metadata_type Returns the type of the metadata found in the IR
      * @param metadata_pos Returns the starting position of the metadata in ir_buf
@@ -119,8 +110,6 @@ namespace ffi::ir_stream {
      * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
      * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
      * data to decode
-     * @return IRErrorCode_Unsupported_Version if the IR uses an unsupported
-     * version
      */
     IRErrorCode decode_preamble (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
                                  size_t& metadata_pos, uint16_t& metadata_size);

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -9,7 +9,7 @@
 #include "../encoding_methods.hpp"
 
 namespace ffi::ir_stream {
-    using encoded_tag_t = uint8_t;
+    using encoded_tag_t = int8_t;
 
     /**
      * Class representing an IR buffer that the decoder sequentially reads from.
@@ -30,6 +30,7 @@ namespace ffi::ir_stream {
         // The following methods should only be used by the decoder
         void init_internal_pos () { m_internal_cursor_pos = m_cursor_pos; }
         void commit_internal_pos () { m_cursor_pos = m_internal_cursor_pos; }
+        size_t const size () const { return m_size; }
 
         /**
          * Tries reading a string view of size = read_size from the ir_buf.
@@ -108,22 +109,23 @@ namespace ffi::ir_stream {
      */
     IRErrorCode get_encoding_type (IrBuffer& ir_buf, bool& is_four_bytes_encoding);
 
-    namespace eight_byte_encoding {
-        /**
-         * Decodes the preamble for the eight-byte encoding IR stream.
-         * @param ir_buf
-         * @param ts_info Returns the timestamp info on success
-         * @return IRErrorCode_Success on success
-         * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-         * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
-         * data to decode
-         * @return IRErrorCode_Unsupported_Version if the IR uses an unsupported
-         * version
-         * @return IRErrorCode_Corrupted_Metadata if the metadata cannot be
-         * decoded
-         */
-        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info);
+    /**
+     * Decodes the preamble for the eight-byte encoding IR stream.
+     * @param ir_buf
+     * @param metadata_type Returns the type of the metadata found in the IR
+     * @param metadata_pos Returns the starting position of the metadata in ir_buf
+     * @param metadata_size Returns the size of the metadata written in the IR
+     * @return IRErrorCode_Success on success
+     * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
+     * data to decode
+     * @return IRErrorCode_Unsupported_Version if the IR uses an unsupported
+     * version
+     */
+    IRErrorCode decode_preamble (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
+                                 size_t& metadata_pos, uint16_t& metadata_size);
 
+    namespace eight_byte_encoding {
         /**
          * Decodes the next message for the eight-byte encoding IR stream.
          * @param ir_buf
@@ -142,23 +144,6 @@ namespace ffi::ir_stream {
     }
 
     namespace four_byte_encoding {
-        /**
-         * Decodes the preamble for the four-byte encoding IR stream.
-         * @param ir_buf
-         * @param ts_info Returns the decoded timestamp info
-         * @param reference_ts Returns the decoded reference timestamp
-         * @return IRErrorCode_Success on success
-         * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-         * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
-         * data to decode
-         * @return IRErrorCode_Unsupported_Version if the IR has a version that
-         * is not supported
-         * @return IRErrorCode_Corrupted_Metadata if the metadata cannot be
-         * decoded
-         */
-        IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info,
-                                     epoch_time_ms_t& reference_ts);
-
         /**
          * Decodes the next message for the four-byte encoding IR stream.
          * @param ir_buf

--- a/components/core/src/type_utils.hpp
+++ b/components/core/src/type_utils.hpp
@@ -51,4 +51,20 @@ struct overloaded : Ts ... {
  */
 template <class... Ts> overloaded (Ts...) -> overloaded<Ts...>;
 
+/**
+ * Cast between pointers after ensuring the source and destination types are
+ * the same size
+ * @tparam Destination The destination type
+ * @tparam Source The source type
+ * @param src The source pointer
+ * @return The casted pointer
+ */
+template <typename Destination, class Source>
+std::enable_if_t<sizeof(Destination) == sizeof(Source), Destination*>
+        size_checked_pointer_cast (Source* src)
+{
+    return reinterpret_cast<Destination*>(src);
+}
+
+
 #endif // TYPE_UTILS_HPP

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -272,7 +272,7 @@ TEMPLATE_TEST_CASE("decode_preamble", "[ffi][decode_preamble]", four_byte_encode
             IRErrorCode::IRErrorCode_Success);
     REQUIRE(encoded_preamble_end_pos == preamble_buffer.get_cursor_pos());
 
-    char* metadata_ptr{reinterpret_cast<char*>(ir_buf.data()) + metadata_pos};
+    char* metadata_ptr{size_checked_pointer_cast<char>(ir_buf.data()) + metadata_pos};
     string_view json_metadata{metadata_ptr, metadata_size};
     auto metadata_json = nlohmann::json::parse(json_metadata);
     REQUIRE(ffi::ir_stream::cProtocol::Metadata::VersionValue ==

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -259,9 +259,9 @@ TEMPLATE_TEST_CASE("decode_preamble", "[ffi][decode_preamble]", four_byte_encode
 
     // Test if preamble can be decoded correctly
     TimestampInfo ts_info;
-    int8_t metadata_type;
-    size_t metadata_pos;
-    uint16_t metadata_size;
+    int8_t metadata_type{0};
+    size_t metadata_pos{0};
+    uint16_t metadata_size{0};
     REQUIRE(decode_preamble(preamble_buffer, metadata_type, metadata_pos, metadata_size) ==
             IRErrorCode::IRErrorCode_Success);
     REQUIRE(encoded_preamble_end_pos == preamble_buffer.get_cursor_pos());

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -1,6 +1,9 @@
 // Catch2
 #include "../submodules/Catch2/single_include/catch2/catch.hpp"
 
+// json
+#include "../../../submodules/json/single_include/nlohmann/json.hpp"
+
 // Project headers
 #include "../src/ffi/encoding_methods.hpp"
 #include "../src/ffi/ir_stream/encoding_methods.hpp"
@@ -66,24 +69,6 @@ bool encode_preamble (string_view timestamp_pattern,
                       epoch_time_ms_t reference_timestamp, vector<int8_t>& ir_buf);
 
 /**
- * Helper function that decodes a preamble of encoding type = encoded_variable_t
- * from the ir_buf
- * @tparam encoded_variable_t Type of the encoded variable
- * @param ir_buf
- * @param ts_info
- * @param reference_ts Returns the reference timestamp decoded from preamble
- * only when encoded_variable_t == four_byte_encoded_variable_t
- * @return IRErrorCode_Success on success, otherwise
- * Same as the ffi::ir_stream::eight_byte_encoding::decode_preamble when
- * encoded_variable_t == eight_byte_encoded_variable_t
- * Same as the ffi::ir_stream::four_byte_encoding::decode_preamble when
- * encoded_variable_t == four_byte_encoded_variable_t
- */
-template <typename encoded_variable_t>
-IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info,
-                             epoch_time_ms_t& reference_ts);
-
-/**
  * Helper function that encodes a message of encoding type = encoded_variable_t
  * and writes into ir_buf
  * @tparam encoded_variable_t Type of the encoded variable
@@ -112,6 +97,13 @@ bool encode_message (epoch_time_ms_t timestamp, string_view message, string& log
  */
 template <typename encoded_variable_t>
 IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message, epoch_time_ms_t& decoded_ts);
+
+/**
+ * Extracts timestamp info from the JSON metadata and stores it into ts_info
+ * @param metadata_json The JSON metadata
+ * @param ts_info Returns the timestamp info
+ */
+static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info);
 
 static epoch_time_ms_t get_current_ts () {
     return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
@@ -167,20 +159,6 @@ bool encode_preamble (string_view timestamp_pattern,
 }
 
 template <typename encoded_variable_t>
-IRErrorCode decode_preamble (IrBuffer& ir_buf, TimestampInfo& ts_info,
-                             epoch_time_ms_t& reference_ts)
-{
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
-
-    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-        return ffi::ir_stream::eight_byte_encoding::decode_preamble(ir_buf, ts_info);
-    } else {
-        return ffi::ir_stream::four_byte_encoding::decode_preamble(ir_buf, ts_info, reference_ts);
-    }
-}
-
-template <typename encoded_variable_t>
 bool encode_message (epoch_time_ms_t timestamp, string_view message, string& logtype,
                      vector<int8_t>& ir_buf) {
     static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
@@ -207,6 +185,14 @@ IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message, epoch_time_m
         return ffi::ir_stream::four_byte_encoding::decode_next_message(ir_buf, message,
                                                                        decoded_ts);
     }
+}
+
+static void set_timestamp_info (const nlohmann::json& metadata_json, TimestampInfo& ts_info) {
+    ts_info.time_zone_id = metadata_json.at(ffi::ir_stream::cProtocol::Metadata::TimeZoneIdKey);
+    ts_info.timestamp_pattern =
+        metadata_json.at(ffi::ir_stream::cProtocol::Metadata::TimestampPatternKey);
+    ts_info.timestamp_pattern_syntax =
+        metadata_json.at(ffi::ir_stream::cProtocol::Metadata::TimestampPatternSyntaxKey);
 }
 
 TEST_CASE("get_encoding_type", "[ffi][get_encoding_type]") {
@@ -273,28 +259,38 @@ TEMPLATE_TEST_CASE("decode_preamble", "[ffi][decode_preamble]", four_byte_encode
 
     // Test if preamble can be decoded correctly
     TimestampInfo ts_info;
-    epoch_time_ms_t decoded_ts;
-    REQUIRE(decode_preamble<TestType>(preamble_buffer, ts_info, decoded_ts) ==
+    int8_t metadata_type;
+    size_t metadata_pos;
+    uint16_t metadata_size;
+    REQUIRE(decode_preamble(preamble_buffer, metadata_type, metadata_pos, metadata_size) ==
             IRErrorCode::IRErrorCode_Success);
+    REQUIRE(encoded_preamble_end_pos == preamble_buffer.get_cursor_pos());
+
+    string_view json_metadata;
+    REQUIRE(preamble_buffer.try_read(json_metadata, metadata_size));
+    auto metadata_json = nlohmann::json::parse(json_metadata);
+    REQUIRE(ffi::ir_stream::cProtocol::Metadata::VersionValue ==
+            metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey));
+    REQUIRE(ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type);
+    set_timestamp_info(metadata_json, ts_info);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);
-    REQUIRE(encoded_preamble_end_pos == preamble_buffer.get_cursor_pos());
     if constexpr (is_same_v<TestType, four_byte_encoded_variable_t>) {
-        REQUIRE(reference_ts == decoded_ts);
+        REQUIRE(reference_ts == std::stoll(metadata_json.at(ffi::ir_stream::cProtocol::Metadata::ReferenceTimestampKey).get<string>()));
     }
 
     // Test if incomplete IR can be detected
     ir_buf.resize(encoded_preamble_end_pos - 1);
     IrBuffer incomplete_preamble_buffer(ir_buf.data(), ir_buf.size());
     incomplete_preamble_buffer.set_cursor_pos(MagicNumberLength);
-    REQUIRE(decode_preamble<TestType>(incomplete_preamble_buffer, ts_info, decoded_ts) ==
+    REQUIRE(decode_preamble(incomplete_preamble_buffer, metadata_type, metadata_pos, metadata_size) ==
             IRErrorCode::IRErrorCode_Incomplete_IR);
 
     // Test if corrupted IR can be detected
     ir_buf[MagicNumberLength] = 0x23;
     IrBuffer corrupted_preamble_buffer(ir_buf.data(), ir_buf.size());
-    REQUIRE(decode_preamble<TestType>(corrupted_preamble_buffer, ts_info, decoded_ts) ==
+    REQUIRE(decode_preamble(corrupted_preamble_buffer, metadata_type, metadata_pos, metadata_size) ==
             IRErrorCode::IRErrorCode_Corrupted_IR);
 }
 
@@ -406,6 +402,7 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]",
     constexpr char time_zone_id[] = "Asia/Tokyo";
     REQUIRE(encode_preamble<TestType>(timestamp_pattern, timestamp_pattern_syntax, time_zone_id,
                                       preamble_ts, ir_buf));
+    const size_t encoded_preamble_end_pos = ir_buf.size();
 
     string message;
     epoch_time_ms_t ts;
@@ -436,8 +433,20 @@ TEMPLATE_TEST_CASE("decode_ir_complete", "[ffi][decode_next_message]",
 
     // Test if preamble can be properly decoded
     TimestampInfo ts_info;
-    REQUIRE(decode_preamble<TestType>(complete_encoding_buffer, ts_info, preamble_ts) ==
+    int8_t metadata_type;
+    size_t metadata_pos;
+    uint16_t metadata_size;
+    REQUIRE(decode_preamble(complete_encoding_buffer, metadata_type, metadata_pos, metadata_size) ==
             IRErrorCode::IRErrorCode_Success);
+    REQUIRE(encoded_preamble_end_pos == complete_encoding_buffer.get_cursor_pos());
+
+    string_view json_metadata;
+    REQUIRE(complete_encoding_buffer.try_read(json_metadata, metadata_size));
+    auto metadata_json = nlohmann::json::parse(json_metadata);
+    REQUIRE(ffi::ir_stream::cProtocol::Metadata::VersionValue ==
+            metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey));
+    REQUIRE(ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type);
+    set_timestamp_info(metadata_json, ts_info);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
     REQUIRE(time_zone_id == ts_info.time_zone_id);
     REQUIRE(timestamp_pattern == ts_info.timestamp_pattern);

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -2,7 +2,7 @@
 #include "../submodules/Catch2/single_include/catch2/catch.hpp"
 
 // json
-#include "../../../submodules/json/single_include/nlohmann/json.hpp"
+#include "../submodules/json/single_include/nlohmann/json.hpp"
 
 // Project headers
 #include "../src/ffi/encoding_methods.hpp"
@@ -26,7 +26,6 @@ using ffi::ir_stream::cProtocol::MagicNumberLength;
 using ffi::ir_stream::get_encoding_type;
 using ffi::ir_stream::IrBuffer;
 using ffi::ir_stream::IRErrorCode;
-using ffi::ir_stream::TimestampInfo;
 using ffi::VariablePlaceholder;
 using ffi::wildcard_query_matches_any_encoded_var;
 using std::chrono::duration_cast;
@@ -97,6 +96,15 @@ bool encode_message (epoch_time_ms_t timestamp, string_view message, string& log
  */
 template <typename encoded_variable_t>
 IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message, epoch_time_ms_t& decoded_ts);
+
+/**
+ * Struct to hold the timestamp info from the IR stream's metadata
+ */
+struct TimestampInfo {
+    std::string timestamp_pattern;
+    std::string timestamp_pattern_syntax;
+    std::string time_zone_id;
+};
 
 /**
  * Extracts timestamp info from the JSON metadata and stores it into ts_info
@@ -266,8 +274,8 @@ TEMPLATE_TEST_CASE("decode_preamble", "[ffi][decode_preamble]", four_byte_encode
             IRErrorCode::IRErrorCode_Success);
     REQUIRE(encoded_preamble_end_pos == preamble_buffer.get_cursor_pos());
 
-    string_view json_metadata;
-    REQUIRE(preamble_buffer.try_read(json_metadata, metadata_size));
+    char* metadata_ptr{reinterpret_cast<char *>(ir_buf.data()) + metadata_pos};
+    string_view json_metadata{metadata_ptr, metadata_size};
     auto metadata_json = nlohmann::json::parse(json_metadata);
     REQUIRE(ffi::ir_stream::cProtocol::Metadata::VersionValue ==
             metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey));


### PR DESCRIPTION
# Description
The metadata in a preamble may be encoding in various formats (e.g. json) with sparse fields as needed by individual use cases. Performing the parsing and validation of this metadata in the ffi layer adds unnecessary complexity and constraints to the metadata as the ffi code must handle all use cases.

This PR changes `decode_preamble` to return the position, size, and type tag of the metadata to the upper layer. This allows the user of the ffi decide how they should parse and validate the metadata. This change also unifies `decode_preamble` for four and eight byte encoding, as there is no difference between their behaviour any more.

# Validation performed
Adjusted preamble decoding unit tests. All [ffi] tagged tests passing.

