### PR TITLE
ffi: Handle invalid encoded floats in decode_float_var

### DIFF
--- a/components/core/src/ffi/encoding_methods.tpp
+++ b/components/core/src/ffi/encoding_methods.tpp
@@ -165,6 +165,14 @@ namespace ffi {
             num_digits = (encoded_float & 0x0F) + 1;
             encoded_float >>= 4;
             digits = encoded_float & cEightByteEncodedFloatDigitsBitMask;
+            // This is the maximum base-10 number with
+            // cMaxDigitsInRepresentableEightByteFloatVar
+            constexpr uint64_t cMaxRepresentableDigitsValue = 9999999999999999;
+            if (digits > cMaxRepresentableDigitsValue) {
+                throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
+                                        "Digits in encoded float are larger than max representable "
+                                        "value.");
+            }
             encoded_float >>= 55;
             is_negative = encoded_float > 0;
         } else {  // std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -306,6 +306,14 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     decoded_value = decode_float_var(encoded_var);
     REQUIRE(decoded_value == value);
 
+    value = "-.0";
+    REQUIRE(encode_float_string(value, encoded_var));
+    decoded_value = decode_float_var(encoded_var);
+    if constexpr (std::is_same_v<TestType, eight_byte_encoded_variable_t>) {
+        REQUIRE(INT64_MIN == encoded_var);
+    }
+    REQUIRE(decoded_value == value);
+
     // Test edges of representable range
     if constexpr (std::is_same_v<TestType, eight_byte_encoded_variable_t>) {
         value = "-999999999999999.9";
@@ -398,6 +406,13 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
 
     value = "1.0L";
     REQUIRE(!encode_float_string(value, encoded_var));
+
+    if constexpr (std::is_same_v<TestType, eight_byte_encoded_variable_t>) {
+        REQUIRE_THROWS_AS(decode_float_var(INT64_MAX), ffi::EncodingException);
+        // NOTE: INT64_MIN is a valid encoded float
+    }
+    // NOTE: All possible values of four_byte_encoded_variable_t are valid
+    // encoded floats
 }
 
 TEMPLATE_TEST_CASE("Encoding messages", "[ffi][encode-message]", eight_byte_encoded_variable_t,

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -306,14 +306,6 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     decoded_value = decode_float_var(encoded_var);
     REQUIRE(decoded_value == value);
 
-    value = "-.0";
-    REQUIRE(encode_float_string(value, encoded_var));
-    decoded_value = decode_float_var(encoded_var);
-    if constexpr (std::is_same_v<TestType, eight_byte_encoded_variable_t>) {
-        REQUIRE(INT64_MIN == encoded_var);
-    }
-    REQUIRE(decoded_value == value);
-
     // Test edges of representable range
     if constexpr (std::is_same_v<TestType, eight_byte_encoded_variable_t>) {
         value = "-999999999999999.9";
@@ -409,7 +401,13 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
 
     if constexpr (std::is_same_v<TestType, eight_byte_encoded_variable_t>) {
         REQUIRE_THROWS_AS(decode_float_var(INT64_MAX), ffi::EncodingException);
-        // NOTE: INT64_MIN is a valid encoded float
+
+        // Validate that INT64_MIN is a valid encoded-float
+        value = "-.0";
+        REQUIRE(encode_float_string(value, encoded_var));
+        REQUIRE(INT64_MIN == encoded_var);
+        decoded_value = decode_float_var(encoded_var);
+        REQUIRE(decoded_value == value);
     }
     // NOTE: All possible values of four_byte_encoded_variable_t are valid
     // encoded floats

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -399,18 +399,29 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     value = "1.0L";
     REQUIRE(!encode_float_string(value, encoded_var));
 
+    // Test boundary values of encode-variable storage types
     if constexpr (std::is_same_v<TestType, eight_byte_encoded_variable_t>) {
-        REQUIRE_THROWS_AS(decode_float_var(INT64_MAX), ffi::EncodingException);
-
-        // Validate that INT64_MIN is a valid encoded-float
         value = "-.0";
         REQUIRE(encode_float_string(value, encoded_var));
         REQUIRE(INT64_MIN == encoded_var);
         decoded_value = decode_float_var(encoded_var);
         REQUIRE(decoded_value == value);
+
+        // INT64_MAX is not a valid encoded-float
+        REQUIRE_THROWS_AS(decode_float_var(INT64_MAX), ffi::EncodingException);
+    } else {  // std::is_same_v<TestType, four_byte_encoded_variable_t>
+        value = "-.0";
+        REQUIRE(encode_float_string(value, encoded_var));
+        REQUIRE(INT32_MIN == encoded_var);
+        decoded_value = decode_float_var(encoded_var);
+        REQUIRE(decoded_value == value);
+
+        value = ".33554431";
+        REQUIRE(encode_float_string(value, encoded_var));
+        REQUIRE(INT32_MAX == encoded_var);
+        decoded_value = decode_float_var(encoded_var);
+        REQUIRE(decoded_value == value);
     }
-    // NOTE: All possible values of four_byte_encoded_variable_t are valid
-    // encoded floats
 }
 
 TEMPLATE_TEST_CASE("Encoding messages", "[ffi][encode-message]", eight_byte_encoded_variable_t,

--- a/components/core/tools/scripts/lib_install/macos-12/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos-12/install-all.sh
@@ -4,12 +4,12 @@ brew update
 brew install \
   boost \
   cmake \
-  fmt \
+  fmt@8.0.1 \
   gcc \
   libarchive \
   lz4 \
   mariadb-connector-c \
   msgpack-cxx \
-  spdlog \
+  spdlog@1.9.2 \
   pkg-config \
   zstd

--- a/components/core/tools/scripts/lib_install/macos-12/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos-12/install-all.sh
@@ -4,12 +4,12 @@ brew update
 brew install \
   boost \
   cmake \
-  fmt@8.0.1 \
+  fmt \
   gcc \
   libarchive \
   lz4 \
   mariadb-connector-c \
   msgpack-cxx \
-  spdlog@1.9.2 \
+  spdlog \
   pkg-config \
   zstd


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

`decode_float_var` assumed all eight-byte encoded floats given as input would be valid, but in practice, this is not true if the encoded data was corrupted. This PR adds handling for such values.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Added new unit tests and validated all unit tests passed.
