### PR TITLE
Extract macOS core build into its own workflow; Fixes for macOS build failures:

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -37,11 +37,12 @@ jobs:
             submodules: recursive
       
       # See https://github.com/actions/setup-python/issues/577
-      - name: Remove preinstalled 2to3 binaries which conflict with brew's installs
+      - name: Remove preinstalled binaries which conflict with brew's installs
         run: |
           rm -f /usr/local/bin/2to3*
           rm -f /usr/local/bin/idle3*
           rm -f /usr/local/bin/pydoc3*
+          rm -f /usr/local/bin/python3*
 
       - name: Install dependencies
         run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -3,28 +3,20 @@ name: build-clp-core-macos
 on:
   push:
     paths:
+      # NOTE: The order of these paths is important since we're using exclusions
       - '.github/workflows/clp-core-build-macos.yaml'
-      - 'components/core/cmake/**'
-      - 'components/core/CMakeLists.txt'
-      - 'components/core/config/**'
-      - 'components/core/src/**'
-      - 'components/core/tests/**'
-      - 'components/core/tools/scripts/db/**'
-      - 'components/core/tools/scripts/deps-download/**'
+      - 'components/core/**'
+      - '!components/core/tools/docker-images/**'
+      - '!components/core/tools/scripts/lib_install/**'
       - 'components/core/tools/scripts/lib_install/macos-12/**'
-      - 'components/core/tools/scripts/lib_install/utils/**'
   pull_request:
     paths:
+      # NOTE: The order of these paths is important since we're using exclusions
       - '.github/workflows/clp-core-build-macos.yaml'
-      - 'components/core/cmake/**'
-      - 'components/core/CMakeLists.txt'
-      - 'components/core/config/**'
-      - 'components/core/src/**'
-      - 'components/core/tests/**'
-      - 'components/core/tools/scripts/db/**'
-      - 'components/core/tools/scripts/deps-download/**'
+      - 'components/core/**'
+      - '!components/core/tools/docker-images/**'
+      - '!components/core/tools/scripts/lib_install/**'
       - 'components/core/tools/scripts/lib_install/macos-12/**'
-      - 'components/core/tools/scripts/lib_install/utils/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/checkout@v3
         with:
             submodules: recursive
+      
+      # See https://github.com/actions/setup-python/issues/577
+      - name: Remove preinstalled 2to3 binaries which conflict with brew's installs
+        run: rm '/usr/local/bin/2to3-*'
 
       - name: Install dependencies
         run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -41,6 +41,7 @@ jobs:
         run: |
           rm -f /usr/local/bin/2to3*
           rm -f /usr/local/bin/idle3*
+          rm -f /usr/local/bin/pydoc3*
 
       - name: Install dependencies
         run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -38,7 +38,9 @@ jobs:
       
       # See https://github.com/actions/setup-python/issues/577
       - name: Remove preinstalled 2to3 binaries which conflict with brew's installs
-        run: rm -f /usr/local/bin/2to3*
+        run: |
+          rm -f /usr/local/bin/2to3*
+          rm -f /usr/local/bin/idle3*
 
       - name: Install dependencies
         run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -1,0 +1,43 @@
+name: build-clp-core-macos
+
+on:
+  push:
+    paths:
+      - '.github/workflows/clp-core-build-macos.yaml'
+      - 'components/core/cmake/**'
+      - 'components/core/CMakeLists.txt'
+      - 'components/core/config/**'
+      - 'components/core/src/**'
+      - 'components/core/tests/**'
+      - 'components/core/tools/scripts/db/**'
+      - 'components/core/tools/scripts/deps-download/**'
+      - 'components/core/tools/scripts/lib_install/macos-12/**'
+      - 'components/core/tools/scripts/lib_install/utils/**'
+  pull_request:
+    paths:
+      - '.github/workflows/clp-core-build-macos.yaml'
+      - 'components/core/cmake/**'
+      - 'components/core/CMakeLists.txt'
+      - 'components/core/config/**'
+      - 'components/core/src/**'
+      - 'components/core/tests/**'
+      - 'components/core/tools/scripts/db/**'
+      - 'components/core/tools/scripts/deps-download/**'
+      - 'components/core/tools/scripts/lib_install/macos-12/**'
+      - 'components/core/tools/scripts/lib_install/utils/**'
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+            submodules: recursive
+
+      - name: Install dependencies
+        run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh
+
+      - name: Build CLP Core
+        uses: ./.github/actions/clp-core-build

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -38,7 +38,7 @@ jobs:
       
       # See https://github.com/actions/setup-python/issues/577
       - name: Remove preinstalled 2to3 binaries which conflict with brew's installs
-        run: rm '/usr/local/bin/2to3-*'
+        run: rm -f /usr/local/bin/2to3*
 
       - name: Install dependencies
         run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -109,17 +109,3 @@ jobs:
 
       - name: Build CLP Core
         uses: ./.github/actions/clp-core-build
-
-  build-macos:
-    runs-on: macos-12
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-            submodules: recursive
-
-      - name: Install dependencies
-        run: ./components/core/tools/scripts/lib_install/macos-12/install-all.sh
-
-      - name: Build CLP Core
-        uses: ./.github/actions/clp-core-build

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -3,12 +3,14 @@ name: build-clp-core
 on:
   push:
     paths:
-      - 'components/core/**'
       - '.github/workflows/clp-core-build.yaml'
+      - 'components/core/**'
+      - '!components/core/tools/scripts/lib_install/macos-12/**'
   pull_request:
     paths:
-      - 'components/core/**'
       - '.github/workflows/clp-core-build.yaml'
+      - 'components/core/**'
+      - '!components/core/tools/scripts/lib_install/macos-12/**'
   workflow_dispatch:
   workflow_run:
     workflows: ["generate-build-dependency-image"]

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -255,6 +255,7 @@ set(SOURCE_FILES_clp
         src/Query.hpp
         src/ReaderInterface.cpp
         src/ReaderInterface.hpp
+        src/spdlog_with_specializations.hpp
         src/SQLiteDB.cpp
         src/SQLiteDB.hpp
         src/SQLitePreparedStatement.cpp
@@ -407,6 +408,7 @@ set(SOURCE_FILES_clg
         src/Query.hpp
         src/ReaderInterface.cpp
         src/ReaderInterface.hpp
+        src/spdlog_with_specializations.hpp
         src/SQLiteDB.cpp
         src/SQLiteDB.hpp
         src/SQLitePreparedStatement.cpp
@@ -546,6 +548,7 @@ set(SOURCE_FILES_clo
         src/Query.hpp
         src/ReaderInterface.cpp
         src/ReaderInterface.hpp
+        src/spdlog_with_specializations.hpp
         src/SQLiteDB.cpp
         src/SQLiteDB.hpp
         src/SQLitePreparedStatement.cpp
@@ -691,7 +694,6 @@ set(SOURCE_FILES_unitTest
         src/ffi/search/CompositeWildcardToken.hpp
         src/ffi/search/ExactVariableToken.cpp
         src/ffi/search/ExactVariableToken.hpp
-        src/ffi/search/fmtlib_specializations.hpp
         src/ffi/search/query_methods.cpp
         src/ffi/search/query_methods.hpp
         src/ffi/search/QueryMethodFailed.hpp
@@ -745,6 +747,7 @@ set(SOURCE_FILES_unitTest
         src/Query.hpp
         src/ReaderInterface.cpp
         src/ReaderInterface.hpp
+        src/spdlog_with_specializations.hpp
         src/SQLiteDB.cpp
         src/SQLiteDB.hpp
         src/SQLitePreparedStatement.cpp

--- a/components/core/cmake/utils.cmake
+++ b/components/core/cmake/utils.cmake
@@ -17,6 +17,7 @@ set(SOURCE_FILES_make-dictionaries-readable
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ParsedMessage.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ReaderInterface.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ReaderInterface.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/spdlog_with_specializations.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/Decompressor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/Decompressor.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/streaming_compression/passthrough/Decompressor.cpp

--- a/components/core/src/ArrayBackedPosIntSet.hpp
+++ b/components/core/src/ArrayBackedPosIntSet.hpp
@@ -5,11 +5,9 @@
 #include <unordered_set>
 #include <vector>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
+#include "spdlog_with_specializations.hpp"
 #include "streaming_compression/zstd/Compressor.hpp"
 #include "TraceableException.hpp"
 

--- a/components/core/src/DictionaryWriter.hpp
+++ b/components/core/src/DictionaryWriter.hpp
@@ -7,14 +7,12 @@
 #include <unordered_set>
 #include <vector>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "ArrayBackedPosIntSet.hpp"
 #include "Defs.h"
 #include "dictionary_utils.hpp"
 #include "FileWriter.hpp"
+#include "spdlog_with_specializations.hpp"
 #include "streaming_compression/passthrough/Compressor.hpp"
 #include "streaming_compression/passthrough/Decompressor.hpp"
 #include "streaming_compression/zstd/Compressor.hpp"

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -4,12 +4,10 @@
 #include <cassert>
 #include <cmath>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
 #include "ffi/encoding_methods.hpp"
+#include "spdlog_with_specializations.hpp"
 #include "string_utils.hpp"
 #include "type_utils.hpp"
 

--- a/components/core/src/FileWriter.cpp
+++ b/components/core/src/FileWriter.cpp
@@ -8,12 +8,10 @@
 #include <cassert>
 #include <cerrno>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
 #include "Platform.hpp"
+#include "spdlog_with_specializations.hpp"
 
 // Define a fdatasync shim for compilation (just compilation) on macOS
 #if defined(__APPLE__) || defined(__MACH__)

--- a/components/core/src/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.cpp
@@ -7,11 +7,9 @@
 // fmt
 #include <fmt/core.h>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "database_utils.hpp"
+#include "spdlog_with_specializations.hpp"
 #include "streaming_archive/Constants.hpp"
 #include "type_utils.hpp"
 

--- a/components/core/src/LibarchiveFileReader.cpp
+++ b/components/core/src/LibarchiveFileReader.cpp
@@ -3,8 +3,8 @@
 // C++ standard libraries
 #include <cstring>
 
-// spdlog
-#include <spdlog/spdlog.h>
+// Project headers
+#include "spdlog_with_specializations.hpp"
 
 ErrorCode LibarchiveFileReader::try_get_pos (size_t& pos) {
     if (nullptr == m_archive) {

--- a/components/core/src/LibarchiveReader.cpp
+++ b/components/core/src/LibarchiveReader.cpp
@@ -3,11 +3,9 @@
 // libarchive
 #include <archive_entry.h>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
+#include "spdlog_with_specializations.hpp"
 
 ErrorCode LibarchiveReader::try_open (size_t buffer_length, const char* buffer, FileReader& file_reader, const std::string& path_if_compressed_file) {
     // Create and initialize internal libarchive

--- a/components/core/src/MySQLDB.cpp
+++ b/components/core/src/MySQLDB.cpp
@@ -1,7 +1,7 @@
 #include "MySQLDB.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
+// Project headers
+#include "spdlog_with_specializations.hpp"
 
 using std::string;
 

--- a/components/core/src/MySQLPreparedStatement.cpp
+++ b/components/core/src/MySQLPreparedStatement.cpp
@@ -1,10 +1,8 @@
 #include "MySQLPreparedStatement.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
+#include "spdlog_with_specializations.hpp"
 
 using std::string;
 

--- a/components/core/src/PageAllocatedVector.hpp
+++ b/components/core/src/PageAllocatedVector.hpp
@@ -10,13 +10,11 @@
 #include <cstring>
 #include <vector>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
 #include "ErrorCode.hpp"
 #include "Platform.hpp"
+#include "spdlog_with_specializations.hpp"
 #include "TraceableException.hpp"
 
 // Define a MREMAP_MAYMOVE shim for compilation (just compilation) on macOS

--- a/components/core/src/SQLiteDB.cpp
+++ b/components/core/src/SQLiteDB.cpp
@@ -1,10 +1,8 @@
 #include "SQLiteDB.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
+#include "spdlog_with_specializations.hpp"
 
 using std::string;
 

--- a/components/core/src/SQLitePreparedStatement.cpp
+++ b/components/core/src/SQLitePreparedStatement.cpp
@@ -1,10 +1,8 @@
 #include "SQLitePreparedStatement.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
+#include "spdlog_with_specializations.hpp"
 
 using std::string;
 

--- a/components/core/src/Thread.cpp
+++ b/components/core/src/Thread.cpp
@@ -1,10 +1,8 @@
 #include "Thread.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "Defs.h"
+#include "spdlog_with_specializations.hpp"
 
 using std::system_error;
 

--- a/components/core/src/TimestampPattern.cpp
+++ b/components/core/src/TimestampPattern.cpp
@@ -8,8 +8,8 @@
 // Date library
 #include "../submodules/date/include/date/date.h"
 
-// spdlog
-#include <spdlog/spdlog.h>
+// Project headers
+#include "spdlog_with_specializations.hpp"
 
 using std::string;
 using std::to_string;

--- a/components/core/src/Utils.cpp
+++ b/components/core/src/Utils.cpp
@@ -14,10 +14,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
+#include "spdlog_with_specializations.hpp"
 #include "string_utils.hpp"
 
 using std::list;

--- a/components/core/src/VariableDictionaryWriter.cpp
+++ b/components/core/src/VariableDictionaryWriter.cpp
@@ -1,10 +1,8 @@
 #include "VariableDictionaryWriter.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "dictionary_utils.hpp"
+#include "spdlog_with_specializations.hpp"
 
 bool VariableDictionaryWriter::add_entry (const std::string& value, variable_dictionary_id_t& id) {
     bool new_entry = false;

--- a/components/core/src/clg/CommandLineArguments.cpp
+++ b/components/core/src/clg/CommandLineArguments.cpp
@@ -7,10 +7,8 @@
 // Boost libraries
 #include <boost/program_options.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
+#include "../spdlog_with_specializations.hpp"
 #include "../version.hpp"
 
 namespace po = boost::program_options;

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -7,7 +7,6 @@
 
 // spdlog
 #include <spdlog/sinks/stdout_sinks.h>
-#include <spdlog/spdlog.h>
 
 // Project headers
 #include "../Defs.h"
@@ -16,6 +15,7 @@
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
 #include "../Profiler.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "../streaming_archive/Constants.hpp"
 #include "CommandLineArguments.hpp"
 

--- a/components/core/src/clo/CommandLineArguments.cpp
+++ b/components/core/src/clo/CommandLineArguments.cpp
@@ -7,10 +7,8 @@
 // Boost libraries
 #include <boost/program_options.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
+#include "../spdlog_with_specializations.hpp"
 #include "../version.hpp"
 
 namespace po = boost::program_options;

--- a/components/core/src/clo/ControllerMonitoringThread.cpp
+++ b/components/core/src/clo/ControllerMonitoringThread.cpp
@@ -3,11 +3,9 @@
 // C standard libraries
 #include <unistd.h>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../networking/socket_utils.hpp"
+#include "../spdlog_with_specializations.hpp"
 
 void ControllerMonitoringThread::thread_method () {
     // Wait for the controller socket to close

--- a/components/core/src/clo/clo.cpp
+++ b/components/core/src/clo/clo.cpp
@@ -13,7 +13,6 @@
 
 // spdlog
 #include <spdlog/sinks/stdout_sinks.h>
-#include <spdlog/spdlog.h>
 
 // Project headers
 #include "../Defs.h"
@@ -21,6 +20,7 @@
 #include "../Grep.hpp"
 #include "../Profiler.hpp"
 #include "../networking/socket_utils.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "../streaming_archive/Constants.hpp"
 #include "../Utils.hpp"
 #include "CommandLineArguments.hpp"

--- a/components/core/src/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/CommandLineArguments.cpp
@@ -8,11 +8,9 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem/operations.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../Defs.h"
+#include "../spdlog_with_specializations.hpp"
 #include "../Utils.hpp"
 #include "../version.hpp"
 

--- a/components/core/src/clp/FileDecompressor.cpp
+++ b/components/core/src/clp/FileDecompressor.cpp
@@ -4,8 +4,8 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
+// Project headers
+#include "../spdlog_with_specializations.hpp"
 
 using std::string;
 

--- a/components/core/src/clp/clp.cpp
+++ b/components/core/src/clp/clp.cpp
@@ -1,7 +1,7 @@
 #include <string>
 
-#include <spdlog/spdlog.h>
-
+// Project headers
+#include "../spdlog_with_specializations.hpp"
 #include "run.hpp"
 
 int main (int argc, const char* argv[]) {

--- a/components/core/src/clp/compression.cpp
+++ b/components/core/src/clp/compression.cpp
@@ -10,12 +10,10 @@
 // libarchive
 #include <archive_entry.h>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "../streaming_archive/writer/Archive.hpp"
 #include "../Utils.hpp"
 #include "FileCompressor.hpp"

--- a/components/core/src/clp/decompression.cpp
+++ b/components/core/src/clp/decompression.cpp
@@ -7,14 +7,12 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../ErrorCode.hpp"
 #include "../FileWriter.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "../streaming_archive/reader/Archive.hpp"
 #include "../TraceableException.hpp"
 #include "../Utils.hpp"

--- a/components/core/src/clp/run.cpp
+++ b/components/core/src/clp/run.cpp
@@ -5,11 +5,11 @@
 
 // spdlog
 #include <spdlog/sinks/stdout_sinks.h>
-#include <spdlog/spdlog.h>
 
 // Project headers
 #include "../compressor_frontend/LogParser.hpp"
 #include "../Profiler.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "../Utils.hpp"
 #include "CommandLineArguments.hpp"
 #include "compression.hpp"

--- a/components/core/src/clp/utils.cpp
+++ b/components/core/src/clp/utils.cpp
@@ -5,13 +5,11 @@
 
 // Boost libraries
 #include <boost/filesystem/operations.hpp>
-
-// spdlog
-#include <spdlog/spdlog.h>
 #include <boost/uuid/random_generator.hpp>
 
 // Project headers
 #include "../ErrorCode.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "../Utils.hpp"
 
 using std::string;

--- a/components/core/src/compressor_frontend/Lexer.tpp
+++ b/components/core/src/compressor_frontend/Lexer.tpp
@@ -5,12 +5,12 @@
 
 // C++ standard libraries
 #include <cassert>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <vector>
 
 // Project headers
 #include "../FileReader.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "Constants.hpp"
 #include "finite_automata/RegexAST.hpp"
 

--- a/components/core/src/compressor_frontend/LogParser.cpp
+++ b/components/core/src/compressor_frontend/LogParser.cpp
@@ -3,10 +3,10 @@
 // C++ standard libraries
 #include <filesystem>
 #include <iostream>
-#include <spdlog/spdlog.h>
 
 // Project headers
 #include "../clp/utils.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "Constants.hpp"
 #include "SchemaParser.hpp"
 

--- a/components/core/src/compressor_frontend/SchemaParser.cpp
+++ b/components/core/src/compressor_frontend/SchemaParser.cpp
@@ -4,11 +4,9 @@
 #include <cmath>
 #include <memory>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../FileReader.hpp"
+#include "../spdlog_with_specializations.hpp"
 #include "Constants.hpp"
 #include "finite_automata/RegexAST.hpp"
 #include "LALR1Parser.hpp"

--- a/components/core/src/compressor_frontend/finite_automata/RegexAST.tpp
+++ b/components/core/src/compressor_frontend/finite_automata/RegexAST.tpp
@@ -3,9 +3,6 @@
 
 #include "RegexAST.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // C++ standard libraries
 #include <algorithm>
 #include <cassert>
@@ -13,6 +10,7 @@
 #include <stack>
 
 // Project headers
+#include "../../spdlog_with_specializations.hpp"
 #include "../Constants.hpp"
 #include "RegexNFA.hpp"
 #include "UnicodeIntervalTree.hpp"

--- a/components/core/src/spdlog_with_specializations.hpp
+++ b/components/core/src/spdlog_with_specializations.hpp
@@ -1,12 +1,28 @@
-#ifndef FFI_SEARCH_FMTLIB_SPECIALIZATIONS_HPP
-#define FFI_SEARCH_FMTLIB_SPECIALIZATIONS_HPP
+#ifndef SPDLOG_WITH_SPECIALIZATIONS_HPP
+#define SPDLOG_WITH_SPECIALIZATIONS_HPP
 
-// fmtlib
 #include <fmt/format.h>
+#include <spdlog/spdlog.h>
 
-// Project headers
-#include "ExactVariableToken.hpp"
-#include "WildcardToken.hpp"
+#include "ErrorCode.hpp"
+#include "ffi/search/ExactVariableToken.hpp"
+#include "ffi/search/WildcardToken.hpp"
+
+template <>
+struct fmt::formatter<ErrorCode> {
+    template <typename ParseContext>
+    constexpr auto parse (ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format (
+            const ErrorCode& error_code,
+            FormatContext& ctx
+    ) {
+        return fmt::format_to(ctx.out(), "{}", static_cast<size_t>(error_code));
+    }
+};
 
 template <typename encoded_variable_t>
 struct fmt::formatter<ffi::search::ExactVariableToken<encoded_variable_t>> {
@@ -45,4 +61,4 @@ struct fmt::formatter<ffi::search::WildcardToken<encoded_variable_t>> {
     }
 };
 
-#endif // FFI_SEARCH_FMTLIB_SPECIALIZATIONS_HPP
+#endif // SPDLOG_WITH_SPECIALIZATIONS_HPP

--- a/components/core/src/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/streaming_archive/reader/Archive.cpp
@@ -11,11 +11,9 @@
 // Boost libraries
 #include <boost/filesystem.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../../EncodedVariableInterpreter.hpp"
+#include "../../spdlog_with_specializations.hpp"
 #include "../../Utils.hpp"
 #include "../Constants.hpp"
 

--- a/components/core/src/streaming_archive/reader/File.cpp
+++ b/components/core/src/streaming_archive/reader/File.cpp
@@ -4,11 +4,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../../EncodedVariableInterpreter.hpp"
+#include "../../spdlog_with_specializations.hpp"
 #include "../Constants.hpp"
 #include "SegmentManager.hpp"
 

--- a/components/core/src/streaming_archive/reader/Segment.cpp
+++ b/components/core/src/streaming_archive/reader/Segment.cpp
@@ -10,11 +10,9 @@
 // Boost libraries
 #include <boost/filesystem.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../../FileReader.hpp"
+#include "../../spdlog_with_specializations.hpp"
 
 using std::make_unique;
 using std::string;

--- a/components/core/src/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/streaming_archive/writer/Archive.cpp
@@ -18,14 +18,12 @@
 // json
 #include "../../../submodules/json/single_include/nlohmann/json.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
+#include "../../compressor_frontend/LogParser.hpp"
 #include "../../EncodedVariableInterpreter.hpp"
+#include "../../spdlog_with_specializations.hpp"
 #include "../../Utils.hpp"
 #include "../Constants.hpp"
-#include "../../compressor_frontend/LogParser.hpp"
 
 using std::list;
 using std::make_unique;

--- a/components/core/src/streaming_archive/writer/Segment.cpp
+++ b/components/core/src/streaming_archive/writer/Segment.cpp
@@ -8,12 +8,10 @@
 #include <cmath>
 #include <cstring>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../../ErrorCode.hpp"
 #include "../../FileWriter.hpp"
+#include "../../spdlog_with_specializations.hpp"
 
 using std::make_unique;
 using std::string;

--- a/components/core/src/streaming_compression/zstd/Compressor.cpp
+++ b/components/core/src/streaming_compression/zstd/Compressor.cpp
@@ -1,10 +1,8 @@
 #include "Compressor.hpp"
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../../Defs.h"
+#include "../../spdlog_with_specializations.hpp"
 
 namespace streaming_compression { namespace zstd {
     Compressor::Compressor () : ::streaming_compression::Compressor(CompressorType::ZSTD), m_compression_stream_contains_data(false),

--- a/components/core/src/streaming_compression/zstd/Decompressor.cpp
+++ b/components/core/src/streaming_compression/zstd/Decompressor.cpp
@@ -6,11 +6,9 @@
 // Boost libraries
 #include <boost/filesystem.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
-
 // Project headers
 #include "../../Defs.h"
+#include "../../spdlog_with_specializations.hpp"
 
 namespace streaming_compression { namespace zstd {
     Decompressor::Decompressor () : ::streaming_compression::Decompressor(CompressorType::ZSTD), m_input_type(InputType::NotInitialized),

--- a/components/core/src/utils/make_dictionaries_readable/CommandLineArguments.cpp
+++ b/components/core/src/utils/make_dictionaries_readable/CommandLineArguments.cpp
@@ -6,8 +6,8 @@
 // Boost libraries
 #include <boost/program_options.hpp>
 
-// spdlog
-#include <spdlog/spdlog.h>
+// Project headers
+#include "../../spdlog_with_specializations.hpp"
 
 namespace po = boost::program_options;
 using std::cerr;

--- a/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
+++ b/components/core/src/utils/make_dictionaries_readable/make-dictionaries-readable.cpp
@@ -7,14 +7,14 @@
 
 // spdlog
 #include <spdlog/sinks/stdout_sinks.h>
-#include <spdlog/spdlog.h>
 
 // Project headers
 #include "../../FileWriter.hpp"
 #include "../../LogTypeDictionaryReader.hpp"
-#include "../../VariableDictionaryReader.hpp"
+#include "../../spdlog_with_specializations.hpp"
 #include "../../streaming_archive/Constants.hpp"
 #include "../../type_utils.hpp"
+#include "../../VariableDictionaryReader.hpp"
 #include "CommandLineArguments.hpp"
 
 using std::string;

--- a/components/core/tools/scripts/lib_install/macos-12/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos-12/install-all.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# Work around GitHub actions having a preinstalled 2to3
-# See https://github.com/actions/setup-python/issues/577
-rm '/usr/local/bin/2to3'
-
 brew update
 brew install \
   boost \

--- a/components/core/tools/scripts/lib_install/macos-12/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos-12/install-all.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Work around GitHub actions having a preinstalled 2to3
+# See https://github.com/actions/setup-python/issues/577
+rm '/usr/local/bin/2to3'
+
 brew update
 brew install \
   boost \


### PR DESCRIPTION
* Add fmtlib specialization for ErrorCode
* Manually remove preinstalled Python in macOS build workflow.

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR fixes two macOS build issues:
1. The version of fmtlib installed by `brew` on macOS was updated causing previously working log statements (spdlog uses fmtlib) that used `ErrorCode` to become compilation errors. This PR adds a fmtlib specialization for `ErrorCode` and creates a new `spdlog.h` wrapper that includes the specializations. Future uses of spdlog should include the wrapper instead of `spdlog/spdlog.h`.
2. This is specific to running in the GitHub workflow: If `brew` decides to upgrade Python, then it will conflict with the version preinstalled in the macOS runner. So this PR also manually removes the preinstalled version so that `brew` can install its version successfully.

This PR also splits the macOS core build workflow from the other core build workflows, so that it's faster to see the result of the macOS workflow.

Sidenote: We also attempted to lock the versions of fmtlib and spdlog that were installed on macOS, but this is non-trivial---we can install a specific version of `fmtlib` or `spdlog` by [downloading the relevant](https://stackoverflow.com/questions/39187812/homebrew-how-to-install-older-versions) `.rb` from the brew repos but those scripts will use the latest version for `fmtlib`/`spdlog` dependencies, causing other build failures.

# Validation performed
<!-- What tests and validation you performed on the change -->
GitHub workflows succeeded.
