### PR TITLE
Retrieve archives that have logs in the given search time window

### DIFF
--- a/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
@@ -37,6 +37,8 @@ def main(argv):
                 CREATE TABLE IF NOT EXISTS `{table_prefix}archives` (
                     `pagination_id` BIGINT unsigned NOT NULL AUTO_INCREMENT,
                     `id` VARCHAR(64) NOT NULL,
+                    `begin_timestamp` BIGINT NOT NULL,
+                    `end_timestamp` BIGINT NOT NULL,
                     `uncompressed_size` BIGINT NOT NULL,
                     `size` BIGINT NOT NULL,
                     `creator_id` VARCHAR(64) NOT NULL,

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -292,10 +292,8 @@ set(SOURCE_FILES_clp
         src/streaming_archive/writer/File.hpp
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
-        src/streaming_compression/Compressor.cpp
         src/streaming_compression/Compressor.hpp
         src/streaming_compression/Constants.hpp
-        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp
@@ -454,7 +452,6 @@ set(SOURCE_FILES_clg
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
         src/streaming_compression/Constants.hpp
-        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp
@@ -600,7 +597,6 @@ set(SOURCE_FILES_clo
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
         src/streaming_compression/Constants.hpp
-        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp
@@ -805,10 +801,8 @@ set(SOURCE_FILES_unitTest
         src/streaming_archive/writer/File.hpp
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
-        src/streaming_compression/Compressor.cpp
         src/streaming_compression/Compressor.hpp
         src/streaming_compression/Constants.hpp
-        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -271,6 +271,8 @@ set(SOURCE_FILES_clp
         src/SQLitePreparedStatement.hpp
         src/Stopwatch.cpp
         src/Stopwatch.hpp
+        src/streaming_archive/ArchiveMetadata.cpp
+        src/streaming_archive/ArchiveMetadata.hpp
         src/streaming_archive/Constants.hpp
         src/streaming_archive/MetadataDB.cpp
         src/streaming_archive/MetadataDB.hpp
@@ -290,8 +292,10 @@ set(SOURCE_FILES_clp
         src/streaming_archive/writer/File.hpp
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
+        src/streaming_compression/Compressor.cpp
         src/streaming_compression/Compressor.hpp
         src/streaming_compression/Constants.hpp
+        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp
@@ -430,6 +434,8 @@ set(SOURCE_FILES_clg
         src/SQLitePreparedStatement.hpp
         src/Stopwatch.cpp
         src/Stopwatch.hpp
+        src/streaming_archive/ArchiveMetadata.cpp
+        src/streaming_archive/ArchiveMetadata.hpp
         src/streaming_archive/Constants.hpp
         src/streaming_archive/MetadataDB.cpp
         src/streaming_archive/MetadataDB.hpp
@@ -448,6 +454,7 @@ set(SOURCE_FILES_clg
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
         src/streaming_compression/Constants.hpp
+        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp
@@ -573,6 +580,8 @@ set(SOURCE_FILES_clo
         src/SQLitePreparedStatement.hpp
         src/Stopwatch.cpp
         src/Stopwatch.hpp
+        src/streaming_archive/ArchiveMetadata.cpp
+        src/streaming_archive/ArchiveMetadata.hpp
         src/streaming_archive/Constants.hpp
         src/streaming_archive/MetadataDB.cpp
         src/streaming_archive/MetadataDB.hpp
@@ -591,6 +600,7 @@ set(SOURCE_FILES_clo
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
         src/streaming_compression/Constants.hpp
+        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp
@@ -774,6 +784,8 @@ set(SOURCE_FILES_unitTest
         src/SQLitePreparedStatement.hpp
         src/Stopwatch.cpp
         src/Stopwatch.hpp
+        src/streaming_archive/ArchiveMetadata.cpp
+        src/streaming_archive/ArchiveMetadata.hpp
         src/streaming_archive/Constants.hpp
         src/streaming_archive/MetadataDB.cpp
         src/streaming_archive/MetadataDB.hpp
@@ -793,8 +805,10 @@ set(SOURCE_FILES_unitTest
         src/streaming_archive/writer/File.hpp
         src/streaming_archive/writer/Segment.cpp
         src/streaming_archive/writer/Segment.hpp
+        src/streaming_compression/Compressor.cpp
         src/streaming_compression/Compressor.hpp
         src/streaming_compression/Constants.hpp
+        src/streaming_compression/Decompressor.cpp
         src/streaming_compression/Decompressor.hpp
         src/streaming_compression/passthrough/Compressor.cpp
         src/streaming_compression/passthrough/Compressor.hpp

--- a/components/core/src/GlobalMetadataDB.hpp
+++ b/components/core/src/GlobalMetadataDB.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 // Project headers
+#include "streaming_archive/ArchiveMetadata.hpp"
 #include "streaming_archive/writer/File.hpp"
 
 /**
@@ -44,21 +45,15 @@ public:
     /**
      * Adds an archive to the global metadata database
      * @param id
-     * @param uncompressed_size
-     * @param size
-     * @param creator_id
-     * @param creation_num
+     * @param metadata
      */
-    virtual void add_archive (const std::string& id, uint64_t uncompressed_size, uint64_t size,
-                              const std::string& creator_id, uint64_t creation_num) = 0;
+    virtual void add_archive (const std::string& id, const streaming_archive::ArchiveMetadata& metadata) = 0;
     /**
      * Updates the size of the archive identified by the given ID in the global metadata database
      * @param archive_id
-     * @param uncompressed_size
-     * @param size
+     * @param metadata
      */
-    virtual void update_archive_size (const std::string& archive_id, uint64_t uncompressed_size,
-                                      uint64_t size) = 0;
+    virtual void update_archive_metadata (const std::string& archive_id, const streaming_archive::ArchiveMetadata& metadata) = 0;
     /**
      * Updates the metadata of the given files in the global metadata database
      * @param archive_id
@@ -72,7 +67,7 @@ public:
      */
     virtual ArchiveIterator* get_archive_iterator () = 0;
     /**
-     * Gets an iterator to iterate over every archive that falls in the given time windown in the global metadata database
+     * Gets an iterator to iterate over every archive that falls in the given time window in the global metadata database
      * @param begin_ts
      * @param end_ts
      * @return The archive iterator

--- a/components/core/src/GlobalMetadataDB.hpp
+++ b/components/core/src/GlobalMetadataDB.hpp
@@ -68,16 +68,16 @@ public:
 
     /**
      * Gets an iterator to iterate over every archive in the global metadata database
+     * @return The archive iterator
+     */
+    virtual ArchiveIterator* get_archive_iterator () = 0;
+    /**
+     * Gets an iterator to iterate over every archive that falls in the given time windown in the global metadata database
      * @param begin_ts
      * @param end_ts
      * @return The archive iterator
      */
-    virtual ArchiveIterator* get_archive_iterator () = 0;
-/**
-     * Gets an iterator to iterate over every archive that contains a given start and end time stamp in the global metadata database
-     * @return The archive iterator
-     */
-virtual ArchiveIterator* get_archive_iterator_for_time_range (epochtime_t begin_ts, epochtime_t end_ts) = 0;
+    virtual ArchiveIterator* get_archive_iterator_for_time_window (epochtime_t begin_ts, epochtime_t end_ts) = 0;
     /**
      * Gets an iterator to iterate over every archive that contains a given file path in the global metadata database
      * @return The archive iterator

--- a/components/core/src/GlobalMetadataDB.hpp
+++ b/components/core/src/GlobalMetadataDB.hpp
@@ -72,7 +72,12 @@ public:
      * @param end_ts
      * @return The archive iterator
      */
-    virtual ArchiveIterator* get_archive_iterator (epochtime_t begin_ts, epochtime_t end_ts) = 0;
+    virtual ArchiveIterator* get_archive_iterator () = 0;
+/**
+     * Gets an iterator to iterate over every archive that contains a given start and end time stamp in the global metadata database
+     * @return The archive iterator
+     */
+virtual ArchiveIterator* get_archive_iterator_for_time_range (epochtime_t begin_ts, epochtime_t end_ts) = 0;
     /**
      * Gets an iterator to iterate over every archive that contains a given file path in the global metadata database
      * @return The archive iterator

--- a/components/core/src/GlobalMetadataDB.hpp
+++ b/components/core/src/GlobalMetadataDB.hpp
@@ -68,9 +68,11 @@ public:
 
     /**
      * Gets an iterator to iterate over every archive in the global metadata database
+     * @param begin_ts
+     * @param end_ts
      * @return The archive iterator
      */
-    virtual ArchiveIterator* get_archive_iterator () = 0;
+    virtual ArchiveIterator* get_archive_iterator (epochtime_t begin_ts, epochtime_t end_ts) = 0;
     /**
      * Gets an iterator to iterate over every archive that contains a given file path in the global metadata database
      * @return The archive iterator

--- a/components/core/src/GlobalMySQLMetadataDB.cpp
+++ b/components/core/src/GlobalMySQLMetadataDB.cpp
@@ -197,10 +197,16 @@ void GlobalMySQLMetadataDB::update_metadata_for_files (const std::string& archiv
     }
 }
 
-GlobalMetadataDB::ArchiveIterator* GlobalMySQLMetadataDB::get_archive_iterator () {
-    auto statement_string = fmt::format("SELECT {} FROM {}{} ORDER BY {} ASC, {} ASC", streaming_archive::cMetadataDB::Archive::Id, m_table_prefix,
-                                        streaming_archive::cMetadataDB::ArchivesTableName, streaming_archive::cMetadataDB::Archive::CreatorId,
-                                        streaming_archive::cMetadataDB::Archive::CreationIx);
+GlobalMetadataDB::ArchiveIterator* GlobalMySQLMetadataDB::get_archive_iterator (epochtime_t begin_ts, epochtime_t end_ts) {
+    auto statement_string = fmt::format("SELECT DISTINCT {}{}.{} FROM {}{} JOIN {}{} ON {}{}.{} = {}{}.{} WHERE {}{}.{} > {} AND {}{}.{} < {} ORDER BY {} ASC, {} ASC",
+                                        m_table_prefix, streaming_archive::cMetadataDB::ArchivesTableName, streaming_archive::cMetadataDB::Archive::Id,
+                                        m_table_prefix, streaming_archive::cMetadataDB::ArchivesTableName,
+                                        m_table_prefix, streaming_archive::cMetadataDB::FilesTableName,
+                                        m_table_prefix, streaming_archive::cMetadataDB::ArchivesTableName, streaming_archive::cMetadataDB::Archive::Id,
+                                        m_table_prefix, streaming_archive::cMetadataDB::FilesTableName, streaming_archive::cMetadataDB::File::ArchiveId,
+                                        m_table_prefix, streaming_archive::cMetadataDB::FilesTableName, streaming_archive::cMetadataDB::File::BeginTimestamp, begin_ts,
+                                        m_table_prefix, streaming_archive::cMetadataDB::FilesTableName, streaming_archive::cMetadataDB::File::EndTimestamp, end_ts,
+                                        streaming_archive::cMetadataDB::Archive::CreatorId, streaming_archive::cMetadataDB::Archive::CreationIx);
     SPDLOG_DEBUG("{}", statement_string);
 
     if (false == m_db.execute_query(statement_string)) {

--- a/components/core/src/GlobalMySQLMetadataDB.hpp
+++ b/components/core/src/GlobalMySQLMetadataDB.hpp
@@ -60,10 +60,8 @@ public:
     void open () override;
     void close () override;
 
-    void add_archive (const std::string& id, uint64_t uncompressed_size, uint64_t size,
-                      const std::string& creator_id, uint64_t creation_num) override;
-    void update_archive_size (const std::string& archive_id, uint64_t uncompressed_size,
-                              uint64_t size) override;
+    void add_archive (const std::string& id, const streaming_archive::ArchiveMetadata& metadata) override;
+    void update_archive_metadata (const std::string& archive_id, const streaming_archive::ArchiveMetadata& metadata) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override;

--- a/components/core/src/GlobalMySQLMetadataDB.hpp
+++ b/components/core/src/GlobalMySQLMetadataDB.hpp
@@ -66,7 +66,7 @@ public:
                               uint64_t size) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
-    GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override;
+    GlobalMetadataDB::ArchiveIterator* get_archive_iterator (epochtime_t begin_ts, epochtime_t end_ts) override;
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator_for_file_path (const std::string& file_path) override;
 
 private:

--- a/components/core/src/GlobalMySQLMetadataDB.hpp
+++ b/components/core/src/GlobalMySQLMetadataDB.hpp
@@ -66,7 +66,8 @@ public:
                               uint64_t size) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
-    GlobalMetadataDB::ArchiveIterator* get_archive_iterator (epochtime_t begin_ts, epochtime_t end_ts) override;
+    GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override;
+    GlobalMetadataDB::ArchiveIterator* get_archive_iterator_for_time_window (epochtime_t begin_ts, epochtime_t end_ts) override;
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator_for_file_path (const std::string& file_path) override;
 
 private:

--- a/components/core/src/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.cpp
@@ -16,6 +16,8 @@
 // Types
 enum class ArchivesTableFieldIndexes : uint16_t {
     Id = 0,
+    BeginTimestamp,
+    EndTimestamp,
     UncompressedSize,
     Size,
     CreatorId,
@@ -23,7 +25,9 @@ enum class ArchivesTableFieldIndexes : uint16_t {
     Length,
 };
 enum class UpdateArchiveSizeStmtFieldIndexes : uint16_t {
-    UncompressedSize = 0,
+    BeginTimestamp = 0,
+    EndTimestamp,
+    UncompressedSize,
     Size,
     Length,
 };
@@ -96,13 +100,9 @@ static SQLitePreparedStatement get_archives_select_statement (SQLiteDB& db) {
 
 
 static SQLitePreparedStatement get_archives_for_time_window_select_statement (SQLiteDB& db, epochtime_t begin_ts, epochtime_t end_ts) {
-    auto statement_string = fmt::format("SELECT DISTINCT {}.{} FROM {} JOIN {} ON {}.{} = {}.{} WHERE {}.{} <= ? AND {}.{} >= ? ORDER BY {} ASC, {} ASC",
-                                        streaming_archive::cMetadataDB::ArchivesTableName, streaming_archive::cMetadataDB::Archive::Id,
-                                        streaming_archive::cMetadataDB::ArchivesTableName, streaming_archive::cMetadataDB::FilesTableName,
-                                        streaming_archive::cMetadataDB::ArchivesTableName, streaming_archive::cMetadataDB::Archive::Id,
-                                        streaming_archive::cMetadataDB::FilesTableName, streaming_archive::cMetadataDB::File::ArchiveId,
-                                        streaming_archive::cMetadataDB::FilesTableName, streaming_archive::cMetadataDB::File::BeginTimestamp,
-                                        streaming_archive::cMetadataDB::FilesTableName, streaming_archive::cMetadataDB::File::EndTimestamp,
+    auto statement_string = fmt::format("SELECT {} FROM {} WHERE {} <= ? AND {} >= ? ORDER BY {} ASC, {} ASC",
+                                        streaming_archive::cMetadataDB::Archive::Id, streaming_archive::cMetadataDB::ArchivesTableName,
+                                        streaming_archive::cMetadataDB::File::BeginTimestamp, streaming_archive::cMetadataDB::File::EndTimestamp,
                                         streaming_archive::cMetadataDB::Archive::CreatorId, streaming_archive::cMetadataDB::Archive::CreationIx);
     SPDLOG_DEBUG("{}", statement_string);
     auto statement = db.prepare_statement(statement_string.c_str(), statement_string.length());
@@ -131,8 +131,8 @@ GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator (SQLiteDB& db) : m_stat
     m_statement.step();
 }
 
-GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator (SQLiteDB& db, epochtime_t begin_ts, epochtime_t end_ts) : m_statement(get_archives_for_time_window_select_statement(db, begin_ts, end_ts))
-{
+GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator(SQLiteDB& db, epochtime_t begin_ts, epochtime_t end_ts) :
+        m_statement(get_archives_for_time_window_select_statement(db, begin_ts, end_ts)) {
     m_statement.step();
 }
 
@@ -164,6 +164,14 @@ void GlobalSQLiteMetadataDB::open () {
     vector<pair<string, string>> archive_field_names_and_types(enum_to_underlying_type(ArchivesTableFieldIndexes::Length));
     archive_field_names_and_types[enum_to_underlying_type(ArchivesTableFieldIndexes::Id)].first = streaming_archive::cMetadataDB::Archive::Id;
     archive_field_names_and_types[enum_to_underlying_type(ArchivesTableFieldIndexes::Id)].second = "TEXT PRIMARY KEY";
+
+    archive_field_names_and_types[enum_to_underlying_type(ArchivesTableFieldIndexes::BeginTimestamp)].first =
+            streaming_archive::cMetadataDB::Archive::BeginTimestamp;
+    archive_field_names_and_types[enum_to_underlying_type(ArchivesTableFieldIndexes::BeginTimestamp)].second = "INTEGER";
+
+    archive_field_names_and_types[enum_to_underlying_type(ArchivesTableFieldIndexes::EndTimestamp)].first =
+            streaming_archive::cMetadataDB::Archive::EndTimestamp;
+    archive_field_names_and_types[enum_to_underlying_type(ArchivesTableFieldIndexes::EndTimestamp)].second = "INTEGER";
 
     archive_field_names_and_types[enum_to_underlying_type(ArchivesTableFieldIndexes::UncompressedSize)].first =
             streaming_archive::cMetadataDB::Archive::UncompressedSize;
@@ -218,6 +226,10 @@ void GlobalSQLiteMetadataDB::open () {
     statement_buffer.clear();
 
     vector<string> update_archive_size_stmt_field_names(enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::Length));
+    update_archive_size_stmt_field_names[enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::BeginTimestamp)] =
+            streaming_archive::cMetadataDB::Archive::BeginTimestamp;
+    update_archive_size_stmt_field_names[enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::EndTimestamp)] =
+            streaming_archive::cMetadataDB::Archive::EndTimestamp;
     update_archive_size_stmt_field_names[enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::UncompressedSize)] =
             streaming_archive::cMetadataDB::Archive::UncompressedSize;
     update_archive_size_stmt_field_names[enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::Size)] =
@@ -256,32 +268,38 @@ void GlobalSQLiteMetadataDB::close () {
     m_is_open = false;
 }
 
-void GlobalSQLiteMetadataDB::add_archive (const string& id, uint64_t uncompressed_size,
-                                          uint64_t size, const string& creator_id,
-                                          uint64_t creation_num)
+void GlobalSQLiteMetadataDB::add_archive (const string& id, const streaming_archive::ArchiveMetadata& metadata)
 {
     if (false == m_is_open) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
     m_insert_archive_statement->bind_text(enum_to_underlying_type(ArchivesTableFieldIndexes::Id) + 1, id, false);
-    m_insert_archive_statement->bind_int64(enum_to_underlying_type(ArchivesTableFieldIndexes::UncompressedSize) + 1, (int64_t)uncompressed_size);
-    m_insert_archive_statement->bind_int64(enum_to_underlying_type(ArchivesTableFieldIndexes::Size) + 1, (int64_t)size);
-    m_insert_archive_statement->bind_text(enum_to_underlying_type(ArchivesTableFieldIndexes::CreatorId) + 1, creator_id, false);
-    m_insert_archive_statement->bind_int64(enum_to_underlying_type(ArchivesTableFieldIndexes::CreationIx) + 1, (int64_t)creation_num);
+    m_insert_archive_statement->bind_int64(enum_to_underlying_type(ArchivesTableFieldIndexes::BeginTimestamp) + 1, (int64_t)metadata.get_begin_timestamp());
+    m_insert_archive_statement->bind_int64(enum_to_underlying_type(ArchivesTableFieldIndexes::EndTimestamp) + 1, (int64_t)metadata.get_end_timestamp());
+    m_insert_archive_statement->bind_int64(
+            enum_to_underlying_type(ArchivesTableFieldIndexes::UncompressedSize) + 1,
+            (int64_t)metadata.get_uncompressed_size_bytes());
+    m_insert_archive_statement->bind_int64(enum_to_underlying_type(ArchivesTableFieldIndexes::Size) + 1, (int64_t)metadata.get_compressed_size_bytes());
+    m_insert_archive_statement->bind_text(enum_to_underlying_type(ArchivesTableFieldIndexes::CreatorId) + 1, metadata.get_creator_id(), false);
+    m_insert_archive_statement->bind_int64(enum_to_underlying_type(ArchivesTableFieldIndexes::CreationIx) + 1, (int64_t)metadata.get_creation_idx());
     m_insert_archive_statement->step();
     m_insert_archive_statement->reset();
 }
 
-void GlobalSQLiteMetadataDB::update_archive_size (const string& archive_id,
-                                                  uint64_t uncompressed_size, uint64_t size)
-{
+void GlobalSQLiteMetadataDB::update_archive_metadata (const string& archive_id, const streaming_archive::ArchiveMetadata& metadata) {
     if (false == m_is_open) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    m_update_archive_size_statement->bind_int64(enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::UncompressedSize) + 1, (int64_t)uncompressed_size);
-    m_update_archive_size_statement->bind_int64(enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::Size) + 1, (int64_t)size);
+    m_update_archive_size_statement->bind_int64(enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::BeginTimestamp) + 1, (int64_t)metadata.get_begin_timestamp());
+    m_update_archive_size_statement->bind_int64(enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::EndTimestamp) + 1, (int64_t)metadata.get_end_timestamp());
+    m_update_archive_size_statement->bind_int64(
+            enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::UncompressedSize) + 1,
+            (int64_t)metadata.get_uncompressed_size_bytes());
+    m_update_archive_size_statement->bind_int64(
+            enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::Size) + 1,
+            (int64_t)metadata.get_compressed_size_bytes());
     m_update_archive_size_statement->bind_text(enum_to_underlying_type(UpdateArchiveSizeStmtFieldIndexes::Length) + 1, archive_id, false);
     m_update_archive_size_statement->step();
     m_update_archive_size_statement->reset();

--- a/components/core/src/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.cpp
@@ -131,7 +131,7 @@ GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator (SQLiteDB& db) : m_stat
     m_statement.step();
 }
 
-GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator (SQLiteDB& db, epochtime_t begin_ts, epochtime_t end_ts) : m_statement(get_archives_select_statement(db))
+GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator (SQLiteDB& db, epochtime_t begin_ts, epochtime_t end_ts) : m_statement(get_archives_for_time_window_select_statement(db, begin_ts, end_ts))
 {
     m_statement.step();
 }

--- a/components/core/src/GlobalSQLiteMetadataDB.hpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.hpp
@@ -67,10 +67,8 @@ public:
     void open () override;
     void close () override;
 
-    void add_archive (const std::string& id, uint64_t uncompressed_size, uint64_t size,
-                      const std::string& creator_id, uint64_t creation_num) override;
-    void update_archive_size (const std::string& archive_id, uint64_t uncompressed_size,
-                              uint64_t size) override;
+    void add_archive (const std::string& id, const streaming_archive::ArchiveMetadata& metadata) override;
+    void update_archive_metadata (const std::string& archive_id, const streaming_archive::ArchiveMetadata& metadata) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override { return new ArchiveIterator(m_db); }

--- a/components/core/src/GlobalSQLiteMetadataDB.hpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.hpp
@@ -47,6 +47,7 @@ public:
         // Constructors
         explicit ArchiveIterator (SQLiteDB& db);
         ArchiveIterator (SQLiteDB& db, const std::string& file_path);
+        ArchiveIterator (SQLiteDB& db, epochtime_t begin_ts, epochtime_t end_ts);
 
         // Methods
         bool contains_element () const override;
@@ -60,6 +61,7 @@ public:
 
     // Constructors
     GlobalSQLiteMetadataDB (const std::string& path) : m_path(path) {}
+    GlobalSQLiteMetadataDB (epochtime_t begin_ts, epochtime_t end_ts) {}
 
     // Methods
     void open () override;
@@ -71,7 +73,8 @@ public:
                               uint64_t size) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
-    GlobalMetadataDB::ArchiveIterator* get_archive_iterator (epochtime_t begin_ts, epochtime_t end_ts) override { return new ArchiveIterator(m_db); }
+    GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override { return new ArchiveIterator(m_db); }
+    GlobalMetadataDB::ArchiveIterator* get_archive_iterator_for_time_window (epochtime_t begin_ts, epochtime_t end_ts) override { return new ArchiveIterator(m_db, begin_ts, end_ts); }
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator_for_file_path (const std::string& path) override { return new ArchiveIterator(m_db, path); }
 
 private:

--- a/components/core/src/GlobalSQLiteMetadataDB.hpp
+++ b/components/core/src/GlobalSQLiteMetadataDB.hpp
@@ -71,7 +71,7 @@ public:
                               uint64_t size) override;
     void update_metadata_for_files (const std::string& archive_id, const std::vector<streaming_archive::writer::File*>& files) override;
 
-    GlobalMetadataDB::ArchiveIterator* get_archive_iterator () override { return new ArchiveIterator(m_db); }
+    GlobalMetadataDB::ArchiveIterator* get_archive_iterator (epochtime_t begin_ts, epochtime_t end_ts) override { return new ArchiveIterator(m_db); }
     GlobalMetadataDB::ArchiveIterator* get_archive_iterator_for_file_path (const std::string& path) override { return new ArchiveIterator(m_db, path); }
 
 private:

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -93,10 +93,12 @@ static void print_result_binary (const string& orig_file_path, const Message& co
 static GlobalMetadataDB::ArchiveIterator* get_archive_iterator (GlobalMetadataDB& global_metadata_db, const std::string& file_path, epochtime_t begin_ts, epochtime_t end_ts);
 
 static GlobalMetadataDB::ArchiveIterator* get_archive_iterator (GlobalMetadataDB& global_metadata_db, const std::string& file_path, epochtime_t begin_ts, epochtime_t end_ts) {
-    if (file_path.empty()) {
-        return global_metadata_db.get_archive_iterator(begin_ts, end_ts);
-    } else {
+    if (!file_path.empty()) {
         return global_metadata_db.get_archive_iterator_for_file_path(file_path);
+    } else if (begin_ts == cEpochTimeMin && end_ts == cEpochTimeMax) {
+        return global_metadata_db.get_archive_iterator();
+    } else {
+        return global_metadata_db.get_archive_iterator_for_time_window(begin_ts, end_ts);
     }
 }
 

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -86,13 +86,15 @@ static void print_result_binary (const string& orig_file_path, const Message& co
  * Gets an archive iterator for the given file path or for all files if the file path is empty
  * @param global_metadata_db
  * @param file_path
+ * @param begin_ts
+ * @param end_ts
  * @return An archive iterator
  */
-static GlobalMetadataDB::ArchiveIterator* get_archive_iterator (GlobalMetadataDB& global_metadata_db, const std::string& file_path);
+static GlobalMetadataDB::ArchiveIterator* get_archive_iterator (GlobalMetadataDB& global_metadata_db, const std::string& file_path, epochtime_t begin_ts, epochtime_t end_ts);
 
-static GlobalMetadataDB::ArchiveIterator* get_archive_iterator (GlobalMetadataDB& global_metadata_db, const std::string& file_path) {
+static GlobalMetadataDB::ArchiveIterator* get_archive_iterator (GlobalMetadataDB& global_metadata_db, const std::string& file_path, epochtime_t begin_ts, epochtime_t end_ts) {
     if (file_path.empty()) {
-        return global_metadata_db.get_archive_iterator();
+        return global_metadata_db.get_archive_iterator(begin_ts, end_ts);
     } else {
         return global_metadata_db.get_archive_iterator_for_file_path(file_path);
     }
@@ -397,7 +399,7 @@ int main (int argc, const char* argv[]) {
 
     string archive_id;
     Archive archive_reader;
-    for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(get_archive_iterator(*global_metadata_db, command_line_args.get_file_path()));
+    for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(get_archive_iterator(*global_metadata_db, command_line_args.get_file_path(), command_line_args.get_search_begin_ts(), command_line_args.get_search_end_ts()));
             archive_ix->contains_element(); archive_ix->get_next())
     {
         archive_ix->get_id(archive_id);

--- a/components/core/src/clp/decompression.cpp
+++ b/components/core/src/clp/decompression.cpp
@@ -8,6 +8,7 @@
 #include <boost/filesystem/path.hpp>
 
 // Project headers
+#include "../Defs.h"
 #include "../ErrorCode.hpp"
 #include "../FileWriter.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
@@ -69,7 +70,7 @@ namespace clp {
             std::unordered_map<string, string> temp_path_to_final_path;
             global_metadata_db->open();
             if (files_to_decompress.empty()) {
-                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator());
+                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator(cEpochTimeMin, cEpochTimeMax));
                         archive_ix->contains_element(); archive_ix->get_next())
                 {
                     archive_ix->get_id(archive_id);
@@ -131,7 +132,7 @@ namespace clp {
                     archive_reader.close();
                 }
             } else { // files_to_decompress.size() > 1
-                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator());
+                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator(cEpochTimeMin, cEpochTimeMax));
                         archive_ix->contains_element(); archive_ix->get_next())
                 {
                     archive_ix->get_id(archive_id);

--- a/components/core/src/clp/decompression.cpp
+++ b/components/core/src/clp/decompression.cpp
@@ -8,7 +8,6 @@
 #include <boost/filesystem/path.hpp>
 
 // Project headers
-#include "../Defs.h"
 #include "../ErrorCode.hpp"
 #include "../FileWriter.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
@@ -70,7 +69,7 @@ namespace clp {
             std::unordered_map<string, string> temp_path_to_final_path;
             global_metadata_db->open();
             if (files_to_decompress.empty()) {
-                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator(cEpochTimeMin, cEpochTimeMax));
+                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator());
                         archive_ix->contains_element(); archive_ix->get_next())
                 {
                     archive_ix->get_id(archive_id);
@@ -132,7 +131,7 @@ namespace clp {
                     archive_reader.close();
                 }
             } else { // files_to_decompress.size() > 1
-                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator(cEpochTimeMin, cEpochTimeMax));
+                for (auto archive_ix = std::unique_ptr<GlobalMetadataDB::ArchiveIterator>(global_metadata_db->get_archive_iterator());
                         archive_ix->contains_element(); archive_ix->get_next())
                 {
                     archive_ix->get_id(archive_id);

--- a/components/core/src/streaming_archive/ArchiveMetadata.cpp
+++ b/components/core/src/streaming_archive/ArchiveMetadata.cpp
@@ -1,0 +1,54 @@
+#include "ArchiveMetadata.hpp"
+
+namespace streaming_archive {
+ArchiveMetadata::ArchiveMetadata(
+        archive_format_version_t archive_format_version,
+        std::string creator_id,
+        uint64_t creation_idx
+)
+        : m_archive_format_version(archive_format_version),
+          m_creator_id(std::move(creator_id)),
+          m_creation_idx(creation_idx) {
+    if (m_creator_id.length() > UINT16_MAX) {
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
+    }
+    m_creator_id_len = m_creator_id.length();
+
+    // NOTE: We set this to the size of this metadata on disk; when adding new
+    // members that will be written to disk, you must update this
+    m_compressed_size += sizeof(m_archive_format_version) + sizeof(m_creator_id_len)
+                               + m_creator_id.length() + sizeof(m_creation_idx)
+                               + sizeof(m_uncompressed_size) + sizeof(m_begin_timestamp)
+                               + sizeof(m_end_timestamp) + sizeof(m_compressed_size);
+}
+
+ArchiveMetadata::ArchiveMetadata(FileReader& file_reader) {
+    file_reader.read_numeric_value(m_archive_format_version, false);
+    file_reader.read_numeric_value(m_creator_id_len, false);
+    file_reader.read_string(m_creator_id_len, m_creator_id, false);
+    file_reader.read_numeric_value(m_uncompressed_size, false);
+    file_reader.read_numeric_value(m_compressed_size, false);
+    file_reader.read_numeric_value(m_begin_timestamp, false);
+    file_reader.read_numeric_value(m_end_timestamp, false);
+}
+
+void ArchiveMetadata::expand_time_range(epochtime_t begin_timestamp, epochtime_t end_timestamp) {
+    if (begin_timestamp < m_begin_timestamp) {
+        m_begin_timestamp = begin_timestamp;
+    }
+    if (end_timestamp > m_end_timestamp) {
+        m_end_timestamp = end_timestamp;
+    }
+}
+
+void ArchiveMetadata::write_to_file(FileWriter& file_writer) const {
+    file_writer.write_numeric_value(m_archive_format_version);
+    file_writer.write_numeric_value(m_creator_id_len);
+    file_writer.write_string(m_creator_id);
+    file_writer.write_numeric_value(m_creation_idx);
+    file_writer.write_numeric_value(m_uncompressed_size + m_dynamic_uncompressed_size);
+    file_writer.write_numeric_value(m_compressed_size + m_dynamic_uncompressed_size);
+    file_writer.write_numeric_value(m_begin_timestamp);
+    file_writer.write_numeric_value(m_end_timestamp);
+}
+}  // namespace streaming_archive

--- a/components/core/src/streaming_archive/ArchiveMetadata.hpp
+++ b/components/core/src/streaming_archive/ArchiveMetadata.hpp
@@ -1,0 +1,110 @@
+#ifndef STREAMING_ARCHIVE_ARCHIVEMETADATA_HPP
+#define STREAMING_ARCHIVE_ARCHIVEMETADATA_HPP
+
+#include <cstdint>
+
+#include "../Defs.h"
+#include "../FileReader.hpp"
+#include "../FileWriter.hpp"
+#include "Constants.hpp"
+
+namespace streaming_archive {
+/**
+ * A class to encapsulate metadata directly relating to an archive.
+ */
+class ArchiveMetadata {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
+
+        // Methods
+        [[nodiscard]] auto what() const noexcept -> char const* override {
+            return "streaming_archive::ArchiveMetadata operation failed";
+        }
+    };
+
+    // Constructors
+    /**
+     * Constructs a metadata object with the given parameters
+     * @param archive_format_version
+     * @param creator_id
+     * @param creation_idx
+     */
+    ArchiveMetadata(
+            archive_format_version_t archive_format_version,
+            std::string creator_id,
+            uint64_t creation_idx
+    );
+
+    /**
+     * Constructs a metadata object and initializes it from the given file
+     * reader
+     * @param file_reader
+     */
+    explicit ArchiveMetadata(FileReader& file_reader);
+
+    // Methods
+    [[nodiscard]] auto get_archive_format_version() const { return m_archive_format_version; }
+
+    [[nodiscard]] auto get_creator_id() const -> std::string const& { return m_creator_id; }
+
+    [[nodiscard]] auto get_creation_idx() const { return m_creation_idx; }
+
+    [[nodiscard]] auto get_uncompressed_size_bytes() const {
+        return m_uncompressed_size + m_dynamic_uncompressed_size;
+    }
+
+    void increment_static_uncompressed_size(uint64_t size_bytes) {
+        m_uncompressed_size += size_bytes;
+    }
+
+    void set_dynamic_uncompressed_size(uint64_t size_bytes) {
+        m_dynamic_uncompressed_size = size_bytes;
+    }
+
+    [[nodiscard]] auto get_compressed_size_bytes() const {
+        return m_compressed_size + m_dynamic_compressed_size;
+    }
+
+    void increment_static_compressed_size(uint64_t size_bytes) { m_compressed_size += size_bytes;
+    }
+
+    void set_dynamic_compressed_size(uint64_t size_bytes) {
+        m_dynamic_compressed_size = size_bytes;
+    }
+
+    [[nodiscard]] auto get_begin_timestamp() const { return m_begin_timestamp; }
+
+    [[nodiscard]] auto get_end_timestamp() const { return m_end_timestamp; }
+
+    /**
+     * Expands the archive's time range based to encompass the given time range
+     * @param begin_timestamp
+     * @param end_timestamp
+     */
+    void expand_time_range(epochtime_t begin_timestamp, epochtime_t end_timestamp);
+
+    void write_to_file(FileWriter& file_writer) const;
+
+private:
+    // Variables
+    archive_format_version_t m_archive_format_version{cArchiveFormatVersion};
+    std::string m_creator_id;
+    uint16_t m_creator_id_len{0};
+    uint64_t m_creation_idx{0};
+    epochtime_t m_begin_timestamp{cEpochTimeMax};
+    epochtime_t m_end_timestamp{cEpochTimeMin};
+    // The size of the data stored in the archive before compression
+    uint64_t m_uncompressed_size{0};
+    uint64_t m_dynamic_uncompressed_size{0};
+    // The size of the archive
+    uint64_t m_compressed_size{0};
+    uint64_t m_dynamic_compressed_size{0};
+};
+}  // namespace streaming_archive
+
+#endif  // STREAMING_ARCHIVE_ARCHIVEMETADATA_HPP

--- a/components/core/src/streaming_archive/Constants.hpp
+++ b/components/core/src/streaming_archive/Constants.hpp
@@ -23,6 +23,8 @@ namespace streaming_archive {
 
         namespace Archive {
             constexpr char Id[] = "id";
+            constexpr char BeginTimestamp[] = "begin_timestamp";
+            constexpr char EndTimestamp[] = "end_timestamp";
             constexpr char UncompressedSize[] = "uncompressed_size";
             constexpr char Size[] = "size";
             constexpr char CreatorId[] = "creator_id";

--- a/components/core/src/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/streaming_archive/reader/Archive.hpp
@@ -36,14 +36,6 @@ namespace streaming_archive { namespace reader {
 
         // Methods
         /**
-         * Read the metadata file
-         * @param path
-         * @param id
-         */
-        static void read_metadata_file (const std::string& path, archive_format_version_t& format_version, size_t& stable_uncompressed_size,
-                                        size_t& stable_size);
-
-        /**
          * Opens archive for reading
          * @param path
          * @throw streaming_archive::reader::Archive::OperationFailed if could not stat file or it isn't a directory or metadata is corrupted

--- a/components/core/src/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/streaming_archive/writer/Archive.cpp
@@ -67,8 +67,7 @@ namespace streaming_archive::writer {
             throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
         }
         const auto& archive_path_string = archive_path.string();
-        m_stable_uncompressed_size = 0;
-        m_stable_size = 0;
+        m_local_metadata = std::make_optional<ArchiveMetadata>(cArchiveFormatVersion, m_creator_id_as_string, m_creation_num);
 
         // Create internal directories if necessary
         retval = mkdir(archive_path_string.c_str(), 0750);
@@ -129,12 +128,7 @@ namespace streaming_archive::writer {
         auto metadata_file_path = archive_path / cMetadataFileName;
         try {
             m_metadata_file_writer.open(metadata_file_path.string(), FileWriter::OpenMode::CREATE_IF_NONEXISTENT_FOR_SEEKABLE_WRITING);
-            // Update size before we write the metadata file so we can store the size in the metadata file
-            m_stable_size += sizeof(cArchiveFormatVersion) + sizeof(m_stable_uncompressed_size) + sizeof(m_stable_size);
-
-            m_metadata_file_writer.write_numeric_value(cArchiveFormatVersion);
-            m_metadata_file_writer.write_numeric_value(m_stable_uncompressed_size);
-            m_metadata_file_writer.write_numeric_value(m_stable_size);
+            m_local_metadata->write_to_file(m_metadata_file_writer);
             m_metadata_file_writer.flush();
         } catch (FileWriter::OperationFailed& e) {
             SPDLOG_CRITICAL("Failed to write archive file metadata collection in file: {}", metadata_file_path.c_str());
@@ -144,7 +138,7 @@ namespace streaming_archive::writer {
         m_global_metadata_db = user_config.global_metadata_db;
 
         m_global_metadata_db->open();
-        m_global_metadata_db->add_archive(m_id_as_string, m_stable_uncompressed_size, m_stable_size, m_creator_id_as_string, m_creation_num);
+        m_global_metadata_db->add_archive(m_id_as_string, *m_local_metadata);
         m_global_metadata_db->close();
 
         m_file = nullptr;
@@ -212,9 +206,6 @@ namespace streaming_archive::writer {
 
         m_global_metadata_db = nullptr;
 
-        m_stable_uncompressed_size = 0;
-        m_stable_size = 0;
-
         m_metadata_db.close();
 
         m_creator_id_as_string.clear();
@@ -277,7 +268,7 @@ namespace streaming_archive::writer {
             m_var_ids_for_file_with_unassigned_segment.insert(var_ids.cbegin(), var_ids.cend());
         }
     }
-    
+
     void Archive::write_msg_using_schema (compressor_frontend::Token*& uncompressed_msg, uint32_t uncompressed_msg_pos, const bool has_delimiter,
                                           const bool has_timestamp) {
         epochtime_t timestamp = 0;
@@ -328,7 +319,7 @@ namespace streaming_archive::writer {
                 }
             }
             switch (token_type) {
-                case (int) compressor_frontend::SymbolID::TokenNewlineId: 
+                case (int) compressor_frontend::SymbolID::TokenNewlineId:
                 case (int) compressor_frontend::SymbolID::TokenUncaughtStringID: {
                     m_logtype_dict_entry.add_constant(token.get_string(), 0, token.get_length());
                     break;
@@ -405,6 +396,8 @@ namespace streaming_archive::writer {
 
         m_file->append_to_segment(m_logtype_dict, segment);
         files_in_segment.emplace_back(m_file);
+        m_local_metadata->increment_static_uncompressed_size(m_file->get_num_uncompressed_bytes());
+        m_local_metadata->expand_time_range(m_file->get_begin_ts(), m_file->get_end_ts());
 
         // Close current segment if its uncompressed size is greater than the target
         if (segment.get_uncompressed_size() >= m_target_segment_uncompressed_size) {
@@ -459,9 +452,9 @@ namespace streaming_archive::writer {
         m_logtype_dict.index_segment(segment_id, segment_logtype_ids);
         m_var_dict.index_segment(segment_id, segment_var_ids);
 
-        m_stable_size += segment.get_compressed_size();
-
         segment.close();
+
+        m_local_metadata->increment_static_compressed_size(segment.get_compressed_size());
 
         #if FLUSH_TO_DISK_ENABLED
             // fsync segments directory to flush segment's directory entry
@@ -485,7 +478,6 @@ namespace streaming_archive::writer {
         m_global_metadata_db->close();
 
         for (auto file : files) {
-            m_stable_uncompressed_size += file->get_num_uncompressed_bytes();
             delete file;
         }
         files.clear();
@@ -499,24 +491,13 @@ namespace streaming_archive::writer {
         m_metadata_db.add_empty_directories(empty_directory_paths);
     }
 
-    size_t Archive::get_stable_uncompressed_size () const {
-        size_t uncompressed_size = m_stable_uncompressed_size;
+    uint64_t Archive::get_dynamic_compressed_size () {
+        uint64_t on_disk_size = m_logtype_dict.get_on_disk_size() + m_var_dict.get_on_disk_size();
 
-        // Add size of files in an unclosed segment
-        for (auto file : m_files_with_timestamps_in_segment) {
-            uncompressed_size += file->get_num_uncompressed_bytes();
+        // Add size of unclosed segments
+        if (m_segment_for_files_with_timestamps.is_open()) {
+            on_disk_size += m_segment_for_files_with_timestamps.get_compressed_size();
         }
-        for (auto file : m_files_without_timestamps_in_segment) {
-            uncompressed_size += file->get_num_uncompressed_bytes();
-        }
-
-        return uncompressed_size;
-    }
-
-    size_t Archive::get_stable_size () const {
-        size_t on_disk_size = m_stable_size + m_logtype_dict.get_on_disk_size() + m_var_dict.get_on_disk_size();
-
-        // Add size of unclosed segment
         if (m_segment_for_files_without_timestamps.is_open()) {
             on_disk_size += m_segment_for_files_without_timestamps.get_compressed_size();
         }
@@ -525,20 +506,19 @@ namespace streaming_archive::writer {
     }
 
     void Archive::update_metadata () {
-        auto stable_uncompressed_size = get_stable_uncompressed_size();
-        auto stable_size = get_stable_size();
+        m_local_metadata->set_dynamic_uncompressed_size(0);
+        m_local_metadata->set_dynamic_compressed_size(get_dynamic_compressed_size());
+        // Rewrite (overwrite) the metadata file
+        m_metadata_file_writer.seek_from_begin(0);
+        m_local_metadata->write_to_file(m_metadata_file_writer);
 
-        m_metadata_file_writer.seek_from_current(-((int64_t)(sizeof(m_stable_uncompressed_size) + sizeof(m_stable_size))));
-        m_metadata_file_writer.write_numeric_value(stable_uncompressed_size);
-        m_metadata_file_writer.write_numeric_value(stable_size);
-
-        m_global_metadata_db->update_archive_size(m_id_as_string, stable_uncompressed_size, stable_size);
+        m_global_metadata_db->update_archive_metadata(m_id_as_string, *m_local_metadata);
 
         if (m_print_archive_stats_progress) {
             nlohmann::json json_msg;
             json_msg["id"] = m_id_as_string;
-            json_msg["uncompressed_size"] = stable_uncompressed_size;
-            json_msg["size"] = stable_size;
+            json_msg["uncompressed_size"] = m_local_metadata->get_uncompressed_size_bytes();
+            json_msg["size"] = m_local_metadata->get_compressed_size_bytes();
             std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore) << std::endl;
         }
     }

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -232,7 +232,7 @@ namespace streaming_archive { namespace writer {
          * @return The size (in bytes) of compressed data whose size may change
          * before the archive is closed
          */
-        size_t get_dynamic_compressed_size ();
+        uint64_t get_dynamic_compressed_size ();
         /**
          * Updates the archive's metadata
          */

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -20,9 +20,10 @@
 #include "../../LogTypeDictionaryWriter.hpp"
 #include "../../VariableDictionaryWriter.hpp"
 #include "../../compressor_frontend/Token.hpp"
+#include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
 
-namespace streaming_archive { namespace writer { 
+namespace streaming_archive { namespace writer {
     class Archive {
     public:
         // Types
@@ -228,15 +229,10 @@ namespace streaming_archive { namespace writer {
                                                       ArrayBackedPosIntSet<variable_dictionary_id_t>& segment_var_ids);
 
         /**
-         * Gets the size of uncompressed data that has been compressed into the archive and will not be changed
-         * @return Size in bytes
+         * @return The size (in bytes) of compressed data whose size may change
+         * before the archive is closed
          */
-        size_t get_stable_uncompressed_size () const;
-        /**
-         * Gets the size of the portion of the archive that will not be changed
-         * @return Size in bytes
-         */
-        size_t get_stable_size () const;
+        size_t get_dynamic_compressed_size ();
         /**
          * Updates the archive's metadata
          */
@@ -288,13 +284,11 @@ namespace streaming_archive { namespace writer {
         ArrayBackedPosIntSet<logtype_dictionary_id_t> m_logtype_ids_in_segment_for_files_without_timestamps;
         ArrayBackedPosIntSet<variable_dictionary_id_t> m_var_ids_in_segment_for_files_without_timestamps;
 
-        size_t m_stable_uncompressed_size;
-        size_t m_stable_size;
-
         int m_compression_level;
 
         MetadataDB m_metadata_db;
 
+        std::optional<ArchiveMetadata> m_local_metadata;
         FileWriter m_metadata_file_writer;
 
         GlobalMetadataDB* m_global_metadata_db;

--- a/components/core/src/streaming_archive/writer/Segment.hpp
+++ b/components/core/src/streaming_archive/writer/Segment.hpp
@@ -64,8 +64,18 @@ namespace streaming_archive { namespace writer {
 
         segment_id_t get_id () const { return m_id; }
         bool is_open () const;
+        /**
+         * @return The amount of data (in bytes) appended (input) to the
+         * segment. Calling this after the segment has been closed will return
+         * the final uncompressed size of the segment.
+         */
         uint64_t get_uncompressed_size ();
-        size_t get_compressed_size () const { return m_file_writer.get_pos(); }
+        /**
+         * @return The on-disk size (in bytes) of the segment. Calling this
+         * after the segment has been closed will return the final compressed
+         * size of the segment.
+         */
+        size_t get_compressed_size ();
 
     private:
         // Variables
@@ -73,6 +83,7 @@ namespace streaming_archive { namespace writer {
         segment_id_t m_id;
 
         uint64_t m_offset;      // total input bytes processed
+        uint64_t m_compressed_size;
 
         FileWriter m_file_writer;
 #if USE_PASSTHROUGH_COMPRESSION

--- a/components/core/tools/scripts/db/init-db.py
+++ b/components/core/tools/scripts/db/init-db.py
@@ -67,6 +67,8 @@ def main(argv):
             mysql_cursor.execute(f"""CREATE TABLE IF NOT EXISTS `{table_prefix}archives` (
                 `pagination_id` BIGINT unsigned NOT NULL AUTO_INCREMENT,
                 `id` VARCHAR(64) NOT NULL,
+                `begin_timestamp` BIGINT NOT NULL,
+                `end_timestamp` BIGINT NOT NULL,
                 `uncompressed_size` BIGINT NOT NULL,
                 `size` BIGINT NOT NULL,
                 `creator_id` VARCHAR(64) NOT NULL,


### PR DESCRIPTION
# Description
When using MySQL as metadata db, only retrieve archive directories that have logs in the given search time window. This will improve search performance.

# Validation performed
Functional tests on Ubuntu bionic.
