### PR TITLE
Change include directives of submodules to use include path rather than relative path.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -324,12 +324,14 @@ set(SOURCE_FILES_clp
         src/version.hpp
         src/WriterInterface.cpp
         src/WriterInterface.hpp
-        submodules/date/include/date/date.h
-        submodules/json/single_include/nlohmann/json.hpp
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         )
 add_executable(clp ${SOURCE_FILES_clp})
+target_include_directories(clp
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/submodules
+        )
 target_link_libraries(clp
         PRIVATE
         Boost::filesystem Boost::iostreams Boost::program_options
@@ -479,12 +481,15 @@ set(SOURCE_FILES_clg
         src/version.hpp
         src/WriterInterface.cpp
         src/WriterInterface.hpp
-        submodules/date/include/date/date.h
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
         )
 add_executable(clg ${SOURCE_FILES_clg})
+target_include_directories(clg
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/submodules
+        )
 target_link_libraries(clg
         PRIVATE
         Boost::filesystem Boost::iostreams Boost::program_options
@@ -622,12 +627,15 @@ set(SOURCE_FILES_clo
         src/version.hpp
         src/WriterInterface.cpp
         src/WriterInterface.hpp
-        submodules/date/include/date/date.h
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
         )
 add_executable(clo ${SOURCE_FILES_clo})
+target_include_directories(clo
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/submodules
+        )
 target_link_libraries(clo
         PRIVATE
         Boost::filesystem Boost::iostreams Boost::program_options
@@ -824,9 +832,6 @@ set(SOURCE_FILES_unitTest
         src/version.hpp
         src/WriterInterface.cpp
         src/WriterInterface.hpp
-        submodules/Catch2/single_include/catch2/catch.hpp
-        submodules/date/include/date/date.h
-        submodules/json/single_include/nlohmann/json.hpp
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
@@ -845,6 +850,10 @@ set(SOURCE_FILES_unitTest
         tests/test-Utils.cpp
         )
 add_executable(unitTest ${SOURCE_FILES_unitTest})
+target_include_directories(unitTest
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/submodules
+        )
 target_link_libraries(unitTest
         PRIVATE
         Boost::filesystem Boost::iostreams Boost::program_options

--- a/components/core/src/GlobalMetadataDBConfig.cpp
+++ b/components/core/src/GlobalMetadataDBConfig.cpp
@@ -4,7 +4,7 @@
 #include <fmt/core.h>
 
 // yaml-cpp
-#include "../submodules/yaml-cpp/include/yaml-cpp/yaml.h"
+#include <yaml-cpp/include/yaml-cpp/yaml.h>
 
 using std::exception;
 using std::invalid_argument;

--- a/components/core/src/SQLiteDB.hpp
+++ b/components/core/src/SQLiteDB.hpp
@@ -5,7 +5,7 @@
 #include <string>
 
 // sqlite3
-#include "../submodules/sqlite3/sqlite3.h"
+#include <sqlite3/sqlite3.h>
 
 // Project headers
 #include "ErrorCode.hpp"

--- a/components/core/src/SQLitePreparedStatement.hpp
+++ b/components/core/src/SQLitePreparedStatement.hpp
@@ -5,7 +5,7 @@
 #include <string>
 
 // sqlite3
-#include "../submodules/sqlite3/sqlite3.h"
+#include <sqlite3/sqlite3.h>
 
 // Project headers
 #include "ErrorCode.hpp"

--- a/components/core/src/TimestampPattern.cpp
+++ b/components/core/src/TimestampPattern.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 // Date library
-#include "../submodules/date/include/date/date.h"
+#include <date/include/date/date.h>
 
 // Project headers
 #include "spdlog_with_specializations.hpp"

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -1,7 +1,7 @@
 #include "encoding_methods.hpp"
 
 // json
-#include "../../../submodules/json/single_include/nlohmann/json.hpp"
+#include <json/single_include/nlohmann/json.hpp>
 
 // Project headers
 #include "byteswap.hpp"

--- a/components/core/src/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/streaming_archive/writer/Archive.cpp
@@ -16,7 +16,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 // json
-#include "../../../submodules/json/single_include/nlohmann/json.hpp"
+#include <json/single_include/nlohmann/json.hpp>
 
 // Project headers
 #include "../../compressor_frontend/LogParser.hpp"

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -2,7 +2,7 @@
 #include <unistd.h>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/EncodedVariableInterpreter.hpp"

--- a/components/core/tests/test-Grep.cpp
+++ b/components/core/tests/test-Grep.cpp
@@ -2,7 +2,7 @@
 #include <string>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/compressor_frontend/Lexer.hpp"

--- a/components/core/tests/test-ParserWithUserSchema.cpp
+++ b/components/core/tests/test-ParserWithUserSchema.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/clp/run.hpp"

--- a/components/core/tests/test-Segment.cpp
+++ b/components/core/tests/test-Segment.cpp
@@ -5,7 +5,7 @@
 #include <boost/filesystem.hpp>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/streaming_archive/reader/Segment.hpp"

--- a/components/core/tests/test-Stopwatch.cpp
+++ b/components/core/tests/test-Stopwatch.cpp
@@ -2,7 +2,7 @@
 #include <unistd.h>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/Stopwatch.hpp"

--- a/components/core/tests/test-StreamingCompression.cpp
+++ b/components/core/tests/test-StreamingCompression.cpp
@@ -5,7 +5,7 @@
 #include <boost/filesystem.hpp>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Zstd library
 #include <zstd.h>

--- a/components/core/tests/test-TimestampPattern.cpp
+++ b/components/core/tests/test-TimestampPattern.cpp
@@ -1,5 +1,5 @@
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/TimestampPattern.hpp"

--- a/components/core/tests/test-Utils.cpp
+++ b/components/core/tests/test-Utils.cpp
@@ -11,7 +11,7 @@
 #include <ratio>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/Utils.hpp"

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -1,5 +1,5 @@
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/ffi/encoding_methods.hpp"

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -1,8 +1,8 @@
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // json
-#include "../submodules/json/single_include/nlohmann/json.hpp"
+#include <json/single_include/nlohmann/json.hpp>
 
 // Project headers
 #include "../src/ffi/encoding_methods.hpp"

--- a/components/core/tests/test-main.cpp
+++ b/components/core/tests/test-main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>

--- a/components/core/tests/test-query_methods.cpp
+++ b/components/core/tests/test-query_methods.cpp
@@ -2,7 +2,7 @@
 #include <unordered_map>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/ffi/encoding_methods.hpp"

--- a/components/core/tests/test-string_utils.cpp
+++ b/components/core/tests/test-string_utils.cpp
@@ -6,7 +6,7 @@
 #include <boost/range/combine.hpp>
 
 // Catch2
-#include "../submodules/Catch2/single_include/catch2/catch.hpp"
+#include <Catch2/single_include/catch2/catch.hpp>
 
 // Project headers
 #include "../src/string_utils.hpp"


### PR DESCRIPTION
# Description
To improve portability and avoid dependency on file structure include directives of submodules are switched from relative paths to using include paths.

# Validation performed
All unit tests passing.

