### PR TITLE
download-dep: Use correct parameter type to support old Python versions.

### DIFF
--- a/components/core/tools/scripts/deps-download/download-dep.py
+++ b/components/core/tools/scripts/deps-download/download-dep.py
@@ -56,7 +56,9 @@ def main(argv):
     file_path = extraction_dir / filename
     urllib.request.urlretrieve(target_url, file_path)
     if config["unzip"]:
-        shutil.unpack_archive(file_path, extraction_dir)
+        # NOTE: We need to convert file_path to a str since unpack_archive only
+        # accepts a path-like object on Python versions >= 3.7
+        shutil.unpack_archive(str(file_path), extraction_dir)
 
     if "hash" in config:
         # Verify hash


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

`download-depy.py` was failing on Ubuntu Bionic and CentOS 7 because the default Python version installed on those OSes doesn't support passing a path-like object to `unpack_archive`. This PR goes back to passing a string in instead of a path-like object.

# Validation performed
<!-- What tests and validation you performed on the change -->

Verified `download-dep.py` succeeds on Ubuntu Bionic and CentOS 7.
