### PR TITLE
Apply clang-format to ffi

### DIFF
--- a/components/core/src/ffi/encoding_methods.cpp
+++ b/components/core/src/ffi/encoding_methods.cpp
@@ -8,8 +8,7 @@ using std::string_view;
 namespace ffi {
 /*
  * For performance, we rely on the ASCII ordering of characters to compare
- * ranges of characters at a time instead of comparing individual
- * characters
+ * ranges of characters at a time instead of comparing individual characters
  */
 bool is_delim(signed char c) {
     return !(

--- a/components/core/src/ffi/encoding_methods.cpp
+++ b/components/core/src/ffi/encoding_methods.cpp
@@ -1,113 +1,116 @@
 #include "encoding_methods.hpp"
 
-// C++ standard libraries
 #include <algorithm>
 #include <string_view>
 
 using std::string_view;
 
 namespace ffi {
-    /*
-     * For performance, we rely on the ASCII ordering of characters to compare
-     * ranges of characters at a time instead of comparing individual
-     * characters
-     */
-    bool is_delim (signed char c) {
-        return !('+' == c || ('-' <= c && c <= '.') || ('0' <= c && c <= '9') ||
-                 ('A' <= c && c <= 'Z') || '\\' == c || '_' == c || ('a' <= c && c <= 'z'));
+/*
+ * For performance, we rely on the ASCII ordering of characters to compare
+ * ranges of characters at a time instead of comparing individual
+ * characters
+ */
+bool is_delim(signed char c) {
+    return !(
+            '+' == c || ('-' <= c && c <= '.') || ('0' <= c && c <= '9') || ('A' <= c && c <= 'Z')
+            || '\\' == c || '_' == c || ('a' <= c && c <= 'z')
+    );
+}
+
+bool is_variable_placeholder(char c) {
+    return (enum_to_underlying_type(VariablePlaceholder::Integer) == c)
+           || (enum_to_underlying_type(VariablePlaceholder::Dictionary) == c)
+           || (enum_to_underlying_type(VariablePlaceholder::Float) == c);
+}
+
+bool could_be_multi_digit_hex_value(const string_view str) {
+    if (str.length() < 2) {
+        return false;
     }
 
-    bool is_variable_placeholder (char c) {
-        return (enum_to_underlying_type(VariablePlaceholder::Integer) == c) ||
-               (enum_to_underlying_type(VariablePlaceholder::Dictionary) == c) ||
-               (enum_to_underlying_type(VariablePlaceholder::Float) == c);
+    return std::all_of(str.cbegin(), str.cend(), [](char c) {
+        return ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F') || ('0' <= c && c <= '9');
+    });
+}
+
+bool is_var(std::string_view value) {
+    size_t begin_pos = 0;
+    size_t end_pos = 0;
+    bool contains_var_placeholder;
+    if (get_bounds_of_next_var(value, begin_pos, end_pos, contains_var_placeholder)) {
+        // Ensure the entire value is a variable
+        return (0 == begin_pos && value.length() == end_pos);
+    } else {
+        return false;
+    }
+}
+
+bool get_bounds_of_next_var(
+        const string_view str,
+        size_t& begin_pos,
+        size_t& end_pos,
+        bool& contains_var_placeholder
+) {
+    auto const msg_length = str.length();
+    if (end_pos >= msg_length) {
+        return false;
     }
 
-    bool could_be_multi_digit_hex_value (const string_view str) {
-        if (str.length() < 2) {
-            return false;
-        }
+    while (true) {
+        begin_pos = end_pos;
 
-        return std::all_of(str.cbegin(), str.cend(), [] (char c) {
-            return ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F') || ('0' <= c && c <= '9');
-        });
-    }
-
-    bool is_var (std::string_view value) {
-        size_t begin_pos = 0;
-        size_t end_pos = 0;
-        bool contains_var_placeholder;
-        if (get_bounds_of_next_var(value, begin_pos, end_pos, contains_var_placeholder)) {
-            // Ensure the entire value is a variable
-            return (0 == begin_pos && value.length() == end_pos);
-        } else {
-            return false;
-        }
-    }
-
-    bool get_bounds_of_next_var (const string_view str, size_t& begin_pos, size_t& end_pos,
-                                 bool& contains_var_placeholder)
-    {
-        const auto msg_length = str.length();
-        if (end_pos >= msg_length) {
-            return false;
-        }
-
-        while (true) {
-            begin_pos = end_pos;
-
-            // Find next non-delimiter
-            bool char_before_var_was_equals_sign = false;
-            char previous_char = 0;
-            for (; begin_pos < msg_length; ++begin_pos) {
-                auto c = str[begin_pos];
-                if (false == is_delim(c)) {
-                    char_before_var_was_equals_sign = ('=' == previous_char);
-                    break;
-                }
-                previous_char = c;
-
-                if (enum_to_underlying_type(VariablePlaceholder::Integer) == c ||
-                    enum_to_underlying_type(VariablePlaceholder::Dictionary) == c ||
-                    enum_to_underlying_type(VariablePlaceholder::Float) == c)
-                {
-                    contains_var_placeholder = true;
-                }
+        // Find next non-delimiter
+        bool char_before_var_was_equals_sign = false;
+        char previous_char = 0;
+        for (; begin_pos < msg_length; ++begin_pos) {
+            auto c = str[begin_pos];
+            if (false == is_delim(c)) {
+                char_before_var_was_equals_sign = ('=' == previous_char);
+                break;
             }
-            if (msg_length == begin_pos) {
-                // Early exit for performance
-                return false;
-            }
+            previous_char = c;
 
-            bool contains_decimal_digit = false;
-            bool contains_alphabet = false;
-
-            // Find next delimiter
-            end_pos = begin_pos;
-            for (; end_pos < msg_length; ++end_pos) {
-                auto c = str[end_pos];
-                if (is_decimal_digit(c)) {
-                    contains_decimal_digit = true;
-                } else if (is_alphabet(c)) {
-                    contains_alphabet = true;
-                } else if (is_delim(c)) {
-                    break;
-                }
-            }
-
-            string_view variable(str.cbegin() + begin_pos, end_pos - begin_pos);
-            // Treat token as variable if:
-            // - it contains a decimal digit, or
-            // - it's directly preceded by an equals sign and contains an alphabet, or
-            // - it could be a multi-digit hex value
-            if (contains_decimal_digit ||
-                (char_before_var_was_equals_sign && contains_alphabet) ||
-                could_be_multi_digit_hex_value(variable))
+            if (enum_to_underlying_type(VariablePlaceholder::Integer) == c
+                || enum_to_underlying_type(VariablePlaceholder::Dictionary) == c
+                || enum_to_underlying_type(VariablePlaceholder::Float) == c)
             {
+                contains_var_placeholder = true;
+            }
+        }
+        if (msg_length == begin_pos) {
+            // Early exit for performance
+            return false;
+        }
+
+        bool contains_decimal_digit = false;
+        bool contains_alphabet = false;
+
+        // Find next delimiter
+        end_pos = begin_pos;
+        for (; end_pos < msg_length; ++end_pos) {
+            auto c = str[end_pos];
+            if (is_decimal_digit(c)) {
+                contains_decimal_digit = true;
+            } else if (is_alphabet(c)) {
+                contains_alphabet = true;
+            } else if (is_delim(c)) {
                 break;
             }
         }
 
-        return (msg_length != begin_pos);
+        string_view variable(str.cbegin() + begin_pos, end_pos - begin_pos);
+        // Treat token as variable if:
+        // - it contains a decimal digit, or
+        // - it's directly preceded by '=' and contains an alphabet char, or
+        // - it could be a multi-digit hex value
+        if (contains_decimal_digit || (char_before_var_was_equals_sign && contains_alphabet)
+            || could_be_multi_digit_hex_value(variable))
+        {
+            break;
+        }
     }
+
+    return (msg_length != begin_pos);
 }
+}  // namespace ffi

--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -7,8 +7,7 @@
 #include "../TraceableException.hpp"
 
 // TODO Some of the methods in this file are mostly duplicated from code that
-//  exists elsewhere in the repo. They should be consolidated in a future
-//  commit.
+// exists elsewhere in the repo. They should be consolidated in a future commit.
 namespace ffi {
 // Types
 using epoch_time_ms_t = int64_t;
@@ -43,11 +42,11 @@ private:
 
 // Constants
 /*
- * These constants can be used by callers to store the version of the
- * schemas and encoding methods they're using. At some point, we may update
- * and/or add built-in schemas/encoding methods. So callers must store the
- * versions they used for encoding to ensure that they can choose the same
- * versions for decoding.
+ * These constants can be used by callers to store the version of the schemas
+ * and encoding methods they're using. At some point, we may update and/or add
+ * built-in schemas/encoding methods. So callers must store the versions they
+ * used for encoding to ensure that they can choose the same versions for
+ * decoding.
  *
  * We use versions which look like package names in anticipation of users
  * writing their own custom schemas and encoding methods.
@@ -124,8 +123,7 @@ bool get_bounds_of_next_var(
 );
 
 /**
- * Encodes the given string into a representable float variable if
- * possible
+ * Encodes the given string into a representable float variable if possible
  * @tparam encoded_variable_t Type of the encoded variable
  * @param str
  * @param encoded_var
@@ -166,8 +164,7 @@ template <typename encoded_variable_t>
 std::string decode_float_var(encoded_variable_t encoded_var);
 
 /**
- * Encodes the given string into a representable integer variable if
- * possible
+ * Encodes the given string into a representable integer variable if possible
  * @tparam encoded_variable_t Type of the encoded variable
  * @param str
  * @param encoded_var
@@ -223,9 +220,8 @@ bool encode_message_generically(
 );
 
 /**
- * Encodes the given message. The simplistic interface is to make it
- * efficient to transfer data between the caller language and this native
- * code.
+ * Encodes the given message. The simplistic interface is to make it efficient
+ * to transfer data between the caller language and this native code.
  * @tparam encoded_variable_t Type of the encoded variable
  * @param message
  * @param logtype
@@ -245,9 +241,9 @@ bool encode_message(
 );
 
 /**
- * Decodes the message from the given logtype, encoded variables, and
- * dictionary variables. The simplistic interface is to make it efficient
- * to transfer data between the caller language and this native code.
+ * Decodes the message from the given logtype, encoded variables, and dictionary
+ * variables. The simplistic interface is to make it efficient to transfer data
+ * between the caller language and this native code.
  * @tparam encoded_variable_t Type of the encoded variable
  * @param logtype
  * @param encoded_vars
@@ -271,9 +267,9 @@ std::string decode_message(
 
 /**
  * Checks if any encoded variable matches the given wildcard query
- * NOTE: This method checks for *either* matching integer encoded variables
- * or matching float encoded variables, based on the variable placeholder
- * template parameter.
+ * NOTE: This method checks for *either* matching integer encoded variables or
+ * matching float encoded variables, based on the variable placeholder template
+ * parameter.
  * @tparam var_placeholder Placeholder for the type of encoded variables
  * that should be checked for matches
  * @tparam encoded_variable_t Type of the encoded variable
@@ -292,10 +288,10 @@ bool wildcard_query_matches_any_encoded_var(
 );
 
 /**
- * Checks whether the given wildcard strings match the given encoded
- * variables (from a message). Specifically, let {w in W} be the set of
- * wildcard strings and {e in E} be the set of encoded variables. This
- * method will return true only if:
+ * Checks whether the given wildcard strings match the given encoded variables
+ * (from a message). Specifically, let {w in W} be the set of wildcard strings
+ * and {e in E} be the set of encoded variables. This method will return true
+ * only if:
  * (1) Each unique `w` matches a unique `e`.
  * (2) When (1) is true, the order of elements in both W and E is unchanged.
  * NOTE: Instead of taking an array of objects, this method takes arrays of

--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -1,312 +1,330 @@
 #ifndef FFI_ENCODING_METHODS_HPP
 #define FFI_ENCODING_METHODS_HPP
 
-// C++ standard libraries
 #include <string>
 #include <vector>
 
-// Project headers
 #include "../TraceableException.hpp"
 
 // TODO Some of the methods in this file are mostly duplicated from code that
 //  exists elsewhere in the repo. They should be consolidated in a future
 //  commit.
 namespace ffi {
-    // Types
-    using epoch_time_ms_t = int64_t;
+// Types
+using epoch_time_ms_t = int64_t;
 
-    using eight_byte_encoded_variable_t = int64_t;
-    using four_byte_encoded_variable_t = int32_t;
+using eight_byte_encoded_variable_t = int64_t;
+using four_byte_encoded_variable_t = int32_t;
 
-    enum class VariablePlaceholder : char {
-        Integer = 0x11,
-        Dictionary = 0x12,
-        Float = 0x13,
-    };
+enum class VariablePlaceholder : char {
+    Integer = 0x11,
+    Dictionary = 0x12,
+    Float = 0x13,
+};
 
-    class EncodingException : public TraceableException {
-    public:
-        // Constructors
-        EncodingException (ErrorCode error_code, const char* const filename, int line_number,
-                           std::string message) :
-                TraceableException(error_code, filename, line_number),
-                m_message(std::move(message)) {}
+class EncodingException : public TraceableException {
+public:
+    // Constructors
+    EncodingException(
+            ErrorCode error_code,
+            char const* const filename,
+            int line_number,
+            std::string message
+    )
+            : TraceableException(error_code, filename, line_number),
+              m_message(std::move(message)) {}
 
-        // Methods
-        [[nodiscard]] const char* what() const noexcept override {
-            return m_message.c_str();
-        }
+    // Methods
+    [[nodiscard]] char const* what() const noexcept override { return m_message.c_str(); }
 
-    private:
-        std::string m_message;
-    };
+private:
+    std::string m_message;
+};
 
-    // Constants
-    /*
-     * These constants can be used by callers to store the version of the
-     * schemas and encoding methods they're using. At some point, we may update
-     * and/or add built-in schemas/encoding methods. So callers must store the
-     * versions they used for encoding to ensure that they can choose the same
-     * versions for decoding.
-     *
-     * We use versions which look like package names in anticipation of users
-     * writing their own custom schemas and encoding methods.
-     */
-    static constexpr char cVariableEncodingMethodsVersion[] =
-            "com.yscope.clp.VariableEncodingMethodsV1";
-    static constexpr char cVariablesSchemaVersion[] = "com.yscope.clp.VariablesSchemaV2";
+// Constants
+/*
+ * These constants can be used by callers to store the version of the
+ * schemas and encoding methods they're using. At some point, we may update
+ * and/or add built-in schemas/encoding methods. So callers must store the
+ * versions they used for encoding to ensure that they can choose the same
+ * versions for decoding.
+ *
+ * We use versions which look like package names in anticipation of users
+ * writing their own custom schemas and encoding methods.
+ */
+static constexpr char cVariableEncodingMethodsVersion[]
+        = "com.yscope.clp.VariableEncodingMethodsV1";
+static constexpr char cVariablesSchemaVersion[] = "com.yscope.clp.VariablesSchemaV2";
 
-    constexpr char cVariablePlaceholderEscapeCharacter = '\\';
+constexpr char cVariablePlaceholderEscapeCharacter = '\\';
 
-    static constexpr char cTooFewDictionaryVarsErrorMessage[] =
-            "There are fewer dictionary variables than dictionary variable delimiters in the "
-            "logtype.";
-    static constexpr char cTooFewEncodedVarsErrorMessage[] =
-            "There are fewer encoded variables than encoded variable delimiters in the logtype.";
-    static constexpr char cUnexpectedEscapeCharacterMessage[] =
-            "Unexpected escape character without escaped value at the end of the logtype.";
+static constexpr char cTooFewDictionaryVarsErrorMessage[]
+        = "There are fewer dictionary variables than dictionary variable delimiters in the "
+          "logtype.";
+static constexpr char cTooFewEncodedVarsErrorMessage[]
+        = "There are fewer encoded variables than encoded variable delimiters in the logtype.";
+static constexpr char cUnexpectedEscapeCharacterMessage[]
+        = "Unexpected escape character without escaped value at the end of the logtype.";
 
-    constexpr size_t cMaxDigitsInRepresentableEightByteFloatVar = 16;
-    constexpr size_t cMaxDigitsInRepresentableFourByteFloatVar = 8;
-    constexpr uint64_t cEightByteEncodedFloatDigitsBitMask = (1ULL << 54) - 1;
-    constexpr uint32_t cFourByteEncodedFloatDigitsBitMask = (1UL << 25) - 1;
+constexpr size_t cMaxDigitsInRepresentableEightByteFloatVar = 16;
+constexpr size_t cMaxDigitsInRepresentableFourByteFloatVar = 8;
+constexpr uint64_t cEightByteEncodedFloatDigitsBitMask = (1ULL << 54) - 1;
+constexpr uint32_t cFourByteEncodedFloatDigitsBitMask = (1UL << 25) - 1;
 
-    /**
-     * Checks if the given character is a delimiter
-     * We treat everything *except* the following quoted characters as a
-     * delimiter: "+-.0-9A-Z\_a-z"
-     * @param c
-     * @return Whether c is a delimiter
-     */
-    bool is_delim (signed char c);
+/**
+ * Checks if the given character is a delimiter
+ * We treat everything *except* the following quoted characters as a
+ * delimiter: "+-.0-9A-Z\_a-z"
+ * @param c
+ * @return Whether c is a delimiter
+ */
+bool is_delim(signed char c);
 
-    /**
-     * @param c
-     * @return Whether the character is a variable placeholder
-     */
-    bool is_variable_placeholder (char c);
+/**
+ * @param c
+ * @return Whether the character is a variable placeholder
+ */
+bool is_variable_placeholder(char c);
 
-    /**
-     * @param str
-     * @return Whether the given string could be a multi-digit hex value
-     */
-    bool could_be_multi_digit_hex_value (std::string_view str);
+/**
+ * @param str
+ * @return Whether the given string could be a multi-digit hex value
+ */
+bool could_be_multi_digit_hex_value(std::string_view str);
 
-    /**
-     * @param value
-     * @return Whether the given value is a variable according to the schemas
-     * specified in ffi::get_bounds_of_next_var
-     */
-    bool is_var (std::string_view value);
+/**
+ * @param value
+ * @return Whether the given value is a variable according to the schemas
+ * specified in ffi::get_bounds_of_next_var
+ */
+bool is_var(std::string_view value);
 
-    /**
-     * Gets the bounds of the next variable in the given string
-     * A variable is a token (word between two delimiters) that matches one of
-     * these schemas:
-     * - ".*[0-9].*"
-     * - "=(.*[a-zA-Z].*)" (the variable is within the capturing group)
-     * - "[a-fA-F0-9]{2,}"
-     * @param str String to search within
-     * @param begin_pos Begin position of last variable, changes to begin
-     * position of next variable
-     * @param end_pos End position of last variable, changes to end position of
-     * next variable
-     * @param contains_var_placeholder Whether the string already contains a
-     * variable placeholder (for efficiency, this is only set to true, so the
-     * caller must reset it to false if necessary)
-     * @return true if a variable was found, false otherwise
-     */
-    bool get_bounds_of_next_var (std::string_view str, size_t& begin_pos, size_t& end_pos,
-                                 bool& contains_var_placeholder);
+/**
+ * Gets the bounds of the next variable in the given string
+ * A variable is a token (word between two delimiters) that matches one of
+ * these schemas:
+ * - ".*[0-9].*"
+ * - "=(.*[a-zA-Z].*)" (the variable is within the capturing group)
+ * - "[a-fA-F0-9]{2,}"
+ * @param str String to search within
+ * @param begin_pos Begin position of last variable, changes to begin
+ * position of next variable
+ * @param end_pos End position of last variable, changes to end position of
+ * next variable
+ * @param contains_var_placeholder Whether the string already contains a
+ * variable placeholder (for efficiency, this is only set to true, so the
+ * caller must reset it to false if necessary)
+ * @return true if a variable was found, false otherwise
+ */
+bool get_bounds_of_next_var(
+        std::string_view str,
+        size_t& begin_pos,
+        size_t& end_pos,
+        bool& contains_var_placeholder
+);
 
-    /**
-     * Encodes the given string into a representable float variable if
-     * possible
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param str
-     * @param encoded_var
-     * @return true on success, false otherwise
-     */
-    template <typename encoded_variable_t>
-    bool encode_float_string (std::string_view str, encoded_variable_t& encoded_var);
+/**
+ * Encodes the given string into a representable float variable if
+ * possible
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param str
+ * @param encoded_var
+ * @return true on success, false otherwise
+ */
+template <typename encoded_variable_t>
+bool encode_float_string(std::string_view str, encoded_variable_t& encoded_var);
 
-    /**
-     * Encodes a float value with the given properties into an encoded variable
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param is_negative
-     * @param digits The digits of the float, ignoring the decimal, as an
-     * integer
-     * @param num_digits The number of digits in \p digits
-     * @param decimal_point_pos The position of the decimal point from the right
-     * of the value
-     * @return The encoded variable
-     */
-    template <typename encoded_variable_t>
-    encoded_variable_t encode_float_properties (
-            bool is_negative,
-            std::conditional_t<std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
-                    uint32_t, uint64_t> digits,
-            size_t num_digits,
-            size_t decimal_point_pos
-    );
+/**
+ * Encodes a float value with the given properties into an encoded variable
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param is_negative
+ * @param digits The digits of the float, ignoring the decimal, as an
+ * integer
+ * @param num_digits The number of digits in \p digits
+ * @param decimal_point_pos The position of the decimal point from the right
+ * of the value
+ * @return The encoded variable
+ */
+template <typename encoded_variable_t>
+encoded_variable_t encode_float_properties(
+        bool is_negative,
+        std::conditional_t<
+                std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
+                uint32_t,
+                uint64_t> digits,
+        size_t num_digits,
+        size_t decimal_point_pos
+);
 
-    /**
-     * Decodes the given encoded float variable into a string
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param encoded_var
-     * @return The decoded value as a string
-     */
-    template <typename encoded_variable_t>
-    std::string decode_float_var (encoded_variable_t encoded_var);
+/**
+ * Decodes the given encoded float variable into a string
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param encoded_var
+ * @return The decoded value as a string
+ */
+template <typename encoded_variable_t>
+std::string decode_float_var(encoded_variable_t encoded_var);
 
-    /**
-     * Encodes the given string into a representable integer variable if
-     * possible
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param str
-     * @param encoded_var
-     * @return true if successfully converted, false otherwise
-     */
-    template <typename encoded_variable_t>
-    bool encode_integer_string (std::string_view str, encoded_variable_t& encoded_var);
-    /**
-     * Decodes the given encoded integer variable into a string
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param encoded_var
-     * @return The decoded value as a string
-     */
-    template <typename encoded_variable_t>
-    std::string decode_integer_var (encoded_variable_t encoded_var);
+/**
+ * Encodes the given string into a representable integer variable if
+ * possible
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param str
+ * @param encoded_var
+ * @return true if successfully converted, false otherwise
+ */
+template <typename encoded_variable_t>
+bool encode_integer_string(std::string_view str, encoded_variable_t& encoded_var);
+/**
+ * Decodes the given encoded integer variable into a string
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param encoded_var
+ * @return The decoded value as a string
+ */
+template <typename encoded_variable_t>
+std::string decode_integer_var(encoded_variable_t encoded_var);
 
-    /**
-     * Encodes the given message and calls the given methods to handle specific
-     * components of the message.
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @tparam ConstantHandler Method to handle constants. Signature:
-     * (std::string_view constant, bool constant_contains_variable_placeholder,
-     * std::string& logtype) -> bool
-     * @tparam FinalConstantHandler Method to handle the constant after the last
-     * variable. Signature: (std::string_view constant, std::string& logtype) -> bool
-     * @tparam EncodedVariableHandler Method to handle encoded variables.
-     * Signature: (encoded_variable_t) -> void
-     * @tparam DictionaryVariableHandler Method to handle dictionary variables.
-     * Signature: (std::string_view message, size_t begin_pos, size_t end_pos) -> bool
-     * @param message
-     * @param logtype
-     * @param constant_handler
-     * @param final_constant_handler
-     * @param encoded_variable_handler
-     * @param dictionary_variable_handler
-     * @return true on success, false otherwise
-     */
-    template <typename encoded_variable_t, typename ConstantHandler, typename FinalConstantHandler,
-            typename EncodedVariableHandler, typename DictionaryVariableHandler>
-    bool encode_message_generically (std::string_view message, std::string& logtype,
-                                     ConstantHandler constant_handler,
-                                     FinalConstantHandler final_constant_handler,
-                                     EncodedVariableHandler encoded_variable_handler,
-                                     DictionaryVariableHandler dictionary_variable_handler);
+/**
+ * Encodes the given message and calls the given methods to handle specific
+ * components of the message.
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @tparam ConstantHandler Method to handle constants. Signature:
+ * (std::string_view constant, bool constant_contains_variable_placeholder,
+ * std::string& logtype) -> bool
+ * @tparam FinalConstantHandler Method to handle the constant after the last
+ * variable. Signature:
+ * (std::string_view constant, std::string& logtype) -> bool
+ * @tparam EncodedVariableHandler Method to handle encoded variables.
+ * Signature: (encoded_variable_t) -> void
+ * @tparam DictionaryVariableHandler Method to handle dictionary variables.
+ * Signature:
+ * (std::string_view message, size_t begin_pos, size_t end_pos) -> bool
+ * @param message
+ * @param logtype
+ * @param constant_handler
+ * @param final_constant_handler
+ * @param encoded_variable_handler
+ * @param dictionary_variable_handler
+ * @return true on success, false otherwise
+ */
+template <
+        typename encoded_variable_t,
+        typename ConstantHandler,
+        typename FinalConstantHandler,
+        typename EncodedVariableHandler,
+        typename DictionaryVariableHandler>
+bool encode_message_generically(
+        std::string_view message,
+        std::string& logtype,
+        ConstantHandler constant_handler,
+        FinalConstantHandler final_constant_handler,
+        EncodedVariableHandler encoded_variable_handler,
+        DictionaryVariableHandler dictionary_variable_handler
+);
 
-    /**
-     * Encodes the given message. The simplistic interface is to make it
-     * efficient to transfer data between the caller language and this native
-     * code.
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param message
-     * @param logtype
-     * @param encoded_vars
-     * @param dictionary_var_bounds A one-dimensional array containing the
-     * bounds (begin_pos followed by end_pos) of each dictionary variable in the
-     * message
-     * @return false if the message contains variable placeholders, true
-     * otherwise
-     */
-    template <typename encoded_variable_t>
-    bool encode_message (std::string_view message, std::string& logtype,
-                         std::vector<encoded_variable_t>& encoded_vars,
-                         std::vector<int32_t>& dictionary_var_bounds);
+/**
+ * Encodes the given message. The simplistic interface is to make it
+ * efficient to transfer data between the caller language and this native
+ * code.
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param message
+ * @param logtype
+ * @param encoded_vars
+ * @param dictionary_var_bounds A one-dimensional array containing the
+ * bounds (begin_pos followed by end_pos) of each dictionary variable in the
+ * message
+ * @return false if the message contains variable placeholders, true
+ * otherwise
+ */
+template <typename encoded_variable_t>
+bool encode_message(
+        std::string_view message,
+        std::string& logtype,
+        std::vector<encoded_variable_t>& encoded_vars,
+        std::vector<int32_t>& dictionary_var_bounds
+);
 
-    /**
-     * Decodes the message from the given logtype, encoded variables, and
-     * dictionary variables. The simplistic interface is to make it efficient
-     * to transfer data between the caller language and this native code.
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param logtype
-     * @param encoded_vars
-     * @param encoded_vars_length
-     * @param all_dictionary_vars The message's dictionary variables, stored
-     * back-to-back in a single byte-array
-     * @param dictionary_var_end_offsets The end-offset of each dictionary
-     * variable in ``all_dictionary_vars``
-     * @param dictionary_var_end_offsets_length
-     * @return The decoded message
-     */
-    template <typename encoded_variable_t>
-    std::string decode_message (
-            std::string_view logtype,
-            encoded_variable_t* encoded_vars,
-            size_t encoded_vars_length,
-            std::string_view all_dictionary_vars,
-            const int32_t* dictionary_var_end_offsets,
-            size_t dictionary_var_end_offsets_length
-    );
+/**
+ * Decodes the message from the given logtype, encoded variables, and
+ * dictionary variables. The simplistic interface is to make it efficient
+ * to transfer data between the caller language and this native code.
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param logtype
+ * @param encoded_vars
+ * @param encoded_vars_length
+ * @param all_dictionary_vars The message's dictionary variables, stored
+ * back-to-back in a single byte-array
+ * @param dictionary_var_end_offsets The end-offset of each dictionary
+ * variable in ``all_dictionary_vars``
+ * @param dictionary_var_end_offsets_length
+ * @return The decoded message
+ */
+template <typename encoded_variable_t>
+std::string decode_message(
+        std::string_view logtype,
+        encoded_variable_t* encoded_vars,
+        size_t encoded_vars_length,
+        std::string_view all_dictionary_vars,
+        int32_t const* dictionary_var_end_offsets,
+        size_t dictionary_var_end_offsets_length
+);
 
-    /**
-     * Checks if any encoded variable matches the given wildcard query
-     * NOTE: This method checks for *either* matching integer encoded variables
-     * or matching float encoded variables, based on the variable placeholder
-     * template parameter.
-     * @tparam var_placeholder Placeholder for the type of encoded variables
-     * that should be checked for matches
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param wildcard_query
-     * @param logtype
-     * @param encoded_vars
-     * @param encoded_vars_length
-     * @return true if a match was found, false otherwise
-     */
-    template <VariablePlaceholder var_placeholder, typename encoded_variable_t>
-    bool wildcard_query_matches_any_encoded_var (
-            std::string_view wildcard_query,
-            std::string_view logtype,
-            encoded_variable_t* encoded_vars,
-            int encoded_vars_length
-    );
+/**
+ * Checks if any encoded variable matches the given wildcard query
+ * NOTE: This method checks for *either* matching integer encoded variables
+ * or matching float encoded variables, based on the variable placeholder
+ * template parameter.
+ * @tparam var_placeholder Placeholder for the type of encoded variables
+ * that should be checked for matches
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param wildcard_query
+ * @param logtype
+ * @param encoded_vars
+ * @param encoded_vars_length
+ * @return true if a match was found, false otherwise
+ */
+template <VariablePlaceholder var_placeholder, typename encoded_variable_t>
+bool wildcard_query_matches_any_encoded_var(
+        std::string_view wildcard_query,
+        std::string_view logtype,
+        encoded_variable_t* encoded_vars,
+        int encoded_vars_length
+);
 
-    /**
-     * Checks whether the given wildcard strings match the given encoded
-     * variables (from a message). Specifically, let {w in W} be the set of
-     * wildcard strings and {e in E} be the set of encoded variables. This
-     * method will return true only if:
-     * (1) Each unique `w` matches a unique `e`.
-     * (2) When (1) is true, the order of elements in both W and E is unchanged.
-     * NOTE: Instead of taking an array of objects, this method takes arrays of
-     * object-members (the result of serializing the objects) so that it can be
-     * called without unnecessarily reconstructing the objects.
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param logtype The message's logtype
-     * @param encoded_vars The message's encoded variables
-     * @param encoded_vars_length The number of encoded variables in \p
-     * encoded_vars
-     * @param wildcard_var_placeholders String of variable placeholders, where
-     * each one indicates how the corresponding wildcard string should be
-     * interpreted.
-     * @param wildcard_var_queries The wildcard strings to compare with the
-     * encoded variables. Callers must ensure each wildcard string contains
-     * no redundant wildcards (e.g. "**") nor unnecessary escape characters
-     * (e.g. "\").
-     * @return Whether the wildcard strings match the encoded variables
-     */
-    template <typename encoded_variable_t>
-    bool wildcard_match_encoded_vars (
-            std::string_view logtype,
-            encoded_variable_t* encoded_vars,
-            size_t encoded_vars_length,
-            std::string_view wildcard_var_placeholders,
-            const std::vector<std::string_view>& wildcard_var_queries
-    );
-}
+/**
+ * Checks whether the given wildcard strings match the given encoded
+ * variables (from a message). Specifically, let {w in W} be the set of
+ * wildcard strings and {e in E} be the set of encoded variables. This
+ * method will return true only if:
+ * (1) Each unique `w` matches a unique `e`.
+ * (2) When (1) is true, the order of elements in both W and E is unchanged.
+ * NOTE: Instead of taking an array of objects, this method takes arrays of
+ * object-members (the result of serializing the objects) so that it can be
+ * called without unnecessarily reconstructing the objects.
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param logtype The message's logtype
+ * @param encoded_vars The message's encoded variables
+ * @param encoded_vars_length The number of encoded variables in \p
+ * encoded_vars
+ * @param wildcard_var_placeholders String of variable placeholders, where
+ * each one indicates how the corresponding wildcard string should be
+ * interpreted.
+ * @param wildcard_var_queries The wildcard strings to compare with the
+ * encoded variables. Callers must ensure each wildcard string contains
+ * no redundant wildcards (e.g. "**") nor unnecessary escape characters
+ * (e.g. "\").
+ * @return Whether the wildcard strings match the encoded variables
+ */
+template <typename encoded_variable_t>
+bool wildcard_match_encoded_vars(
+        std::string_view logtype,
+        encoded_variable_t* encoded_vars,
+        size_t encoded_vars_length,
+        std::string_view wildcard_var_placeholders,
+        std::vector<std::string_view> const& wildcard_var_queries
+);
+}  // namespace ffi
 
 #include "encoding_methods.tpp"
 
-#endif // FFI_ENCODING_METHODS_HPP
+#endif  // FFI_ENCODING_METHODS_HPP

--- a/components/core/src/ffi/encoding_methods.tpp
+++ b/components/core/src/ffi/encoding_methods.tpp
@@ -399,16 +399,18 @@ bool encode_message(
         std::vector<encoded_variable_t>& encoded_vars,
         std::vector<int32_t>& dictionary_var_bounds
 ) {
-    auto constant_handler
-            = [](std::string_view constant, bool contains_variable_placeholder, std::string& logtype
-              ) {
-                  if (contains_variable_placeholder) {
-                      return false;
-                  }
+    auto constant_handler = [](  // clang-format off
+            std::string_view constant,
+            bool contains_variable_placeholder,
+            std::string& logtype
+    ) {  // clang-format on
+        if (contains_variable_placeholder) {
+            return false;
+        }
 
-                  logtype.append(constant);
-                  return true;
-              };
+        logtype.append(constant);
+        return true;
+    };
     auto final_constant_handler =
             [&constant_handler](std::string_view constant, std::string& logtype) {
                 // Ensure final constant doesn't contain a variable placeholder

--- a/components/core/src/ffi/encoding_methods.tpp
+++ b/components/core/src/ffi/encoding_methods.tpp
@@ -1,566 +1,650 @@
 #ifndef FFI_ENCODING_METHODS_TPP
 #define FFI_ENCODING_METHODS_TPP
 
-// C++ standard libraries
 #include <algorithm>
 
-// Project headers
 #include "../string_utils.hpp"
 #include "../type_utils.hpp"
 
 namespace ffi {
-    template <typename encoded_variable_t>
-    bool encode_float_string (std::string_view str, encoded_variable_t& encoded_var) {
-        const auto value_length = str.length();
-        if (0 == value_length) {
-            // Can't convert an empty string
-            return false;
-        }
-
-        size_t pos = 0;
-        constexpr size_t cMaxDigitsInRepresentableFloatVar =
-                std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
-                        ? cMaxDigitsInRepresentableFourByteFloatVar
-                        : cMaxDigitsInRepresentableEightByteFloatVar;
-        size_t max_length = cMaxDigitsInRepresentableFloatVar + 1;  // +1 for decimal point
-
-        // Check for a negative sign
-        bool is_negative = false;
-        if ('-' == str[pos]) {
-            is_negative = true;
-            ++pos;
-            // Include sign in max length
-            ++max_length;
-        }
-
-        // Check if value can be represented in encoded format
-        if (value_length > max_length) {
-            return false;
-        }
-
-        size_t num_digits = 0;
-        size_t decimal_point_pos = std::string::npos;
-        std::conditional_t<std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
-                uint32_t, uint64_t> digits = 0;
-        for (; pos < value_length; ++pos) {
-            auto c = str[pos];
-            if ('0' <= c && c <= '9') {
-                digits *= 10;
-                digits += (c - '0');
-                ++num_digits;
-            } else if (std::string::npos == decimal_point_pos && '.' == c) {
-                decimal_point_pos = value_length - 1 - pos;
-            } else {
-                // Invalid character
-                return false;
-            }
-        }
-        if (std::string::npos == decimal_point_pos || 0 == decimal_point_pos || 0 == num_digits) {
-            // No decimal point found, decimal point is after all digits, or no
-            // digits found
-            return false;
-        }
-
-        encoded_var = encode_float_properties<encoded_variable_t>(is_negative, digits, num_digits,
-                                                                  decimal_point_pos);
-
-        return true;
-    }
-
-    template <typename encoded_variable_t>
-    encoded_variable_t encode_float_properties (
-            bool is_negative,
-            std::conditional_t<std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
-                    uint32_t, uint64_t> digits,
-            size_t num_digits,
-            size_t decimal_point_pos
-    ) {
-        static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                      std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
-        if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-            // Encode into 64 bits with the following format (from MSB to LSB):
-            // -  1 bit : is negative
-            // -  1 bit : unused
-            // - 54 bits: The digits of the float without the decimal, as an
-            //            integer
-            // -  4 bits: # of decimal digits minus 1
-            //     - This format can represent floats with between 1 and 16 decimal
-            //       digits, so we use 4 bits and map the range [1, 16] to
-            //       [0x0, 0xF]
-            // -  4 bits: position of the decimal from the right minus 1
-            //     - To see why the position is taken from the right, consider
-            //       (1) "-123456789012345.6", (2) "-.1234567890123456", and
-            //       (3) ".1234567890123456"
-            //         - For (1), the decimal point is at index 16 from the left and
-            //           index 1 from the right.
-            //         - For (2), the decimal point is at index 1 from the left and
-            //           index 16 from the right.
-            //         - For (3), the decimal point is at index 0 from the left and
-            //           index 16 from the right.
-            //         - So if we take the decimal position from the left, it can
-            //           range from 0 to 16 because of the negative sign. Whereas
-            //           from the right, the negative sign is inconsequential.
-            //     - Thus, we use 4 bits and map the range [1, 16] to [0x0, 0xF].
-            uint64_t encoded_float = 0;
-            if (is_negative) {
-                encoded_float = 1;
-            }
-            encoded_float <<= 55;  // 1 unused + 54 for digits of the float
-            encoded_float |= digits & cEightByteEncodedFloatDigitsBitMask;
-            encoded_float <<= 4;
-            encoded_float |= (num_digits - 1) & 0x0F;
-            encoded_float <<= 4;
-            encoded_float |= (decimal_point_pos - 1) & 0x0F;
-            return bit_cast<encoded_variable_t>(encoded_float);
-        } else {  // std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
-            if (digits > cFourByteEncodedFloatDigitsBitMask) {
-                // digits is larger than maximum representable
-                return false;
-            }
-
-            // Encode into 32 bits with the following format (from MSB to LSB):
-            // -  1 bit : is negative
-            // - 25 bits: The digits of the float without the decimal, as an
-            //            integer
-            // -  3 bits: # of decimal digits minus 1
-            //     - This format can represent floats with between 1 and 8 decimal
-            //       digits, so we use 3 bits and map the range [1, 8] to
-            //       [0x0, 0x7]
-            // -  3 bits: position of the decimal from the right minus 1
-            //     - To see why the position is taken from the right, consider
-            //       (1) "-1234567.8", (2) "-.12345678", and (3) ".12345678"
-            //         - For (1), the decimal point is at index 8 from the left and
-            //           index 1 from the right.
-            //         - For (2), the decimal point is at index 1 from the left and
-            //           index 8 from the right.
-            //         - For (3), the decimal point is at index 0 from the left and
-            //           index 8 from the right.
-            //         - So if we take the decimal position from the left, it can
-            //           range from 0 to 8 because of the negative sign. Whereas
-            //           from the right, the negative sign is inconsequential.
-            //     - Thus, we use 3 bits and map the range [1, 8] to [0x0, 0x7].
-            uint32_t encoded_float = 0;
-            if (is_negative) {
-                encoded_float = 1;
-            }
-            encoded_float <<= 25;  // 25 for digits of the float
-            encoded_float |= digits & cFourByteEncodedFloatDigitsBitMask;
-            encoded_float <<= 3;
-            encoded_float |= (num_digits - 1) & 0x07;
-            encoded_float <<= 3;
-            encoded_float |= (decimal_point_pos - 1) & 0x07;
-            return bit_cast<encoded_variable_t>(encoded_float);
-        }
-    }
-
-    template <typename encoded_variable_t>
-    std::string decode_float_var (encoded_variable_t encoded_var) {
-        std::string value;
-
-        uint8_t decimal_point_pos;
-        uint8_t num_digits;
-        std::conditional_t<std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
-                uint32_t, uint64_t> digits;
-        bool is_negative;
-        static_assert(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                      std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
-        if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-            auto encoded_float = bit_cast<uint64_t>(encoded_var);
-
-            // Decode according to the format described in encode_float_string
-            decimal_point_pos = (encoded_float & 0x0F) + 1;
-            encoded_float >>= 4;
-            num_digits = (encoded_float & 0x0F) + 1;
-            encoded_float >>= 4;
-            digits = encoded_float & cEightByteEncodedFloatDigitsBitMask;
-            // This is the maximum base-10 number with
-            // cMaxDigitsInRepresentableEightByteFloatVar
-            constexpr uint64_t cMaxRepresentableDigitsValue = 9999999999999999;
-            if (digits > cMaxRepresentableDigitsValue) {
-                throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                        "Digits in encoded float are larger than max representable "
-                                        "value.");
-            }
-            encoded_float >>= 55;
-            is_negative = encoded_float > 0;
-        } else {  // std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
-            auto encoded_float = bit_cast<uint32_t>(encoded_var);
-
-            // Decode according to the format described in encode_string_as_float_compact_var
-            decimal_point_pos = (encoded_float & 0x07) + 1;
-            encoded_float >>= 3;
-            num_digits = (encoded_float & 0x07) + 1;
-            encoded_float >>= 3;
-            digits = encoded_float & cFourByteEncodedFloatDigitsBitMask;
-            encoded_float >>= 25;
-            is_negative = encoded_float > 0;
-        }
-
-        if (num_digits < decimal_point_pos) {
-            throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                    "Invalid decimal-point position in encoded float.");
-        }
-
-        size_t value_length = num_digits + 1 + is_negative;
-        value.resize(value_length);
-        size_t num_chars_to_process = value_length;
-
-        // Add sign
-        if (is_negative) {
-            value[0] = '-';
-            --num_chars_to_process;
-        }
-
-        // Decode until the decimal or the non-zero digits are exhausted
-        size_t pos = value_length - 1;
-        auto decimal_point_pos_from_left = value_length - 1 - decimal_point_pos;
-        for (; pos > decimal_point_pos_from_left && digits > 0; --pos) {
-            value[pos] = (char)('0' + (digits % 10));
-            digits /= 10;
-            --num_chars_to_process;
-        }
-
-        if (digits > 0) {
-            constexpr char cTooManyDigitsErrorMsg[] = "Encoded number of digits doesn't match "
-                                                      "encoded digits in encoded float.";
-            if (0 == num_chars_to_process) {
-                throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                        cTooManyDigitsErrorMsg);
-            }
-            // Skip decimal since it's added at the end
-            --pos;
-            --num_chars_to_process;
-
-            while (digits > 0) {
-                if (0 == num_chars_to_process) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooManyDigitsErrorMsg);
-                }
-
-                value[pos--] = (char)('0' + (digits % 10));
-                digits /= 10;
-                --num_chars_to_process;
-            }
-        }
-
-        // Add remaining zeros
-        for (; num_chars_to_process > 0; --num_chars_to_process) {
-            value[pos--] = '0';
-        }
-
-        // Add decimal
-        value[decimal_point_pos_from_left] = '.';
-
-        return value;
-    }
-
-    template <typename encoded_variable_t>
-    bool encode_integer_string (std::string_view str, encoded_variable_t& encoded_var) {
-        size_t length = str.length();
-        if (0 == length) {
-            // Empty string cannot be converted
-            return false;
-        }
-
-        // Ensure start of value is an integer with no zero-padding or positive
-        // sign
-        if ('-' == str[0]) {
-            // Ensure first character after sign is a non-zero integer
-            if (length < 2 || str[1] < '1' || '9' < str[1]) {
-                return false;
-            }
-        } else {
-            // Ensure first character is a digit
-            if (str[0] < '0' || '9' < str[0]) {
-                return false;
-            }
-
-            // Ensure value is not zero-padded
-            if (length > 1 && '0' == str[0]) {
-                return false;
-            }
-        }
-
-        encoded_variable_t result;
-        if (false == convert_string_to_int(str, result)) {
-            // Conversion failed
-            return false;
-        } else {
-            encoded_var = result;
-        }
-
-        return true;
-    }
-
-    template <typename encoded_variable_t>
-    std::string decode_integer_var (encoded_variable_t encoded_var) {
-        return std::to_string(encoded_var);
-    }
-
-    template <typename encoded_variable_t, typename ConstantHandler, typename FinalConstantHandler,
-            typename EncodedVariableHandler, typename DictionaryVariableHandler>
-    bool encode_message_generically (std::string_view message, std::string& logtype,
-                                     ConstantHandler constant_handler,
-                                     FinalConstantHandler final_constant_handler,
-                                     EncodedVariableHandler encoded_variable_handler,
-                                     DictionaryVariableHandler dictionary_variable_handler)
-    {
-        size_t var_begin_pos = 0;
-        size_t var_end_pos = 0;
-        bool constant_contains_variable_placeholder = false;
-        size_t constant_begin_pos = 0;
-        logtype.clear();
-        logtype.reserve(message.length());
-        while (get_bounds_of_next_var(message, var_begin_pos, var_end_pos,
-                                      constant_contains_variable_placeholder))
-        {
-            std::string_view constant{&message[constant_begin_pos],
-                                      var_begin_pos - constant_begin_pos};
-            if (false == constant_handler(constant, constant_contains_variable_placeholder,
-                                          logtype))
-            {
-                return false;
-            }
-            constant_begin_pos = var_end_pos;
-
-            // Encode the variable
-            std::string_view var_string{&message[var_begin_pos], var_end_pos - var_begin_pos};
-            encoded_variable_t encoded_variable;
-            if (encode_float_string(var_string, encoded_variable)) {
-                logtype += enum_to_underlying_type(VariablePlaceholder::Float);
-                encoded_variable_handler(encoded_variable);
-            } else if (encode_integer_string(var_string, encoded_variable)) {
-                logtype += enum_to_underlying_type(VariablePlaceholder::Integer);
-                encoded_variable_handler(encoded_variable);
-            } else {
-                logtype += enum_to_underlying_type(VariablePlaceholder::Dictionary);
-                if (false == dictionary_variable_handler(message, var_begin_pos, var_end_pos)) {
-                    return false;
-                }
-            }
-        }
-        // Append any remaining message content to the logtype
-        if (constant_begin_pos < message.length()) {
-            std::string_view constant{&message[constant_begin_pos],
-                                      message.length() - constant_begin_pos};
-            if (false == final_constant_handler(constant, logtype)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    template <typename encoded_variable_t>
-    bool encode_message (std::string_view message, std::string& logtype,
-                         std::vector<encoded_variable_t>& encoded_vars,
-                         std::vector<int32_t>& dictionary_var_bounds)
-    {
-        auto constant_handler = [] (std::string_view constant, bool contains_variable_placeholder,
-                                    std::string& logtype)
-        {
-            if (contains_variable_placeholder) {
-                return false;
-            }
-
-            logtype.append(constant);
-            return true;
-        };
-        auto final_constant_handler = [&constant_handler] (std::string_view constant,
-                                                           std::string& logtype)
-        {
-            // Ensure the final constant doesn't contain a variable placeholder
-            bool contains_variable_placeholder = std::any_of(constant.cbegin(), constant.cend(),
-                                                             is_variable_placeholder);
-            return constant_handler(constant, contains_variable_placeholder, logtype);
-        };
-        auto encoded_variable_handler = [&encoded_vars] (encoded_variable_t encoded_variable) {
-            encoded_vars.push_back(encoded_variable);
-        };
-        auto dictionary_variable_handler = [&dictionary_var_bounds] (std::string_view,
-                size_t begin_pos, size_t end_pos)
-        {
-            if (begin_pos > INT32_MAX || end_pos > INT32_MAX) {
-                return false;
-            }
-
-            dictionary_var_bounds.push_back(static_cast<int32_t>(begin_pos));
-            dictionary_var_bounds.push_back(static_cast<int32_t>(end_pos));
-            return true;
-        };
-
-        if (false == encode_message_generically<encoded_variable_t>(
-                message, logtype, constant_handler, final_constant_handler,
-                encoded_variable_handler, dictionary_variable_handler
-        )) {
-            return false;
-        }
-
-        return true;
-    }
-
-    template <typename encoded_variable_t>
-    std::string decode_message (
-            std::string_view logtype,
-            encoded_variable_t* encoded_vars,
-            size_t encoded_vars_length,
-            std::string_view all_dictionary_vars,
-            const int32_t* dictionary_var_end_offsets,
-            size_t dictionary_var_end_offsets_length
-    ) {
-        std::string message;
-        size_t last_variable_end_pos = 0;
-        size_t dictionary_var_begin_pos = 0;
-        size_t dictionary_var_bounds_ix = 0;
-        size_t encoded_vars_ix = 0;
-        for (size_t i = 0; i < logtype.length(); ++i) {
-            auto c = logtype[i];
-            if (enum_to_underlying_type(VariablePlaceholder::Float) == c) {
-                message.append(logtype, last_variable_end_pos, i - last_variable_end_pos);
-                last_variable_end_pos = i + 1;
-                if (encoded_vars_ix >= encoded_vars_length) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooFewEncodedVarsErrorMessage);
-                }
-                message.append(decode_float_var(encoded_vars[encoded_vars_ix]));
-                ++encoded_vars_ix;
-            } else if (enum_to_underlying_type(VariablePlaceholder::Integer) == c) {
-                message.append(logtype, last_variable_end_pos, i - last_variable_end_pos);
-                last_variable_end_pos = i + 1;
-                if (encoded_vars_ix >= encoded_vars_length) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooFewEncodedVarsErrorMessage);
-                }
-                message.append(decode_integer_var(encoded_vars[encoded_vars_ix]));
-                ++encoded_vars_ix;
-            } else if (enum_to_underlying_type(VariablePlaceholder::Dictionary) == c) {
-                message.append(logtype, last_variable_end_pos, i - last_variable_end_pos);
-                last_variable_end_pos = i + 1;
-                if (dictionary_var_bounds_ix >= dictionary_var_end_offsets_length) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooFewDictionaryVarsErrorMessage);
-                }
-                auto end_pos = dictionary_var_end_offsets[dictionary_var_bounds_ix];
-                message.append(all_dictionary_vars, dictionary_var_begin_pos,
-                               end_pos - dictionary_var_begin_pos);
-                dictionary_var_begin_pos = end_pos;
-                ++dictionary_var_bounds_ix;
-            }
-        }
-        // Add remainder
-        if (last_variable_end_pos < logtype.length()) {
-            message.append(logtype, last_variable_end_pos);
-        }
-
-        return message;
-    }
-
-    template <VariablePlaceholder var_placeholder, typename encoded_variable_t>
-    bool wildcard_query_matches_any_encoded_var (
-            std::string_view wildcard_query,
-            std::string_view logtype,
-            encoded_variable_t* encoded_vars,
-            int encoded_vars_length
-    ) {
-        size_t encoded_vars_ix = 0;
-        for (auto c : logtype) {
-            if (enum_to_underlying_type(VariablePlaceholder::Float) == c) {
-                if (encoded_vars_ix >= encoded_vars_length) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooFewEncodedVarsErrorMessage);
-                }
-
-                if constexpr (VariablePlaceholder::Float == var_placeholder) {
-                    auto decoded_var = decode_float_var(encoded_vars[encoded_vars_ix]);
-                    if (wildcard_match_unsafe(decoded_var, wildcard_query)) {
-                        return true;
-                    }
-                }
-
-                ++encoded_vars_ix;
-            } else if (enum_to_underlying_type(VariablePlaceholder::Integer) == c) {
-                if (encoded_vars_ix >= encoded_vars_length) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooFewEncodedVarsErrorMessage);
-                }
-
-                if constexpr (VariablePlaceholder::Integer == var_placeholder) {
-                    auto decoded_var = decode_integer_var(encoded_vars[encoded_vars_ix]);
-                    if (wildcard_match_unsafe(decoded_var, wildcard_query)) {
-                        return true;
-                    }
-                }
-
-                ++encoded_vars_ix;
-            }
-        }
-
+template <typename encoded_variable_t>
+bool encode_float_string(std::string_view str, encoded_variable_t& encoded_var) {
+    auto const value_length = str.length();
+    if (0 == value_length) {
+        // Can't convert an empty string
         return false;
     }
 
-    template <typename encoded_variable_t>
-    bool wildcard_match_encoded_vars (
-            std::string_view logtype,
-            encoded_variable_t* encoded_vars,
-            size_t encoded_vars_length,
-            std::string_view wildcard_var_placeholders,
-            const std::vector<std::string_view>& wildcard_var_queries
-    ) {
-        // Validate arguments
-        if (nullptr == encoded_vars) {
-            throw EncodingException(ErrorCode_BadParam, __FILENAME__, __LINE__,
-                                    cTooFewEncodedVarsErrorMessage);
+    size_t pos = 0;
+    constexpr size_t cMaxDigitsInRepresentableFloatVar
+            = std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
+                      ? cMaxDigitsInRepresentableFourByteFloatVar
+                      : cMaxDigitsInRepresentableEightByteFloatVar;
+    // +1 for decimal point
+    size_t max_length = cMaxDigitsInRepresentableFloatVar + 1;
+
+    // Check for a negative sign
+    bool is_negative = false;
+    if ('-' == str[pos]) {
+        is_negative = true;
+        ++pos;
+        // Include sign in max length
+        ++max_length;
+    }
+
+    // Check if value can be represented in encoded format
+    if (value_length > max_length) {
+        return false;
+    }
+
+    size_t num_digits = 0;
+    size_t decimal_point_pos = std::string::npos;
+    std::conditional_t<
+            std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
+            uint32_t,
+            uint64_t>
+            digits = 0;
+    for (; pos < value_length; ++pos) {
+        auto c = str[pos];
+        if ('0' <= c && c <= '9') {
+            digits *= 10;
+            digits += (c - '0');
+            ++num_digits;
+        } else if (std::string::npos == decimal_point_pos && '.' == c) {
+            decimal_point_pos = value_length - 1 - pos;
+        } else {
+            // Invalid character
+            return false;
         }
-        if (wildcard_var_queries.size() != wildcard_var_placeholders.length()) {
-            throw EncodingException(ErrorCode_BadParam, __FILENAME__, __LINE__,
-                                    cTooFewEncodedVarsErrorMessage);
+    }
+    if (std::string::npos == decimal_point_pos || 0 == decimal_point_pos || 0 == num_digits) {
+        // No decimal point found, decimal point is after all digits, or no
+        // digits found
+        return false;
+    }
+
+    encoded_var = encode_float_properties<encoded_variable_t>(
+            is_negative,
+            digits,
+            num_digits,
+            decimal_point_pos
+    );
+
+    return true;
+}
+
+template <typename encoded_variable_t>
+encoded_variable_t encode_float_properties(
+        bool is_negative,
+        std::conditional_t<
+                std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
+                uint32_t,
+                uint64_t> digits,
+        size_t num_digits,
+        size_t decimal_point_pos
+) {
+    static_assert(
+            (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+             || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        // Encode into 64 bits with the following format (from MSB to LSB):
+        // -  1 bit : is negative
+        // -  1 bit : unused
+        // - 54 bits: The digits of the float without the decimal, as an
+        //            integer
+        // -  4 bits: # of decimal digits minus 1
+        //     - This format can represent floats with between 1 and 16 decimal
+        //       digits, so we use 4 bits and map the range [1, 16] to
+        //       [0x0, 0xF]
+        // -  4 bits: position of the decimal from the right minus 1
+        //     - To see why the position is taken from the right, consider
+        //       (1) "-123456789012345.6", (2) "-.1234567890123456", and
+        //       (3) ".1234567890123456"
+        //         - For (1), the decimal point is at index 16 from the left and
+        //         index 1 from the right.
+        //         - For (2), the decimal point is at index 1 from the left and
+        //           index 16 from the right.
+        //         - For (3), the decimal point is at index 0 from the left and
+        //           index 16 from the right.
+        //         - So if we take the decimal position from the left, it can
+        //           range from 0 to 16 because of the negative sign. Whereas
+        //           from the right, the negative sign is inconsequential.
+        //     - Thus, we use 4 bits and map the range [1, 16] to [0x0, 0xF].
+        uint64_t encoded_float = 0;
+        if (is_negative) {
+            encoded_float = 1;
+        }
+        encoded_float <<= 55;  // 1 unused + 54 for digits of the float
+        encoded_float |= digits & cEightByteEncodedFloatDigitsBitMask;
+        encoded_float <<= 4;
+        encoded_float |= (num_digits - 1) & 0x0F;
+        encoded_float <<= 4;
+        encoded_float |= (decimal_point_pos - 1) & 0x0F;
+        return bit_cast<encoded_variable_t>(encoded_float);
+    } else {
+        // std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
+        if (digits > cFourByteEncodedFloatDigitsBitMask) {
+            // digits is larger than maximum representable
+            return false;
         }
 
-        auto wildcard_var_queries_len = wildcard_var_queries.size();
-        size_t var_ix = 0;
-        size_t wildcard_var_ix = 0;
-        for (auto c : logtype) {
-            if (enum_to_underlying_type(VariablePlaceholder::Float) == c) {
-                if (var_ix >= encoded_vars_length) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooFewEncodedVarsErrorMessage);
-                }
-
-                if (wildcard_var_placeholders[wildcard_var_ix] == c) {
-                    auto decoded_var = decode_float_var(encoded_vars[var_ix]);
-                    if (wildcard_match_unsafe(decoded_var, wildcard_var_queries[wildcard_var_ix]))
-                    {
-                        ++wildcard_var_ix;
-                        if (wildcard_var_ix == wildcard_var_queries_len) {
-                            break;
-                        }
-                    }
-                }
-
-                ++var_ix;
-            } else if (enum_to_underlying_type(VariablePlaceholder::Integer) == c) {
-                if (var_ix >= encoded_vars_length) {
-                    throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                            cTooFewEncodedVarsErrorMessage);
-                }
-
-                if (wildcard_var_placeholders[wildcard_var_ix] == c) {
-                    auto decoded_var = decode_integer_var(encoded_vars[var_ix]);
-                    if (wildcard_match_unsafe(decoded_var, wildcard_var_queries[wildcard_var_ix]))
-                    {
-                        ++wildcard_var_ix;
-                        if (wildcard_var_ix == wildcard_var_queries_len) {
-                            break;
-                        }
-                    }
-                }
-
-                ++var_ix;
-            }
+        // Encode into 32 bits with the following format (from MSB to LSB):
+        // -  1 bit : is negative
+        // - 25 bits: The digits of the float without the decimal, as an
+        //            integer
+        // -  3 bits: # of decimal digits minus 1
+        //     - This format can represent floats with between 1 and 8 decimal
+        //       digits, so we use 3 bits and map the range [1, 8] to
+        //       [0x0, 0x7]
+        // -  3 bits: position of the decimal from the right minus 1
+        //     - To see why the position is taken from the right, consider
+        //       (1) "-1234567.8", (2) "-.12345678", and (3) ".12345678"
+        //         - For (1), the decimal point is at index 8 from the left and
+        //           index 1 from the right.
+        //         - For (2), the decimal point is at index 1 from the left and
+        //           index 8 from the right.
+        //         - For (3), the decimal point is at index 0 from the left and
+        //           index 8 from the right.
+        //         - So if we take the decimal position from the left, it can
+        //           range from 0 to 8 because of the negative sign. Whereas
+        //           from the right, the negative sign is inconsequential.
+        //     - Thus, we use 3 bits and map the range [1, 8] to [0x0, 0x7].
+        uint32_t encoded_float = 0;
+        if (is_negative) {
+            encoded_float = 1;
         }
-
-        return (wildcard_var_queries_len == wildcard_var_ix);
+        encoded_float <<= 25;  // 25 for digits of the float
+        encoded_float |= digits & cFourByteEncodedFloatDigitsBitMask;
+        encoded_float <<= 3;
+        encoded_float |= (num_digits - 1) & 0x07;
+        encoded_float <<= 3;
+        encoded_float |= (decimal_point_pos - 1) & 0x07;
+        return bit_cast<encoded_variable_t>(encoded_float);
     }
 }
 
-#endif // FFI_ENCODING_METHODS_TPP
+template <typename encoded_variable_t>
+std::string decode_float_var(encoded_variable_t encoded_var) {
+    std::string value;
+
+    uint8_t decimal_point_pos;
+    uint8_t num_digits;
+    std::conditional_t<
+            std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
+            uint32_t,
+            uint64_t>
+            digits;
+    bool is_negative;
+    static_assert(
+            (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+             || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
+    if constexpr (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        auto encoded_float = bit_cast<uint64_t>(encoded_var);
+
+        // Decode according to the format described in encode_float_string
+        decimal_point_pos = (encoded_float & 0x0F) + 1;
+        encoded_float >>= 4;
+        num_digits = (encoded_float & 0x0F) + 1;
+        encoded_float >>= 4;
+        digits = encoded_float & cEightByteEncodedFloatDigitsBitMask;
+        // This is the maximum base-10 number with
+        // cMaxDigitsInRepresentableEightByteFloatVar
+        constexpr uint64_t cMaxRepresentableDigitsValue = 9'999'999'999'999'999;
+        if (digits > cMaxRepresentableDigitsValue) {
+            throw EncodingException(
+                    ErrorCode_Corrupt,
+                    __FILENAME__,
+                    __LINE__,
+                    "Digits in encoded float are larger than max representable "
+                    "value."
+            );
+        }
+        encoded_float >>= 55;
+        is_negative = encoded_float > 0;
+    } else {
+        // std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
+        auto encoded_float = bit_cast<uint32_t>(encoded_var);
+
+        // Decode according to the format in encode_string_as_float_compact_var
+        decimal_point_pos = (encoded_float & 0x07) + 1;
+        encoded_float >>= 3;
+        num_digits = (encoded_float & 0x07) + 1;
+        encoded_float >>= 3;
+        digits = encoded_float & cFourByteEncodedFloatDigitsBitMask;
+        encoded_float >>= 25;
+        is_negative = encoded_float > 0;
+    }
+
+    if (num_digits < decimal_point_pos) {
+        throw EncodingException(
+                ErrorCode_Corrupt,
+                __FILENAME__,
+                __LINE__,
+                "Invalid decimal-point position in encoded float."
+        );
+    }
+
+    size_t value_length = num_digits + 1 + is_negative;
+    value.resize(value_length);
+    size_t num_chars_to_process = value_length;
+
+    // Add sign
+    if (is_negative) {
+        value[0] = '-';
+        --num_chars_to_process;
+    }
+
+    // Decode until the decimal or the non-zero digits are exhausted
+    size_t pos = value_length - 1;
+    auto decimal_point_pos_from_left = value_length - 1 - decimal_point_pos;
+    for (; pos > decimal_point_pos_from_left && digits > 0; --pos) {
+        value[pos] = (char)('0' + (digits % 10));
+        digits /= 10;
+        --num_chars_to_process;
+    }
+
+    if (digits > 0) {
+        constexpr char cTooManyDigitsErrorMsg[] = "Encoded number of digits doesn't match "
+                                                  "encoded digits in encoded float.";
+        if (0 == num_chars_to_process) {
+            throw EncodingException(
+                    ErrorCode_Corrupt,
+                    __FILENAME__,
+                    __LINE__,
+                    cTooManyDigitsErrorMsg
+            );
+        }
+        // Skip decimal since it's added at the end
+        --pos;
+        --num_chars_to_process;
+
+        while (digits > 0) {
+            if (0 == num_chars_to_process) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooManyDigitsErrorMsg
+                );
+            }
+
+            value[pos--] = (char)('0' + (digits % 10));
+            digits /= 10;
+            --num_chars_to_process;
+        }
+    }
+
+    // Add remaining zeros
+    for (; num_chars_to_process > 0; --num_chars_to_process) {
+        value[pos--] = '0';
+    }
+
+    // Add decimal
+    value[decimal_point_pos_from_left] = '.';
+
+    return value;
+}
+
+template <typename encoded_variable_t>
+bool encode_integer_string(std::string_view str, encoded_variable_t& encoded_var) {
+    size_t length = str.length();
+    if (0 == length) {
+        // Empty string cannot be converted
+        return false;
+    }
+
+    // Ensure start of value is an integer with no zero-padding or positive
+    // sign
+    if ('-' == str[0]) {
+        // Ensure first character after sign is a non-zero integer
+        if (length < 2 || str[1] < '1' || '9' < str[1]) {
+            return false;
+        }
+    } else {
+        // Ensure first character is a digit
+        if (str[0] < '0' || '9' < str[0]) {
+            return false;
+        }
+
+        // Ensure value is not zero-padded
+        if (length > 1 && '0' == str[0]) {
+            return false;
+        }
+    }
+
+    encoded_variable_t result;
+    if (false == convert_string_to_int(str, result)) {
+        // Conversion failed
+        return false;
+    } else {
+        encoded_var = result;
+    }
+
+    return true;
+}
+
+template <typename encoded_variable_t>
+std::string decode_integer_var(encoded_variable_t encoded_var) {
+    return std::to_string(encoded_var);
+}
+
+template <
+        typename encoded_variable_t,
+        typename ConstantHandler,
+        typename FinalConstantHandler,
+        typename EncodedVariableHandler,
+        typename DictionaryVariableHandler>
+bool encode_message_generically(
+        std::string_view message,
+        std::string& logtype,
+        ConstantHandler constant_handler,
+        FinalConstantHandler final_constant_handler,
+        EncodedVariableHandler encoded_variable_handler,
+        DictionaryVariableHandler dictionary_variable_handler
+) {
+    size_t var_begin_pos = 0;
+    size_t var_end_pos = 0;
+    bool constant_contains_variable_placeholder = false;
+    size_t constant_begin_pos = 0;
+    logtype.clear();
+    logtype.reserve(message.length());
+    while (get_bounds_of_next_var(
+            message,
+            var_begin_pos,
+            var_end_pos,
+            constant_contains_variable_placeholder
+    ))
+    {
+        std::string_view constant{&message[constant_begin_pos], var_begin_pos - constant_begin_pos};
+        if (false == constant_handler(constant, constant_contains_variable_placeholder, logtype)) {
+            return false;
+        }
+        constant_begin_pos = var_end_pos;
+
+        // Encode the variable
+        std::string_view var_string{&message[var_begin_pos], var_end_pos - var_begin_pos};
+        encoded_variable_t encoded_variable;
+        if (encode_float_string(var_string, encoded_variable)) {
+            logtype += enum_to_underlying_type(VariablePlaceholder::Float);
+            encoded_variable_handler(encoded_variable);
+        } else if (encode_integer_string(var_string, encoded_variable)) {
+            logtype += enum_to_underlying_type(VariablePlaceholder::Integer);
+            encoded_variable_handler(encoded_variable);
+        } else {
+            logtype += enum_to_underlying_type(VariablePlaceholder::Dictionary);
+            if (false == dictionary_variable_handler(message, var_begin_pos, var_end_pos)) {
+                return false;
+            }
+        }
+    }
+    // Append any remaining message content to the logtype
+    if (constant_begin_pos < message.length()) {
+        std::string_view constant{
+                &message[constant_begin_pos],
+                message.length() - constant_begin_pos};
+        if (false == final_constant_handler(constant, logtype)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template <typename encoded_variable_t>
+bool encode_message(
+        std::string_view message,
+        std::string& logtype,
+        std::vector<encoded_variable_t>& encoded_vars,
+        std::vector<int32_t>& dictionary_var_bounds
+) {
+    auto constant_handler
+            = [](std::string_view constant, bool contains_variable_placeholder, std::string& logtype
+              ) {
+                  if (contains_variable_placeholder) {
+                      return false;
+                  }
+
+                  logtype.append(constant);
+                  return true;
+              };
+    auto final_constant_handler =
+            [&constant_handler](std::string_view constant, std::string& logtype) {
+                // Ensure final constant doesn't contain a variable placeholder
+                bool contains_variable_placeholder
+                        = std::any_of(constant.cbegin(), constant.cend(), is_variable_placeholder);
+                return constant_handler(constant, contains_variable_placeholder, logtype);
+            };
+    auto encoded_variable_handler = [&encoded_vars](encoded_variable_t encoded_variable) {
+        encoded_vars.push_back(encoded_variable);
+    };
+    auto dictionary_variable_handler
+            = [&dictionary_var_bounds](std::string_view, size_t begin_pos, size_t end_pos) {
+                  if (begin_pos > INT32_MAX || end_pos > INT32_MAX) {
+                      return false;
+                  }
+
+                  dictionary_var_bounds.push_back(static_cast<int32_t>(begin_pos));
+                  dictionary_var_bounds.push_back(static_cast<int32_t>(end_pos));
+                  return true;
+              };
+
+    if (false
+        == encode_message_generically<encoded_variable_t>(
+                message,
+                logtype,
+                constant_handler,
+                final_constant_handler,
+                encoded_variable_handler,
+                dictionary_variable_handler
+        ))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+template <typename encoded_variable_t>
+std::string decode_message(
+        std::string_view logtype,
+        encoded_variable_t* encoded_vars,
+        size_t encoded_vars_length,
+        std::string_view all_dictionary_vars,
+        int32_t const* dictionary_var_end_offsets,
+        size_t dictionary_var_end_offsets_length
+) {
+    std::string message;
+    size_t last_variable_end_pos = 0;
+    size_t dictionary_var_begin_pos = 0;
+    size_t dictionary_var_bounds_ix = 0;
+    size_t encoded_vars_ix = 0;
+    for (size_t i = 0; i < logtype.length(); ++i) {
+        auto c = logtype[i];
+        if (enum_to_underlying_type(VariablePlaceholder::Float) == c) {
+            message.append(logtype, last_variable_end_pos, i - last_variable_end_pos);
+            last_variable_end_pos = i + 1;
+            if (encoded_vars_ix >= encoded_vars_length) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooFewEncodedVarsErrorMessage
+                );
+            }
+            message.append(decode_float_var(encoded_vars[encoded_vars_ix]));
+            ++encoded_vars_ix;
+        } else if (enum_to_underlying_type(VariablePlaceholder::Integer) == c) {
+            message.append(logtype, last_variable_end_pos, i - last_variable_end_pos);
+            last_variable_end_pos = i + 1;
+            if (encoded_vars_ix >= encoded_vars_length) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooFewEncodedVarsErrorMessage
+                );
+            }
+            message.append(decode_integer_var(encoded_vars[encoded_vars_ix]));
+            ++encoded_vars_ix;
+        } else if (enum_to_underlying_type(VariablePlaceholder::Dictionary) == c) {
+            message.append(logtype, last_variable_end_pos, i - last_variable_end_pos);
+            last_variable_end_pos = i + 1;
+            if (dictionary_var_bounds_ix >= dictionary_var_end_offsets_length) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooFewDictionaryVarsErrorMessage
+                );
+            }
+            auto end_pos = dictionary_var_end_offsets[dictionary_var_bounds_ix];
+            message.append(
+                    all_dictionary_vars,
+                    dictionary_var_begin_pos,
+                    end_pos - dictionary_var_begin_pos
+            );
+            dictionary_var_begin_pos = end_pos;
+            ++dictionary_var_bounds_ix;
+        }
+    }
+    // Add remainder
+    if (last_variable_end_pos < logtype.length()) {
+        message.append(logtype, last_variable_end_pos);
+    }
+
+    return message;
+}
+
+template <VariablePlaceholder var_placeholder, typename encoded_variable_t>
+bool wildcard_query_matches_any_encoded_var(
+        std::string_view wildcard_query,
+        std::string_view logtype,
+        encoded_variable_t* encoded_vars,
+        int encoded_vars_length
+) {
+    size_t encoded_vars_ix = 0;
+    for (auto c : logtype) {
+        if (enum_to_underlying_type(VariablePlaceholder::Float) == c) {
+            if (encoded_vars_ix >= encoded_vars_length) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooFewEncodedVarsErrorMessage
+                );
+            }
+
+            if constexpr (VariablePlaceholder::Float == var_placeholder) {
+                auto decoded_var = decode_float_var(encoded_vars[encoded_vars_ix]);
+                if (wildcard_match_unsafe(decoded_var, wildcard_query)) {
+                    return true;
+                }
+            }
+
+            ++encoded_vars_ix;
+        } else if (enum_to_underlying_type(VariablePlaceholder::Integer) == c) {
+            if (encoded_vars_ix >= encoded_vars_length) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooFewEncodedVarsErrorMessage
+                );
+            }
+
+            if constexpr (VariablePlaceholder::Integer == var_placeholder) {
+                auto decoded_var = decode_integer_var(encoded_vars[encoded_vars_ix]);
+                if (wildcard_match_unsafe(decoded_var, wildcard_query)) {
+                    return true;
+                }
+            }
+
+            ++encoded_vars_ix;
+        }
+    }
+
+    return false;
+}
+
+template <typename encoded_variable_t>
+bool wildcard_match_encoded_vars(
+        std::string_view logtype,
+        encoded_variable_t* encoded_vars,
+        size_t encoded_vars_length,
+        std::string_view wildcard_var_placeholders,
+        std::vector<std::string_view> const& wildcard_var_queries
+) {
+    // Validate arguments
+    if (nullptr == encoded_vars) {
+        throw EncodingException(
+                ErrorCode_BadParam,
+                __FILENAME__,
+                __LINE__,
+                cTooFewEncodedVarsErrorMessage
+        );
+    }
+    if (wildcard_var_queries.size() != wildcard_var_placeholders.length()) {
+        throw EncodingException(
+                ErrorCode_BadParam,
+                __FILENAME__,
+                __LINE__,
+                cTooFewEncodedVarsErrorMessage
+        );
+    }
+
+    auto wildcard_var_queries_len = wildcard_var_queries.size();
+    size_t var_ix = 0;
+    size_t wildcard_var_ix = 0;
+    for (auto c : logtype) {
+        if (enum_to_underlying_type(VariablePlaceholder::Float) == c) {
+            if (var_ix >= encoded_vars_length) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooFewEncodedVarsErrorMessage
+                );
+            }
+
+            if (wildcard_var_placeholders[wildcard_var_ix] == c) {
+                auto decoded_var = decode_float_var(encoded_vars[var_ix]);
+                if (wildcard_match_unsafe(decoded_var, wildcard_var_queries[wildcard_var_ix])) {
+                    ++wildcard_var_ix;
+                    if (wildcard_var_ix == wildcard_var_queries_len) {
+                        break;
+                    }
+                }
+            }
+
+            ++var_ix;
+        } else if (enum_to_underlying_type(VariablePlaceholder::Integer) == c) {
+            if (var_ix >= encoded_vars_length) {
+                throw EncodingException(
+                        ErrorCode_Corrupt,
+                        __FILENAME__,
+                        __LINE__,
+                        cTooFewEncodedVarsErrorMessage
+                );
+            }
+
+            if (wildcard_var_placeholders[wildcard_var_ix] == c) {
+                auto decoded_var = decode_integer_var(encoded_vars[var_ix]);
+                if (wildcard_match_unsafe(decoded_var, wildcard_var_queries[wildcard_var_ix])) {
+                    ++wildcard_var_ix;
+                    if (wildcard_var_ix == wildcard_var_queries_len) {
+                        break;
+                    }
+                }
+            }
+
+            ++var_ix;
+        }
+    }
+
+    return (wildcard_var_queries_len == wildcard_var_ix);
+}
+}  // namespace ffi
+
+#endif  // FFI_ENCODING_METHODS_TPP

--- a/components/core/src/ffi/ir_stream/byteswap.hpp
+++ b/components/core/src/ffi/ir_stream/byteswap.hpp
@@ -1,14 +1,13 @@
 #ifndef FFI_IR_STREAM_BYTESWAP_HPP
 #define FFI_IR_STREAM_BYTESWAP_HPP
 
-// C standard libraries
 #ifdef __APPLE__
-#include <libkern/OSByteOrder.h>
-#define bswap_16(x) OSSwapInt16(x)
-#define bswap_32(x) OSSwapInt32(x)
-#define bswap_64(x) OSSwapInt64(x)
+    #include <libkern/OSByteOrder.h>
+    #define bswap_16(x) OSSwapInt16(x)
+    #define bswap_32(x) OSSwapInt32(x)
+    #define bswap_64(x) OSSwapInt64(x)
 #else
-#include <byteswap.h>
+    #include <byteswap.h>
 #endif
 
-#endif // FFI_IR_STREAM_BYTESWAP_HPP
+#endif  // FFI_IR_STREAM_BYTESWAP_HPP

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -526,7 +526,12 @@ IRErrorCode get_encoding_type(IrBuffer& ir_buf, bool& is_four_bytes_encoding) {
     }
     if (0 == memcmp(buffer, cProtocol::FourByteEncodingMagicNumber, cProtocol::MagicNumberLength)) {
         is_four_bytes_encoding = true;
-    } else if (0 == memcmp(buffer, cProtocol::EightByteEncodingMagicNumber, cProtocol::MagicNumberLength))
+    } else if ((0
+                == memcmp(
+                        buffer,
+                        cProtocol::EightByteEncodingMagicNumber,
+                        cProtocol::MagicNumberLength
+                )))
     {
         is_four_bytes_encoding = false;
     } else {

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -149,7 +149,10 @@ bool IrBuffer::try_read(void* dest, size_t read_size) {
 
 template <typename encoded_variable_t>
 static bool is_variable_tag(encoded_tag_t tag, bool& is_encoded_var) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(
+            (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+             || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
 
     if (tag == cProtocol::Payload::VarStrLenUByte || tag == cProtocol::Payload::VarStrLenUShort
         || tag == cProtocol::Payload::VarStrLenInt)
@@ -260,7 +263,10 @@ parse_dictionary_var(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& d
 
 template <typename encoded_variable_t>
 IRErrorCode parse_timestamp(IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(
+            (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+             || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         if (cProtocol::Payload::TimestampVal != encoded_tag) {
@@ -341,9 +347,8 @@ generic_decode_next_message(IrBuffer& ir_buf, string& message, epoch_time_ms_t& 
         return error_code;
     }
 
-    // NOTE: for the eight-byte encoding, the timestamp is the actual
-    // timestamp; for the four-byte encoding, the timestamp is a timestamp
-    // delta
+    // NOTE: for the eight-byte encoding, the timestamp is the actual timestamp;
+    // for the four-byte encoding, the timestamp is a timestamp delta
     if (false == ir_buf.try_read(encoded_tag)) {
         return IRErrorCode_Incomplete_IR;
     }
@@ -475,8 +480,8 @@ static string decode_message(
             }
 
             case cVariablePlaceholderEscapeCharacter: {
-                // Ensure the escape character is followed by a
-                // character that's being escaped
+                // Ensure the escape character is followed by a character that's
+                // being escaped
                 if (cur_pos == logtype.length() - 1) {
                     throw EncodingException(
                             ErrorCode_Corrupt,
@@ -495,9 +500,9 @@ static string decode_message(
                 next_static_text_begin_pos = cur_pos + 1;
                 // The character after the escape character is static text
                 // (regardless of whether it is a variable placeholder), so
-                // increment cur_pos by 1 to ensure we don't process the
-                // next character in any of the other cases (instead it will
-                // be added to the message).
+                // increment cur_pos by 1 to ensure we don't process the next
+                // character in any of the other cases (instead it will be added
+                // to the message).
                 ++cur_pos;
 
                 break;

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -1,6 +1,5 @@
 #include "decoding_methods.hpp"
 
-// Project headers
 #include "byteswap.hpp"
 #include "protocol_constants.hpp"
 
@@ -10,544 +9,571 @@ using std::string_view;
 using std::vector;
 
 namespace ffi::ir_stream {
-    /**
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param tag
-     * @param is_encoded_var Returns true if tag is for an encoded variable (as
-     * opposed to a dictionary variable)
-     * @return Whether the tag is a variable tag
-     */
-    template <typename encoded_variable_t>
-    static bool is_variable_tag (encoded_tag_t tag, bool& is_encoded_var);
+/**
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param tag
+ * @param is_encoded_var Returns true if tag is for an encoded variable (as
+ * opposed to a dictionary variable)
+ * @return Whether the tag is a variable tag
+ */
+template <typename encoded_variable_t>
+static bool is_variable_tag(encoded_tag_t tag, bool& is_encoded_var);
 
-    /**
-     * Decodes an integer from ir_buf
-     * @tparam integer_t Type of the integer to decode
-     * @param ir_buf
-     * @param value Returns the decoded integer
-     * @return true on success, false if the ir_buf doesn't contain enough data
-     * to decode
-     */
-    template <typename integer_t>
-    static bool decode_int (IrBuffer& ir_buf, integer_t& value);
+/**
+ * Decodes an integer from ir_buf
+ * @tparam integer_t Type of the integer to decode
+ * @param ir_buf
+ * @param value Returns the decoded integer
+ * @return true on success, false if the ir_buf doesn't contain enough data
+ * to decode
+ */
+template <typename integer_t>
+static bool decode_int(IrBuffer& ir_buf, integer_t& value);
 
-    /**
-     * Decodes the next logtype string from ir_buf
-     * @param ir_buf
-     * @param encoded_tag
-     * @param logtype Returns the logtype string
-     * @return IRErrorCode_Success on success
-     * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-     * to decode
-     */
-    static IRErrorCode parse_logtype (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
-                                      string_view& logtype);
+/**
+ * Decodes the next logtype string from ir_buf
+ * @param ir_buf
+ * @param encoded_tag
+ * @param logtype Returns the logtype string
+ * @return IRErrorCode_Success on success
+ * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+ * to decode
+ */
+static IRErrorCode parse_logtype(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& logtype);
 
-    /**
-     * Decodes the next dictionary-type variable string from ir_buf
-     * @param ir_buf
-     * @param encoded_tag
-     * @param dict_var Returns the dictionary variable
-     * @return IRErrorCode_Success on success
-     * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain enough
-     * data to decode
-     */
-    static IRErrorCode parse_dictionary_var (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
-                                             string_view& dict_var);
+/**
+ * Decodes the next dictionary-type variable string from ir_buf
+ * @param ir_buf
+ * @param encoded_tag
+ * @param dict_var Returns the dictionary variable
+ * @return IRErrorCode_Success on success
+ * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+ * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain enough
+ * data to decode
+ */
+static IRErrorCode
+parse_dictionary_var(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& dict_var);
 
-    /**
-     * Parses the next timestamp from ir_buf
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param ir_buf
-     * @param encoded_tag
-     * @param ts Returns the timestamp delta if
-     * encoded_variable_t == four_byte_encoded_variable_t or the actual
-     * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
-     * @return IRErrorCode_Success on success
-     * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-     * to decode
-     */
-    template <typename encoded_variable_t>
-    IRErrorCode parse_timestamp (IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
+/**
+ * Parses the next timestamp from ir_buf
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param ir_buf
+ * @param encoded_tag
+ * @param ts Returns the timestamp delta if
+ * encoded_variable_t == four_byte_encoded_variable_t or the actual
+ * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
+ * @return IRErrorCode_Success on success
+ * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+ * to decode
+ */
+template <typename encoded_variable_t>
+IRErrorCode parse_timestamp(IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
 
-    /**
-     * Decodes the next encoded message from ir_buf
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param ir_buf
-     * @param message Returns the decoded message
-     * @param timestamp Returns the timestamp delta if
-     * encoded_variable_t == four_byte_encoded_variable_t or the actual
-     * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
-     * @return IRErrorCode_Success on success
-     * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_Decode_Error if the encoded message cannot be
-     * properly decoded
-     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-     * to decode
-     */
-    template <typename encoded_variable_t>
-    static IRErrorCode generic_decode_next_message (IrBuffer& ir_buf, string& message,
-                                                    epoch_time_ms_t& timestamp);
+/**
+ * Decodes the next encoded message from ir_buf
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param ir_buf
+ * @param message Returns the decoded message
+ * @param timestamp Returns the timestamp delta if
+ * encoded_variable_t == four_byte_encoded_variable_t or the actual
+ * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
+ * @return IRErrorCode_Success on success
+ * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+ * @return IRErrorCode_Decode_Error if the encoded message cannot be
+ * properly decoded
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+ * to decode
+ */
+template <typename encoded_variable_t>
+static IRErrorCode
+generic_decode_next_message(IrBuffer& ir_buf, string& message, epoch_time_ms_t& timestamp);
 
-    /**
-     * Reads metadata information from the ir_buf
-     * @param ir_buf
-     * @param metadata_type Returns the type of the metadata found in the IR
-     * @param metadata_pos Returns the starting position of the metadata in ir_buf
-     * @param metadata_size Returns the size of the metadata written in the IR
-     * @return IRErrorCode_Success on success
-     * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-     * to decode
-     */
-    static IRErrorCode read_metadata_info (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
-                                           uint16_t& metadata_size);
+/**
+ * Reads metadata information from the ir_buf
+ * @param ir_buf
+ * @param metadata_type Returns the type of the metadata found in the IR
+ * @param metadata_pos Returns the starting position of the metadata in ir_buf
+ * @param metadata_size Returns the size of the metadata written in the IR
+ * @return IRErrorCode_Success on success
+ * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+ * to decode
+ */
+static IRErrorCode
+read_metadata_info(IrBuffer& ir_buf, encoded_tag_t& metadata_type, uint16_t& metadata_size);
 
-    /**
-     * Decodes the message from the given logtype, encoded variables, and
-     * dictionary variables. This function properly handles escaped variable
-     * placeholders in the logtype, as opposed to ffi::decode_message that
-     * doesn't handle escaped placeholders for simplicity
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param logtype
-     * @param encoded_vars
-     * @param dictionary_vars
-     * @return The decoded message
-     * @throw EncodingException if the message can't be decoded
-     */
-    template <typename encoded_variable_t>
-    static string decode_message (
+/**
+ * Decodes the message from the given logtype, encoded variables, and
+ * dictionary variables. This function properly handles escaped variable
+ * placeholders in the logtype, as opposed to ffi::decode_message that
+ * doesn't handle escaped placeholders for simplicity
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param logtype
+ * @param encoded_vars
+ * @param dictionary_vars
+ * @return The decoded message
+ * @throw EncodingException if the message can't be decoded
+ */
+template <typename encoded_variable_t>
+static string decode_message(
         string_view logtype,
-        const vector<encoded_variable_t>& encoded_vars,
-        const vector<string_view>& dictionary_vars
-    );
+        vector<encoded_variable_t> const& encoded_vars,
+        vector<string_view> const& dictionary_vars
+);
 
-    bool IrBuffer::try_read (string_view& str_view, size_t read_size) {
-        if (read_will_overflow(read_size)) {
-            return false;
-        }
-        str_view = string_view(reinterpret_cast<const char*>(m_data + m_internal_cursor_pos),
-                               read_size);
-        m_internal_cursor_pos += read_size;
+bool IrBuffer::try_read(string_view& str_view, size_t read_size) {
+    if (read_will_overflow(read_size)) {
+        return false;
+    }
+    str_view
+            = string_view(reinterpret_cast<char const*>(m_data + m_internal_cursor_pos), read_size);
+    m_internal_cursor_pos += read_size;
+    return true;
+}
+
+template <typename integer_t>
+bool IrBuffer::try_read(integer_t& data) {
+    return try_read(&data, sizeof(data));
+}
+
+bool IrBuffer::try_read(void* dest, size_t read_size) {
+    if (read_will_overflow(read_size)) {
+        return false;
+    }
+    memcpy(dest, (m_data + m_internal_cursor_pos), read_size);
+    m_internal_cursor_pos += read_size;
+    return true;
+}
+
+template <typename encoded_variable_t>
+static bool is_variable_tag(encoded_tag_t tag, bool& is_encoded_var) {
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    if (tag == cProtocol::Payload::VarStrLenUByte || tag == cProtocol::Payload::VarStrLenUShort
+        || tag == cProtocol::Payload::VarStrLenInt)
+    {
+        is_encoded_var = false;
         return true;
     }
 
-    template <typename integer_t>
-    bool IrBuffer::try_read (integer_t& data) {
-        return try_read(&data, sizeof(data));
-    }
-
-    bool IrBuffer::try_read (void* dest, size_t read_size) {
-        if (read_will_overflow(read_size)) {
-            return false;
-        }
-        memcpy(dest, (m_data + m_internal_cursor_pos), read_size);
-        m_internal_cursor_pos += read_size;
-        return true;
-    }
-
-    template <typename encoded_variable_t>
-    static bool is_variable_tag (encoded_tag_t tag, bool& is_encoded_var) {
-        static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                      is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
-
-        if (tag == cProtocol::Payload::VarStrLenUByte ||
-            tag == cProtocol::Payload::VarStrLenUShort ||
-            tag == cProtocol::Payload::VarStrLenInt) {
-            is_encoded_var = false;
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        if (tag == cProtocol::Payload::VarEightByteEncoding) {
+            is_encoded_var = true;
             return true;
         }
-
-        if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-            if (tag == cProtocol::Payload::VarEightByteEncoding) {
-                is_encoded_var = true;
-                return true;
-            }
-        } else {
-            if (tag == cProtocol::Payload::VarFourByteEncoding) {
-                is_encoded_var = true;
-                return true;
-            }
+    } else {
+        if (tag == cProtocol::Payload::VarFourByteEncoding) {
+            is_encoded_var = true;
+            return true;
         }
+    }
+    return false;
+}
+
+template <typename integer_t>
+static bool decode_int(IrBuffer& ir_buf, integer_t& value) {
+    integer_t value_small_endian;
+    if (ir_buf.try_read(value_small_endian) == false) {
         return false;
     }
 
-    template <typename integer_t>
-    static bool decode_int (IrBuffer& ir_buf, integer_t& value) {
-        integer_t value_small_endian;
-        if (ir_buf.try_read(value_small_endian) == false) {
-            return false;
-        }
-
-        constexpr auto read_size = sizeof(integer_t);
-        static_assert(read_size == 1 || read_size == 2 || read_size == 4 || read_size == 8);
-        if constexpr (read_size == 1) {
-            value = value_small_endian;
-        } else if constexpr (read_size == 2) {
-            value = bswap_16(value_small_endian);
-        } else if constexpr (read_size == 4) {
-            value = bswap_32(value_small_endian);
-        } else if constexpr (read_size == 8) {
-            value = bswap_64(value_small_endian);
-        }
-        return true;
+    constexpr auto read_size = sizeof(integer_t);
+    static_assert(read_size == 1 || read_size == 2 || read_size == 4 || read_size == 8);
+    if constexpr (read_size == 1) {
+        value = value_small_endian;
+    } else if constexpr (read_size == 2) {
+        value = bswap_16(value_small_endian);
+    } else if constexpr (read_size == 4) {
+        value = bswap_32(value_small_endian);
+    } else if constexpr (read_size == 8) {
+        value = bswap_64(value_small_endian);
     }
-
-    static IRErrorCode parse_logtype (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
-                                      string_view& logtype)
-    {
-        size_t logtype_length;
-        if (encoded_tag == cProtocol::Payload::LogtypeStrLenUByte) {
-            uint8_t length;
-            if (false == decode_int(ir_buf, length)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-            logtype_length = length;
-        } else if (encoded_tag == cProtocol::Payload::LogtypeStrLenUShort) {
-            uint16_t length;
-            if (false == decode_int(ir_buf, length)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-            logtype_length = length;
-        } else if (encoded_tag == cProtocol::Payload::LogtypeStrLenInt) {
-            int32_t length;
-            if (false == decode_int(ir_buf, length)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-            logtype_length = length;
-        } else {
-            return IRErrorCode_Corrupted_IR;
-        }
-
-        if (ir_buf.try_read(logtype, logtype_length) == false) {
-            return IRErrorCode_Incomplete_IR;
-        }
-        return IRErrorCode_Success;
-    }
-
-    static IRErrorCode parse_dictionary_var (IrBuffer& ir_buf, encoded_tag_t encoded_tag,
-                                             string_view& dict_var) {
-        // Decode variable's length
-        size_t var_length;
-        if (cProtocol::Payload::VarStrLenUByte == encoded_tag) {
-            uint8_t length;
-            if (false == decode_int(ir_buf, length)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-            var_length = length;
-        } else if (cProtocol::Payload::VarStrLenUShort == encoded_tag) {
-            uint16_t length;
-            if (false == decode_int(ir_buf, length)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-            var_length = length;
-        } else if (cProtocol::Payload::VarStrLenInt == encoded_tag) {
-            int32_t length;
-            if (false == decode_int(ir_buf, length)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-            var_length = length;
-        } else {
-            return IRErrorCode_Corrupted_IR;
-        }
-
-        // Read the dictionary variable
-        if (false == ir_buf.try_read(dict_var, var_length)) {
-            return IRErrorCode_Incomplete_IR;
-        }
-
-        return IRErrorCode_Success;
-    }
-
-    template <typename encoded_variable_t>
-    IRErrorCode parse_timestamp (IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts)
-    {
-        static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                      is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
-
-        if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
-            if (cProtocol::Payload::TimestampVal != encoded_tag) {
-                return IRErrorCode_Corrupted_IR;
-            }
-            if (false == decode_int(ir_buf, ts)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-        } else {
-            if (cProtocol::Payload::TimestampDeltaByte == encoded_tag) {
-                int8_t ts_delta;
-                if (false == decode_int(ir_buf, ts_delta)) {
-                    return IRErrorCode_Incomplete_IR;
-                }
-                ts = ts_delta;
-            } else if (cProtocol::Payload::TimestampDeltaShort == encoded_tag) {
-                int16_t ts_delta;
-                if (false == decode_int(ir_buf, ts_delta)) {
-                    return IRErrorCode_Incomplete_IR;
-                }
-                ts = ts_delta;
-            } else if (cProtocol::Payload::TimestampDeltaInt == encoded_tag) {
-                int32_t ts_delta;
-                if (false == decode_int(ir_buf, ts_delta)) {
-                    return IRErrorCode_Incomplete_IR;
-                }
-                ts = ts_delta;
-            } else {
-                return IRErrorCode_Corrupted_IR;
-            }
-        }
-        return IRErrorCode_Success;
-    }
-
-    template <typename encoded_variable_t>
-    static IRErrorCode generic_decode_next_message (IrBuffer& ir_buf, string& message,
-                                                    epoch_time_ms_t& timestamp)
-    {
-        ir_buf.init_internal_pos();
-
-        encoded_tag_t encoded_tag;
-        if (false == ir_buf.try_read(encoded_tag)) {
-            return IRErrorCode_Incomplete_IR;
-        }
-        if (cProtocol::Eof == encoded_tag) {
-            return IRErrorCode_Eof;
-        }
-
-        // Handle variables
-        vector<encoded_variable_t> encoded_vars;
-        vector<string_view> dict_vars;
-        encoded_variable_t encoded_variable;
-        string_view var_str;
-        bool is_encoded_var;
-        while (is_variable_tag<encoded_variable_t>(encoded_tag, is_encoded_var)) {
-            if (is_encoded_var) {
-                if (false == decode_int(ir_buf, encoded_variable)) {
-                    return IRErrorCode_Incomplete_IR;
-                }
-                encoded_vars.push_back(encoded_variable);
-            } else {
-                if (auto error_code = parse_dictionary_var(ir_buf, encoded_tag, var_str);
-                        IRErrorCode_Success != error_code)
-                {
-                    return error_code;
-                }
-                dict_vars.emplace_back(var_str);
-            }
-            if (false == ir_buf.try_read(encoded_tag)) {
-                return IRErrorCode_Incomplete_IR;
-            }
-        }
-
-        // Handle logtype
-        string_view logtype;
-        if (auto error_code = parse_logtype(ir_buf, encoded_tag, logtype);
-                IRErrorCode_Success != error_code)
-        {
-            return error_code;
-        }
-
-        // NOTE: for the eight-byte encoding, the timestamp is the actual
-        // timestamp; for the four-byte encoding, the timestamp is a timestamp
-        // delta
-        if (false == ir_buf.try_read(encoded_tag)) {
-            return IRErrorCode_Incomplete_IR;
-        }
-        if (auto error_code = parse_timestamp<encoded_variable_t>(ir_buf, encoded_tag, timestamp);
-                IRErrorCode_Success != error_code) {
-            return error_code;
-        }
-
-        try {
-            message = decode_message(logtype, encoded_vars, dict_vars);
-        } catch (const EncodingException& e) {
-            return IRErrorCode_Decode_Error;
-        }
-
-        ir_buf.commit_internal_pos();
-        return IRErrorCode_Success;
-    }
-
-    static IRErrorCode read_metadata_info (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
-                                           uint16_t& metadata_size) {
-        if (false == ir_buf.try_read(metadata_type)) {
-            return IRErrorCode_Incomplete_IR;
-        }
-
-        // Read metadata length
-        encoded_tag_t encoded_tag;
-        if (false == ir_buf.try_read(encoded_tag)) {
-            return IRErrorCode_Incomplete_IR;
-        }
-        switch (encoded_tag) {
-            case cProtocol::Metadata::LengthUByte:
-                uint8_t ubyte_res;
-                if (false == decode_int(ir_buf, ubyte_res)) {
-                    return IRErrorCode_Incomplete_IR;
-                }
-                metadata_size = ubyte_res;
-                break;
-            case cProtocol::Metadata::LengthUShort:
-                uint16_t ushort_res;
-                if (false == decode_int(ir_buf, ushort_res)) {
-                    return IRErrorCode_Incomplete_IR;
-                }
-                metadata_size = ushort_res;
-                break;
-            default:
-                return IRErrorCode_Corrupted_IR;
-        }
-        return IRErrorCode_Success;
-    }
-
-    template <typename encoded_variable_t>
-    static string decode_message (
-            string_view logtype,
-            const vector<encoded_variable_t>& encoded_vars,
-            const vector<string_view>& dictionary_vars
-    ) {
-        string message;
-        size_t encoded_vars_length = encoded_vars.size();
-        size_t dict_vars_length = dictionary_vars.size();
-        size_t next_static_text_begin_pos = 0;
-
-        size_t dictionary_vars_ix = 0;
-        size_t encoded_vars_ix = 0;
-        for (size_t cur_pos = 0; cur_pos < logtype.length(); ++cur_pos) {
-            auto c = logtype[cur_pos];
-            switch(c) {
-                case enum_to_underlying_type(VariablePlaceholder::Float): {
-                    message.append(logtype, next_static_text_begin_pos,
-                                   cur_pos - next_static_text_begin_pos);
-                    next_static_text_begin_pos = cur_pos + 1;
-                    if (encoded_vars_ix >= encoded_vars_length) {
-                        throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                                cTooFewEncodedVarsErrorMessage);
-                    }
-                    message.append(decode_float_var(encoded_vars[encoded_vars_ix]));
-                    ++encoded_vars_ix;
-
-                    break;
-                }
-
-                case enum_to_underlying_type(VariablePlaceholder::Integer): {
-                    message.append(logtype, next_static_text_begin_pos,
-                                   cur_pos - next_static_text_begin_pos);
-                    next_static_text_begin_pos = cur_pos + 1;
-                    if (encoded_vars_ix >= encoded_vars_length) {
-                        throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                                cTooFewEncodedVarsErrorMessage);
-                    }
-                    message.append(decode_integer_var(encoded_vars[encoded_vars_ix]));
-                    ++encoded_vars_ix;
-
-                    break;
-                }
-
-                case enum_to_underlying_type(VariablePlaceholder::Dictionary): {
-                    message.append(logtype, next_static_text_begin_pos,
-                                   cur_pos - next_static_text_begin_pos);
-                    next_static_text_begin_pos = cur_pos + 1;
-                    if (dictionary_vars_ix >= dict_vars_length) {
-                        throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                                cTooFewDictionaryVarsErrorMessage);
-                    }
-                    message.append(dictionary_vars[dictionary_vars_ix]);
-                    ++dictionary_vars_ix;
-
-                    break;
-                }
-
-                case cVariablePlaceholderEscapeCharacter: {
-                    // Ensure the escape character is followed by a
-                    // character that's being escaped
-                    if (cur_pos == logtype.length() - 1) {
-                        throw EncodingException(ErrorCode_Corrupt, __FILENAME__, __LINE__,
-                                                cUnexpectedEscapeCharacterMessage);
-                    }
-                    message.append(logtype, next_static_text_begin_pos,
-                                   cur_pos - next_static_text_begin_pos);
-
-                    // Skip the escape character
-                    next_static_text_begin_pos = cur_pos + 1;
-                    // The character after the escape character is static text
-                    // (regardless of whether it is a variable placeholder), so
-                    // increment cur_pos by 1 to ensure we don't process the
-                    // next character in any of the other cases (instead it will
-                    // be added to the message).
-                    ++cur_pos;
-
-                    break;
-                }
-            }
-        }
-        // Add remainder
-        if (next_static_text_begin_pos < logtype.length()) {
-            message.append(logtype, next_static_text_begin_pos);
-        }
-
-        return message;
-    }
-
-    IRErrorCode get_encoding_type (IrBuffer& ir_buf, bool& is_four_bytes_encoding) {
-        ir_buf.init_internal_pos();
-
-        int8_t buffer[cProtocol::MagicNumberLength];
-        if (false == ir_buf.try_read(buffer, cProtocol::MagicNumberLength)) {
-            return IRErrorCode_Incomplete_IR;
-        }
-        if (0 == memcmp(buffer, cProtocol::FourByteEncodingMagicNumber,
-                        cProtocol::MagicNumberLength)) {
-            is_four_bytes_encoding = true;
-        } else if (0 == memcmp(buffer, cProtocol::EightByteEncodingMagicNumber,
-                               cProtocol::MagicNumberLength)) {
-            is_four_bytes_encoding = false;
-        } else {
-            return IRErrorCode_Corrupted_IR;
-        }
-        ir_buf.commit_internal_pos();
-        return IRErrorCode_Success;
-    }
-
-    IRErrorCode decode_preamble (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
-                                 size_t& metadata_pos, uint16_t& metadata_size)
-    {
-        ir_buf.init_internal_pos();
-
-        if (auto error_code = read_metadata_info(ir_buf, metadata_type, metadata_size);
-                error_code != IRErrorCode_Success) {
-            return error_code;
-        }
-
-        size_t pos{ir_buf.get_cursor_pos()};
-        ir_buf.commit_internal_pos();
-        metadata_pos = ir_buf.get_cursor_pos();
-        if (ir_buf.size() < metadata_pos + metadata_size) {
-            ir_buf.set_cursor_pos(pos);
-            return IRErrorCode_Incomplete_IR;
-        }
-        ir_buf.set_cursor_pos(metadata_pos + metadata_size);
-        return IRErrorCode_Success;
-    }
-
-    namespace four_byte_encoding {
-        IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message,
-                                         epoch_time_ms_t& timestamp_delta)
-        {
-            return generic_decode_next_message<four_byte_encoded_variable_t>(
-                    ir_buf, message, timestamp_delta
-            );
-        }
-    }
-
-    namespace eight_byte_encoding {
-        IRErrorCode decode_next_message (IrBuffer& ir_buf, string& message,
-                                         epoch_time_ms_t& timestamp)
-        {
-            return generic_decode_next_message<eight_byte_encoded_variable_t>(
-                    ir_buf, message, timestamp
-            );
-        }
-    }
+    return true;
 }
+
+static IRErrorCode
+parse_logtype(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& logtype) {
+    size_t logtype_length;
+    if (encoded_tag == cProtocol::Payload::LogtypeStrLenUByte) {
+        uint8_t length;
+        if (false == decode_int(ir_buf, length)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+        logtype_length = length;
+    } else if (encoded_tag == cProtocol::Payload::LogtypeStrLenUShort) {
+        uint16_t length;
+        if (false == decode_int(ir_buf, length)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+        logtype_length = length;
+    } else if (encoded_tag == cProtocol::Payload::LogtypeStrLenInt) {
+        int32_t length;
+        if (false == decode_int(ir_buf, length)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+        logtype_length = length;
+    } else {
+        return IRErrorCode_Corrupted_IR;
+    }
+
+    if (ir_buf.try_read(logtype, logtype_length) == false) {
+        return IRErrorCode_Incomplete_IR;
+    }
+    return IRErrorCode_Success;
+}
+
+static IRErrorCode
+parse_dictionary_var(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& dict_var) {
+    // Decode variable's length
+    size_t var_length;
+    if (cProtocol::Payload::VarStrLenUByte == encoded_tag) {
+        uint8_t length;
+        if (false == decode_int(ir_buf, length)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+        var_length = length;
+    } else if (cProtocol::Payload::VarStrLenUShort == encoded_tag) {
+        uint16_t length;
+        if (false == decode_int(ir_buf, length)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+        var_length = length;
+    } else if (cProtocol::Payload::VarStrLenInt == encoded_tag) {
+        int32_t length;
+        if (false == decode_int(ir_buf, length)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+        var_length = length;
+    } else {
+        return IRErrorCode_Corrupted_IR;
+    }
+
+    // Read the dictionary variable
+    if (false == ir_buf.try_read(dict_var, var_length)) {
+        return IRErrorCode_Incomplete_IR;
+    }
+
+    return IRErrorCode_Success;
+}
+
+template <typename encoded_variable_t>
+IRErrorCode parse_timestamp(IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts) {
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+
+    if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
+        if (cProtocol::Payload::TimestampVal != encoded_tag) {
+            return IRErrorCode_Corrupted_IR;
+        }
+        if (false == decode_int(ir_buf, ts)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+    } else {
+        if (cProtocol::Payload::TimestampDeltaByte == encoded_tag) {
+            int8_t ts_delta;
+            if (false == decode_int(ir_buf, ts_delta)) {
+                return IRErrorCode_Incomplete_IR;
+            }
+            ts = ts_delta;
+        } else if (cProtocol::Payload::TimestampDeltaShort == encoded_tag) {
+            int16_t ts_delta;
+            if (false == decode_int(ir_buf, ts_delta)) {
+                return IRErrorCode_Incomplete_IR;
+            }
+            ts = ts_delta;
+        } else if (cProtocol::Payload::TimestampDeltaInt == encoded_tag) {
+            int32_t ts_delta;
+            if (false == decode_int(ir_buf, ts_delta)) {
+                return IRErrorCode_Incomplete_IR;
+            }
+            ts = ts_delta;
+        } else {
+            return IRErrorCode_Corrupted_IR;
+        }
+    }
+    return IRErrorCode_Success;
+}
+
+template <typename encoded_variable_t>
+static IRErrorCode
+generic_decode_next_message(IrBuffer& ir_buf, string& message, epoch_time_ms_t& timestamp) {
+    ir_buf.init_internal_pos();
+
+    encoded_tag_t encoded_tag;
+    if (false == ir_buf.try_read(encoded_tag)) {
+        return IRErrorCode_Incomplete_IR;
+    }
+    if (cProtocol::Eof == encoded_tag) {
+        return IRErrorCode_Eof;
+    }
+
+    // Handle variables
+    vector<encoded_variable_t> encoded_vars;
+    vector<string_view> dict_vars;
+    encoded_variable_t encoded_variable;
+    string_view var_str;
+    bool is_encoded_var;
+    while (is_variable_tag<encoded_variable_t>(encoded_tag, is_encoded_var)) {
+        if (is_encoded_var) {
+            if (false == decode_int(ir_buf, encoded_variable)) {
+                return IRErrorCode_Incomplete_IR;
+            }
+            encoded_vars.push_back(encoded_variable);
+        } else {
+            if (auto error_code = parse_dictionary_var(ir_buf, encoded_tag, var_str);
+                IRErrorCode_Success != error_code)
+            {
+                return error_code;
+            }
+            dict_vars.emplace_back(var_str);
+        }
+        if (false == ir_buf.try_read(encoded_tag)) {
+            return IRErrorCode_Incomplete_IR;
+        }
+    }
+
+    // Handle logtype
+    string_view logtype;
+    if (auto error_code = parse_logtype(ir_buf, encoded_tag, logtype);
+        IRErrorCode_Success != error_code)
+    {
+        return error_code;
+    }
+
+    // NOTE: for the eight-byte encoding, the timestamp is the actual
+    // timestamp; for the four-byte encoding, the timestamp is a timestamp
+    // delta
+    if (false == ir_buf.try_read(encoded_tag)) {
+        return IRErrorCode_Incomplete_IR;
+    }
+    if (auto error_code = parse_timestamp<encoded_variable_t>(ir_buf, encoded_tag, timestamp);
+        IRErrorCode_Success != error_code)
+    {
+        return error_code;
+    }
+
+    try {
+        message = decode_message(logtype, encoded_vars, dict_vars);
+    } catch (EncodingException const& e) {
+        return IRErrorCode_Decode_Error;
+    }
+
+    ir_buf.commit_internal_pos();
+    return IRErrorCode_Success;
+}
+
+static IRErrorCode
+read_metadata_info(IrBuffer& ir_buf, encoded_tag_t& metadata_type, uint16_t& metadata_size) {
+    if (false == ir_buf.try_read(metadata_type)) {
+        return IRErrorCode_Incomplete_IR;
+    }
+
+    // Read metadata length
+    encoded_tag_t encoded_tag;
+    if (false == ir_buf.try_read(encoded_tag)) {
+        return IRErrorCode_Incomplete_IR;
+    }
+    switch (encoded_tag) {
+        case cProtocol::Metadata::LengthUByte:
+            uint8_t ubyte_res;
+            if (false == decode_int(ir_buf, ubyte_res)) {
+                return IRErrorCode_Incomplete_IR;
+            }
+            metadata_size = ubyte_res;
+            break;
+        case cProtocol::Metadata::LengthUShort:
+            uint16_t ushort_res;
+            if (false == decode_int(ir_buf, ushort_res)) {
+                return IRErrorCode_Incomplete_IR;
+            }
+            metadata_size = ushort_res;
+            break;
+        default:
+            return IRErrorCode_Corrupted_IR;
+    }
+    return IRErrorCode_Success;
+}
+
+template <typename encoded_variable_t>
+static string decode_message(
+        string_view logtype,
+        vector<encoded_variable_t> const& encoded_vars,
+        vector<string_view> const& dictionary_vars
+) {
+    string message;
+    size_t encoded_vars_length = encoded_vars.size();
+    size_t dict_vars_length = dictionary_vars.size();
+    size_t next_static_text_begin_pos = 0;
+
+    size_t dictionary_vars_ix = 0;
+    size_t encoded_vars_ix = 0;
+    for (size_t cur_pos = 0; cur_pos < logtype.length(); ++cur_pos) {
+        auto c = logtype[cur_pos];
+        switch (c) {
+            case enum_to_underlying_type(VariablePlaceholder::Float): {
+                message.append(
+                        logtype,
+                        next_static_text_begin_pos,
+                        cur_pos - next_static_text_begin_pos
+                );
+                next_static_text_begin_pos = cur_pos + 1;
+                if (encoded_vars_ix >= encoded_vars_length) {
+                    throw EncodingException(
+                            ErrorCode_Corrupt,
+                            __FILENAME__,
+                            __LINE__,
+                            cTooFewEncodedVarsErrorMessage
+                    );
+                }
+                message.append(decode_float_var(encoded_vars[encoded_vars_ix]));
+                ++encoded_vars_ix;
+
+                break;
+            }
+
+            case enum_to_underlying_type(VariablePlaceholder::Integer): {
+                message.append(
+                        logtype,
+                        next_static_text_begin_pos,
+                        cur_pos - next_static_text_begin_pos
+                );
+                next_static_text_begin_pos = cur_pos + 1;
+                if (encoded_vars_ix >= encoded_vars_length) {
+                    throw EncodingException(
+                            ErrorCode_Corrupt,
+                            __FILENAME__,
+                            __LINE__,
+                            cTooFewEncodedVarsErrorMessage
+                    );
+                }
+                message.append(decode_integer_var(encoded_vars[encoded_vars_ix]));
+                ++encoded_vars_ix;
+
+                break;
+            }
+
+            case enum_to_underlying_type(VariablePlaceholder::Dictionary): {
+                message.append(
+                        logtype,
+                        next_static_text_begin_pos,
+                        cur_pos - next_static_text_begin_pos
+                );
+                next_static_text_begin_pos = cur_pos + 1;
+                if (dictionary_vars_ix >= dict_vars_length) {
+                    throw EncodingException(
+                            ErrorCode_Corrupt,
+                            __FILENAME__,
+                            __LINE__,
+                            cTooFewDictionaryVarsErrorMessage
+                    );
+                }
+                message.append(dictionary_vars[dictionary_vars_ix]);
+                ++dictionary_vars_ix;
+
+                break;
+            }
+
+            case cVariablePlaceholderEscapeCharacter: {
+                // Ensure the escape character is followed by a
+                // character that's being escaped
+                if (cur_pos == logtype.length() - 1) {
+                    throw EncodingException(
+                            ErrorCode_Corrupt,
+                            __FILENAME__,
+                            __LINE__,
+                            cUnexpectedEscapeCharacterMessage
+                    );
+                }
+                message.append(
+                        logtype,
+                        next_static_text_begin_pos,
+                        cur_pos - next_static_text_begin_pos
+                );
+
+                // Skip the escape character
+                next_static_text_begin_pos = cur_pos + 1;
+                // The character after the escape character is static text
+                // (regardless of whether it is a variable placeholder), so
+                // increment cur_pos by 1 to ensure we don't process the
+                // next character in any of the other cases (instead it will
+                // be added to the message).
+                ++cur_pos;
+
+                break;
+            }
+        }
+    }
+    // Add remainder
+    if (next_static_text_begin_pos < logtype.length()) {
+        message.append(logtype, next_static_text_begin_pos);
+    }
+
+    return message;
+}
+
+IRErrorCode get_encoding_type(IrBuffer& ir_buf, bool& is_four_bytes_encoding) {
+    ir_buf.init_internal_pos();
+
+    int8_t buffer[cProtocol::MagicNumberLength];
+    if (false == ir_buf.try_read(buffer, cProtocol::MagicNumberLength)) {
+        return IRErrorCode_Incomplete_IR;
+    }
+    if (0 == memcmp(buffer, cProtocol::FourByteEncodingMagicNumber, cProtocol::MagicNumberLength)) {
+        is_four_bytes_encoding = true;
+    } else if (0 == memcmp(buffer, cProtocol::EightByteEncodingMagicNumber, cProtocol::MagicNumberLength))
+    {
+        is_four_bytes_encoding = false;
+    } else {
+        return IRErrorCode_Corrupted_IR;
+    }
+    ir_buf.commit_internal_pos();
+    return IRErrorCode_Success;
+}
+
+IRErrorCode decode_preamble(
+        IrBuffer& ir_buf,
+        encoded_tag_t& metadata_type,
+        size_t& metadata_pos,
+        uint16_t& metadata_size
+) {
+    ir_buf.init_internal_pos();
+
+    if (auto error_code = read_metadata_info(ir_buf, metadata_type, metadata_size);
+        error_code != IRErrorCode_Success)
+    {
+        return error_code;
+    }
+
+    size_t pos{ir_buf.get_cursor_pos()};
+    ir_buf.commit_internal_pos();
+    metadata_pos = ir_buf.get_cursor_pos();
+    if (ir_buf.size() < metadata_pos + metadata_size) {
+        ir_buf.set_cursor_pos(pos);
+        return IRErrorCode_Incomplete_IR;
+    }
+    ir_buf.set_cursor_pos(metadata_pos + metadata_size);
+    return IRErrorCode_Success;
+}
+
+namespace four_byte_encoding {
+    IRErrorCode
+    decode_next_message(IrBuffer& ir_buf, string& message, epoch_time_ms_t& timestamp_delta) {
+        return generic_decode_next_message<four_byte_encoded_variable_t>(
+                ir_buf,
+                message,
+                timestamp_delta
+        );
+    }
+}  // namespace four_byte_encoding
+
+namespace eight_byte_encoding {
+    IRErrorCode decode_next_message(IrBuffer& ir_buf, string& message, epoch_time_ms_t& timestamp) {
+        return generic_decode_next_message<eight_byte_encoded_variable_t>(
+                ir_buf,
+                message,
+                timestamp
+        );
+    }
+}  // namespace eight_byte_encoding
+}  // namespace ffi::ir_stream

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -24,8 +24,8 @@ static bool is_variable_tag(encoded_tag_t tag, bool& is_encoded_var);
  * @tparam integer_t Type of the integer to decode
  * @param ir_buf
  * @param value Returns the decoded integer
- * @return true on success, false if the ir_buf doesn't contain enough data
- * to decode
+ * @return true on success, false if the ir_buf doesn't contain enough data to
+ * decode
  */
 template <typename integer_t>
 static bool decode_int(IrBuffer& ir_buf, integer_t& value);
@@ -37,8 +37,8 @@ static bool decode_int(IrBuffer& ir_buf, integer_t& value);
  * @param logtype Returns the logtype string
  * @return IRErrorCode_Success on success
  * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
- * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
- * to decode
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+ * decode
  */
 static IRErrorCode parse_logtype(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& logtype);
 
@@ -49,8 +49,8 @@ static IRErrorCode parse_logtype(IrBuffer& ir_buf, encoded_tag_t encoded_tag, st
  * @param dict_var Returns the dictionary variable
  * @return IRErrorCode_Success on success
  * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
- * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain enough
- * data to decode
+ * @return IRErrorCode_Incomplete_IR if input buffer doesn't contain enough data
+ * to decode
  */
 static IRErrorCode
 parse_dictionary_var(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& dict_var);
@@ -61,12 +61,12 @@ parse_dictionary_var(IrBuffer& ir_buf, encoded_tag_t encoded_tag, string_view& d
  * @param ir_buf
  * @param encoded_tag
  * @param ts Returns the timestamp delta if
- * encoded_variable_t == four_byte_encoded_variable_t or the actual
- * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
+ * encoded_variable_t == four_byte_encoded_variable_t or the actual timestamp if
+ * encoded_variable_t == eight_byte_encoded_variable_t
  * @return IRErrorCode_Success on success
  * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
- * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
- * to decode
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+ * decode
  */
 template <typename encoded_variable_t>
 IRErrorCode parse_timestamp(IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_time_ms_t& ts);
@@ -77,14 +77,14 @@ IRErrorCode parse_timestamp(IrBuffer& ir_buf, encoded_tag_t encoded_tag, epoch_t
  * @param ir_buf
  * @param message Returns the decoded message
  * @param timestamp Returns the timestamp delta if
- * encoded_variable_t == four_byte_encoded_variable_t or the actual
- * timestamp if encoded_variable_t == eight_byte_encoded_variable_t
+ * encoded_variable_t == four_byte_encoded_variable_t or the actual timestamp if
+ * encoded_variable_t == eight_byte_encoded_variable_t
  * @return IRErrorCode_Success on success
  * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
- * @return IRErrorCode_Decode_Error if the encoded message cannot be
- * properly decoded
- * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
- * to decode
+ * @return IRErrorCode_Decode_Error if the encoded message cannot be properly
+ * decoded
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+ * decode
  */
 template <typename encoded_variable_t>
 static IRErrorCode
@@ -98,17 +98,17 @@ generic_decode_next_message(IrBuffer& ir_buf, string& message, epoch_time_ms_t& 
  * @param metadata_size Returns the size of the metadata written in the IR
  * @return IRErrorCode_Success on success
  * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
- * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
- * to decode
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+ * decode
  */
 static IRErrorCode
 read_metadata_info(IrBuffer& ir_buf, encoded_tag_t& metadata_type, uint16_t& metadata_size);
 
 /**
- * Decodes the message from the given logtype, encoded variables, and
- * dictionary variables. This function properly handles escaped variable
- * placeholders in the logtype, as opposed to ffi::decode_message that
- * doesn't handle escaped placeholders for simplicity
+ * Decodes the message from the given logtype, encoded variables, and dictionary
+ * variables. This function properly handles escaped variable placeholders in
+ * the logtype, as opposed to ffi::decode_message that doesn't handle escaped
+ * placeholders for simplicity
  * @tparam encoded_variable_t Type of the encoded variable
  * @param logtype
  * @param encoded_vars

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -1,154 +1,159 @@
 #ifndef FFI_IR_STREAM_DECODING_METHODS_HPP
 #define FFI_IR_STREAM_DECODING_METHODS_HPP
 
-// C++ standard libraries
 #include <string_view>
 #include <vector>
 
-// Project headers
 #include "../encoding_methods.hpp"
 
 namespace ffi::ir_stream {
-    using encoded_tag_t = int8_t;
+using encoded_tag_t = int8_t;
+
+/**
+ * Class representing an IR buffer that the decoder sequentially reads from.
+ * The class maintains an internal cursor such that every successful read
+ * increments the cursor.
+ */
+class IrBuffer {
+public:
+    IrBuffer(int8_t const* data, size_t size)
+            : m_data(data),
+              m_size(size),
+              m_cursor_pos(0),
+              m_internal_cursor_pos(0) {}
+
+    [[nodiscard]] size_t get_cursor_pos() const { return m_cursor_pos; }
+
+    void set_cursor_pos(size_t cursor_pos) { m_cursor_pos = cursor_pos; }
+
+    // The following methods should only be used by the decoder
+    void init_internal_pos() { m_internal_cursor_pos = m_cursor_pos; }
+
+    void commit_internal_pos() { m_cursor_pos = m_internal_cursor_pos; }
+
+    size_t size() const { return m_size; }
 
     /**
-     * Class representing an IR buffer that the decoder sequentially reads from.
-     * The class maintains an internal cursor such that every successful read
-     * increments the cursor.
-     */
-    class IrBuffer {
-    public:
-        IrBuffer (const int8_t* data, size_t size) :
-                m_data(data),
-                m_size(size),
-                m_cursor_pos(0),
-                m_internal_cursor_pos(0) {}
-
-        [[nodiscard]] size_t get_cursor_pos () const { return m_cursor_pos; }
-        void set_cursor_pos (size_t cursor_pos) { m_cursor_pos = cursor_pos; }
-
-        // The following methods should only be used by the decoder
-        void init_internal_pos () { m_internal_cursor_pos = m_cursor_pos; }
-        void commit_internal_pos () { m_cursor_pos = m_internal_cursor_pos; }
-        size_t size () const { return m_size; }
-
-        /**
-         * Tries reading a string view of size = read_size from the ir_buf.
-         * @param str_view Returns the string view
-         * @param read_size
-         * @return true on success, false if the ir_buf doesn't contain enough
-         * data to decode
-         **/
-        [[nodiscard]] bool try_read (std::string_view& str_view, size_t read_size);
-
-        /**
-         * Tries reading an integer of size = sizeof(integer_t) from the ir_buf
-         * @tparam integer_t
-         * @param data Returns the integer
-         * @return true on success, false if the ir_buf doesn't contain enough
-         * data to decode
-         */
-        template <typename integer_t>
-        [[nodiscard]] bool try_read (integer_t& data);
-
-        /**
-         * Tries reading data of size = read_size from the ir_buf. On success,
-         * stores the data into dest.
-         * @param dest
-         * @param read_size
-         * @return true on success, false if the ir_buf doesn't contain enough
-         * data to decode
-         */
-        [[nodiscard]] bool try_read (void* dest, size_t read_size);
-
-    private:
-        /**
-         * @param read_size
-         * @return Whether a read of the given size will exceed the size of the
-         * buffer
-         */
-        [[nodiscard]] bool read_will_overflow (size_t read_size) const {
-            return (m_internal_cursor_pos + read_size) > m_size;
-        }
-
-        const int8_t* const m_data;
-        const size_t m_size;
-        size_t m_cursor_pos;
-        // Internal cursor position to help restore cursor pos if/when decoding
-        // fails
-        size_t m_internal_cursor_pos;
-    };
-
-    typedef enum {
-        IRErrorCode_Success,
-        IRErrorCode_Decode_Error,
-        IRErrorCode_Eof,
-        IRErrorCode_Corrupted_IR,
-        IRErrorCode_Corrupted_Metadata,
-        IRErrorCode_Incomplete_IR,
-        IRErrorCode_Unsupported_Version,
-    } IRErrorCode;
+     * Tries reading a string view of size = read_size from the ir_buf.
+     * @param str_view Returns the string view
+     * @param read_size
+     * @return true on success, false if the ir_buf doesn't contain enough
+     * data to decode
+     **/
+    [[nodiscard]] bool try_read(std::string_view& str_view, size_t read_size);
 
     /**
-     * Decodes the encoding type for the encoded IR stream
-     * @param ir_buf
-     * @param is_four_bytes_encoding Returns the encoding type
-     * @return ErrorCode_Success on success
-     * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
-     * decode
-     */
-    IRErrorCode get_encoding_type (IrBuffer& ir_buf, bool& is_four_bytes_encoding);
-
-    /**
-     * Decodes the preamble for an IR stream.
-     * @param ir_buf
-     * @param metadata_type Returns the type of the metadata found in the IR
-     * @param metadata_pos Returns the starting position of the metadata in ir_buf
-     * @param metadata_size Returns the size of the metadata written in the IR
-     * @return IRErrorCode_Success on success
-     * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
+     * Tries reading an integer of size = sizeof(integer_t) from the ir_buf
+     * @tparam integer_t
+     * @param data Returns the integer
+     * @return true on success, false if the ir_buf doesn't contain enough
      * data to decode
      */
-    IRErrorCode decode_preamble (IrBuffer& ir_buf, encoded_tag_t& metadata_type,
-                                 size_t& metadata_pos, uint16_t& metadata_size);
+    template <typename integer_t>
+    [[nodiscard]] bool try_read(integer_t& data);
 
-    namespace eight_byte_encoding {
-        /**
-         * Decodes the next message for the eight-byte encoding IR stream.
-         * @param ir_buf
-         * @param message Returns the decoded message
-         * @param timestamp Returns the decoded timestamp
-         * @return ErrorCode_Success on success
-         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
-         * @return ErrorCode_Decode_Error if the encoded message cannot be
-         * properly decoded
-         * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-         * to decode
-         * @return ErrorCode_End_of_IR if the IR ends
-         */
-        IRErrorCode decode_next_message (IrBuffer& ir_buf, std::string& message,
-                                         epoch_time_ms_t& timestamp);
+    /**
+     * Tries reading data of size = read_size from the ir_buf. On success,
+     * stores the data into dest.
+     * @param dest
+     * @param read_size
+     * @return true on success, false if the ir_buf doesn't contain enough
+     * data to decode
+     */
+    [[nodiscard]] bool try_read(void* dest, size_t read_size);
+
+private:
+    /**
+     * @param read_size
+     * @return Whether a read of the given size will exceed the size of the
+     * buffer
+     */
+    [[nodiscard]] bool read_will_overflow(size_t read_size) const {
+        return (m_internal_cursor_pos + read_size) > m_size;
     }
 
-    namespace four_byte_encoding {
-        /**
-         * Decodes the next message for the four-byte encoding IR stream.
-         * @param ir_buf
-         * @param message Returns the decoded message
-         * @param timestamp_delta Returns the decoded timestamp delta
-         * @return ErrorCode_Success on success
-         * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
-         * @return ErrorCode_Decode_Error if the encoded message cannot be
-         * properly decoded
-         * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-         * to decode
-         * @return ErrorCode_End_of_IR if the IR ends
-         */
-        IRErrorCode decode_next_message (IrBuffer& ir_buf, std::string& message,
-                                         epoch_time_ms_t& timestamp_delta);
-    }
-}
+    int8_t const* const m_data;
+    const size_t m_size;
+    size_t m_cursor_pos;
+    // Internal cursor position to help restore cursor pos if/when decoding
+    // fails
+    size_t m_internal_cursor_pos;
+};
 
-#endif //FFI_IR_STREAM_DECODING_METHODS_HPP
+typedef enum {
+    IRErrorCode_Success,
+    IRErrorCode_Decode_Error,
+    IRErrorCode_Eof,
+    IRErrorCode_Corrupted_IR,
+    IRErrorCode_Corrupted_Metadata,
+    IRErrorCode_Incomplete_IR,
+    IRErrorCode_Unsupported_Version,
+} IRErrorCode;
+
+/**
+ * Decodes the encoding type for the encoded IR stream
+ * @param ir_buf
+ * @param is_four_bytes_encoding Returns the encoding type
+ * @return ErrorCode_Success on success
+ * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+ * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+ * decode
+ */
+IRErrorCode get_encoding_type(IrBuffer& ir_buf, bool& is_four_bytes_encoding);
+
+/**
+ * Decodes the preamble for an IR stream.
+ * @param ir_buf
+ * @param metadata_type Returns the type of the metadata found in the IR
+ * @param metadata_pos Returns the starting position of the metadata in ir_buf
+ * @param metadata_size Returns the size of the metadata written in the IR
+ * @return IRErrorCode_Success on success
+ * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
+ * data to decode
+ */
+IRErrorCode decode_preamble(
+        IrBuffer& ir_buf,
+        encoded_tag_t& metadata_type,
+        size_t& metadata_pos,
+        uint16_t& metadata_size
+);
+
+namespace eight_byte_encoding {
+    /**
+     * Decodes the next message for the eight-byte encoding IR stream.
+     * @param ir_buf
+     * @param message Returns the decoded message
+     * @param timestamp Returns the decoded timestamp
+     * @return ErrorCode_Success on success
+     * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+     * @return ErrorCode_Decode_Error if the encoded message cannot be
+     * properly decoded
+     * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+     * to decode
+     * @return ErrorCode_End_of_IR if the IR ends
+     */
+    IRErrorCode
+    decode_next_message(IrBuffer& ir_buf, std::string& message, epoch_time_ms_t& timestamp);
+}  // namespace eight_byte_encoding
+
+namespace four_byte_encoding {
+    /**
+     * Decodes the next message for the four-byte encoding IR stream.
+     * @param ir_buf
+     * @param message Returns the decoded message
+     * @param timestamp_delta Returns the decoded timestamp delta
+     * @return ErrorCode_Success on success
+     * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
+     * @return ErrorCode_Decode_Error if the encoded message cannot be
+     * properly decoded
+     * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
+     * to decode
+     * @return ErrorCode_End_of_IR if the IR ends
+     */
+    IRErrorCode
+    decode_next_message(IrBuffer& ir_buf, std::string& message, epoch_time_ms_t& timestamp_delta);
+}  // namespace four_byte_encoding
+}  // namespace ffi::ir_stream
+
+#endif  // FFI_IR_STREAM_DECODING_METHODS_HPP

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -10,9 +10,9 @@ namespace ffi::ir_stream {
 using encoded_tag_t = int8_t;
 
 /**
- * Class representing an IR buffer that the decoder sequentially reads from.
- * The class maintains an internal cursor such that every successful read
- * increments the cursor.
+ * Class representing an IR buffer that the decoder sequentially reads from. The
+ * class maintains an internal cursor such that every successful read increments
+ * the cursor.
  */
 class IrBuffer {
 public:
@@ -37,17 +37,17 @@ public:
      * Tries reading a string view of size = read_size from the ir_buf.
      * @param str_view Returns the string view
      * @param read_size
-     * @return true on success, false if the ir_buf doesn't contain enough
-     * data to decode
-     **/
+     * @return true on success, false if the ir_buf doesn't contain enough data
+     * to decode
+     */
     [[nodiscard]] bool try_read(std::string_view& str_view, size_t read_size);
 
     /**
      * Tries reading an integer of size = sizeof(integer_t) from the ir_buf
      * @tparam integer_t
      * @param data Returns the integer
-     * @return true on success, false if the ir_buf doesn't contain enough
-     * data to decode
+     * @return true on success, false if the ir_buf doesn't contain enough data
+     * to decode
      */
     template <typename integer_t>
     [[nodiscard]] bool try_read(integer_t& data);
@@ -57,8 +57,8 @@ public:
      * stores the data into dest.
      * @param dest
      * @param read_size
-     * @return true on success, false if the ir_buf doesn't contain enough
-     * data to decode
+     * @return true on success, false if the ir_buf doesn't contain enough data
+     * to decode
      */
     [[nodiscard]] bool try_read(void* dest, size_t read_size);
 
@@ -109,8 +109,8 @@ IRErrorCode get_encoding_type(IrBuffer& ir_buf, bool& is_four_bytes_encoding);
  * @param metadata_size Returns the size of the metadata written in the IR
  * @return IRErrorCode_Success on success
  * @return IRErrorCode_Corrupted_IR if ir_buf contains invalid IR
- * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough
- * data to decode
+ * @return IRErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+ * decode
  */
 IRErrorCode decode_preamble(
         IrBuffer& ir_buf,
@@ -127,10 +127,10 @@ namespace eight_byte_encoding {
      * @param timestamp Returns the decoded timestamp
      * @return ErrorCode_Success on success
      * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return ErrorCode_Decode_Error if the encoded message cannot be
-     * properly decoded
-     * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-     * to decode
+     * @return ErrorCode_Decode_Error if the encoded message cannot be properly
+     * decoded
+     * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+     * decode
      * @return ErrorCode_End_of_IR if the IR ends
      */
     IRErrorCode
@@ -145,10 +145,10 @@ namespace four_byte_encoding {
      * @param timestamp_delta Returns the decoded timestamp delta
      * @return ErrorCode_Success on success
      * @return ErrorCode_Corrupted_IR if ir_buf contains invalid IR
-     * @return ErrorCode_Decode_Error if the encoded message cannot be
-     * properly decoded
-     * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data
-     * to decode
+     * @return ErrorCode_Decode_Error if the encoded message cannot be properly
+     * decoded
+     * @return ErrorCode_Incomplete_IR if ir_buf doesn't contain enough data to
+     * decode
      * @return ErrorCode_End_of_IR if the IR ends
      */
     IRErrorCode

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -54,8 +54,8 @@ static void add_base_metadata_fields(
  * Appends a constant to the logtype, escaping variable placeholders when
  * @p contains_variable_placeholder is true
  * @param constant
- * @param contains_variable_placeholder Whether the constant contains a
- * variable placeholder
+ * @param contains_variable_placeholder Whether the constant contains a variable
+ * placeholder
  * @param logtype
  * @return true
  */

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -1,319 +1,352 @@
 #include "encoding_methods.hpp"
 
-// json
 #include <json/single_include/nlohmann/json.hpp>
 
-// Project headers
 #include "byteswap.hpp"
 #include "protocol_constants.hpp"
 
-using std::string_view;
 using std::string;
+using std::string_view;
 using std::vector;
 
 namespace ffi::ir_stream {
-    // Local function prototypes
+// Local function prototypes
+/**
+ * Encodes an integer into the IR stream
+ * @tparam integer_t
+ * @param value
+ * @param ir_buf
+ */
+template <typename integer_t>
+static void encode_int(integer_t value, vector<int8_t>& ir_buf);
+
+/**
+ * Encodes the given logtype into the IR stream
+ * @param logtype
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+static bool encode_logtype(string_view logtype, vector<int8_t>& ir_buf);
+
+/**
+ * Encodes the given metadata into the IR stream
+ * @param metadata
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+static bool encode_metadata(nlohmann::json& metadata, vector<int8_t>& ir_buf);
+
+/**
+ * Adds the basic metadata fields to the given JSON object
+ * @param timestamp_pattern
+ * @param timestamp_pattern_syntax
+ * @param time_zone_id
+ * @param metadata
+ */
+static void add_base_metadata_fields(
+        string_view timestamp_pattern,
+        string_view timestamp_pattern_syntax,
+        string_view time_zone_id,
+        nlohmann::json& metadata
+);
+
+/**
+ * Appends a constant to the logtype, escaping variable placeholders when
+ * @p contains_variable_placeholder is true
+ * @param constant
+ * @param contains_variable_placeholder Whether the constant contains a
+ * variable placeholder
+ * @param logtype
+ * @return true
+ */
+static bool append_constant_to_logtype(
+        string_view constant,
+        bool contains_variable_placeholder,
+        string& logtype
+);
+
+/**
+ * Appends the final constant to the logtype, escaping variable placeholders as
+ * necessary
+ * @param constant
+ * @param logtype
+ * @return Same as append_constant_to_logtype
+ */
+static bool append_final_constant_to_logtype(string_view constant, string& logtype);
+
+/**
+ * A functor for encoding dictionary variables in a message
+ */
+class DictionaryVariableHandler {
+public:
     /**
-     * Encodes an integer into the IR stream
-     * @tparam integer_t
-     * @param value
-     * @param ir_buf
+     * Functor constructor
+     * @param ir_buf Output buffer for the encoded data
      */
-    template <typename integer_t>
-    static void encode_int (integer_t value, vector<int8_t>& ir_buf);
+    explicit DictionaryVariableHandler(vector<int8_t>& ir_buf) : m_ir_buf(ir_buf) {}
 
-    /**
-     * Encodes the given logtype into the IR stream
-     * @param logtype
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    static bool encode_logtype (string_view logtype, vector<int8_t>& ir_buf);
-
-    /**
-     * Encodes the given metadata into the IR stream
-     * @param metadata
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    static bool encode_metadata (nlohmann::json& metadata, vector<int8_t>& ir_buf);
-
-    /**
-     * Adds the basic metadata fields to the given JSON object
-     * @param timestamp_pattern
-     * @param timestamp_pattern_syntax
-     * @param time_zone_id
-     * @param metadata
-     */
-    static void add_base_metadata_fields (string_view timestamp_pattern,
-                                          string_view timestamp_pattern_syntax,
-                                          string_view time_zone_id, nlohmann::json& metadata);
-
-    /**
-     * Appends a constant to the logtype, escaping variable placeholders when
-     * @p contains_variable_placeholder is true
-     * @param constant
-     * @param contains_variable_placeholder Whether the constant contains a
-     * variable placeholder
-     * @param logtype
-     * @return true
-     */
-    static bool append_constant_to_logtype (string_view constant,
-                                            bool contains_variable_placeholder, string& logtype);
-
-    /**
-     * Appends the final constant to the logtype, escaping variable
-     * placeholders as necessary
-     * @param constant
-     * @param logtype
-     * @return Same as append_constant_to_logtype
-     */
-    static bool append_final_constant_to_logtype (string_view constant, string& logtype);
-
-    /**
-     * A functor for encoding dictionary variables in a message
-     */
-    class DictionaryVariableHandler {
-    public:
-        /**
-         * Functor constructor
-         * @param ir_buf Output buffer for the encoded data
-         */
-        explicit DictionaryVariableHandler (vector<int8_t>& ir_buf) : m_ir_buf(ir_buf) {}
-
-        bool operator() (string_view message, size_t begin_pos, size_t end_pos) {
-            auto length = end_pos - begin_pos;
-            if (length <= UINT8_MAX) {
-                m_ir_buf.push_back(cProtocol::Payload::VarStrLenUByte);
-                m_ir_buf.push_back(bit_cast<int8_t>(static_cast<uint8_t>(length)));
-            } else if (length <= UINT16_MAX) {
-                m_ir_buf.push_back(cProtocol::Payload::VarStrLenUShort);
-                encode_int(static_cast<uint16_t>(length), m_ir_buf);
-            } else if (length <= INT32_MAX) {
-                m_ir_buf.push_back(cProtocol::Payload::VarStrLenInt);
-                encode_int(static_cast<int32_t>(length), m_ir_buf);
-            } else {
-                return false;
-            }
-            auto message_begin = message.cbegin();
-            m_ir_buf.insert(m_ir_buf.cend(), message_begin + begin_pos, message_begin + end_pos);
-            return true;
-        }
-    private:
-        vector<int8_t>& m_ir_buf;
-    };
-
-    template <typename integer_t>
-    static void encode_int (integer_t value, vector<int8_t>& ir_buf) {
-        integer_t value_big_endian;
-        static_assert(sizeof(integer_t) == 2 || sizeof(integer_t) == 4 || sizeof(integer_t) == 8);
-        if constexpr (sizeof(value) == 2) {
-            value_big_endian = bswap_16(value);
-        } else if constexpr (sizeof(value) == 4) {
-            value_big_endian = bswap_32(value);
-        } else if constexpr (sizeof(value) == 8) {
-            value_big_endian = bswap_64(value);
-        }
-        auto data = reinterpret_cast<int8_t*>(&value_big_endian);
-        ir_buf.insert(ir_buf.end(), data, data + sizeof(value));
-    }
-
-    static bool encode_logtype (string_view logtype, vector<int8_t>& ir_buf) {
-        auto length = logtype.length();
+    bool operator()(string_view message, size_t begin_pos, size_t end_pos) {
+        auto length = end_pos - begin_pos;
         if (length <= UINT8_MAX) {
-            ir_buf.push_back(cProtocol::Payload::LogtypeStrLenUByte);
-            ir_buf.push_back(bit_cast<int8_t>(static_cast<uint8_t>(length)));
+            m_ir_buf.push_back(cProtocol::Payload::VarStrLenUByte);
+            m_ir_buf.push_back(bit_cast<int8_t>(static_cast<uint8_t>(length)));
         } else if (length <= UINT16_MAX) {
-            ir_buf.push_back(cProtocol::Payload::LogtypeStrLenUShort);
-            encode_int(static_cast<uint16_t>(length), ir_buf);
+            m_ir_buf.push_back(cProtocol::Payload::VarStrLenUShort);
+            encode_int(static_cast<uint16_t>(length), m_ir_buf);
         } else if (length <= INT32_MAX) {
-            ir_buf.push_back(cProtocol::Payload::LogtypeStrLenInt);
-            encode_int(static_cast<int32_t>(length), ir_buf);
+            m_ir_buf.push_back(cProtocol::Payload::VarStrLenInt);
+            encode_int(static_cast<int32_t>(length), m_ir_buf);
         } else {
-            // Logtype is too long for encoding
             return false;
         }
-        ir_buf.insert(ir_buf.cend(), logtype.cbegin(), logtype.cend());
+        auto message_begin = message.cbegin();
+        m_ir_buf.insert(m_ir_buf.cend(), message_begin + begin_pos, message_begin + end_pos);
         return true;
     }
 
-    static bool encode_metadata (nlohmann::json& metadata, vector<int8_t>& ir_buf) {
-        ir_buf.push_back(cProtocol::Metadata::EncodingJson);
+private:
+    vector<int8_t>& m_ir_buf;
+};
 
-        auto metadata_serialized = metadata.dump(-1, ' ', false,
-                                                 nlohmann::json::error_handler_t::ignore);
-        auto metadata_serialized_length = metadata_serialized.length();
-        if (metadata_serialized_length <= UINT8_MAX) {
-            ir_buf.push_back(cProtocol::Metadata::LengthUByte);
-            ir_buf.push_back(bit_cast<int8_t>(static_cast<uint8_t>(metadata_serialized_length)));
-        } else if (metadata_serialized_length <= UINT16_MAX) {
-            ir_buf.push_back(cProtocol::Metadata::LengthUShort);
-            encode_int(static_cast<uint16_t>(metadata_serialized_length), ir_buf);
-        } else {
-            // Can't encode metadata longer than 64 KiB
-            return false;
-        }
-        ir_buf.insert(ir_buf.cend(), metadata_serialized.cbegin(), metadata_serialized.cend());
-
-        return true;
+template <typename integer_t>
+static void encode_int(integer_t value, vector<int8_t>& ir_buf) {
+    integer_t value_big_endian;
+    static_assert(sizeof(integer_t) == 2 || sizeof(integer_t) == 4 || sizeof(integer_t) == 8);
+    if constexpr (sizeof(value) == 2) {
+        value_big_endian = bswap_16(value);
+    } else if constexpr (sizeof(value) == 4) {
+        value_big_endian = bswap_32(value);
+    } else if constexpr (sizeof(value) == 8) {
+        value_big_endian = bswap_64(value);
     }
-
-    static void add_base_metadata_fields (string_view timestamp_pattern,
-                                          string_view timestamp_pattern_syntax,
-                                          string_view time_zone_id, nlohmann::json& metadata)
-    {
-        metadata[cProtocol::Metadata::VersionKey] = cProtocol::Metadata::VersionValue;
-        metadata[cProtocol::Metadata::VariablesSchemaIdKey] = cVariablesSchemaVersion;
-        metadata[cProtocol::Metadata::VariableEncodingMethodsIdKey] =
-                cVariableEncodingMethodsVersion;
-        metadata[cProtocol::Metadata::TimestampPatternKey] = timestamp_pattern;
-        metadata[cProtocol::Metadata::TimestampPatternSyntaxKey] = timestamp_pattern_syntax;
-        metadata[cProtocol::Metadata::TimeZoneIdKey] = time_zone_id;
-    }
-
-    static bool append_constant_to_logtype (string_view constant, bool, string& logtype)
-    {
-        size_t begin_pos = 0;
-        auto constant_len = constant.length();
-        for (size_t i = 0; i < constant_len; ++i) {
-            auto c = constant[i];
-            if (cVariablePlaceholderEscapeCharacter == c || is_variable_placeholder(c)) {
-                logtype.append(constant, begin_pos, i - begin_pos);
-                logtype += cVariablePlaceholderEscapeCharacter;
-                // NOTE: We don't need to append the character of interest
-                // immediately since the next constant copy operation will
-                // get it
-                begin_pos = i;
-            }
-        }
-        logtype.append(constant, begin_pos, constant_len - begin_pos);
-        return true;
-    }
-
-    static bool append_final_constant_to_logtype (string_view constant, string& logtype) {
-        // Since we don't know if the last constant contains a variable
-        // placeholder, we'll simply say it does and append_constant_to_logtype
-        // will escape one if it finds one
-        return append_constant_to_logtype(constant, true, logtype);
-    }
-
-    namespace eight_byte_encoding {
-        bool encode_preamble (string_view timestamp_pattern, string_view timestamp_pattern_syntax,
-                              string_view time_zone_id, vector<int8_t>& ir_buf)
-        {
-            // Write magic number
-            for (auto b : cProtocol::EightByteEncodingMagicNumber) {
-                ir_buf.push_back(b);
-            }
-
-            // Assemble metadata
-            nlohmann::json metadata_json;
-            add_base_metadata_fields(timestamp_pattern, timestamp_pattern_syntax, time_zone_id,
-                                     metadata_json);
-
-            return encode_metadata(metadata_json, ir_buf);
-        }
-
-        bool encode_message (epoch_time_ms_t timestamp, string_view message, string& logtype,
-                             vector<int8_t>& ir_buf)
-        {
-            auto encoded_var_handler = [&ir_buf] (eight_byte_encoded_variable_t encoded_var) {
-                ir_buf.push_back(cProtocol::Payload::VarEightByteEncoding);
-                encode_int(encoded_var, ir_buf);
-            };
-
-            if (false == encode_message_generically<eight_byte_encoded_variable_t>(
-                    message, logtype, append_constant_to_logtype, append_final_constant_to_logtype,
-                    encoded_var_handler, DictionaryVariableHandler(ir_buf)
-            )) {
-                return false;
-            }
-
-            if (false == encode_logtype(logtype, ir_buf)) {
-                return false;
-            }
-
-            // Encode timestamp
-            ir_buf.push_back(cProtocol::Payload::TimestampVal);
-            encode_int(timestamp, ir_buf);
-
-            return true;
-        }
-    }
-
-    namespace four_byte_encoding {
-        bool encode_preamble (
-                string_view timestamp_pattern,
-                string_view timestamp_pattern_syntax,
-                string_view time_zone_id,
-                epoch_time_ms_t reference_timestamp,
-                vector<int8_t>& ir_buf
-        ) {
-            // Write magic number
-            for (auto b : cProtocol::FourByteEncodingMagicNumber) {
-                ir_buf.push_back(b);
-            }
-
-            // Assemble metadata
-            nlohmann::json metadata_json;
-            add_base_metadata_fields(timestamp_pattern, timestamp_pattern_syntax, time_zone_id,
-                                     metadata_json);
-            metadata_json[cProtocol::Metadata::ReferenceTimestampKey] =
-                    std::to_string(reference_timestamp);
-
-            return encode_metadata(metadata_json, ir_buf);
-        }
-
-        bool encode_message (epoch_time_ms_t timestamp_delta, string_view message, string& logtype,
-                             vector<int8_t>& ir_buf)
-        {
-            if (false == encode_message(message, logtype, ir_buf)) {
-                return false;
-            }
-
-            if (false == encode_timestamp(timestamp_delta, ir_buf)) {
-                return false;
-            }
-
-            return true;
-        }
-
-        bool encode_message (string_view message, string& logtype, vector<int8_t>& ir_buf) {
-            auto encoded_var_handler = [&ir_buf] (four_byte_encoded_variable_t encoded_var) {
-                ir_buf.push_back(cProtocol::Payload::VarFourByteEncoding);
-                encode_int(encoded_var, ir_buf);
-            };
-
-            if (false == encode_message_generically<four_byte_encoded_variable_t>(
-                    message, logtype, append_constant_to_logtype, append_final_constant_to_logtype,
-                    encoded_var_handler, DictionaryVariableHandler(ir_buf)
-            )) {
-                return false;
-            }
-
-            if (false == encode_logtype(logtype, ir_buf)) {
-                return false;
-            }
-
-            return true;
-        }
-
-        bool encode_timestamp (epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf) {
-            if (INT8_MIN <= timestamp_delta && timestamp_delta <= INT8_MAX) {
-                ir_buf.push_back(cProtocol::Payload::TimestampDeltaByte);
-                ir_buf.push_back(static_cast<int8_t>(timestamp_delta));
-            } else if (INT16_MIN <= timestamp_delta && timestamp_delta <= INT16_MAX) {
-                ir_buf.push_back(cProtocol::Payload::TimestampDeltaShort);
-                encode_int(static_cast<int16_t>(timestamp_delta), ir_buf);
-            } else if (INT32_MIN <= timestamp_delta && timestamp_delta <= INT32_MAX) {
-                ir_buf.push_back(cProtocol::Payload::TimestampDeltaInt);
-                encode_int(static_cast<int32_t>(timestamp_delta), ir_buf);
-            } else {
-                // Delta exceeds maximum representable by an int (24.86 days)
-                return false;
-            }
-
-            return true;
-        }
-    }
+    auto data = reinterpret_cast<int8_t*>(&value_big_endian);
+    ir_buf.insert(ir_buf.end(), data, data + sizeof(value));
 }
+
+static bool encode_logtype(string_view logtype, vector<int8_t>& ir_buf) {
+    auto length = logtype.length();
+    if (length <= UINT8_MAX) {
+        ir_buf.push_back(cProtocol::Payload::LogtypeStrLenUByte);
+        ir_buf.push_back(bit_cast<int8_t>(static_cast<uint8_t>(length)));
+    } else if (length <= UINT16_MAX) {
+        ir_buf.push_back(cProtocol::Payload::LogtypeStrLenUShort);
+        encode_int(static_cast<uint16_t>(length), ir_buf);
+    } else if (length <= INT32_MAX) {
+        ir_buf.push_back(cProtocol::Payload::LogtypeStrLenInt);
+        encode_int(static_cast<int32_t>(length), ir_buf);
+    } else {
+        // Logtype is too long for encoding
+        return false;
+    }
+    ir_buf.insert(ir_buf.cend(), logtype.cbegin(), logtype.cend());
+    return true;
+}
+
+static bool encode_metadata(nlohmann::json& metadata, vector<int8_t>& ir_buf) {
+    ir_buf.push_back(cProtocol::Metadata::EncodingJson);
+
+    auto metadata_serialized
+            = metadata.dump(-1, ' ', false, nlohmann::json::error_handler_t::ignore);
+    auto metadata_serialized_length = metadata_serialized.length();
+    if (metadata_serialized_length <= UINT8_MAX) {
+        ir_buf.push_back(cProtocol::Metadata::LengthUByte);
+        ir_buf.push_back(bit_cast<int8_t>(static_cast<uint8_t>(metadata_serialized_length)));
+    } else if (metadata_serialized_length <= UINT16_MAX) {
+        ir_buf.push_back(cProtocol::Metadata::LengthUShort);
+        encode_int(static_cast<uint16_t>(metadata_serialized_length), ir_buf);
+    } else {
+        // Can't encode metadata longer than 64 KiB
+        return false;
+    }
+    ir_buf.insert(ir_buf.cend(), metadata_serialized.cbegin(), metadata_serialized.cend());
+
+    return true;
+}
+
+static void add_base_metadata_fields(
+        string_view timestamp_pattern,
+        string_view timestamp_pattern_syntax,
+        string_view time_zone_id,
+        nlohmann::json& metadata
+) {
+    metadata[cProtocol::Metadata::VersionKey] = cProtocol::Metadata::VersionValue;
+    metadata[cProtocol::Metadata::VariablesSchemaIdKey] = cVariablesSchemaVersion;
+    metadata[cProtocol::Metadata::VariableEncodingMethodsIdKey] = cVariableEncodingMethodsVersion;
+    metadata[cProtocol::Metadata::TimestampPatternKey] = timestamp_pattern;
+    metadata[cProtocol::Metadata::TimestampPatternSyntaxKey] = timestamp_pattern_syntax;
+    metadata[cProtocol::Metadata::TimeZoneIdKey] = time_zone_id;
+}
+
+static bool append_constant_to_logtype(string_view constant, bool, string& logtype) {
+    size_t begin_pos = 0;
+    auto constant_len = constant.length();
+    for (size_t i = 0; i < constant_len; ++i) {
+        auto c = constant[i];
+        if (cVariablePlaceholderEscapeCharacter == c || is_variable_placeholder(c)) {
+            logtype.append(constant, begin_pos, i - begin_pos);
+            logtype += cVariablePlaceholderEscapeCharacter;
+            // NOTE: We don't need to append the character of interest
+            // immediately since the next constant copy operation will get it
+            begin_pos = i;
+        }
+    }
+    logtype.append(constant, begin_pos, constant_len - begin_pos);
+    return true;
+}
+
+static bool append_final_constant_to_logtype(string_view constant, string& logtype) {
+    // Since we don't know if the last constant contains a variable placeholder,
+    // we'll simply say it does and append_constant_to_logtype will escape one
+    // if it finds one
+    return append_constant_to_logtype(constant, true, logtype);
+}
+
+namespace eight_byte_encoding {
+    bool encode_preamble(
+            string_view timestamp_pattern,
+            string_view timestamp_pattern_syntax,
+            string_view time_zone_id,
+            vector<int8_t>& ir_buf
+    ) {
+        // Write magic number
+        for (auto b : cProtocol::EightByteEncodingMagicNumber) {
+            ir_buf.push_back(b);
+        }
+
+        // Assemble metadata
+        nlohmann::json metadata_json;
+        add_base_metadata_fields(
+                timestamp_pattern,
+                timestamp_pattern_syntax,
+                time_zone_id,
+                metadata_json
+        );
+
+        return encode_metadata(metadata_json, ir_buf);
+    }
+
+    bool encode_message(
+            epoch_time_ms_t timestamp,
+            string_view message,
+            string& logtype,
+            vector<int8_t>& ir_buf
+    ) {
+        auto encoded_var_handler = [&ir_buf](eight_byte_encoded_variable_t encoded_var) {
+            ir_buf.push_back(cProtocol::Payload::VarEightByteEncoding);
+            encode_int(encoded_var, ir_buf);
+        };
+
+        if (false
+            == encode_message_generically<eight_byte_encoded_variable_t>(
+                    message,
+                    logtype,
+                    append_constant_to_logtype,
+                    append_final_constant_to_logtype,
+                    encoded_var_handler,
+                    DictionaryVariableHandler(ir_buf)
+            ))
+        {
+            return false;
+        }
+
+        if (false == encode_logtype(logtype, ir_buf)) {
+            return false;
+        }
+
+        // Encode timestamp
+        ir_buf.push_back(cProtocol::Payload::TimestampVal);
+        encode_int(timestamp, ir_buf);
+
+        return true;
+    }
+}  // namespace eight_byte_encoding
+
+namespace four_byte_encoding {
+    bool encode_preamble(
+            string_view timestamp_pattern,
+            string_view timestamp_pattern_syntax,
+            string_view time_zone_id,
+            epoch_time_ms_t reference_timestamp,
+            vector<int8_t>& ir_buf
+    ) {
+        // Write magic number
+        for (auto b : cProtocol::FourByteEncodingMagicNumber) {
+            ir_buf.push_back(b);
+        }
+
+        // Assemble metadata
+        nlohmann::json metadata_json;
+        add_base_metadata_fields(
+                timestamp_pattern,
+                timestamp_pattern_syntax,
+                time_zone_id,
+                metadata_json
+        );
+        metadata_json[cProtocol::Metadata::ReferenceTimestampKey]
+                = std::to_string(reference_timestamp);
+
+        return encode_metadata(metadata_json, ir_buf);
+    }
+
+    bool encode_message(
+            epoch_time_ms_t timestamp_delta,
+            string_view message,
+            string& logtype,
+            vector<int8_t>& ir_buf
+    ) {
+        if (false == encode_message(message, logtype, ir_buf)) {
+            return false;
+        }
+
+        if (false == encode_timestamp(timestamp_delta, ir_buf)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool encode_message(string_view message, string& logtype, vector<int8_t>& ir_buf) {
+        auto encoded_var_handler = [&ir_buf](four_byte_encoded_variable_t encoded_var) {
+            ir_buf.push_back(cProtocol::Payload::VarFourByteEncoding);
+            encode_int(encoded_var, ir_buf);
+        };
+
+        if (false
+            == encode_message_generically<four_byte_encoded_variable_t>(
+                    message,
+                    logtype,
+                    append_constant_to_logtype,
+                    append_final_constant_to_logtype,
+                    encoded_var_handler,
+                    DictionaryVariableHandler(ir_buf)
+            ))
+        {
+            return false;
+        }
+
+        if (false == encode_logtype(logtype, ir_buf)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool encode_timestamp(epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf) {
+        if (INT8_MIN <= timestamp_delta && timestamp_delta <= INT8_MAX) {
+            ir_buf.push_back(cProtocol::Payload::TimestampDeltaByte);
+            ir_buf.push_back(static_cast<int8_t>(timestamp_delta));
+        } else if (INT16_MIN <= timestamp_delta && timestamp_delta <= INT16_MAX) {
+            ir_buf.push_back(cProtocol::Payload::TimestampDeltaShort);
+            encode_int(static_cast<int16_t>(timestamp_delta), ir_buf);
+        } else if (INT32_MIN <= timestamp_delta && timestamp_delta <= INT32_MAX) {
+            ir_buf.push_back(cProtocol::Payload::TimestampDeltaInt);
+            encode_int(static_cast<int32_t>(timestamp_delta), ir_buf);
+        } else {
+            // Delta exceeds maximum representable by an int (24.86 days)
+            return false;
+        }
+
+        return true;
+    }
+}  // namespace four_byte_encoding
+}  // namespace ffi::ir_stream

--- a/components/core/src/ffi/ir_stream/encoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.hpp
@@ -1,85 +1,97 @@
 #ifndef FFI_IR_STREAM_ENCODING_METHODS_HPP
 #define FFI_IR_STREAM_ENCODING_METHODS_HPP
 
-// C++ standard libraries
 #include <string_view>
 #include <vector>
 
-// Project headers
 #include "../encoding_methods.hpp"
 
 namespace ffi::ir_stream {
-    namespace eight_byte_encoding {
-        /**
-         * Encodes the preamble for the eight-byte encoding IR stream
-         * @param timestamp_pattern
-         * @param timestamp_pattern_syntax
-         * @param time_zone_id
-         * @param ir_buf
-         * @return true on success, false otherwise
-         */
-        bool encode_preamble (std::string_view timestamp_pattern,
-                              std::string_view timestamp_pattern_syntax,
-                              std::string_view time_zone_id, std::vector<int8_t>& ir_buf);
+namespace eight_byte_encoding {
+    /**
+     * Encodes the preamble for the eight-byte encoding IR stream
+     * @param timestamp_pattern
+     * @param timestamp_pattern_syntax
+     * @param time_zone_id
+     * @param ir_buf
+     * @return true on success, false otherwise
+     */
+    bool encode_preamble(
+            std::string_view timestamp_pattern,
+            std::string_view timestamp_pattern_syntax,
+            std::string_view time_zone_id,
+            std::vector<int8_t>& ir_buf
+    );
 
-        /**
-         * Encodes the given message into the eight-byte encoding IR stream
-         * @param timestamp
-         * @param message
-         * @param logtype
-         * @param ir_buf
-         * @return true on success, false otherwise
-         */
-        bool encode_message (epoch_time_ms_t timestamp, std::string_view message,
-                             std::string& logtype, std::vector<int8_t>& ir_buf);
-    }
+    /**
+     * Encodes the given message into the eight-byte encoding IR stream
+     * @param timestamp
+     * @param message
+     * @param logtype
+     * @param ir_buf
+     * @return true on success, false otherwise
+     */
+    bool encode_message(
+            epoch_time_ms_t timestamp,
+            std::string_view message,
+            std::string& logtype,
+            std::vector<int8_t>& ir_buf
+    );
+}  // namespace eight_byte_encoding
 
-    namespace four_byte_encoding {
-        /**
-         * Encodes the preamble for the four-byte encoding IR stream
-         * @param timestamp_pattern
-         * @param timestamp_pattern_syntax
-         * @param time_zone_id
-         * @param reference_timestamp
-         * @param ir_buf
-         * @return true on success, false otherwise
-         */
-        bool encode_preamble (std::string_view timestamp_pattern,
-                              std::string_view timestamp_pattern_syntax,
-                              std::string_view time_zone_id, epoch_time_ms_t reference_timestamp,
-                              std::vector<int8_t>& ir_buf);
+namespace four_byte_encoding {
+    /**
+     * Encodes the preamble for the four-byte encoding IR stream
+     * @param timestamp_pattern
+     * @param timestamp_pattern_syntax
+     * @param time_zone_id
+     * @param reference_timestamp
+     * @param ir_buf
+     * @return true on success, false otherwise
+     */
+    bool encode_preamble(
+            std::string_view timestamp_pattern,
+            std::string_view timestamp_pattern_syntax,
+            std::string_view time_zone_id,
+            epoch_time_ms_t reference_timestamp,
+            std::vector<int8_t>& ir_buf
+    );
 
-        /**
-         * Encodes the given message into the four-byte encoding IR stream
-         * @param timestamp_delta
-         * @param message
-         * @param logtype
-         * @param ir_buf
-         * @return true on success, false otherwise
-         */
-        bool encode_message (epoch_time_ms_t timestamp_delta, std::string_view message,
-                             std::string& logtype, std::vector<int8_t>& ir_buf);
+    /**
+     * Encodes the given message into the four-byte encoding IR stream
+     * @param timestamp_delta
+     * @param message
+     * @param logtype
+     * @param ir_buf
+     * @return true on success, false otherwise
+     */
+    bool encode_message(
+            epoch_time_ms_t timestamp_delta,
+            std::string_view message,
+            std::string& logtype,
+            std::vector<int8_t>& ir_buf
+    );
 
-        /**
-         * Encodes the given message into the four-byte encoding IR stream
-         * without encoding timestamp delta
-         * @param message
-         * @param logtype
-         * @param ir_buf
-         * @return true on success, false otherwise
-         */
-        bool encode_message (std::string_view message, std::string& logtype,
-                             std::vector<int8_t>& ir_buf);
+    /**
+     * Encodes the given message into the four-byte encoding IR stream
+     * without encoding timestamp delta
+     * @param message
+     * @param logtype
+     * @param ir_buf
+     * @return true on success, false otherwise
+     */
+    bool
+    encode_message(std::string_view message, std::string& logtype, std::vector<int8_t>& ir_buf);
 
-        /**
-         * Encodes the given timestamp delta into the four-byte encoding IR
-         * stream
-         * @param timestamp_delta
-         * @param ir_buf
-         * @return true on success, false otherwise
-         */
-        bool encode_timestamp (epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf);
-    }
-}
+    /**
+     * Encodes the given timestamp delta into the four-byte encoding IR
+     * stream
+     * @param timestamp_delta
+     * @param ir_buf
+     * @return true on success, false otherwise
+     */
+    bool encode_timestamp(epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf);
+}  // namespace four_byte_encoding
+}  // namespace ffi::ir_stream
 
-#endif //FFI_IR_STREAM_ENCODING_METHODS_HPP
+#endif  // FFI_IR_STREAM_ENCODING_METHODS_HPP

--- a/components/core/src/ffi/ir_stream/encoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.hpp
@@ -73,8 +73,8 @@ namespace four_byte_encoding {
     );
 
     /**
-     * Encodes the given message into the four-byte encoding IR stream
-     * without encoding timestamp delta
+     * Encodes the given message into the four-byte encoding IR stream without
+     * encoding timestamp delta
      * @param message
      * @param logtype
      * @param ir_buf
@@ -84,8 +84,7 @@ namespace four_byte_encoding {
     encode_message(std::string_view message, std::string& logtype, std::vector<int8_t>& ir_buf);
 
     /**
-     * Encodes the given timestamp delta into the four-byte encoding IR
-     * stream
+     * Encodes the given timestamp delta into the four-byte encoding IR stream
      * @param timestamp_delta
      * @param ir_buf
      * @return true on success, false otherwise

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -1,58 +1,55 @@
 #ifndef FFI_IR_STREAM_PROTOCOL_CONSTANTS_HPP
 #define FFI_IR_STREAM_PROTOCOL_CONSTANTS_HPP
 
-// C++ standard libraries
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
 namespace ffi::ir_stream::cProtocol {
-    constexpr int8_t FourByteEncodingMagicNumber[] = {
-            static_cast<int8_t>(0xFD), 0x2F, static_cast<int8_t>(0xB5), 0x29
-    };
-    constexpr int8_t EightByteEncodingMagicNumber[] = {
-            static_cast<int8_t>(0xFD), 0x2F, static_cast<int8_t>(0xB5), 0x30
-    };
-    constexpr std::enable_if<
-            sizeof(EightByteEncodingMagicNumber) == sizeof(FourByteEncodingMagicNumber),
-            size_t
-    >::type MagicNumberLength = sizeof(EightByteEncodingMagicNumber);
-    namespace Metadata {
-        constexpr int8_t EncodingJson = 0x1;
-        constexpr int8_t LengthUByte = 0x11;
-        constexpr int8_t LengthUShort = 0x12;
+namespace Metadata {
+    constexpr int8_t EncodingJson = 0x1;
+    constexpr int8_t LengthUByte = 0x11;
+    constexpr int8_t LengthUShort = 0x12;
 
-        constexpr char VersionKey[] = "VERSION";
-        constexpr char VersionValue[] = "v0.0.0";
+    constexpr char VersionKey[] = "VERSION";
+    constexpr char VersionValue[] = "v0.0.0";
 
-        constexpr char TimestampPatternKey[] = "TIMESTAMP_PATTERN";
-        constexpr char TimestampPatternSyntaxKey[] = "TIMESTAMP_PATTERN_SYNTAX";
-        constexpr char TimeZoneIdKey[] = "TZ_ID";
-        constexpr char ReferenceTimestampKey[] = "REFERENCE_TIMESTAMP";
+    constexpr char TimestampPatternKey[] = "TIMESTAMP_PATTERN";
+    constexpr char TimestampPatternSyntaxKey[] = "TIMESTAMP_PATTERN_SYNTAX";
+    constexpr char TimeZoneIdKey[] = "TZ_ID";
+    constexpr char ReferenceTimestampKey[] = "REFERENCE_TIMESTAMP";
 
-        constexpr char VariablesSchemaIdKey[] = "VARIABLES_SCHEMA_ID";
-        constexpr char VariableEncodingMethodsIdKey[] = "VARIABLE_ENCODING_METHODS_ID";
-    }
+    constexpr char VariablesSchemaIdKey[] = "VARIABLES_SCHEMA_ID";
+    constexpr char VariableEncodingMethodsIdKey[] = "VARIABLE_ENCODING_METHODS_ID";
+}  // namespace Metadata
 
-    namespace Payload {
-        constexpr int8_t VarFourByteEncoding = 0x18;
-        constexpr int8_t VarEightByteEncoding = 0x19;
+namespace Payload {
+    constexpr int8_t VarFourByteEncoding = 0x18;
+    constexpr int8_t VarEightByteEncoding = 0x19;
 
-        constexpr int8_t VarStrLenUByte = 0x11;
-        constexpr int8_t VarStrLenUShort = 0x12;
-        constexpr int8_t VarStrLenInt = 0x13;
+    constexpr int8_t VarStrLenUByte = 0x11;
+    constexpr int8_t VarStrLenUShort = 0x12;
+    constexpr int8_t VarStrLenInt = 0x13;
 
-        constexpr int8_t LogtypeStrLenUByte = 0x21;
-        constexpr int8_t LogtypeStrLenUShort = 0x22;
-        constexpr int8_t LogtypeStrLenInt = 0x23;
+    constexpr int8_t LogtypeStrLenUByte = 0x21;
+    constexpr int8_t LogtypeStrLenUShort = 0x22;
+    constexpr int8_t LogtypeStrLenInt = 0x23;
 
-        constexpr int8_t TimestampVal = 0x30;
-        constexpr int8_t TimestampDeltaByte = 0x31;
-        constexpr int8_t TimestampDeltaShort = 0x32;
-        constexpr int8_t TimestampDeltaInt = 0x33;
-    }
+    constexpr int8_t TimestampVal = 0x30;
+    constexpr int8_t TimestampDeltaByte = 0x31;
+    constexpr int8_t TimestampDeltaShort = 0x32;
+    constexpr int8_t TimestampDeltaInt = 0x33;
+}  // namespace Payload
 
-    constexpr int8_t Eof = 0x0;
-}
+constexpr int8_t FourByteEncodingMagicNumber[]
+        = {static_cast<int8_t>(0xFD), 0x2F, static_cast<int8_t>(0xB5), 0x29};
+constexpr int8_t EightByteEncodingMagicNumber[]
+        = {static_cast<int8_t>(0xFD), 0x2F, static_cast<int8_t>(0xB5), 0x30};
+constexpr std::enable_if<
+        sizeof(EightByteEncodingMagicNumber) == sizeof(FourByteEncodingMagicNumber),
+        size_t>::type MagicNumberLength
+        = sizeof(EightByteEncodingMagicNumber);
+constexpr int8_t Eof = 0x0;
+}  // namespace ffi::ir_stream::cProtocol
 
-#endif // FFI_IR_STREAM_PROTOCOL_CONSTANTS_HPP
+#endif  // FFI_IR_STREAM_PROTOCOL_CONSTANTS_HPP

--- a/components/core/src/ffi/search/CompositeWildcardToken.cpp
+++ b/components/core/src/ffi/search/CompositeWildcardToken.cpp
@@ -111,8 +111,8 @@ bool CompositeWildcardToken<encoded_variable_t>::generate_next_interpretation() 
 }
 
 /**
- * To turn a CompositeWildcardToken into ExactVariableTokens and
- * WildcardTokens, we use the following algorithm.
+ * To turn a CompositeWildcardToken into ExactVariableTokens and WildcardTokens,
+ * we use the following algorithm.
  *
  * Glossary:
  * - "token" - either an ExactVariableToken or a WildcardToken.

--- a/components/core/src/ffi/search/CompositeWildcardToken.cpp
+++ b/components/core/src/ffi/search/CompositeWildcardToken.cpp
@@ -60,14 +60,15 @@ void CompositeWildcardToken<encoded_variable_t>::add_to_query(
         }
         std::visit(
                 overloaded{
-                        [&logtype_query,
-                         &variable_tokens](ExactVariableToken<encoded_variable_t> const& exact_var
-                        ) {
+                        [&logtype_query, &variable_tokens](  // clang-format off
+                                ExactVariableToken<encoded_variable_t> const& exact_var
+                        ) {  // clang-format on
                             exact_var.add_to_logtype_query(logtype_query);
                             variable_tokens.emplace_back(exact_var);
                         },
-                        [&logtype_query,
-                         &variable_tokens](WildcardToken<encoded_variable_t> const& wildcard_var) {
+                        [&logtype_query, &variable_tokens](  // clang-format off
+                                WildcardToken<encoded_variable_t> const& wildcard_var
+                        ) {  // clang-format on
                             if (wildcard_var.add_to_logtype_query(logtype_query)) {
                                 variable_tokens.emplace_back(wildcard_var);
                             }

--- a/components/core/src/ffi/search/CompositeWildcardToken.cpp
+++ b/components/core/src/ffi/search/CompositeWildcardToken.cpp
@@ -6,258 +6,270 @@ using std::variant;
 using std::vector;
 
 namespace ffi::search {
-    static auto TokenGetBeginPos = [] (const auto& token) { return token.get_begin_pos(); };
-    static auto TokenGetEndPos = [] (const auto& token) { return token.get_end_pos(); };
+static auto TokenGetBeginPos = [](auto const& token) { return token.get_begin_pos(); };
+static auto TokenGetEndPos = [](auto const& token) { return token.get_end_pos(); };
 
-    template <typename encoded_variable_t>
-    CompositeWildcardToken<encoded_variable_t>::CompositeWildcardToken (
-            string_view query, size_t begin_pos, size_t end_pos
-    ) : QueryToken(query, begin_pos, end_pos) {
-        // Find wildcards
-        bool is_escaped = false;
-        for (size_t i = begin_pos; i < end_pos; ++i) {
-            auto c = query[i];
+template <typename encoded_variable_t>
+CompositeWildcardToken<encoded_variable_t>::CompositeWildcardToken(
+        string_view query,
+        size_t begin_pos,
+        size_t end_pos
+)
+        : QueryToken(query, begin_pos, end_pos) {
+    // Find wildcards
+    bool is_escaped = false;
+    for (size_t i = begin_pos; i < end_pos; ++i) {
+        auto c = query[i];
 
-            if (is_escaped) {
-                is_escaped = false;
-            } else if ('\\' == c) {
-                is_escaped = true;
-            } else if (is_wildcard(c)) {
-                m_wildcards.emplace_back(c, i, begin_pos == i || end_pos - 1 == i);
-            }
+        if (is_escaped) {
+            is_escaped = false;
+        } else if ('\\' == c) {
+            is_escaped = true;
+        } else if (is_wildcard(c)) {
+            m_wildcards.emplace_back(c, i, begin_pos == i || end_pos - 1 == i);
         }
-        if (m_wildcards.empty()) {
-            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-        }
-
-        tokenize_into_wildcard_variable_tokens();
+    }
+    if (m_wildcards.empty()) {
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
     }
 
-    template <typename encoded_variable_t>
-    void CompositeWildcardToken<encoded_variable_t>::add_to_query (
-            string& logtype_query,
-            vector<variant<ExactVariableToken<encoded_variable_t>,
-                    WildcardToken<encoded_variable_t>>>& variable_tokens
-    ) const {
-        // We need to handle '*' carefully when building the logtype query since
-        // we may have a token like "a1*b2" with interpretation ["a1*", "*b2"].
-        // In this case, we want to make sure the logtype query only ends up
-        // with one '*' rather than one for the suffix of "a1*" and one for the
-        // prefix of "*b2". So the algorithm below only adds a '*' to the
-        // logtype query if the current variable has a prefix '*' (i.e., we
-        // ignore suffix '*'). Then after the loop, if the last variable had a
-        // suffix '*', we add a '*' to the logtype query before adding any
-        // remaining query content.
-        auto constant_begin_pos = m_begin_pos;
-        for (const auto& var : m_variables) {
-            auto begin_pos = std::visit(TokenGetBeginPos, var);
-            // Copy from the end of the last variable to the beginning of this
-            // one (if this wildcard variable doesn't overlap with the previous
-            // one)
-            if (begin_pos > constant_begin_pos) {
-                logtype_query.append(m_query, constant_begin_pos, begin_pos - constant_begin_pos);
-            }
-            std::visit(overloaded{
-                    [&logtype_query, &variable_tokens] (
-                            const ExactVariableToken<encoded_variable_t>& exact_var
-                    ) {
-                        exact_var.add_to_logtype_query(logtype_query);
-                        variable_tokens.emplace_back(exact_var);
-                    },
-                    [&logtype_query, &variable_tokens] (
-                            const WildcardToken<encoded_variable_t>& wildcard_var
-                    ) {
-                        if (wildcard_var.add_to_logtype_query(logtype_query)) {
-                            variable_tokens.emplace_back(wildcard_var);
-                        }
-                    }
-            }, var);
-            constant_begin_pos = std::visit(TokenGetEndPos, var);
+    tokenize_into_wildcard_variable_tokens();
+}
+
+template <typename encoded_variable_t>
+void CompositeWildcardToken<encoded_variable_t>::add_to_query(
+        string& logtype_query,
+        vector<variant<ExactVariableToken<encoded_variable_t>, WildcardToken<encoded_variable_t>>>&
+                variable_tokens
+) const {
+    // We need to handle '*' carefully when building the logtype query since
+    // we may have a token like "a1*b2" with interpretation ["a1*", "*b2"].
+    // In this case, we want to make sure the logtype query only ends up
+    // with one '*' rather than one for the suffix of "a1*" and one for the
+    // prefix of "*b2". So the algorithm below only adds a '*' to the
+    // logtype query if the current variable has a prefix '*' (i.e., we
+    // ignore suffix '*'). Then after the loop, if the last variable had a
+    // suffix '*', we add a '*' to the logtype query before adding any
+    // remaining query content.
+    auto constant_begin_pos = m_begin_pos;
+    for (auto const& var : m_variables) {
+        auto begin_pos = std::visit(TokenGetBeginPos, var);
+        // Copy from the end of the last variable to the beginning of this
+        // one (if this wildcard variable doesn't overlap with the previous
+        // one)
+        if (begin_pos > constant_begin_pos) {
+            logtype_query.append(m_query, constant_begin_pos, begin_pos - constant_begin_pos);
         }
-        // Add the remainder
-        if (false == m_variables.empty()) {
-            const auto& last_var = m_variables.back();
-            if (std::holds_alternative<WildcardToken<encoded_variable_t>>(last_var)) {
-                const auto& wildcard_var =
-                        std::get<WildcardToken<encoded_variable_t>>(last_var);
-                if (wildcard_var.has_suffix_star_wildcard()) {
-                    logtype_query += enum_to_underlying_type(WildcardType::ZeroOrMoreChars);
-                }
-            }
-        }
-        logtype_query.append(m_query, constant_begin_pos, m_end_pos - constant_begin_pos);
+        std::visit(
+                overloaded{
+                        [&logtype_query,
+                         &variable_tokens](ExactVariableToken<encoded_variable_t> const& exact_var
+                        ) {
+                            exact_var.add_to_logtype_query(logtype_query);
+                            variable_tokens.emplace_back(exact_var);
+                        },
+                        [&logtype_query,
+                         &variable_tokens](WildcardToken<encoded_variable_t> const& wildcard_var) {
+                            if (wildcard_var.add_to_logtype_query(logtype_query)) {
+                                variable_tokens.emplace_back(wildcard_var);
+                            }
+                        }},
+                var
+        );
+        constant_begin_pos = std::visit(TokenGetEndPos, var);
     }
-
-    template <typename encoded_variable_t>
-    bool CompositeWildcardToken<encoded_variable_t>::generate_next_interpretation () {
-        for (auto& v : m_variables) {
-            if (std::holds_alternative<WildcardToken<encoded_variable_t>>(v)) {
-                auto& wildcard_var = std::get<WildcardToken<encoded_variable_t>>(v);
-                if (wildcard_var.next_interpretation()) {
-                    return true;
-                }
+    // Add the remainder
+    if (false == m_variables.empty()) {
+        auto const& last_var = m_variables.back();
+        if (std::holds_alternative<WildcardToken<encoded_variable_t>>(last_var)) {
+            auto const& wildcard_var = std::get<WildcardToken<encoded_variable_t>>(last_var);
+            if (wildcard_var.has_suffix_star_wildcard()) {
+                logtype_query += enum_to_underlying_type(WildcardType::ZeroOrMoreChars);
             }
         }
+    }
+    logtype_query.append(m_query, constant_begin_pos, m_end_pos - constant_begin_pos);
+}
 
-        for (auto& w : m_wildcards) {
-            if (w.next_interpretation()) {
-                tokenize_into_wildcard_variable_tokens();
+template <typename encoded_variable_t>
+bool CompositeWildcardToken<encoded_variable_t>::generate_next_interpretation() {
+    for (auto& v : m_variables) {
+        if (std::holds_alternative<WildcardToken<encoded_variable_t>>(v)) {
+            auto& wildcard_var = std::get<WildcardToken<encoded_variable_t>>(v);
+            if (wildcard_var.next_interpretation()) {
                 return true;
             }
         }
-
-        return false;
     }
 
-    /**
-     * To turn a CompositeWildcardToken into ExactVariableTokens and
-     * WildcardTokens, we use the following algorithm.
-     *
-     * Glossary:
-     * - "token" - either an ExactVariableToken or a WildcardToken.
-     * - "delimiter-wildcard" - a wildcard that is interpreted as matching
-     *   delimiters.
-     *
-     * Overview:
-     * - Each '*' at the edge of a token has one interpretation:
-     *   1. matching a combination of non-delimiters and delimiters.
-     * - Every other '*' has two interpretations:
-     *   1. matching a combination of non-delimiters and delimiters, or
-     *   2. only matching non-delimiters.
-     * - Each '?' has two interpretations:
-     *   1. matching a non-delimiter, or
-     *   2. matching a delimiter.
-     * - When tokenizing a CompositeWildcardToken, if none of its wildcards can
-     *   match a delimiter, then the interpretation is simply the entire
-     *   CompositeWildcardToken.
-     * - However, if one of the wildcards can match a delimiter, then the
-     *   CompositeWildcardToken splits into two tokens at the delimiter.
-     * - Finally, if a WildcardToken is delimited by a '*'-delimiter-wildcard,
-     *   then the '*' should be included in the WildcardToken (see the
-     *   generalization in README.md).
-     *
-     * Algorithm:
-     * - To implement this algorithm, we need to search the
-     *   CompositeWildcardToken for every substring bounded by
-     *   wildcard-delimiters.
-     * - For example, consider the CompositeWildcardToken "abc*def?ghi?123" and
-     *   assume all wildcards are delimiter-wildcards:
-     *   - The first token will be a WildcardToken, "abc*" (note that the '*' is
-     *     included).
-     *   - The second token will be a WildcardToken, "*def" (note that the '*' is
-     *     included again).
-     *   - The third substring will be static text, "ghi". Since this is neither
-     *     a WildcardText nor an ExactVariableToken, it will be ignored.
-     *   - The fourth token will be an ExactVariableToken, "123".
-     * - If instead only the first '?' is interpreted as matching a delimiter,
-     *   then the tokens will be ["*abc*def", "ghi?123"].
-     *
-     * NOTE: We could cache wildcard variables that we generate (using their
-     * bounds in the query as the cache key) so that we don't end up
-     * regenerating them in other tokenizations. This isn't a performance
-     * problem now, but could be an issue if we need to search the variable
-     * dictionary for each generated WildcardToken.
-     */
-    template <typename encoded_variable_t>
-    void CompositeWildcardToken<encoded_variable_t>::tokenize_into_wildcard_variable_tokens ()  {
-        m_variables.clear();
+    for (auto& w : m_wildcards) {
+        if (w.next_interpretation()) {
+            tokenize_into_wildcard_variable_tokens();
+            return true;
+        }
+    }
 
-        const QueryWildcard* last_wildcard = nullptr;
-        bool wildcard_in_var = false;
-        size_t var_begin_pos, var_end_pos;
-        for (const auto& w : m_wildcards) {
-            switch (w.get_current_interpretation()) {
-                case WildcardInterpretation::NoDelimiters:
-                    wildcard_in_var = true;
-                    break;
-                case WildcardInterpretation::ContainsDelimiters: {
-                    auto wildcard_pos = w.get_pos_in_query();
-                    if (wildcard_pos == m_begin_pos) {
-                        last_wildcard = &w;
-                        // Nothing to do yet since wildcard is at the beginning
-                        // of the token
-                        continue;
-                    }
+    return false;
+}
 
-                    // Determine var_begin_pos
-                    if (nullptr == last_wildcard) {
-                        var_begin_pos = m_begin_pos;
-                    } else {
-                        if (WildcardType::ZeroOrMoreChars == last_wildcard->get_type()) {
-                            // Include the wildcard in the token
-                            var_begin_pos = last_wildcard->get_pos_in_query();
-                            wildcard_in_var = true;
-                        } else {
-                            // Token starts after the wildcard
-                            var_begin_pos = last_wildcard->get_pos_in_query() + 1;
-                        }
-                    }
+/**
+ * To turn a CompositeWildcardToken into ExactVariableTokens and
+ * WildcardTokens, we use the following algorithm.
+ *
+ * Glossary:
+ * - "token" - either an ExactVariableToken or a WildcardToken.
+ * - "delimiter-wildcard" - a wildcard that is interpreted as matching
+ *   delimiters.
+ *
+ * Overview:
+ * - Each '*' at the edge of a token has one interpretation:
+ *   1. matching a combination of non-delimiters and delimiters.
+ * - Every other '*' has two interpretations:
+ *   1. matching a combination of non-delimiters and delimiters, or
+ *   2. only matching non-delimiters.
+ * - Each '?' has two interpretations:
+ *   1. matching a non-delimiter, or
+ *   2. matching a delimiter.
+ * - When tokenizing a CompositeWildcardToken, if none of its wildcards can
+ *   match a delimiter, then the interpretation is simply the entire
+ *   CompositeWildcardToken.
+ * - However, if one of the wildcards can match a delimiter, then the
+ *   CompositeWildcardToken splits into two tokens at the delimiter.
+ * - Finally, if a WildcardToken is delimited by a '*'-delimiter-wildcard,
+ *   then the '*' should be included in the WildcardToken (see the
+ *   generalization in README.md).
+ *
+ * Algorithm:
+ * - To implement this algorithm, we need to search the
+ *   CompositeWildcardToken for every substring bounded by
+ *   wildcard-delimiters.
+ * - For example, consider the CompositeWildcardToken "abc*def?ghi?123" and
+ *   assume all wildcards are delimiter-wildcards:
+ *   - The first token will be a WildcardToken, "abc*" (note that the '*' is
+ *     included).
+ *   - The second token will be a WildcardToken, "*def" (note that the '*' is
+ *     included again).
+ *   - The third substring will be static text, "ghi". Since this is neither
+ *     a WildcardText nor an ExactVariableToken, it will be ignored.
+ *   - The fourth token will be an ExactVariableToken, "123".
+ * - If instead only the first '?' is interpreted as matching a delimiter,
+ *   then the tokens will be ["*abc*def", "ghi?123"].
+ *
+ * NOTE: We could cache wildcard variables that we generate (using their
+ * bounds in the query as the cache key) so that we don't end up
+ * regenerating them in other tokenizations. This isn't a performance
+ * problem now, but could be an issue if we need to search the variable
+ * dictionary for each generated WildcardToken.
+ */
+template <typename encoded_variable_t>
+void CompositeWildcardToken<encoded_variable_t>::tokenize_into_wildcard_variable_tokens() {
+    m_variables.clear();
 
-                    // Determine var_end_pos
-                    if (WildcardType::ZeroOrMoreChars == w.get_type()) {
+    QueryWildcard const* last_wildcard = nullptr;
+    bool wildcard_in_var = false;
+    size_t var_begin_pos, var_end_pos;
+    for (auto const& w : m_wildcards) {
+        switch (w.get_current_interpretation()) {
+            case WildcardInterpretation::NoDelimiters:
+                wildcard_in_var = true;
+                break;
+            case WildcardInterpretation::ContainsDelimiters: {
+                auto wildcard_pos = w.get_pos_in_query();
+                if (wildcard_pos == m_begin_pos) {
+                    last_wildcard = &w;
+                    // Nothing to do yet since wildcard is at the beginning
+                    // of the token
+                    continue;
+                }
+
+                // Determine var_begin_pos
+                if (nullptr == last_wildcard) {
+                    var_begin_pos = m_begin_pos;
+                } else {
+                    if (WildcardType::ZeroOrMoreChars == last_wildcard->get_type()) {
                         // Include the wildcard in the token
-                        var_end_pos = wildcard_pos + 1;
+                        var_begin_pos = last_wildcard->get_pos_in_query();
                         wildcard_in_var = true;
                     } else {
-                        // Token ends before the wildcard
-                        var_end_pos = wildcard_pos;
+                        // Token starts after the wildcard
+                        var_begin_pos = last_wildcard->get_pos_in_query() + 1;
                     }
-
-                    try_add_wildcard_variable(var_begin_pos, var_end_pos, wildcard_in_var);
-
-                    last_wildcard = &w;
-                    wildcard_in_var = false;
-                    break;
                 }
-                default:
-                    throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+
+                // Determine var_end_pos
+                if (WildcardType::ZeroOrMoreChars == w.get_type()) {
+                    // Include the wildcard in the token
+                    var_end_pos = wildcard_pos + 1;
+                    wildcard_in_var = true;
+                } else {
+                    // Token ends before the wildcard
+                    var_end_pos = wildcard_pos;
+                }
+
+                try_add_wildcard_variable(var_begin_pos, var_end_pos, wildcard_in_var);
+
+                last_wildcard = &w;
+                wildcard_in_var = false;
+                break;
             }
-        }
-
-        if (nullptr == last_wildcard) {
-            // NOTE: Since the token contains a wildcard (this is the
-            // CompositeWildcardToken class), there's no way this could be an
-            // ExactVariableToken
-            m_variables.emplace_back(
-                    std::in_place_type<WildcardToken<encoded_variable_t>>, m_query,
-                    m_begin_pos, m_end_pos);
-        } else if (last_wildcard->get_pos_in_query() < m_end_pos - 1) {
-            if (WildcardType::ZeroOrMoreChars == last_wildcard->get_type()) {
-                // Include the wildcard in the token
-                var_begin_pos = last_wildcard->get_pos_in_query();
-                wildcard_in_var = true;
-            } else {
-                var_begin_pos = last_wildcard->get_pos_in_query() + 1;
-            }
-
-            var_end_pos = m_end_pos;
-
-            try_add_wildcard_variable(var_begin_pos, var_end_pos, wildcard_in_var);
+            default:
+                throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
         }
     }
 
-    template <typename encoded_variable_t>
-    void CompositeWildcardToken<encoded_variable_t>::try_add_wildcard_variable (
-            size_t begin_pos, size_t end_pos, bool wildcard_in_token
-    ) {
-        if (wildcard_in_token) {
-            m_variables.emplace_back(
-                    std::in_place_type<WildcardToken<encoded_variable_t>>,
-                    m_query, begin_pos, end_pos
-            );
+    if (nullptr == last_wildcard) {
+        // NOTE: Since the token contains a wildcard (this is the
+        // CompositeWildcardToken class), there's no way this could be an
+        // ExactVariableToken
+        m_variables.emplace_back(
+                std::in_place_type<WildcardToken<encoded_variable_t>>,
+                m_query,
+                m_begin_pos,
+                m_end_pos
+        );
+    } else if (last_wildcard->get_pos_in_query() < m_end_pos - 1) {
+        if (WildcardType::ZeroOrMoreChars == last_wildcard->get_type()) {
+            // Include the wildcard in the token
+            var_begin_pos = last_wildcard->get_pos_in_query();
+            wildcard_in_var = true;
         } else {
-            string_view var(m_query.cbegin() + begin_pos, end_pos - begin_pos);
-            if (is_var(var)) {
-                m_variables.emplace_back(
-                        std::in_place_type<ExactVariableToken<encoded_variable_t>>,
-                        m_query, begin_pos, end_pos
-                );
-            }
+            var_begin_pos = last_wildcard->get_pos_in_query() + 1;
+        }
+
+        var_end_pos = m_end_pos;
+
+        try_add_wildcard_variable(var_begin_pos, var_end_pos, wildcard_in_var);
+    }
+}
+
+template <typename encoded_variable_t>
+void CompositeWildcardToken<encoded_variable_t>::try_add_wildcard_variable(
+        size_t begin_pos,
+        size_t end_pos,
+        bool wildcard_in_token
+) {
+    if (wildcard_in_token) {
+        m_variables.emplace_back(
+                std::in_place_type<WildcardToken<encoded_variable_t>>,
+                m_query,
+                begin_pos,
+                end_pos
+        );
+    } else {
+        string_view var(m_query.cbegin() + begin_pos, end_pos - begin_pos);
+        if (is_var(var)) {
+            m_variables.emplace_back(
+                    std::in_place_type<ExactVariableToken<encoded_variable_t>>,
+                    m_query,
+                    begin_pos,
+                    end_pos
+            );
         }
     }
-
-    // Explicitly declare specializations to avoid having to validate that the
-    // template parameters are supported
-    template class ffi::search::CompositeWildcardToken<ffi::eight_byte_encoded_variable_t>;
-    template class ffi::search::CompositeWildcardToken<ffi::four_byte_encoded_variable_t>;
 }
+
+// Explicitly declare specializations to avoid having to validate that the
+// template parameters are supported
+template class ffi::search::CompositeWildcardToken<ffi::eight_byte_encoded_variable_t>;
+template class ffi::search::CompositeWildcardToken<ffi::four_byte_encoded_variable_t>;
+}  // namespace ffi::search

--- a/components/core/src/ffi/search/CompositeWildcardToken.cpp
+++ b/components/core/src/ffi/search/CompositeWildcardToken.cpp
@@ -42,21 +42,19 @@ void CompositeWildcardToken<encoded_variable_t>::add_to_query(
         vector<variant<ExactVariableToken<encoded_variable_t>, WildcardToken<encoded_variable_t>>>&
                 variable_tokens
 ) const {
-    // We need to handle '*' carefully when building the logtype query since
-    // we may have a token like "a1*b2" with interpretation ["a1*", "*b2"].
-    // In this case, we want to make sure the logtype query only ends up
-    // with one '*' rather than one for the suffix of "a1*" and one for the
-    // prefix of "*b2". So the algorithm below only adds a '*' to the
-    // logtype query if the current variable has a prefix '*' (i.e., we
-    // ignore suffix '*'). Then after the loop, if the last variable had a
-    // suffix '*', we add a '*' to the logtype query before adding any
-    // remaining query content.
+    // We need to handle '*' carefully when building the logtype query since we
+    // may have a token like "a1*b2" with interpretation ["a1*", "*b2"]. In this
+    // case, we want to make sure the logtype query only ends up with one '*'
+    // rather than one for the suffix of "a1*" and one for the prefix of "*b2".
+    // So the algorithm below only adds a '*' to the logtype query if the
+    // current variable has a prefix '*' (i.e., we ignore suffix '*'). Then
+    // after the loop, if the last variable had a suffix '*', we add a '*' to
+    // the logtype query before adding any remaining query content.
     auto constant_begin_pos = m_begin_pos;
     for (auto const& var : m_variables) {
         auto begin_pos = std::visit(TokenGetBeginPos, var);
-        // Copy from the end of the last variable to the beginning of this
-        // one (if this wildcard variable doesn't overlap with the previous
-        // one)
+        // Copy from the end of the last variable to the beginning of this one
+        // (if this wildcard variable doesn't overlap with the previous one)
         if (begin_pos > constant_begin_pos) {
             logtype_query.append(m_query, constant_begin_pos, begin_pos - constant_begin_pos);
         }
@@ -155,11 +153,11 @@ bool CompositeWildcardToken<encoded_variable_t>::generate_next_interpretation() 
  * - If instead only the first '?' is interpreted as matching a delimiter,
  *   then the tokens will be ["*abc*def", "ghi?123"].
  *
- * NOTE: We could cache wildcard variables that we generate (using their
- * bounds in the query as the cache key) so that we don't end up
- * regenerating them in other tokenizations. This isn't a performance
- * problem now, but could be an issue if we need to search the variable
- * dictionary for each generated WildcardToken.
+ * NOTE: We could cache wildcard variables that we generate (using their bounds
+ * in the query as the cache key) so that we don't end up regenerating them in
+ * other tokenizations. This isn't a performance problem now, but could be an
+ * issue if we need to search the variable dictionary for each generated
+ * WildcardToken.
  */
 template <typename encoded_variable_t>
 void CompositeWildcardToken<encoded_variable_t>::tokenize_into_wildcard_variable_tokens() {
@@ -177,8 +175,8 @@ void CompositeWildcardToken<encoded_variable_t>::tokenize_into_wildcard_variable
                 auto wildcard_pos = w.get_pos_in_query();
                 if (wildcard_pos == m_begin_pos) {
                     last_wildcard = &w;
-                    // Nothing to do yet since wildcard is at the beginning
-                    // of the token
+                    // Nothing to do yet since wildcard is at the beginning of
+                    // the token
                     continue;
                 }
 

--- a/components/core/src/ffi/search/CompositeWildcardToken.hpp
+++ b/components/core/src/ffi/search/CompositeWildcardToken.hpp
@@ -13,18 +13,18 @@
 namespace ffi::search {
 /**
  * A token delimited by delimiters and non-wildcards. Note that the original
- * query string is stored by reference, so it must remain valid while the
- * token exists.
+ * query string is stored by reference, so it must remain valid while the token
+ * exists.
  * <br>
  * For instance, in the query "var:*abc?def*", "*abc?def*" would be a
- * CompositeWildcardToken. This is different from a WildcardToken which can
- * be delimited by wildcards. For instance, "*abc" could be a
- * WildcardToken, where it's delimited by '?' (on the right).
+ * CompositeWildcardToken. This is different from a WildcardToken which can be
+ * delimited by wildcards. For instance, "*abc" could be a WildcardToken, where
+ * it's delimited by '?' (on the right).
  * <br>
- * By interpreting wildcards (as matching delimiters/non-delimiters) within
- * a CompositeWildcardToken and then tokenizing the CompositeWildcardToken's
- * value, we can generate ExactVariableTokens and WildcardTokens. That's
- * why this is called a CompositeWildcardToken.
+ * By interpreting wildcards (as matching delimiters/non-delimiters) within a
+ * CompositeWildcardToken and then tokenizing the CompositeWildcardToken's
+ * value, we can generate ExactVariableTokens and WildcardTokens. That's why
+ * this is called a CompositeWildcardToken.
  * @tparam encoded_variable_t Type for encoded variable values
  */
 template <typename encoded_variable_t>
@@ -48,8 +48,8 @@ public:
 
     // Methods
     /**
-     * Populates the logtype query and @p variable_tokens based on the
-     * current interpretation of wildcards and WildcardTokens
+     * Populates the logtype query and @p variable_tokens based on the current
+     * interpretation of wildcards and WildcardTokens
      * @param logtype_query
      * @param variable_tokens
      */
@@ -75,9 +75,9 @@ private:
      */
     void tokenize_into_wildcard_variable_tokens();
     /**
-     * Adds the token given by the string bounds to the vector of variables,
-     * iff the token contains a wildcard (and so could be a variable) or the
-     * token is indeed a variable.
+     * Adds the token given by the string bounds to the vector of variables, iff
+     * the token contains a wildcard (and so could be a variable) or the token
+     * is indeed a variable.
      * @param begin_pos
      * @param end_pos
      * @param wildcard_in_token

--- a/components/core/src/ffi/search/CompositeWildcardToken.hpp
+++ b/components/core/src/ffi/search/CompositeWildcardToken.hpp
@@ -1,95 +1,95 @@
 #ifndef FFI_SEARCH_COMPOSITEWILDCARDTOKEN_HPP
 #define FFI_SEARCH_COMPOSITEWILDCARDTOKEN_HPP
 
-// C++ standard libraries
 #include <string_view>
 #include <variant>
 #include <vector>
 
-// Project headers
 #include "ExactVariableToken.hpp"
 #include "QueryToken.hpp"
 #include "QueryWildcard.hpp"
 #include "WildcardToken.hpp"
 
 namespace ffi::search {
-    /**
-     * A token delimited by delimiters and non-wildcards. Note that the original
-     * query string is stored by reference, so it must remain valid while the
-     * token exists.
-     * <br>
-     * For instance, in the query "var:*abc?def*", "*abc?def*" would be a
-     * CompositeWildcardToken. This is different from a WildcardToken which can
-     * be delimited by wildcards. For instance, "*abc" could be a
-     * WildcardToken, where it's delimited by '?' (on the right).
-     * <br>
-     * By interpreting wildcards (as matching delimiters/non-delimiters) within
-     * a CompositeWildcardToken and then tokenizing the CompositeWildcardToken's
-     * value, we can generate ExactVariableTokens and WildcardTokens. That's
-     * why this is called a CompositeWildcardToken.
-     * @tparam encoded_variable_t Type for encoded variable values
-     */
-    template <typename encoded_variable_t>
-    class CompositeWildcardToken : public QueryToken {
+/**
+ * A token delimited by delimiters and non-wildcards. Note that the original
+ * query string is stored by reference, so it must remain valid while the
+ * token exists.
+ * <br>
+ * For instance, in the query "var:*abc?def*", "*abc?def*" would be a
+ * CompositeWildcardToken. This is different from a WildcardToken which can
+ * be delimited by wildcards. For instance, "*abc" could be a
+ * WildcardToken, where it's delimited by '?' (on the right).
+ * <br>
+ * By interpreting wildcards (as matching delimiters/non-delimiters) within
+ * a CompositeWildcardToken and then tokenizing the CompositeWildcardToken's
+ * value, we can generate ExactVariableTokens and WildcardTokens. That's
+ * why this is called a CompositeWildcardToken.
+ * @tparam encoded_variable_t Type for encoded variable values
+ */
+template <typename encoded_variable_t>
+class CompositeWildcardToken : public QueryToken {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed (ErrorCode error_code, const char* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            [[nodiscard]] const char* what () const noexcept override {
-                return "ffi::search::CompositeWildcardToken operation failed";
-            }
-        };
-
         // Constructors
-        CompositeWildcardToken (std::string_view query, size_t begin_pos, size_t end_pos);
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /**
-         * Populates the logtype query and @p variable_tokens based on the
-         * current interpretation of wildcards and WildcardTokens
-         * @param logtype_query
-         * @param variable_tokens
-         */
-        void add_to_query (
-                std::string& logtype_query,
-                std::vector<std::variant<ExactVariableToken<encoded_variable_t>,
-                        WildcardToken<encoded_variable_t>>>& variable_tokens
-        ) const;
-
-        /**
-         * Generates the next interpretation of this token
-         * @return true if there was another interpretation to advance to
-         * @return false if we overflowed to the first interpretation
-         */
-        bool generate_next_interpretation ();
-
-    private:
-        // Methods
-        /**
-         * Tokenizes this CompositeWildcardToken into ExactVariableTokens and
-         * WildcardTokens based on the current interpretation of wildcards
-         */
-        void tokenize_into_wildcard_variable_tokens ();
-        /**
-         * Adds the token given by the string bounds to the vector of variables,
-         * iff the token contains a wildcard (and so could be a variable) or the
-         * token is indeed a variable.
-         * @param begin_pos
-         * @param end_pos
-         * @param wildcard_in_token
-         */
-        void try_add_wildcard_variable (size_t begin_pos, size_t end_pos, bool wildcard_in_token);
-
-        // Variables
-        std::vector<QueryWildcard> m_wildcards;
-        std::vector<std::variant<ExactVariableToken<encoded_variable_t>,
-                WildcardToken<encoded_variable_t>>> m_variables;
+        [[nodiscard]] char const* what() const noexcept override {
+            return "ffi::search::CompositeWildcardToken operation failed";
+        }
     };
-}
 
-#endif // FFI_SEARCH_COMPOSITEWILDCARDTOKEN_HPP
+    // Constructors
+    CompositeWildcardToken(std::string_view query, size_t begin_pos, size_t end_pos);
+
+    // Methods
+    /**
+     * Populates the logtype query and @p variable_tokens based on the
+     * current interpretation of wildcards and WildcardTokens
+     * @param logtype_query
+     * @param variable_tokens
+     */
+    void add_to_query(
+            std::string& logtype_query,
+            std::vector<std::variant<
+                    ExactVariableToken<encoded_variable_t>,
+                    WildcardToken<encoded_variable_t>>>& variable_tokens
+    ) const;
+
+    /**
+     * Generates the next interpretation of this token
+     * @return true if there was another interpretation to advance to
+     * @return false if we overflowed to the first interpretation
+     */
+    bool generate_next_interpretation();
+
+private:
+    // Methods
+    /**
+     * Tokenizes this CompositeWildcardToken into ExactVariableTokens and
+     * WildcardTokens based on the current interpretation of wildcards
+     */
+    void tokenize_into_wildcard_variable_tokens();
+    /**
+     * Adds the token given by the string bounds to the vector of variables,
+     * iff the token contains a wildcard (and so could be a variable) or the
+     * token is indeed a variable.
+     * @param begin_pos
+     * @param end_pos
+     * @param wildcard_in_token
+     */
+    void try_add_wildcard_variable(size_t begin_pos, size_t end_pos, bool wildcard_in_token);
+
+    // Variables
+    std::vector<QueryWildcard> m_wildcards;
+    std::vector<
+            std::variant<ExactVariableToken<encoded_variable_t>, WildcardToken<encoded_variable_t>>>
+            m_variables;
+};
+}  // namespace ffi::search
+
+#endif  // FFI_SEARCH_COMPOSITEWILDCARDTOKEN_HPP

--- a/components/core/src/ffi/search/ExactVariableToken.cpp
+++ b/components/core/src/ffi/search/ExactVariableToken.cpp
@@ -3,26 +3,29 @@
 using std::string_view;
 
 namespace ffi::search {
-    template <typename encoded_variable_t>
-    ExactVariableToken<encoded_variable_t>::ExactVariableToken (
-            string_view query, size_t begin_pos, size_t end_pos
-    ) : QueryToken(query, begin_pos, end_pos) {
-        auto token = query.substr(begin_pos, end_pos - begin_pos);
-        if (encode_float_string(token, m_encoded_value)) {
-            m_type = TokenType::FloatVariable;
-            m_placeholder = VariablePlaceholder::Float;
-        } else if (encode_integer_string(token, m_encoded_value)) {
-            m_type = TokenType::IntegerVariable;
-            m_placeholder = VariablePlaceholder::Integer;
-        } else {
-            m_type = TokenType::DictionaryVariable;
-            m_placeholder = VariablePlaceholder::Dictionary;
-            m_encoded_value = 0;
-        }
+template <typename encoded_variable_t>
+ExactVariableToken<encoded_variable_t>::ExactVariableToken(
+        string_view query,
+        size_t begin_pos,
+        size_t end_pos
+)
+        : QueryToken(query, begin_pos, end_pos) {
+    auto token = query.substr(begin_pos, end_pos - begin_pos);
+    if (encode_float_string(token, m_encoded_value)) {
+        m_type = TokenType::FloatVariable;
+        m_placeholder = VariablePlaceholder::Float;
+    } else if (encode_integer_string(token, m_encoded_value)) {
+        m_type = TokenType::IntegerVariable;
+        m_placeholder = VariablePlaceholder::Integer;
+    } else {
+        m_type = TokenType::DictionaryVariable;
+        m_placeholder = VariablePlaceholder::Dictionary;
+        m_encoded_value = 0;
     }
-
-    // Explicitly declare specializations to avoid having to validate that the
-    // template parameters are supported
-    template class ExactVariableToken<ffi::eight_byte_encoded_variable_t>;
-    template class ExactVariableToken<ffi::four_byte_encoded_variable_t>;
 }
+
+// Explicitly declare specializations to avoid having to validate that the
+// template parameters are supported
+template class ExactVariableToken<ffi::eight_byte_encoded_variable_t>;
+template class ExactVariableToken<ffi::four_byte_encoded_variable_t>;
+}  // namespace ffi::search

--- a/components/core/src/ffi/search/ExactVariableToken.hpp
+++ b/components/core/src/ffi/search/ExactVariableToken.hpp
@@ -8,8 +8,8 @@
 namespace ffi::search {
 /**
  * A token representing an exact variable (as opposed to a variable with
- * wildcards). Note that the original query string is stored by reference,
- * so it must remain valid while the token exists.
+ * wildcards). Note that the original query string is stored by reference, so it
+ * must remain valid while the token exists.
  * @tparam encoded_variable_t Type for encoded variable values
  */
 template <typename encoded_variable_t>
@@ -17,8 +17,8 @@ class ExactVariableToken : public QueryToken {
 public:
     // Constructors
     /**
-     * Constructs an exact variable token. NOTE: It's the callers
-     * responsibility to ensure that the token is indeed a variable.
+     * Constructs an exact variable token. NOTE: It's the callers responsibility
+     * to ensure that the token is indeed a variable.
      * @param query
      * @param begin_pos
      * @param end_pos

--- a/components/core/src/ffi/search/ExactVariableToken.hpp
+++ b/components/core/src/ffi/search/ExactVariableToken.hpp
@@ -1,53 +1,51 @@
 #ifndef FFI_SEARCH_EXACTVARIABLETOKEN_HPP
 #define FFI_SEARCH_EXACTVARIABLETOKEN_HPP
 
-// Project headers
 #include "../../Defs.h"
 #include "../encoding_methods.hpp"
 #include "QueryToken.hpp"
 
 namespace ffi::search {
+/**
+ * A token representing an exact variable (as opposed to a variable with
+ * wildcards). Note that the original query string is stored by reference,
+ * so it must remain valid while the token exists.
+ * @tparam encoded_variable_t Type for encoded variable values
+ */
+template <typename encoded_variable_t>
+class ExactVariableToken : public QueryToken {
+public:
+    // Constructors
     /**
-     * A token representing an exact variable (as opposed to a variable with
-     * wildcards). Note that the original query string is stored by reference,
-     * so it must remain valid while the token exists.
-     * @tparam encoded_variable_t Type for encoded variable values
+     * Constructs an exact variable token. NOTE: It's the callers
+     * responsibility to ensure that the token is indeed a variable.
+     * @param query
+     * @param begin_pos
+     * @param end_pos
      */
-    template<typename encoded_variable_t>
-    class ExactVariableToken : public QueryToken {
-    public:
-        // Constructors
-        /**
-         * Constructs an exact variable token. NOTE: It's the callers
-         * responsibility to ensure that the token is indeed a variable.
-         * @param query
-         * @param begin_pos
-         * @param end_pos
-         */
-        ExactVariableToken (std::string_view query, size_t begin_pos, size_t end_pos);
+    ExactVariableToken(std::string_view query, size_t begin_pos, size_t end_pos);
 
-        // Methods
-        bool operator== (const ExactVariableToken& rhs) const {
-            return static_cast<const ffi::search::QueryToken&>(*this)
-                   == static_cast<const ffi::search::QueryToken&>(rhs)
-                   && m_encoded_value == rhs.m_encoded_value
-                   && m_placeholder == rhs.m_placeholder;
-        }
-        bool operator!= (const ExactVariableToken& rhs) const {
-            return !(rhs == *this);
-        }
+    // Methods
+    bool operator==(ExactVariableToken const& rhs) const {
+        return static_cast<ffi::search::QueryToken const&>(*this)
+                       == static_cast<ffi::search::QueryToken const&>(rhs)
+               && m_encoded_value == rhs.m_encoded_value && m_placeholder == rhs.m_placeholder;
+    }
 
-        void add_to_logtype_query (std::string& logtype_query) const {
-            logtype_query += enum_to_underlying_type(m_placeholder);
-        }
+    bool operator!=(ExactVariableToken const& rhs) const { return !(rhs == *this); }
 
-        [[nodiscard]] encoded_variable_t get_encoded_value () const { return m_encoded_value; }
-        [[nodiscard]] VariablePlaceholder get_placeholder () const { return m_placeholder; }
+    void add_to_logtype_query(std::string& logtype_query) const {
+        logtype_query += enum_to_underlying_type(m_placeholder);
+    }
 
-    private:
-        encoded_variable_t m_encoded_value;
-        VariablePlaceholder m_placeholder;
-    };
-}
+    [[nodiscard]] encoded_variable_t get_encoded_value() const { return m_encoded_value; }
 
-#endif // FFI_SEARCH_EXACTVARIABLETOKEN_HPP
+    [[nodiscard]] VariablePlaceholder get_placeholder() const { return m_placeholder; }
+
+private:
+    encoded_variable_t m_encoded_value;
+    VariablePlaceholder m_placeholder;
+};
+}  // namespace ffi::search
+
+#endif  // FFI_SEARCH_EXACTVARIABLETOKEN_HPP

--- a/components/core/src/ffi/search/QueryMethodFailed.hpp
+++ b/components/core/src/ffi/search/QueryMethodFailed.hpp
@@ -1,29 +1,29 @@
 #ifndef FFI_SEARCH_QUERYMETHODFAILED_HPP
 #define FFI_SEARCH_QUERYMETHODFAILED_HPP
 
-// C++ standard libraries
 #include <string>
 
-// Project headers
 #include "../../TraceableException.hpp"
 
 namespace ffi::search {
-    class QueryMethodFailed : public TraceableException {
-    public:
-        // Constructors
-        QueryMethodFailed (ErrorCode error_code, const char* const filename, int line_number,
-                           std::string message) :
-                TraceableException(error_code, filename, line_number), m_message(
-                std::move(message)) {}
+class QueryMethodFailed : public TraceableException {
+public:
+    // Constructors
+    QueryMethodFailed(
+            ErrorCode error_code,
+            char const* const filename,
+            int line_number,
+            std::string message
+    )
+            : TraceableException(error_code, filename, line_number),
+              m_message(std::move(message)) {}
 
-        // Methods
-        [[nodiscard]] const char* what () const noexcept override {
-            return m_message.c_str();
-        }
+    // Methods
+    [[nodiscard]] char const* what() const noexcept override { return m_message.c_str(); }
 
-    private:
-        std::string m_message;
-    };
-}
+private:
+    std::string m_message;
+};
+}  // namespace ffi::search
 
-#endif // FFI_SEARCH_QUERYMETHODFAILED_HPP
+#endif  // FFI_SEARCH_QUERYMETHODFAILED_HPP

--- a/components/core/src/ffi/search/QueryToken.hpp
+++ b/components/core/src/ffi/search/QueryToken.hpp
@@ -1,51 +1,52 @@
 #ifndef FFI_SEARCH_QUERYTOKEN_HPP
 #define FFI_SEARCH_QUERYTOKEN_HPP
 
-// C++ standard libraries
 #include <string_view>
 
 namespace ffi::search {
-    enum class TokenType {
-        StaticText = 0,
-        IntegerVariable,
-        FloatVariable,
-        DictionaryVariable
-    };
+enum class TokenType {
+    StaticText = 0,
+    IntegerVariable,
+    FloatVariable,
+    DictionaryVariable
+};
 
-    /**
-     * Class representing a token in a query. Note that the original query
-     * string is stored by reference, so it must remain valid while the token
-     * exists.
-     */
-    class QueryToken {
-    public:
-        // Constructors
-        QueryToken (std::string_view query, size_t begin_pos, size_t end_pos) : m_query(query),
-                m_begin_pos(begin_pos), m_end_pos(end_pos), m_type(TokenType::StaticText) {}
+/**
+ * Class representing a token in a query. Note that the original query
+ * string is stored by reference, so it must remain valid while the token
+ * exists.
+ */
+class QueryToken {
+public:
+    // Constructors
+    QueryToken(std::string_view query, size_t begin_pos, size_t end_pos)
+            : m_query(query),
+              m_begin_pos(begin_pos),
+              m_end_pos(end_pos),
+              m_type(TokenType::StaticText) {}
 
-        // Methods
-        bool operator== (const QueryToken& rhs) const {
-            return m_query == rhs.m_query
-                   && m_begin_pos == rhs.m_begin_pos
-                   && m_end_pos == rhs.m_end_pos
-                   && m_type == rhs.m_type;
-        }
-        bool operator!= (const QueryToken& rhs) const {
-            return !(rhs == *this);
-        }
+    // Methods
+    bool operator==(QueryToken const& rhs) const {
+        return m_query == rhs.m_query && m_begin_pos == rhs.m_begin_pos
+               && m_end_pos == rhs.m_end_pos && m_type == rhs.m_type;
+    }
 
-        [[nodiscard]] size_t get_begin_pos () const { return m_begin_pos; }
-        [[nodiscard]] size_t get_end_pos () const { return m_end_pos; }
-        [[nodiscard]] std::string_view get_value () const {
-            return m_query.substr(m_begin_pos, m_end_pos - m_begin_pos);
-        }
+    bool operator!=(QueryToken const& rhs) const { return !(rhs == *this); }
 
-    protected:
-        std::string_view m_query;
-        size_t m_begin_pos;
-        size_t m_end_pos;
-        TokenType m_type;
-    };
-}
+    [[nodiscard]] size_t get_begin_pos() const { return m_begin_pos; }
 
-#endif // FFI_SEARCH_QUERYTOKEN_HPP
+    [[nodiscard]] size_t get_end_pos() const { return m_end_pos; }
+
+    [[nodiscard]] std::string_view get_value() const {
+        return m_query.substr(m_begin_pos, m_end_pos - m_begin_pos);
+    }
+
+protected:
+    std::string_view m_query;
+    size_t m_begin_pos;
+    size_t m_end_pos;
+    TokenType m_type;
+};
+}  // namespace ffi::search
+
+#endif  // FFI_SEARCH_QUERYTOKEN_HPP

--- a/components/core/src/ffi/search/QueryToken.hpp
+++ b/components/core/src/ffi/search/QueryToken.hpp
@@ -12,9 +12,8 @@ enum class TokenType {
 };
 
 /**
- * Class representing a token in a query. Note that the original query
- * string is stored by reference, so it must remain valid while the token
- * exists.
+ * Class representing a token in a query. Note that the original query string is
+ * stored by reference, so it must remain valid while the token exists.
  */
 class QueryToken {
 public:

--- a/components/core/src/ffi/search/QueryWildcard.cpp
+++ b/components/core/src/ffi/search/QueryWildcard.cpp
@@ -1,37 +1,36 @@
 #include "QueryWildcard.hpp"
 
-// Project headers
 #include "../../type_utils.hpp"
 
 namespace ffi::search {
-    QueryWildcard::QueryWildcard (char wildcard, size_t pos_in_query, bool is_boundary_wildcard) {
-        if (enum_to_underlying_type(WildcardType::AnyChar) != wildcard
-            && enum_to_underlying_type(WildcardType::ZeroOrMoreChars) != wildcard)
-        {
-            throw QueryWildcardOperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-        }
-        m_type = static_cast<WildcardType>(wildcard);
-        m_pos_in_query = pos_in_query;
-
-        if (is_boundary_wildcard && WildcardType::ZeroOrMoreChars == m_type) {
-            // We don't need to consider the "NoDelimiters" case for '*' at the
-            // ends of the token since it wouldn't change the interpretation of
-            // the token. See the README for more details.
-            m_possible_interpretations.emplace_back(WildcardInterpretation::ContainsDelimiters);
-        } else {
-            m_possible_interpretations.emplace_back(WildcardInterpretation::ContainsDelimiters);
-            m_possible_interpretations.emplace_back(WildcardInterpretation::NoDelimiters);
-        }
-        m_current_interpretation_idx = 0;
+QueryWildcard::QueryWildcard(char wildcard, size_t pos_in_query, bool is_boundary_wildcard) {
+    if (enum_to_underlying_type(WildcardType::AnyChar) != wildcard
+        && enum_to_underlying_type(WildcardType::ZeroOrMoreChars) != wildcard)
+    {
+        throw QueryWildcardOperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
     }
+    m_type = static_cast<WildcardType>(wildcard);
+    m_pos_in_query = pos_in_query;
 
-    bool QueryWildcard::next_interpretation ()  {
-        ++m_current_interpretation_idx;
-        if (m_current_interpretation_idx < m_possible_interpretations.size()) {
-            return true;
-        } else {
-            m_current_interpretation_idx = 0;
-            return false;
-        }
+    if (is_boundary_wildcard && WildcardType::ZeroOrMoreChars == m_type) {
+        // We don't need to consider the "NoDelimiters" case for '*' at the
+        // ends of the token since it wouldn't change the interpretation of
+        // the token. See the README for more details.
+        m_possible_interpretations.emplace_back(WildcardInterpretation::ContainsDelimiters);
+    } else {
+        m_possible_interpretations.emplace_back(WildcardInterpretation::ContainsDelimiters);
+        m_possible_interpretations.emplace_back(WildcardInterpretation::NoDelimiters);
+    }
+    m_current_interpretation_idx = 0;
+}
+
+bool QueryWildcard::next_interpretation() {
+    ++m_current_interpretation_idx;
+    if (m_current_interpretation_idx < m_possible_interpretations.size()) {
+        return true;
+    } else {
+        m_current_interpretation_idx = 0;
+        return false;
     }
 }
+}  // namespace ffi::search

--- a/components/core/src/ffi/search/QueryWildcard.cpp
+++ b/components/core/src/ffi/search/QueryWildcard.cpp
@@ -13,9 +13,9 @@ QueryWildcard::QueryWildcard(char wildcard, size_t pos_in_query, bool is_boundar
     m_pos_in_query = pos_in_query;
 
     if (is_boundary_wildcard && WildcardType::ZeroOrMoreChars == m_type) {
-        // We don't need to consider the "NoDelimiters" case for '*' at the
-        // ends of the token since it wouldn't change the interpretation of
-        // the token. See the README for more details.
+        // We don't need to consider the "NoDelimiters" case for '*' at the ends
+        // of the token since it wouldn't change the interpretation of the
+        // token. See the README for more details.
         m_possible_interpretations.emplace_back(WildcardInterpretation::ContainsDelimiters);
     } else {
         m_possible_interpretations.emplace_back(WildcardInterpretation::ContainsDelimiters);

--- a/components/core/src/ffi/search/QueryWildcard.hpp
+++ b/components/core/src/ffi/search/QueryWildcard.hpp
@@ -49,8 +49,8 @@ public:
      * Constructs a query wildcard
      * @param wildcard
      * @param pos_in_query
-     * @param is_boundary_wildcard Whether this wildcard is at either end of
-     * the query token
+     * @param is_boundary_wildcard Whether this wildcard is at either end of the
+     * query token
      */
     QueryWildcard(char wildcard, size_t pos_in_query, bool is_boundary_wildcard);
 

--- a/components/core/src/ffi/search/QueryWildcard.hpp
+++ b/components/core/src/ffi/search/QueryWildcard.hpp
@@ -1,84 +1,81 @@
 #ifndef FFI_SEARCH_QUERYWILDCARD_HPP
 #define FFI_SEARCH_QUERYWILDCARD_HPP
 
-// C++ standard libraries
 #include <vector>
 
-// Project headers
 #include "../../TraceableException.hpp"
 
 namespace ffi::search {
-    enum class WildcardType : char {
-        AnyChar = '?',
-        ZeroOrMoreChars = '*',
-    };
+enum class WildcardType : char {
+    AnyChar = '?',
+    ZeroOrMoreChars = '*',
+};
 
-    /**
-     * Possible interpretations of what is matched by a wildcard in a query
-     */
-    enum class WildcardInterpretation {
-        // Matches anything except delimiters
-        NoDelimiters = 0,
-        // For '*', matches anything including delimiters
-        // For '?', matches a delimiter
-        ContainsDelimiters,
-    };
+/**
+ * Possible interpretations of what is matched by a wildcard in a query
+ */
+enum class WildcardInterpretation {
+    // Matches anything except delimiters
+    NoDelimiters = 0,
+    // For '*', matches anything including delimiters
+    // For '?', matches a delimiter
+    ContainsDelimiters,
+};
 
-    /**
-     * Class representing a wildcard in a query
-     */
-    class QueryWildcard {
+/**
+ * Class representing a wildcard in a query
+ */
+class QueryWildcard {
+public:
+    // Types
+    class QueryWildcardOperationFailed : public TraceableException {
     public:
-        // Types
-        class QueryWildcardOperationFailed : public TraceableException {
-        public:
-            // Constructors
-            QueryWildcardOperationFailed (
-                    ErrorCode error_code, const char* const filename, int line_number
-            ) : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            [[nodiscard]] const char* what () const noexcept override {
-                return "ffi::search::QueryWildcard operation failed";
-            }
-        };
-
         // Constructors
-        /**
-         * Constructs a query wildcard
-         * @param wildcard
-         * @param pos_in_query
-         * @param is_boundary_wildcard Whether this wildcard is at either end of
-         * the query token
-         */
-        QueryWildcard (char wildcard, size_t pos_in_query, bool is_boundary_wildcard);
+        QueryWildcardOperationFailed(
+                ErrorCode error_code,
+                char const* const filename,
+                int line_number
+        )
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /**
-         * Advances to the next interpretation of the query wildcard
-         * @return true if there was another interpretation to advance to
-         * @return false if we overflowed to the first interpretation
-         */
-        bool next_interpretation ();
-
-        [[nodiscard]] WildcardInterpretation get_current_interpretation () const {
-            return m_possible_interpretations[m_current_interpretation_idx];
+        [[nodiscard]] char const* what() const noexcept override {
+            return "ffi::search::QueryWildcard operation failed";
         }
-
-        [[nodiscard]] size_t get_pos_in_query () const {
-            return m_pos_in_query;
-        }
-
-        [[nodiscard]] WildcardType get_type () const {
-            return m_type;
-        }
-
-    private:
-        WildcardType m_type;
-        size_t m_pos_in_query;
-        std::vector<WildcardInterpretation> m_possible_interpretations;
-        size_t m_current_interpretation_idx;
     };
-}
 
-#endif // FFI_SEARCH_QUERYWILDCARD_HPP
+    // Constructors
+    /**
+     * Constructs a query wildcard
+     * @param wildcard
+     * @param pos_in_query
+     * @param is_boundary_wildcard Whether this wildcard is at either end of
+     * the query token
+     */
+    QueryWildcard(char wildcard, size_t pos_in_query, bool is_boundary_wildcard);
+
+    // Methods
+    /**
+     * Advances to the next interpretation of the query wildcard
+     * @return true if there was another interpretation to advance to
+     * @return false if we overflowed to the first interpretation
+     */
+    bool next_interpretation();
+
+    [[nodiscard]] WildcardInterpretation get_current_interpretation() const {
+        return m_possible_interpretations[m_current_interpretation_idx];
+    }
+
+    [[nodiscard]] size_t get_pos_in_query() const { return m_pos_in_query; }
+
+    [[nodiscard]] WildcardType get_type() const { return m_type; }
+
+private:
+    WildcardType m_type;
+    size_t m_pos_in_query;
+    std::vector<WildcardInterpretation> m_possible_interpretations;
+    size_t m_current_interpretation_idx;
+};
+}  // namespace ffi::search
+
+#endif  // FFI_SEARCH_QUERYWILDCARD_HPP

--- a/components/core/src/ffi/search/Subquery.cpp
+++ b/components/core/src/ffi/search/Subquery.cpp
@@ -1,6 +1,5 @@
 #include "Subquery.hpp"
 
-// Project headers
 #include "QueryWildcard.hpp"
 
 using std::string;
@@ -8,30 +7,28 @@ using std::variant;
 using std::vector;
 
 namespace ffi::search {
-    template <typename encoded_variable_t>
-    Subquery<encoded_variable_t>::Subquery (string logtype_query,
-                                            Subquery::QueryVariables variables)
-            : m_logtype_query(std::move(logtype_query)), m_logtype_query_contains_wildcards(false),
-            m_query_vars(variables)
-    {
-        // Determine if the query contains variables
-        bool is_escaped = false;
-        for (const auto c : m_logtype_query) {
-            if (is_escaped) {
-                is_escaped = false;
-            } else if ('\\' == c) {
-                is_escaped = true;
-            } else if (enum_to_underlying_type(WildcardType::ZeroOrMoreChars) == c
-                       || enum_to_underlying_type(WildcardType::AnyChar) == c)
-            {
-                m_logtype_query_contains_wildcards = true;
-                break;
-            }
+template <typename encoded_variable_t>
+Subquery<encoded_variable_t>::Subquery(string logtype_query, Subquery::QueryVariables variables)
+        : m_logtype_query(std::move(logtype_query)),
+          m_logtype_query_contains_wildcards(false),
+          m_query_vars(variables) {
+    // Determine if the query contains variables
+    bool is_escaped = false;
+    for (auto const c : m_logtype_query) {
+        if (is_escaped) {
+            is_escaped = false;
+        } else if ('\\' == c) {
+            is_escaped = true;
+        } else if (enum_to_underlying_type(WildcardType::ZeroOrMoreChars) == c || enum_to_underlying_type(WildcardType::AnyChar) == c)
+        {
+            m_logtype_query_contains_wildcards = true;
+            break;
         }
     }
-
-    // Explicitly declare specializations to avoid having to validate that the
-    // template parameters are supported
-    template class Subquery<eight_byte_encoded_variable_t>;
-    template class Subquery<four_byte_encoded_variable_t>;
 }
+
+// Explicitly declare specializations to avoid having to validate that the
+// template parameters are supported
+template class Subquery<eight_byte_encoded_variable_t>;
+template class Subquery<four_byte_encoded_variable_t>;
+}  // namespace ffi::search

--- a/components/core/src/ffi/search/Subquery.cpp
+++ b/components/core/src/ffi/search/Subquery.cpp
@@ -19,7 +19,8 @@ Subquery<encoded_variable_t>::Subquery(string logtype_query, Subquery::QueryVari
             is_escaped = false;
         } else if ('\\' == c) {
             is_escaped = true;
-        } else if (enum_to_underlying_type(WildcardType::ZeroOrMoreChars) == c || enum_to_underlying_type(WildcardType::AnyChar) == c)
+        } else if ((enum_to_underlying_type(WildcardType::ZeroOrMoreChars) == c
+                    || enum_to_underlying_type(WildcardType::AnyChar) == c))
         {
             m_logtype_query_contains_wildcards = true;
             break;

--- a/components/core/src/ffi/search/Subquery.hpp
+++ b/components/core/src/ffi/search/Subquery.hpp
@@ -1,62 +1,55 @@
 #ifndef FFI_SEARCH_SUBQUERY_HPP
 #define FFI_SEARCH_SUBQUERY_HPP
 
-// C++ standard libraries
 #include <string>
 #include <variant>
 #include <vector>
 
-// Project headers
 #include "ExactVariableToken.hpp"
 #include "WildcardToken.hpp"
 
 namespace ffi::search {
+/**
+ * A class representing a subquery. Each subquery encompasses a single
+ * logtype query and zero or more variable queries. Both the logtype and
+ * variables may contain wildcards.
+ * @tparam encoded_variable_t The type of encoded variables
+ */
+template <typename encoded_variable_t>
+class Subquery {
+public:
+    using QueryVariables = std::vector<std::variant<
+            ExactVariableToken<encoded_variable_t>,
+            WildcardToken<encoded_variable_t>>>;
+
+    // Constructors
+    Subquery(std::string logtype_query, QueryVariables variables);
+
+    // Methods
+    [[nodiscard]] std::string const& get_logtype_query() const { return m_logtype_query; }
+
+    [[nodiscard]] bool logtype_query_contains_wildcards() const {
+        return m_logtype_query_contains_wildcards;
+    }
+
+    [[nodiscard]] QueryVariables const& get_query_vars() const { return m_query_vars; }
+
     /**
-     * A class representing a subquery. Each subquery encompasses a single
-     * logtype query and zero or more variable queries. Both the logtype and
-     * variables may contain wildcards.
-     * @tparam encoded_variable_t The type of encoded variables
+     * @param logtype_query
+     * @param variables
+     * @return Whether the given logtype query and query variables match this
+     * subquery.
      */
-    template<typename encoded_variable_t>
-    class Subquery {
-    public:
-        using QueryVariables = std::vector<
-                std::variant<
-                        ExactVariableToken<encoded_variable_t>,
-                        WildcardToken<encoded_variable_t>
-                >
-        >;
+    bool equals(std::string const& logtype_query, Subquery::QueryVariables const& variables) const {
+        return logtype_query == m_logtype_query && variables == m_query_vars;
+    }
 
-        // Constructors
-        Subquery (std::string logtype_query, QueryVariables variables);
+private:
+    // Variables
+    std::string m_logtype_query;
+    bool m_logtype_query_contains_wildcards;
+    QueryVariables m_query_vars;
+};
+}  // namespace ffi::search
 
-        // Methods
-        [[nodiscard]] const std::string& get_logtype_query () const { return m_logtype_query; }
-        [[nodiscard]] bool logtype_query_contains_wildcards () const {
-            return m_logtype_query_contains_wildcards;
-        }
-        [[nodiscard]] const QueryVariables& get_query_vars () const {
-            return m_query_vars;
-        }
-
-        /**
-         * @param logtype_query
-         * @param variables
-         * @return Whether the given logtype query and query variables match this
-         * subquery.
-         */
-        bool equals (const std::string& logtype_query,
-                     const Subquery::QueryVariables& variables) const
-        {
-            return logtype_query == m_logtype_query && variables == m_query_vars;
-        }
-
-    private:
-        // Variables
-        std::string m_logtype_query;
-        bool m_logtype_query_contains_wildcards;
-        QueryVariables m_query_vars;
-    };
-}
-
-#endif // FFI_SEARCH_SUBQUERY_HPP
+#endif  // FFI_SEARCH_SUBQUERY_HPP

--- a/components/core/src/ffi/search/Subquery.hpp
+++ b/components/core/src/ffi/search/Subquery.hpp
@@ -10,9 +10,9 @@
 
 namespace ffi::search {
 /**
- * A class representing a subquery. Each subquery encompasses a single
- * logtype query and zero or more variable queries. Both the logtype and
- * variables may contain wildcards.
+ * A class representing a subquery. Each subquery encompasses a single logtype
+ * query and zero or more variable queries. Both the logtype and variables may
+ * contain wildcards.
  * @tparam encoded_variable_t The type of encoded variables
  */
 template <typename encoded_variable_t>

--- a/components/core/src/ffi/search/WildcardToken.cpp
+++ b/components/core/src/ffi/search/WildcardToken.cpp
@@ -104,11 +104,11 @@ static bool could_be_int_var(const string_view token) {
 }
 
 /**
- * To check if the token could be static text, formally, we need to check if
- * the token matches the complement of all variable schemas ORed together
- * (~((schema1)|(schema2)|...). Another way of looking at this is if the
- * token contains anything which indicates it's definitely a variable, then
- * it can't be static text.
+ * To check if the token could be static text, formally, we need to check if the
+ * token matches the complement of all variable schemas ORed together
+ * (~((schema1)|(schema2)|...). Another way of looking at this is if the token
+ * contains anything which indicates it's definitely a variable, then it can't
+ * be static text.
  */
 static bool could_be_static_text(string_view query, size_t begin_pos, size_t end_pos) {
     bool is_escaped = false;
@@ -129,8 +129,8 @@ static bool could_be_static_text(string_view query, size_t begin_pos, size_t end
     if (begin_pos > 0 && '=' == query[begin_pos - 1]) {
         if ('?' == query[begin_pos] && contains_alphabet) {
             // "=?...<alphabet>..." must be a variable since
-            // 1. '?' would only be included in the variable token if it
-            //    was treated as a non-delimiter, and
+            // 1. '?' would only be included in the variable token if it was
+            //    treated as a non-delimiter, and
             // 2. an '=' followed by non-delimiters and an alphabet is
             //    definitely a variable.
             return false;

--- a/components/core/src/ffi/search/WildcardToken.cpp
+++ b/components/core/src/ffi/search/WildcardToken.cpp
@@ -168,12 +168,12 @@ WildcardToken<encoded_variable_t>::WildcardToken(
 
 template <typename encoded_variable_t>
 bool WildcardToken<encoded_variable_t>::add_to_logtype_query(string& logtype_query) const {
-    // Recall from CompositeWildcardToken::add_to_query: We need to handle
-    // '*' carefully when adding to the logtype query since we may have a
-    // token like "a1*b2" with interpretation ["a1*", "*b2"], i.e., the
-    // first token's suffix '*' is the second token's prefix '*'. So we only
-    // add the current token's prefix '*' below and ignore any suffix '*'
-    // since they will be captured by the next token.
+    // Recall from CompositeWildcardToken::add_to_query: We need to handle '*'
+    // carefully when adding to the logtype query since we may have a token like
+    // "a1*b2" with interpretation ["a1*", "*b2"], i.e., the first token's
+    // suffix '*' is the second token's prefix '*'. So we only add the current
+    // token's prefix '*' below and ignore any suffix '*' since they will be
+    // captured by the next token.
     auto current_interpretation = m_possible_variable_types[m_current_interpretation_idx];
     if (TokenType::StaticText == current_interpretation) {
         if (m_has_suffix_star_wildcard) {

--- a/components/core/src/ffi/search/WildcardToken.cpp
+++ b/components/core/src/ffi/search/WildcardToken.cpp
@@ -1,9 +1,7 @@
 #include "WildcardToken.hpp"
 
-// C++ standard libraries
 #include <string_view>
 
-// Project headers
 #include "../../string_utils.hpp"
 #include "../../type_utils.hpp"
 #include "../encoding_methods.hpp"
@@ -13,209 +11,212 @@ using std::string;
 using std::string_view;
 
 namespace ffi::search {
-    // Local function prototypes
-    /**
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param token
-     * @return Whether the given string could be an encoded float variable
-     */
-    template <typename encoded_variable_t>
-    static bool could_be_float_var (string_view token);
-    /**
-     * @tparam encoded_variable_t Type of the encoded variable
-     * @param token
-     * @return Whether the given string could be an encoded integer variable
-     */
-    template <typename encoded_variable_t>
-    static bool could_be_int_var (string_view token);
-    /**
-     * @param query
-     * @param begin_pos
-     * @param end_pos
-     * @return Whether the given string could be static text in a log message
-     */
-    static bool could_be_static_text (string_view query, size_t begin_pos, size_t end_pos);
+// Local function prototypes
+/**
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param token
+ * @return Whether the given string could be an encoded float variable
+ */
+template <typename encoded_variable_t>
+static bool could_be_float_var(string_view token);
+/**
+ * @tparam encoded_variable_t Type of the encoded variable
+ * @param token
+ * @return Whether the given string could be an encoded integer variable
+ */
+template <typename encoded_variable_t>
+static bool could_be_int_var(string_view token);
+/**
+ * @param query
+ * @param begin_pos
+ * @param end_pos
+ * @return Whether the given string could be static text in a log message
+ */
+static bool could_be_static_text(string_view query, size_t begin_pos, size_t end_pos);
 
-    template <typename encoded_variable_t>
-    static bool could_be_float_var (const string_view token) {
-        size_t num_decimals = 0;
-        size_t num_negative_signs = 0;
-        size_t num_digits = 0;
-        for (auto c : token) {
-            if ('.' == c) {
-                ++num_decimals;
-                if (num_decimals > 1) {
-                    // Contains multiple decimal points
-                    return false;
-                }
-            } else if ('-' == c) {
-                ++num_negative_signs;
-                if (num_negative_signs > 1) {
-                    // Contains multiple negative signs
-                    return false;
-                }
-            } else if ('0' <= c && c <= '9') {
-                ++num_digits;
-                constexpr size_t cMaxDigitsInRepresentableFloatVar =
-                        std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
-                        ? cMaxDigitsInRepresentableFourByteFloatVar
-                        : cMaxDigitsInRepresentableEightByteFloatVar;
-                if (num_digits > cMaxDigitsInRepresentableFloatVar) {
-                    // More digits than is representable
-                    return false;
-                }
-            } else if ('*' != c && '?' != c) {
-                // Not a wildcard
+template <typename encoded_variable_t>
+static bool could_be_float_var(const string_view token) {
+    size_t num_decimals = 0;
+    size_t num_negative_signs = 0;
+    size_t num_digits = 0;
+    for (auto c : token) {
+        if ('.' == c) {
+            ++num_decimals;
+            if (num_decimals > 1) {
+                // Contains multiple decimal points
                 return false;
             }
-        }
-        return true;
-    }
-
-    template <typename encoded_variable_t>
-    static bool could_be_int_var (const string_view token) {
-        size_t num_negative_signs = 0;
-        size_t num_digits = 0;
-        for (auto c : token) {
-            if ('-' == c) {
-                ++num_negative_signs;
-                if (num_negative_signs > 1) {
-                    // Contains multiple negative signs
-                    return false;
-                }
-            } else if ('0' <= c && c <= '9') {
-                ++num_digits;
-                // ceil(log10(INT32_MAX))
-                constexpr size_t cMaxDigitsInRepresentableFourByteIntVar = 10;
-                // ceil(log10(INT64_MAX))
-                constexpr size_t cMaxDigitsInRepresentableEightByteIntVar = 19;
-                constexpr size_t cMaxDigitsInRepresentableIntVar =
-                        std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
-                        ? cMaxDigitsInRepresentableFourByteIntVar
-                        : cMaxDigitsInRepresentableEightByteIntVar;
-                if (num_digits > cMaxDigitsInRepresentableIntVar) {
-                    // More digits than is representable
-                    return false;
-                }
-            } else if ('*' != c && '?' != c) {
-                // Not a wildcard
+        } else if ('-' == c) {
+            ++num_negative_signs;
+            if (num_negative_signs > 1) {
+                // Contains multiple negative signs
                 return false;
             }
-        }
-        return true;
-    }
-
-    /**
-     * To check if the token could be static text, formally, we need to check if
-     * the token matches the complement of all variable schemas ORed together
-     * (~((schema1)|(schema2)|...). Another way of looking at this is if the
-     * token contains anything which indicates it's definitely a variable, then
-     * it can't be static text.
-     */
-    static bool could_be_static_text (string_view query, size_t begin_pos, size_t end_pos) {
-        bool is_escaped = false;
-        bool contains_alphabet = false;
-        for (size_t i = begin_pos; i < end_pos; ++i) {
-            auto c = query[i];
-            if (is_escaped) {
-                is_escaped = false;
-            } else if ('\\' == c) {
-                is_escaped = true;
-            } else if (is_decimal_digit(c)) {
-                return false;
-            } else if (is_alphabet(c)) {
-                contains_alphabet = true;
-            }
-        }
-
-        if (begin_pos > 0 && '=' == query[begin_pos - 1]) {
-            if ('?' == query[begin_pos] && contains_alphabet) {
-                // "=?...<alphabet>..." must be a variable since
-                // 1. '?' would only be included in the variable token if it
-                //    was treated as a non-delimiter, and
-                // 2. an '=' followed by non-delimiters and an alphabet is
-                //    definitely a variable.
+        } else if ('0' <= c && c <= '9') {
+            ++num_digits;
+            constexpr size_t cMaxDigitsInRepresentableFloatVar
+                    = std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
+                              ? cMaxDigitsInRepresentableFourByteFloatVar
+                              : cMaxDigitsInRepresentableEightByteFloatVar;
+            if (num_digits > cMaxDigitsInRepresentableFloatVar) {
+                // More digits than is representable
                 return false;
             }
-        }
-
-        return true;
-    }
-
-    template <typename encoded_variable_t>
-    WildcardToken<encoded_variable_t>::WildcardToken (
-            string_view query, size_t begin_pos, size_t end_pos
-    ) : QueryToken(query, begin_pos, end_pos), m_has_prefix_star_wildcard('*' == query[begin_pos]),
-        m_has_suffix_star_wildcard('*' == query[end_pos - 1])
-    {
-        auto token = string_view(query.cbegin() + begin_pos, end_pos - begin_pos);
-        if (could_be_int_var<encoded_variable_t>(token)) {
-            m_possible_variable_types.push_back(TokenType::IntegerVariable);
-        }
-        if (could_be_float_var<encoded_variable_t>(token)) {
-            m_possible_variable_types.push_back(TokenType::FloatVariable);
-        }
-        if (could_be_static_text(query, begin_pos, end_pos)) {
-            m_possible_variable_types.push_back(TokenType::StaticText);
-        }
-        // Value must contain a wildcard and a non-delimiter, so it can be a
-        // dictionary variable
-        m_possible_variable_types.push_back(TokenType::DictionaryVariable);
-
-        m_current_interpretation_idx = 0;
-    }
-
-    template <typename encoded_variable_t>
-    bool WildcardToken<encoded_variable_t>::add_to_logtype_query (string& logtype_query) const {
-        // Recall from CompositeWildcardToken::add_to_query: We need to handle
-        // '*' carefully when adding to the logtype query since we may have a
-        // token like "a1*b2" with interpretation ["a1*", "*b2"], i.e., the
-        // first token's suffix '*' is the second token's prefix '*'. So we only
-        // add the current token's prefix '*' below and ignore any suffix '*'
-        // since they will be captured by the next token.
-        auto current_interpretation = m_possible_variable_types[m_current_interpretation_idx];
-        if (TokenType::StaticText == current_interpretation) {
-            if (m_has_suffix_star_wildcard) {
-                // Ignore the suffix '*'
-                logtype_query.append(m_query, m_begin_pos, (m_end_pos - 1) - m_begin_pos);
-            } else {
-                logtype_query.append(m_query, m_begin_pos, m_end_pos - m_begin_pos);
-            }
-            return false;
-        } else {
-            if (m_has_prefix_star_wildcard) {
-                logtype_query += enum_to_underlying_type(WildcardType::ZeroOrMoreChars);
-            }
-            switch (current_interpretation) {
-                case TokenType::DictionaryVariable:
-                    logtype_query += enum_to_underlying_type(VariablePlaceholder::Dictionary);
-                    break;
-                case TokenType::FloatVariable:
-                    logtype_query += enum_to_underlying_type(VariablePlaceholder::Float);
-                    break;
-                case TokenType::IntegerVariable:
-                    logtype_query += enum_to_underlying_type(VariablePlaceholder::Integer);
-                    break;
-                default:
-                    throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
-            }
-            return true;
-        }
-    }
-
-    template <typename encoded_variable_t>
-    bool WildcardToken<encoded_variable_t>::next_interpretation () {
-        ++m_current_interpretation_idx;
-        if (m_current_interpretation_idx < m_possible_variable_types.size()) {
-            return true;
-        } else {
-            m_current_interpretation_idx = 0;
+        } else if ('*' != c && '?' != c) {
+            // Not a wildcard
             return false;
         }
     }
-
-    // Explicitly declare specializations to avoid having to validate that the
-    // template parameters are supported
-    template class WildcardToken<ffi::eight_byte_encoded_variable_t>;
-    template class WildcardToken<ffi::four_byte_encoded_variable_t>;
+    return true;
 }
+
+template <typename encoded_variable_t>
+static bool could_be_int_var(const string_view token) {
+    size_t num_negative_signs = 0;
+    size_t num_digits = 0;
+    for (auto c : token) {
+        if ('-' == c) {
+            ++num_negative_signs;
+            if (num_negative_signs > 1) {
+                // Contains multiple negative signs
+                return false;
+            }
+        } else if ('0' <= c && c <= '9') {
+            ++num_digits;
+            // ceil(log10(INT32_MAX))
+            constexpr size_t cMaxDigitsInRepresentableFourByteIntVar = 10;
+            // ceil(log10(INT64_MAX))
+            constexpr size_t cMaxDigitsInRepresentableEightByteIntVar = 19;
+            constexpr size_t cMaxDigitsInRepresentableIntVar
+                    = std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
+                              ? cMaxDigitsInRepresentableFourByteIntVar
+                              : cMaxDigitsInRepresentableEightByteIntVar;
+            if (num_digits > cMaxDigitsInRepresentableIntVar) {
+                // More digits than is representable
+                return false;
+            }
+        } else if ('*' != c && '?' != c) {
+            // Not a wildcard
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * To check if the token could be static text, formally, we need to check if
+ * the token matches the complement of all variable schemas ORed together
+ * (~((schema1)|(schema2)|...). Another way of looking at this is if the
+ * token contains anything which indicates it's definitely a variable, then
+ * it can't be static text.
+ */
+static bool could_be_static_text(string_view query, size_t begin_pos, size_t end_pos) {
+    bool is_escaped = false;
+    bool contains_alphabet = false;
+    for (size_t i = begin_pos; i < end_pos; ++i) {
+        auto c = query[i];
+        if (is_escaped) {
+            is_escaped = false;
+        } else if ('\\' == c) {
+            is_escaped = true;
+        } else if (is_decimal_digit(c)) {
+            return false;
+        } else if (is_alphabet(c)) {
+            contains_alphabet = true;
+        }
+    }
+
+    if (begin_pos > 0 && '=' == query[begin_pos - 1]) {
+        if ('?' == query[begin_pos] && contains_alphabet) {
+            // "=?...<alphabet>..." must be a variable since
+            // 1. '?' would only be included in the variable token if it
+            //    was treated as a non-delimiter, and
+            // 2. an '=' followed by non-delimiters and an alphabet is
+            //    definitely a variable.
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template <typename encoded_variable_t>
+WildcardToken<encoded_variable_t>::WildcardToken(
+        string_view query,
+        size_t begin_pos,
+        size_t end_pos
+)
+        : QueryToken(query, begin_pos, end_pos),
+          m_has_prefix_star_wildcard('*' == query[begin_pos]),
+          m_has_suffix_star_wildcard('*' == query[end_pos - 1]) {
+    auto token = string_view(query.cbegin() + begin_pos, end_pos - begin_pos);
+    if (could_be_int_var<encoded_variable_t>(token)) {
+        m_possible_variable_types.push_back(TokenType::IntegerVariable);
+    }
+    if (could_be_float_var<encoded_variable_t>(token)) {
+        m_possible_variable_types.push_back(TokenType::FloatVariable);
+    }
+    if (could_be_static_text(query, begin_pos, end_pos)) {
+        m_possible_variable_types.push_back(TokenType::StaticText);
+    }
+    // Value must contain a wildcard and a non-delimiter, so it can be a
+    // dictionary variable
+    m_possible_variable_types.push_back(TokenType::DictionaryVariable);
+
+    m_current_interpretation_idx = 0;
+}
+
+template <typename encoded_variable_t>
+bool WildcardToken<encoded_variable_t>::add_to_logtype_query(string& logtype_query) const {
+    // Recall from CompositeWildcardToken::add_to_query: We need to handle
+    // '*' carefully when adding to the logtype query since we may have a
+    // token like "a1*b2" with interpretation ["a1*", "*b2"], i.e., the
+    // first token's suffix '*' is the second token's prefix '*'. So we only
+    // add the current token's prefix '*' below and ignore any suffix '*'
+    // since they will be captured by the next token.
+    auto current_interpretation = m_possible_variable_types[m_current_interpretation_idx];
+    if (TokenType::StaticText == current_interpretation) {
+        if (m_has_suffix_star_wildcard) {
+            // Ignore the suffix '*'
+            logtype_query.append(m_query, m_begin_pos, (m_end_pos - 1) - m_begin_pos);
+        } else {
+            logtype_query.append(m_query, m_begin_pos, m_end_pos - m_begin_pos);
+        }
+        return false;
+    } else {
+        if (m_has_prefix_star_wildcard) {
+            logtype_query += enum_to_underlying_type(WildcardType::ZeroOrMoreChars);
+        }
+        switch (current_interpretation) {
+            case TokenType::DictionaryVariable:
+                logtype_query += enum_to_underlying_type(VariablePlaceholder::Dictionary);
+                break;
+            case TokenType::FloatVariable:
+                logtype_query += enum_to_underlying_type(VariablePlaceholder::Float);
+                break;
+            case TokenType::IntegerVariable:
+                logtype_query += enum_to_underlying_type(VariablePlaceholder::Integer);
+                break;
+            default:
+                throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+        }
+        return true;
+    }
+}
+
+template <typename encoded_variable_t>
+bool WildcardToken<encoded_variable_t>::next_interpretation() {
+    ++m_current_interpretation_idx;
+    if (m_current_interpretation_idx < m_possible_variable_types.size()) {
+        return true;
+    } else {
+        m_current_interpretation_idx = 0;
+        return false;
+    }
+}
+
+// Explicitly declare specializations to avoid having to validate that the
+// template parameters are supported
+template class WildcardToken<ffi::eight_byte_encoded_variable_t>;
+template class WildcardToken<ffi::four_byte_encoded_variable_t>;
+}  // namespace ffi::search

--- a/components/core/src/ffi/search/WildcardToken.hpp
+++ b/components/core/src/ffi/search/WildcardToken.hpp
@@ -1,88 +1,81 @@
 #ifndef FFI_WILDCARDTOKEN_HPP
 #define FFI_WILDCARDTOKEN_HPP
 
-// C++ standard libraries
 #include <vector>
 
-// Project headers
 #include "../../TraceableException.hpp"
 #include "QueryToken.hpp"
 
 namespace ffi::search {
-    /**
-     * A token containing one or more wildcards. Note that the original query
-     * string is stored by reference, so it must remain valid while the token
-     * exists.
-     * @tparam encoded_variable_t
-     */
-    template <typename encoded_variable_t>
-    class WildcardToken : public QueryToken {
+/**
+ * A token containing one or more wildcards. Note that the original query
+ * string is stored by reference, so it must remain valid while the token
+ * exists.
+ * @tparam encoded_variable_t
+ */
+template <typename encoded_variable_t>
+class WildcardToken : public QueryToken {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed (ErrorCode error_code, const char* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            [[nodiscard]] const char* what () const noexcept override {
-                return "ffi::search::WildcardToken operation failed";
-            }
-        };
-
         // Constructors
-        WildcardToken (std::string_view query, size_t begin_pos, size_t end_pos);
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        bool operator== (const WildcardToken& rhs) const {
-            return static_cast<const ffi::search::QueryToken&>(*this)
-                   == static_cast<const ffi::search::QueryToken&>(rhs)
-                   && m_has_prefix_star_wildcard == rhs.m_has_prefix_star_wildcard
-                   && m_has_suffix_star_wildcard == rhs.m_has_suffix_star_wildcard
-                   && m_possible_variable_types == rhs.m_possible_variable_types
-                   && m_current_interpretation_idx == rhs.m_current_interpretation_idx;
+        [[nodiscard]] char const* what() const noexcept override {
+            return "ffi::search::WildcardToken operation failed";
         }
-        bool operator!= (const WildcardToken& rhs) const {
-            return !(rhs == *this);
-        }
-
-        /**
-         * Adds this token to the given logtype query. NOTE: We don't add this
-         * token's suffix '*' (if any) to the logtype query since we expect it
-         * will be added as the next token's prefix '*' (or if this is the last
-         * token, we expect the caller will add the suffix '*').
-         * @param logtype_query
-         * @return true if the token is interpreted as a variable
-         * @return false if the token is interpreted as static text
-         */
-        bool add_to_logtype_query (std::string& logtype_query) const;
-
-        /**
-         * Advances to the next interpretation of this WildcardToken
-         * @return true if there was another interpretation to advance to
-         * @return false if we overflowed to the first interpretation
-         */
-        bool next_interpretation ();
-
-        [[nodiscard]] bool has_suffix_star_wildcard () const {
-            return m_has_suffix_star_wildcard;
-        }
-
-        [[nodiscard]] bool has_prefix_star_wildcard () const {
-            return m_has_prefix_star_wildcard;
-        }
-
-        [[nodiscard]] TokenType get_current_interpretation () const {
-            return m_possible_variable_types[m_current_interpretation_idx];
-        }
-
-    private:
-        bool m_has_prefix_star_wildcard;
-        bool m_has_suffix_star_wildcard;
-        std::vector<TokenType> m_possible_variable_types;
-        size_t m_current_interpretation_idx;
     };
-}
 
-#endif // FFI_WILDCARDTOKEN_HPP
+    // Constructors
+    WildcardToken(std::string_view query, size_t begin_pos, size_t end_pos);
+
+    // Methods
+    bool operator==(WildcardToken const& rhs) const {
+        return static_cast<ffi::search::QueryToken const&>(*this)
+                       == static_cast<ffi::search::QueryToken const&>(rhs)
+               && m_has_prefix_star_wildcard == rhs.m_has_prefix_star_wildcard
+               && m_has_suffix_star_wildcard == rhs.m_has_suffix_star_wildcard
+               && m_possible_variable_types == rhs.m_possible_variable_types
+               && m_current_interpretation_idx == rhs.m_current_interpretation_idx;
+    }
+
+    bool operator!=(WildcardToken const& rhs) const { return !(rhs == *this); }
+
+    /**
+     * Adds this token to the given logtype query. NOTE: We don't add this
+     * token's suffix '*' (if any) to the logtype query since we expect it
+     * will be added as the next token's prefix '*' (or if this is the last
+     * token, we expect the caller will add the suffix '*').
+     * @param logtype_query
+     * @return true if the token is interpreted as a variable
+     * @return false if the token is interpreted as static text
+     */
+    bool add_to_logtype_query(std::string& logtype_query) const;
+
+    /**
+     * Advances to the next interpretation of this WildcardToken
+     * @return true if there was another interpretation to advance to
+     * @return false if we overflowed to the first interpretation
+     */
+    bool next_interpretation();
+
+    [[nodiscard]] bool has_suffix_star_wildcard() const { return m_has_suffix_star_wildcard; }
+
+    [[nodiscard]] bool has_prefix_star_wildcard() const { return m_has_prefix_star_wildcard; }
+
+    [[nodiscard]] TokenType get_current_interpretation() const {
+        return m_possible_variable_types[m_current_interpretation_idx];
+    }
+
+private:
+    bool m_has_prefix_star_wildcard;
+    bool m_has_suffix_star_wildcard;
+    std::vector<TokenType> m_possible_variable_types;
+    size_t m_current_interpretation_idx;
+};
+}  // namespace ffi::search
+
+#endif  // FFI_WILDCARDTOKEN_HPP

--- a/components/core/src/ffi/search/WildcardToken.hpp
+++ b/components/core/src/ffi/search/WildcardToken.hpp
@@ -8,9 +8,8 @@
 
 namespace ffi::search {
 /**
- * A token containing one or more wildcards. Note that the original query
- * string is stored by reference, so it must remain valid while the token
- * exists.
+ * A token containing one or more wildcards. Note that the original query string
+ * is stored by reference, so it must remain valid while the token exists.
  * @tparam encoded_variable_t
  */
 template <typename encoded_variable_t>
@@ -46,9 +45,9 @@ public:
 
     /**
      * Adds this token to the given logtype query. NOTE: We don't add this
-     * token's suffix '*' (if any) to the logtype query since we expect it
-     * will be added as the next token's prefix '*' (or if this is the last
-     * token, we expect the caller will add the suffix '*').
+     * token's suffix '*' (if any) to the logtype query since we expect it will
+     * be added as the next token's prefix '*' (or if this is the last token, we
+     * expect the caller will add the suffix '*').
      * @param logtype_query
      * @return true if the token is interpreted as a variable
      * @return false if the token is interpreted as static text

--- a/components/core/src/ffi/search/query_methods.cpp
+++ b/components/core/src/ffi/search/query_methods.cpp
@@ -16,11 +16,11 @@ static auto TokenGetEndPos = [](auto const& token) { return token.get_end_pos();
 /**
  * Finds the next delimiter that's not also a wildcard
  * @param value
- * @param pos Position to the start the search from, returns the position of
- * the delimiter (if found)
+ * @param pos Position to the start the search from, returns the position of the
+ * delimiter (if found)
  * @param contains_alphabet Returns whether the string contains an alphabet
- * @param contains_decimal_digit Returns whether the string contains a
- * decimal digit
+ * @param contains_decimal_digit Returns whether the string contains a decimal
+ * digit
  * @param contains_wildcard Returns whether the string contains a wildcard
  */
 static void find_delimiter(
@@ -31,25 +31,25 @@ static void find_delimiter(
         bool& contains_wildcard
 );
 /**
- * Finds the next wildcard or non-delimiter in the given string, starting
- * from the given position
+ * Finds the next wildcard or non-delimiter in the given string, starting from
+ * the given position
  * @param value
- * @param pos Position to the start the search from, returns the position of
- * the wildcard or non-delimiter (if found)
+ * @param pos Position to the start the search from, returns the position of the
+ * wildcard or non-delimiter (if found)
  * @param contains_wildcard Returns whether the string contains a wildcard
  * @return Whether a wildcard/non-delimiter was found
  */
 static bool find_wildcard_or_non_delimiter(string_view value, size_t& pos, bool& contains_wildcard);
 
 /**
- * Tokenizes the given wildcard query into exact variables (as would be
- * found by ffi::get_bounds_of_next_var) and potential variables, i.e., any
- * token with a wildcard.
+ * Tokenizes the given wildcard query into exact variables (as would be found by
+ * ffi::get_bounds_of_next_var) and potential variables, i.e., any token with a
+ * wildcard.
  * @tparam encoded_variable_t Type for encoded variable values
  * @param wildcard_query
  * @param tokens
- * @param composite_wildcard_token_indexes Indexes of the tokens in \p
- * tokens which contain wildcards
+ * @param composite_wildcard_token_indexes Indexes of the tokens in \p tokens
+ * which contain wildcards
  */
 template <typename encoded_variable_t>
 static void tokenize_query(

--- a/components/core/src/ffi/search/query_methods.cpp
+++ b/components/core/src/ffi/search/query_methods.cpp
@@ -96,13 +96,15 @@ void generate_subqueries(
 
             std::visit(
                     overloaded{
-                            [&logtype_query,
-                             &query_vars](ExactVariableToken<encoded_variable_t> const& token) {
+                            [&logtype_query, &query_vars](  // clang-format off
+                                    ExactVariableToken<encoded_variable_t> const& token
+                            ) {  // clang-format on
                                 token.add_to_logtype_query(logtype_query);
                                 query_vars.emplace_back(token);
                             },
-                            [&logtype_query,
-                             &query_vars](CompositeWildcardToken<encoded_variable_t> const& token) {
+                            [&logtype_query, &query_vars](  // clang-format off
+                                    CompositeWildcardToken<encoded_variable_t> const& token
+                            ) {  // clang-format on
                                 token.add_to_query(logtype_query, query_vars);
                             }},
                     token

--- a/components/core/src/ffi/search/query_methods.cpp
+++ b/components/core/src/ffi/search/query_methods.cpp
@@ -1,6 +1,5 @@
 #include "query_methods.hpp"
 
-// Project headers
 #include "CompositeWildcardToken.hpp"
 #include "QueryMethodFailed.hpp"
 
@@ -11,258 +10,288 @@ using std::variant;
 using std::vector;
 
 namespace ffi::search {
-    static auto TokenGetBeginPos = [] (const auto& token) { return token.get_begin_pos(); };
-    static auto TokenGetEndPos = [] (const auto& token) { return token.get_end_pos(); };
+static auto TokenGetBeginPos = [](auto const& token) { return token.get_begin_pos(); };
+static auto TokenGetEndPos = [](auto const& token) { return token.get_end_pos(); };
 
-    /**
-     * Finds the next delimiter that's not also a wildcard
-     * @param value
-     * @param pos Position to the start the search from, returns the position of
-     * the delimiter (if found)
-     * @param contains_alphabet Returns whether the string contains an alphabet
-     * @param contains_decimal_digit Returns whether the string contains a
-     * decimal digit
-     * @param contains_wildcard Returns whether the string contains a wildcard
-     */
-    static void find_delimiter (string_view value, size_t& pos, bool& contains_alphabet,
-                                bool& contains_decimal_digit, bool& contains_wildcard);
-    /**
-     * Finds the next wildcard or non-delimiter in the given string, starting
-     * from the given position
-     * @param value
-     * @param pos Position to the start the search from, returns the position of
-     * the wildcard or non-delimiter (if found)
-     * @param contains_wildcard Returns whether the string contains a wildcard
-     * @return Whether a wildcard/non-delimiter was found
-     */
-    static bool find_wildcard_or_non_delimiter (string_view value, size_t& pos,
-                                                bool& contains_wildcard);
+/**
+ * Finds the next delimiter that's not also a wildcard
+ * @param value
+ * @param pos Position to the start the search from, returns the position of
+ * the delimiter (if found)
+ * @param contains_alphabet Returns whether the string contains an alphabet
+ * @param contains_decimal_digit Returns whether the string contains a
+ * decimal digit
+ * @param contains_wildcard Returns whether the string contains a wildcard
+ */
+static void find_delimiter(
+        string_view value,
+        size_t& pos,
+        bool& contains_alphabet,
+        bool& contains_decimal_digit,
+        bool& contains_wildcard
+);
+/**
+ * Finds the next wildcard or non-delimiter in the given string, starting
+ * from the given position
+ * @param value
+ * @param pos Position to the start the search from, returns the position of
+ * the wildcard or non-delimiter (if found)
+ * @param contains_wildcard Returns whether the string contains a wildcard
+ * @return Whether a wildcard/non-delimiter was found
+ */
+static bool find_wildcard_or_non_delimiter(string_view value, size_t& pos, bool& contains_wildcard);
 
-    /**
-     * Tokenizes the given wildcard query into exact variables (as would be
-     * found by ffi::get_bounds_of_next_var) and potential variables, i.e., any
-     * token with a wildcard.
-     * @tparam encoded_variable_t Type for encoded variable values
-     * @param wildcard_query
-     * @param tokens
-     * @param composite_wildcard_token_indexes Indexes of the tokens in \p
-     * tokens which contain wildcards
-     */
-    template <typename encoded_variable_t>
-    static void tokenize_query (
-            string_view wildcard_query,
-            vector<variant<ExactVariableToken<encoded_variable_t>,
-                    CompositeWildcardToken<encoded_variable_t>>>& tokens,
-            vector<size_t>& composite_wildcard_token_indexes
-    );
+/**
+ * Tokenizes the given wildcard query into exact variables (as would be
+ * found by ffi::get_bounds_of_next_var) and potential variables, i.e., any
+ * token with a wildcard.
+ * @tparam encoded_variable_t Type for encoded variable values
+ * @param wildcard_query
+ * @param tokens
+ * @param composite_wildcard_token_indexes Indexes of the tokens in \p
+ * tokens which contain wildcards
+ */
+template <typename encoded_variable_t>
+static void tokenize_query(
+        string_view wildcard_query,
+        vector<
+                variant<ExactVariableToken<encoded_variable_t>,
+                        CompositeWildcardToken<encoded_variable_t>>>& tokens,
+        vector<size_t>& composite_wildcard_token_indexes
+);
 
-    template<typename encoded_variable_t>
-    void generate_subqueries (string_view wildcard_query,
-                              vector<Subquery<encoded_variable_t>>& sub_queries)
-    {
-        if (wildcard_query.empty()) {
-            throw QueryMethodFailed(ErrorCode_BadParam, __FILENAME__, __LINE__,
-                                    "wildcard_query cannot be empty");
-        }
-
-        vector<variant<ExactVariableToken<encoded_variable_t>,
-                CompositeWildcardToken<encoded_variable_t>>> tokens;
-        vector<size_t> composite_wildcard_token_indexes;
-        tokenize_query(wildcard_query, tokens, composite_wildcard_token_indexes);
-
-        bool all_interpretations_complete = false;
-        string logtype_query;
-        vector<variant<ExactVariableToken<encoded_variable_t>,
-                WildcardToken<encoded_variable_t>>> query_vars;
-        while (false == all_interpretations_complete) {
-            logtype_query.clear();
-            query_vars.clear();
-            size_t constant_begin_pos = 0;
-            for (const auto& token : tokens) {
-                auto begin_pos = std::visit(TokenGetBeginPos, token);
-                logtype_query.append(wildcard_query, constant_begin_pos,
-                                     begin_pos - constant_begin_pos);
-
-                std::visit(overloaded{
-                        [&logtype_query, &query_vars] (
-                                const ExactVariableToken<encoded_variable_t>& token
-                        ) {
-                            token.add_to_logtype_query(logtype_query);
-                            query_vars.emplace_back(token);
-                        },
-                        [&logtype_query, &query_vars] (
-                                const CompositeWildcardToken<encoded_variable_t>& token
-                        ) {
-                            token.add_to_query(logtype_query, query_vars);
-                        }
-                }, token);
-
-                constant_begin_pos = std::visit(TokenGetEndPos, token);
-            }
-            logtype_query.append(wildcard_query, constant_begin_pos);
-
-            // Save sub-query if it's unique
-            bool sub_query_exists = false;
-            for (const auto& sub_query : sub_queries) {
-                if (sub_query.equals(logtype_query, query_vars)) {
-                    sub_query_exists = true;
-                    break;
-                }
-            }
-            if (false == sub_query_exists) {
-                sub_queries.emplace_back(logtype_query, query_vars);
-            }
-
-            // Generate next interpretation if any
-            all_interpretations_complete = true;
-            for (auto i : composite_wildcard_token_indexes) {
-                auto& w = std::get<CompositeWildcardToken<encoded_variable_t>>(tokens[i]);
-                if (w.generate_next_interpretation()) {
-                    all_interpretations_complete = false;
-                    break;
-                }
-            }
-        }
+template <typename encoded_variable_t>
+void generate_subqueries(
+        string_view wildcard_query,
+        vector<Subquery<encoded_variable_t>>& sub_queries
+) {
+    if (wildcard_query.empty()) {
+        throw QueryMethodFailed(
+                ErrorCode_BadParam,
+                __FILENAME__,
+                __LINE__,
+                "wildcard_query cannot be empty"
+        );
     }
 
-    template <typename encoded_variable_t>
-    void tokenize_query (
-            string_view wildcard_query,
-            vector<variant<ExactVariableToken<encoded_variable_t>,
-                    CompositeWildcardToken<encoded_variable_t>>>& tokens,
-            vector<size_t>& composite_wildcard_token_indexes
-    ) {
-        // Tokenize query using delimiters to get definite variables and tokens
-        // containing wildcards (potential variables)
-        size_t end_pos = 0;
-        while (true) {
-            auto begin_pos = end_pos;
+    vector<
+            variant<ExactVariableToken<encoded_variable_t>,
+                    CompositeWildcardToken<encoded_variable_t>>>
+            tokens;
+    vector<size_t> composite_wildcard_token_indexes;
+    tokenize_query(wildcard_query, tokens, composite_wildcard_token_indexes);
 
-            bool contains_wildcard;
-            if (false == find_wildcard_or_non_delimiter(wildcard_query, begin_pos,
-                                                        contains_wildcard))
-            {
+    bool all_interpretations_complete = false;
+    string logtype_query;
+    vector<variant<ExactVariableToken<encoded_variable_t>, WildcardToken<encoded_variable_t>>>
+            query_vars;
+    while (false == all_interpretations_complete) {
+        logtype_query.clear();
+        query_vars.clear();
+        size_t constant_begin_pos = 0;
+        for (auto const& token : tokens) {
+            auto begin_pos = std::visit(TokenGetBeginPos, token);
+            logtype_query
+                    .append(wildcard_query, constant_begin_pos, begin_pos - constant_begin_pos);
+
+            std::visit(
+                    overloaded{
+                            [&logtype_query,
+                             &query_vars](ExactVariableToken<encoded_variable_t> const& token) {
+                                token.add_to_logtype_query(logtype_query);
+                                query_vars.emplace_back(token);
+                            },
+                            [&logtype_query,
+                             &query_vars](CompositeWildcardToken<encoded_variable_t> const& token) {
+                                token.add_to_query(logtype_query, query_vars);
+                            }},
+                    token
+            );
+
+            constant_begin_pos = std::visit(TokenGetEndPos, token);
+        }
+        logtype_query.append(wildcard_query, constant_begin_pos);
+
+        // Save sub-query if it's unique
+        bool sub_query_exists = false;
+        for (auto const& sub_query : sub_queries) {
+            if (sub_query.equals(logtype_query, query_vars)) {
+                sub_query_exists = true;
                 break;
             }
+        }
+        if (false == sub_query_exists) {
+            sub_queries.emplace_back(logtype_query, query_vars);
+        }
 
-            bool contains_decimal_digit = false;
-            bool contains_alphabet = false;
-            end_pos = begin_pos;
-            find_delimiter(wildcard_query, end_pos, contains_alphabet, contains_decimal_digit,
-                           contains_wildcard);
-
-            if (contains_wildcard) {
-                // Only consider tokens which contain more than just a wildcard
-                if (end_pos - begin_pos > 1) {
-                    tokens.emplace_back(
-                            std::in_place_type<CompositeWildcardToken<encoded_variable_t>>,
-                            wildcard_query,
-                            begin_pos, end_pos);
-                    composite_wildcard_token_indexes.push_back(tokens.size() - 1);
-                }
-            } else {
-                string_view variable(wildcard_query.cbegin() + begin_pos, end_pos - begin_pos);
-                // Treat token as variable if:
-                // - it contains a decimal digit, or
-                // - it's directly preceded by an equals sign and contains an
-                //   alphabet, or
-                // - it could be a multi-digit hex value
-                if (contains_decimal_digit ||
-                    (begin_pos > 0 && '=' == wildcard_query[begin_pos - 1] && contains_alphabet) ||
-                    ffi::could_be_multi_digit_hex_value(variable)) {
-                    tokens.emplace_back(
-                            std::in_place_type<ExactVariableToken<encoded_variable_t>>,
-                            wildcard_query, begin_pos, end_pos);
-                }
+        // Generate next interpretation if any
+        all_interpretations_complete = true;
+        for (auto i : composite_wildcard_token_indexes) {
+            auto& w = std::get<CompositeWildcardToken<encoded_variable_t>>(tokens[i]);
+            if (w.generate_next_interpretation()) {
+                all_interpretations_complete = false;
+                break;
             }
         }
     }
-
-    static void find_delimiter (string_view value, size_t& pos, bool& contains_alphabet,
-                                bool& contains_decimal_digit, bool& contains_wildcard)
-    {
-        bool is_escaped = false;
-        for (; pos < value.length(); ++pos) {
-            auto c = value[pos];
-
-            if (is_escaped) {
-                is_escaped = false;
-
-                if (is_delim(c)) {
-                    // Found escaped delimiter, so reverse the index to
-                    // exclude the escape character
-                    --pos;
-                    return;
-                }
-            } else if ('\\' == c) {
-                is_escaped = true;
-            } else {
-                if (is_wildcard(c)) {
-                    contains_wildcard = true;
-                } else if (is_delim(c)) {
-                    // Found delimiter that's not also a wildcard
-                    return;
-                }
-            }
-
-            if (is_decimal_digit(c)) {
-                contains_decimal_digit = true;
-            } else if (is_alphabet(c)) {
-                contains_alphabet = true;
-            }
-        }
-    }
-
-    static bool find_wildcard_or_non_delimiter (string_view value, size_t& pos,
-                                                bool& contains_wildcard)
-    {
-        bool is_escaped = false;
-        contains_wildcard = false;
-        for (; pos < value.length(); ++pos) {
-            auto c = value[pos];
-
-            if (is_escaped) {
-                is_escaped = false;
-
-                if (false == is_delim(c)) {
-                    // Found escaped non-delimiter, so reverse the index to
-                    // retain the escape character
-                    --pos;
-                    return true;
-                }
-            } else if ('\\' == c) {
-                is_escaped = true;
-            } else {
-                if (is_wildcard(c)) {
-                    contains_wildcard = true;
-                    return true;
-                } else if (false == is_delim(c)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    // Explicitly declare specializations to avoid having to validate that the
-    // template parameters are supported
-    template void generate_subqueries<eight_byte_encoded_variable_t> (string_view wildcard_query,
-            vector<Subquery<eight_byte_encoded_variable_t>>& sub_queries);
-    template void generate_subqueries<four_byte_encoded_variable_t> (string_view wildcard_query,
-            vector<Subquery<four_byte_encoded_variable_t>>& sub_queries);
-    template void tokenize_query<ffi::eight_byte_encoded_variable_t> (
-            string_view wildcard_query,
-            vector<variant<ExactVariableToken<eight_byte_encoded_variable_t>,
-                    CompositeWildcardToken<eight_byte_encoded_variable_t>>>& tokens,
-            vector<size_t>& composite_wildcard_token_indexes
-    );
-    template void tokenize_query<ffi::four_byte_encoded_variable_t>(
-            string_view wildcard_query,
-            vector<variant<ExactVariableToken<four_byte_encoded_variable_t>,
-                    CompositeWildcardToken<four_byte_encoded_variable_t>>>& tokens,
-            vector<size_t>& composite_wildcard_token_indexes
-    );
-
 }
 
+template <typename encoded_variable_t>
+void tokenize_query(
+        string_view wildcard_query,
+        vector<
+                variant<ExactVariableToken<encoded_variable_t>,
+                        CompositeWildcardToken<encoded_variable_t>>>& tokens,
+        vector<size_t>& composite_wildcard_token_indexes
+) {
+    // Tokenize query using delimiters to get definite variables and tokens
+    // containing wildcards (potential variables)
+    size_t end_pos = 0;
+    while (true) {
+        auto begin_pos = end_pos;
+
+        bool contains_wildcard;
+        if (false == find_wildcard_or_non_delimiter(wildcard_query, begin_pos, contains_wildcard)) {
+            break;
+        }
+
+        bool contains_decimal_digit = false;
+        bool contains_alphabet = false;
+        end_pos = begin_pos;
+        find_delimiter(
+                wildcard_query,
+                end_pos,
+                contains_alphabet,
+                contains_decimal_digit,
+                contains_wildcard
+        );
+
+        if (contains_wildcard) {
+            // Only consider tokens which contain more than just a wildcard
+            if (end_pos - begin_pos > 1) {
+                tokens.emplace_back(
+                        std::in_place_type<CompositeWildcardToken<encoded_variable_t>>,
+                        wildcard_query,
+                        begin_pos,
+                        end_pos
+                );
+                composite_wildcard_token_indexes.push_back(tokens.size() - 1);
+            }
+        } else {
+            string_view variable(wildcard_query.cbegin() + begin_pos, end_pos - begin_pos);
+            // Treat token as variable if:
+            // - it contains a decimal digit, or
+            // - it's directly preceded by an equals sign and contains an
+            //   alphabet, or
+            // - it could be a multi-digit hex value
+            if (contains_decimal_digit
+                || (begin_pos > 0 && '=' == wildcard_query[begin_pos - 1] && contains_alphabet)
+                || ffi::could_be_multi_digit_hex_value(variable))
+            {
+                tokens.emplace_back(
+                        std::in_place_type<ExactVariableToken<encoded_variable_t>>,
+                        wildcard_query,
+                        begin_pos,
+                        end_pos
+                );
+            }
+        }
+    }
+}
+
+static void find_delimiter(
+        string_view value,
+        size_t& pos,
+        bool& contains_alphabet,
+        bool& contains_decimal_digit,
+        bool& contains_wildcard
+) {
+    bool is_escaped = false;
+    for (; pos < value.length(); ++pos) {
+        auto c = value[pos];
+
+        if (is_escaped) {
+            is_escaped = false;
+
+            if (is_delim(c)) {
+                // Found escaped delimiter, so reverse the index to
+                // exclude the escape character
+                --pos;
+                return;
+            }
+        } else if ('\\' == c) {
+            is_escaped = true;
+        } else {
+            if (is_wildcard(c)) {
+                contains_wildcard = true;
+            } else if (is_delim(c)) {
+                // Found delimiter that's not also a wildcard
+                return;
+            }
+        }
+
+        if (is_decimal_digit(c)) {
+            contains_decimal_digit = true;
+        } else if (is_alphabet(c)) {
+            contains_alphabet = true;
+        }
+    }
+}
+
+static bool
+find_wildcard_or_non_delimiter(string_view value, size_t& pos, bool& contains_wildcard) {
+    bool is_escaped = false;
+    contains_wildcard = false;
+    for (; pos < value.length(); ++pos) {
+        auto c = value[pos];
+
+        if (is_escaped) {
+            is_escaped = false;
+
+            if (false == is_delim(c)) {
+                // Found escaped non-delimiter, so reverse the index to
+                // retain the escape character
+                --pos;
+                return true;
+            }
+        } else if ('\\' == c) {
+            is_escaped = true;
+        } else {
+            if (is_wildcard(c)) {
+                contains_wildcard = true;
+                return true;
+            } else if (false == is_delim(c)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+// Explicitly declare specializations to avoid having to validate that the
+// template parameters are supported
+template void generate_subqueries<eight_byte_encoded_variable_t>(
+        string_view wildcard_query,
+        vector<Subquery<eight_byte_encoded_variable_t>>& sub_queries
+);
+template void generate_subqueries<four_byte_encoded_variable_t>(
+        string_view wildcard_query,
+        vector<Subquery<four_byte_encoded_variable_t>>& sub_queries
+);
+template void tokenize_query<ffi::eight_byte_encoded_variable_t>(
+        string_view wildcard_query,
+        vector<
+                variant<ExactVariableToken<eight_byte_encoded_variable_t>,
+                        CompositeWildcardToken<eight_byte_encoded_variable_t>>>& tokens,
+        vector<size_t>& composite_wildcard_token_indexes
+);
+template void tokenize_query<ffi::four_byte_encoded_variable_t>(
+        string_view wildcard_query,
+        vector<
+                variant<ExactVariableToken<four_byte_encoded_variable_t>,
+                        CompositeWildcardToken<four_byte_encoded_variable_t>>>& tokens,
+        vector<size_t>& composite_wildcard_token_indexes
+);
+
+}  // namespace ffi::search

--- a/components/core/src/ffi/search/query_methods.cpp
+++ b/components/core/src/ffi/search/query_methods.cpp
@@ -214,8 +214,8 @@ static void find_delimiter(
             is_escaped = false;
 
             if (is_delim(c)) {
-                // Found escaped delimiter, so reverse the index to
-                // exclude the escape character
+                // Found escaped delimiter, so reverse the index to exclude the
+                // escape character
                 --pos;
                 return;
             }
@@ -249,8 +249,8 @@ find_wildcard_or_non_delimiter(string_view value, size_t& pos, bool& contains_wi
             is_escaped = false;
 
             if (false == is_delim(c)) {
-                // Found escaped non-delimiter, so reverse the index to
-                // retain the escape character
+                // Found escaped non-delimiter, so reverse the index to retain
+                // the escape character
                 --pos;
                 return true;
             }

--- a/components/core/src/ffi/search/query_methods.hpp
+++ b/components/core/src/ffi/search/query_methods.hpp
@@ -1,22 +1,22 @@
 #ifndef FFI_SEARCH_QUERY_METHODS_HPP
 #define FFI_SEARCH_QUERY_METHODS_HPP
 
-// C++ standard libraries
 #include <string>
 #include <string_view>
 #include <variant>
 #include <vector>
 
-// Project headers
 #include "CompositeWildcardToken.hpp"
 #include "ExactVariableToken.hpp"
 #include "Subquery.hpp"
 #include "WildcardToken.hpp"
 
 namespace ffi::search {
-    template <typename encoded_variable_t>
-    void generate_subqueries (std::string_view wildcard_query,
-                              std::vector<Subquery<encoded_variable_t>>& sub_queries);
-}
+template <typename encoded_variable_t>
+void generate_subqueries(
+        std::string_view wildcard_query,
+        std::vector<Subquery<encoded_variable_t>>& sub_queries
+);
+}  // namespace ffi::search
 
-#endif // FFI_SEARCH_QUERY_METHODS_HPP
+#endif  // FFI_SEARCH_QUERY_METHODS_HPP


### PR DESCRIPTION
# Description
Applies clang format to the ffi sub-directories and also adjusts comments to be <= 80.

Removes header group comments (e.g. // Project headers) now that clang-format organizes them.

# Validation performed
All unit tests passing.

