### PR TITLE
Remove verbosity field for a log type entry

### DIFF
--- a/components/core/src/Defs.h
+++ b/components/core/src/Defs.h
@@ -42,17 +42,6 @@ typedef uint64_t pipeline_id_t;
 constexpr pipeline_id_t cPipelineIdMax = std::numeric_limits<pipeline_id_t>::max();
 typedef std::atomic_uint64_t atomic_pipeline_id_t;
 
-enum LogVerbosity : uint8_t {
-    LogVerbosity_FATAL = 0,
-    LogVerbosity_ERROR,
-    LogVerbosity_WARN,
-    LogVerbosity_INFO,
-    LogVerbosity_DEBUG,
-    LogVerbosity_TRACE,
-    LogVerbosity_UNKNOWN,
-    LogVerbosity_Length
-};
-
 // Macros
 // Rounds up VALUE to be a multiple of MULTIPLE
 #define ROUND_UP_TO_MULTIPLE(VALUE, MULTIPLE) ((VALUE + MULTIPLE - 1) / MULTIPLE) * MULTIPLE

--- a/components/core/src/LogTypeDictionaryEntry.cpp
+++ b/components/core/src/LogTypeDictionaryEntry.cpp
@@ -49,7 +49,7 @@ size_t LogTypeDictionaryEntry::get_var_info (size_t var_ix, VarDelim& var_delim)
 
 size_t LogTypeDictionaryEntry::get_data_size () const {
     // NOTE: sizeof(vector[0]) is executed at compile time so there's no risk of an exception at runtime
-    return sizeof(m_id) + sizeof(m_verbosity) + m_value.length() + m_var_positions.size() * sizeof(m_var_positions[0]) +
+    return sizeof(m_id) + m_value.length() + m_var_positions.size() * sizeof(m_var_positions[0]) +
            m_ids_of_segments_containing_entry.size() * sizeof(segment_id_t);
 }
 
@@ -91,13 +91,11 @@ bool LogTypeDictionaryEntry::parse_next_var (const string& msg, size_t& var_begi
 
 void LogTypeDictionaryEntry::clear () {
     m_value.clear();
-    m_verbosity = LogVerbosity_Length;
     m_var_positions.clear();
 }
 
 void LogTypeDictionaryEntry::write_to_file (streaming_compression::Compressor& compressor) const {
     compressor.write_numeric_value(m_id);
-    compressor.write_numeric_value<uint8_t>(m_verbosity);
 
     string escaped_value;
     get_value_with_unfounded_variables_escaped(escaped_value);
@@ -114,13 +112,6 @@ ErrorCode LogTypeDictionaryEntry::try_read_from_file (streaming_compression::Dec
     if (ErrorCode_Success != error_code) {
         return error_code;
     }
-
-    uint8_t verbosity;
-    error_code = decompressor.try_read_numeric_value<uint8_t>(verbosity);
-    if (ErrorCode_Success != error_code) {
-        return error_code;
-    }
-    m_verbosity = (LogVerbosity)verbosity;
 
     uint64_t escaped_value_length;
     error_code = decompressor.try_read_numeric_value(escaped_value_length);

--- a/components/core/src/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/LogTypeDictionaryEntry.hpp
@@ -41,7 +41,7 @@ public:
     };
 
     // Constructors
-    LogTypeDictionaryEntry () : m_verbosity(LogVerbosity_Length) {}
+    LogTypeDictionaryEntry () = default;
     // Use default copy constructor
     LogTypeDictionaryEntry (const LogTypeDictionaryEntry&) = default;
 
@@ -123,7 +123,6 @@ public:
      */
     void reserve_constant_length (size_t length) { m_value.reserve(length); }
     void set_id (logtype_dictionary_id_t id) { m_id = id; }
-    void set_verbosity (LogVerbosity verbosity) { m_verbosity = verbosity; }
 
     void clear ();
 
@@ -154,7 +153,6 @@ private:
     void get_value_with_unfounded_variables_escaped (std::string& escaped_logtype_value) const;
 
     // Variables
-    LogVerbosity m_verbosity;
     std::vector<size_t> m_var_positions;
 };
 

--- a/components/core/src/LogTypeDictionaryWriter.cpp
+++ b/components/core/src/LogTypeDictionaryWriter.cpp
@@ -16,25 +16,6 @@ bool LogTypeDictionaryWriter::add_entry (LogTypeDictionaryEntry& logtype_entry, 
     } else {
         // Dictionary entry doesn't exist so create it
 
-        // Determine verbosity
-        LogVerbosity verbosity;
-        if (string::npos != value.find("FATAL")) {
-            verbosity = LogVerbosity_FATAL;
-        } else if (string::npos != value.find("ERROR")) {
-            verbosity = LogVerbosity_ERROR;
-        } else if (string::npos != value.find("WARN")) {
-            verbosity = LogVerbosity_WARN;
-        } else if (string::npos != value.find("INFO")) {
-            verbosity = LogVerbosity_INFO;
-        } else if (string::npos != value.find("DEBUG")) {
-            verbosity = LogVerbosity_DEBUG;
-        } else if (string::npos != value.find("TRACE")) {
-            verbosity = LogVerbosity_TRACE;
-        } else {
-            verbosity = LogVerbosity_UNKNOWN;
-        }
-        logtype_entry.set_verbosity(verbosity);
-
         // Assign ID
         logtype_id = m_next_id;
         ++m_next_id;

--- a/components/core/src/streaming_archive/Constants.hpp
+++ b/components/core/src/streaming_archive/Constants.hpp
@@ -5,7 +5,7 @@
 #define STREAMING_ARCHIVE_CONSTANTS_HPP
 
 namespace streaming_archive {
-    constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevVersionFlag | 6;
+    constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevVersionFlag | 7;
     constexpr char cSegmentsDirname[] = "s";
     constexpr char cSegmentListFilename[] = "segment_list.txt";
     constexpr char cLogTypeDictFilename[] = "logtype.dict";


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Verbosity is a required field for a log type entry since the majority of unstructured logs have such information. However, we don't actually use this field. Besides, in the case of semi-structured logs, this information is typically stored in a dedicated field (e.g., `level`), and the actual log text does not include it. Removing this field saves ingestion time and storage space.

# Validation performed
<!-- What tests and validation you performed on the change -->
 
* Validated compression/decompression/search continues to work.
* Validated unit tests still pass.

