### PR TITLE
FFI: Comment out unused parameter to allow ffi-go to build with werror

### DIFF
--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -172,7 +172,7 @@ namespace ffi::ir_stream {
     }
 
     static bool append_constant_to_logtype (string_view constant,
-                                            bool contains_variable_placeholder, string& logtype)
+                                            bool /*contains_variable_placeholder*/, string& logtype)
     {
         size_t begin_pos = 0;
         auto constant_len = constant.length();

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -171,8 +171,7 @@ namespace ffi::ir_stream {
         metadata[cProtocol::Metadata::TimeZoneIdKey] = time_zone_id;
     }
 
-    static bool append_constant_to_logtype (string_view constant,
-                                            bool /*contains_variable_placeholder*/, string& logtype)
+    static bool append_constant_to_logtype (string_view constant, bool, string& logtype)
     {
         size_t begin_pos = 0;
         auto constant_len = constant.length();


### PR DESCRIPTION
# Description
Quick fix so that the library component of clp-ffi-go can build with `-Werror`.

# Validation performed
All unit tests passing, both release and debug.

