### PR TITLE
Introduce a timestamp dictionary to store timestamp pattern formats

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -308,6 +308,12 @@ set(SOURCE_FILES_clp
         src/string_utils.hpp
         src/StringReader.cpp
         src/StringReader.hpp
+        src/TimestampDictionaryEntry.cpp
+        src/TimestampDictionaryEntry.hpp
+        src/TimestampDictionaryReader.cpp
+        src/TimestampDictionaryReader.hpp
+        src/TimestampDictionaryWriter.cpp
+        src/TimestampDictionaryWriter.hpp
         src/TimestampPattern.cpp
         src/TimestampPattern.hpp
         src/TraceableException.cpp
@@ -466,6 +472,10 @@ set(SOURCE_FILES_clg
         src/string_utils.hpp
         src/StringReader.cpp
         src/StringReader.hpp
+        src/TimestampDictionaryEntry.cpp
+        src/TimestampDictionaryEntry.hpp
+        src/TimestampDictionaryReader.cpp
+        src/TimestampDictionaryReader.hpp
         src/TimestampPattern.cpp
         src/TimestampPattern.hpp
         src/TraceableException.cpp
@@ -613,6 +623,10 @@ set(SOURCE_FILES_clo
         src/StringReader.hpp
         src/Thread.cpp
         src/Thread.hpp
+        src/TimestampDictionaryEntry.cpp
+        src/TimestampDictionaryEntry.hpp
+        src/TimestampDictionaryReader.cpp
+        src/TimestampDictionaryReader.hpp
         src/TimestampPattern.cpp
         src/TimestampPattern.hpp
         src/TraceableException.cpp
@@ -818,6 +832,12 @@ set(SOURCE_FILES_unitTest
         src/string_utils.tpp
         src/StringReader.cpp
         src/StringReader.hpp
+        src/TimestampDictionaryEntry.cpp
+        src/TimestampDictionaryEntry.hpp
+        src/TimestampDictionaryReader.cpp
+        src/TimestampDictionaryReader.hpp
+        src/TimestampDictionaryWriter.cpp
+        src/TimestampDictionaryWriter.hpp
         src/TimestampPattern.cpp
         src/TimestampPattern.hpp
         src/TraceableException.cpp

--- a/components/core/src/Defs.h
+++ b/components/core/src/Defs.h
@@ -21,6 +21,11 @@ typedef int64_t logtype_dictionary_id_t;
 constexpr logtype_dictionary_id_t cLogtypeDictionaryIdMax =
         std::numeric_limits<logtype_dictionary_id_t>::max();
 
+typedef int8_t timestamp_dictionary_id_t;
+constexpr variable_dictionary_id_t cTimestampDictionaryIdMax =
+        std::numeric_limits<timestamp_dictionary_id_t>::max();
+#define INVALID_TIMESTAMP_DICTIONARY_ID -1        
+
 typedef uint16_t archive_format_version_t;
 // This flag is used to maintain two separate streams of archive format
 // versions:

--- a/components/core/src/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/LogTypeDictionaryEntry.hpp
@@ -11,7 +11,6 @@
 #include "FileReader.hpp"
 #include "streaming_compression/zstd/Compressor.hpp"
 #include "streaming_compression/zstd/Decompressor.hpp"
-#include "TraceableException.hpp"
 #include "type_utils.hpp"
 
 /**

--- a/components/core/src/TimestampDictionaryEntry.cpp
+++ b/components/core/src/TimestampDictionaryEntry.cpp
@@ -1,0 +1,39 @@
+#include "TimestampDictionaryEntry.hpp"
+
+size_t TimestampDictionaryEntry::get_data_size () const {
+    return sizeof(m_id) + m_value.length();
+}
+
+void TimestampDictionaryEntry::write_to_file (streaming_compression::Compressor& compressor) const {
+    compressor.write_numeric_value(m_id);
+    compressor.write_numeric_value<uint64_t>(m_value.length());
+    compressor.write_string(m_value);
+}
+
+ErrorCode TimestampDictionaryEntry::try_read_from_file (streaming_compression::Decompressor& decompressor) {
+    ErrorCode error_code;
+
+    error_code = decompressor.try_read_numeric_value<timestamp_dictionary_id_t>(m_id);
+    if (ErrorCode_Success != error_code) {
+        return error_code;
+    }
+
+    uint64_t value_length;
+    error_code = decompressor.try_read_numeric_value(value_length);
+    if (ErrorCode_Success != error_code) {
+        return error_code;
+    }
+    error_code = decompressor.try_read_string(value_length, m_value);
+    if (ErrorCode_Success != error_code) {
+        return error_code;
+    }
+
+    return error_code;
+}
+
+void TimestampDictionaryEntry::read_from_file (streaming_compression::Decompressor& decompressor) {
+    auto error_code = try_read_from_file(decompressor);
+    if (ErrorCode_Success != error_code) {
+        throw OperationFailed(error_code, __FILENAME__, __LINE__);
+    }
+}

--- a/components/core/src/TimestampDictionaryEntry.hpp
+++ b/components/core/src/TimestampDictionaryEntry.hpp
@@ -1,0 +1,67 @@
+#ifndef TIMESTAMPDICTIONARYENTRY_HPP
+#define TIMESTAMPDICTIONARYENTRY_HPP
+
+#include "Defs.h"
+#include "DictionaryEntry.hpp"
+#include "ErrorCode.hpp"
+#include "streaming_compression/zstd/Compressor.hpp"
+#include "streaming_compression/zstd/Decompressor.hpp"
+#include "TraceableException.hpp"
+
+/**
+ * Class representing a timestamp dictionary entry
+ */
+class TimestampDictionaryEntry : public DictionaryEntry<timestamp_dictionary_id_t> {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed (ErrorCode error_code, const char* const filename, int line_number) : TraceableException (error_code, filename, line_number) {}
+
+        // Methods
+        const char* what () const noexcept override {
+            return "TimestampDictionaryEntry operation failed";
+        }
+    };
+
+    // Constructors
+    TimestampDictionaryEntry () = default;
+    TimestampDictionaryEntry (const std::string& value, timestamp_dictionary_id_t id) : DictionaryEntry<timestamp_dictionary_id_t>(value, id) {}
+
+    // Use default copy constructor
+    TimestampDictionaryEntry (const TimestampDictionaryEntry&) = default;
+
+    // Assignment operators
+    // Use default
+    TimestampDictionaryEntry& operator= (const TimestampDictionaryEntry&) = default;
+
+    // Methods
+    /**
+     * Gets the size (in-memory) of the data contained in this entry
+     * @return Size of the data contained in this entry
+     */
+    size_t get_data_size () const;
+
+    void clear () { m_value.clear(); }
+
+    /**
+     * Writes an entry to file
+     * @param compressor
+     */
+    void write_to_file (streaming_compression::Compressor& compressor) const;
+    /**
+     * Tries to read an entry from the given decompressor
+     * @param decompressor
+     * @return Same as streaming_compression::Decompressor::try_read_numeric_value
+     * @return Same as streaming_compression::Decompressor::try_read_string
+     */
+    ErrorCode try_read_from_file (streaming_compression::Decompressor& decompressor);
+    /**
+     * Reads an entry from the given decompressor
+     * @param decompressor
+     */
+    void read_from_file (streaming_compression::Decompressor& decompressor);
+};
+
+#endif // TIMESTAMPDICTIONARYENTRY_HPP

--- a/components/core/src/TimestampDictionaryReader.cpp
+++ b/components/core/src/TimestampDictionaryReader.cpp
@@ -1,0 +1,1 @@
+#include "TimestampDictionaryEntry.hpp"

--- a/components/core/src/TimestampDictionaryReader.hpp
+++ b/components/core/src/TimestampDictionaryReader.hpp
@@ -1,0 +1,17 @@
+#ifndef TIMESTAMPDICTIONARYREADER_HPP
+#define TIMESTAMPDICTIONARYREADER_HPP
+
+#include "Defs.h"
+#include "DictionaryReader.hpp"
+#include "TimestampDictionaryEntry.hpp"
+
+/**
+ * Class for reading timestamp dictionaries from disk and performing operations on them
+ */
+class TimestampDictionaryReader : public DictionaryReader<timestamp_dictionary_id_t , TimestampDictionaryEntry> {
+public:
+    // Constructor
+    TimestampDictionaryReader () : DictionaryReader<timestamp_dictionary_id_t, TimestampDictionaryEntry> (false) {}
+};
+
+#endif

--- a/components/core/src/TimestampDictionaryWriter.cpp
+++ b/components/core/src/TimestampDictionaryWriter.cpp
@@ -1,0 +1,33 @@
+#include "TimestampDictionaryWriter.hpp"
+
+bool TimestampDictionaryWriter::add_entry (const std::string& value, timestamp_dictionary_id_t& id) {
+    bool new_entry = false;
+
+    const auto ix = m_value_to_id.find(value);
+    if (m_value_to_id.end() != ix) {
+        id = ix->second;
+    } else {
+        // Entry doesn't exist so create it
+
+        if (m_next_id > m_max_id) {
+            SPDLOG_ERROR("VariableDictionaryWriter ran out of IDs.");
+            throw OperationFailed(ErrorCode_OutOfBounds, __FILENAME__, __LINE__);
+        }
+
+        // Assign ID
+        id = m_next_id;
+        ++m_next_id;
+
+        // Insert the ID obtained from the database into the dictionary
+        auto entry = TimestampDictionaryEntry(value, id);
+        m_value_to_id[value] = id;
+
+        new_entry = true;
+
+        // TODO: This doesn't account for the segment index that's constantly updated
+        m_data_size += entry.get_data_size();
+
+        entry.write_to_file(m_dictionary_compressor);
+    }
+    return new_entry;
+}

--- a/components/core/src/TimestampDictionaryWriter.hpp
+++ b/components/core/src/TimestampDictionaryWriter.hpp
@@ -1,0 +1,38 @@
+#ifndef TIMESTAMPDICTIONARYWRITER_HPP
+#define TIMESTAMPDICTIONARYWRITER_HPP
+
+// Project headers
+#include "Defs.h"
+#include "DictionaryWriter.hpp"
+#include "TimestampDictionaryEntry.hpp"
+
+/**
+ * Class for performing operations on timestamp dictionaries and writing them to disk
+ */
+class TimestampDictionaryWriter : public DictionaryWriter<timestamp_dictionary_id_t, TimestampDictionaryEntry> {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed (ErrorCode error_code, const char* const filename, int line_number) : TraceableException (error_code, filename, line_number) {}
+
+        // Methods
+        const char* what () const noexcept override {
+            return "TimestampDictionaryWriter operation failed";
+        }
+    };
+
+    // Constructor
+    TimestampDictionaryWriter (): DictionaryWriter<timestamp_dictionary_id_t, TimestampDictionaryEntry> (false) {}
+
+    // Methods
+    /**
+     * Adds the given timestamp to the dictionary if it doesn't exist.
+     * @param value
+     * @param id ID of the timestamp matching the given entry
+     */
+    bool add_entry (const std::string& value, timestamp_dictionary_id_t& id);
+};
+
+#endif // TIMESTAMPDICTIONARYWRITER_HPP

--- a/components/core/src/TimestampPattern.cpp
+++ b/components/core/src/TimestampPattern.cpp
@@ -180,6 +180,10 @@ uint8_t TimestampPattern::get_num_spaces_before_ts () const {
     return m_num_spaces_before_ts;
 }
 
+const string TimestampPattern::get_encoded_string() const {
+    return to_string(m_num_spaces_before_ts) + m_format;
+}
+
 bool TimestampPattern::is_empty () const {
     return m_format.empty();
 }

--- a/components/core/src/TimestampPattern.hpp
+++ b/components/core/src/TimestampPattern.hpp
@@ -90,6 +90,11 @@ public:
      */
     uint8_t get_num_spaces_before_ts () const;
     /**
+     * Gets the encoded string representation of the timestamp pattern
+     * @return See description
+     */
+    const std::string get_encoded_string () const;
+    /**
      * Gets if the timestamp pattern is empty
      * @return true if empty, false otherwise
      */

--- a/components/core/src/VariableDictionaryWriter.hpp
+++ b/components/core/src/VariableDictionaryWriter.hpp
@@ -23,6 +23,7 @@ public:
         }
     };
 
+    // Methods
     /**
      * Adds the given variable to the dictionary if it doesn't exist.
      * @param value

--- a/components/core/src/dictionary_utils.cpp
+++ b/components/core/src/dictionary_utils.cpp
@@ -1,15 +1,18 @@
 #include "dictionary_utils.hpp"
 
-void open_dictionary_for_reading (const std::string& dictionary_path, const std::string& segment_index_path, size_t decompressor_file_read_buffer_capacity,
-                                  FileReader& dictionary_file_reader, streaming_compression::Decompressor& dictionary_decompressor,
-                                  FileReader& segment_index_file_reader, streaming_compression::Decompressor& segment_index_decompressor)
+void open_dictionary_for_reading (const std::string& dictionary_path, size_t decompressor_file_read_buffer_capacity, FileReader& dictionary_file_reader,
+                                  streaming_compression::Decompressor& dictionary_decompressor)
 {
     dictionary_file_reader.open(dictionary_path);
     // Skip header
     dictionary_file_reader.seek_from_begin(sizeof(uint64_t));
     // Open decompressor
     dictionary_decompressor.open(dictionary_file_reader, decompressor_file_read_buffer_capacity);
+}
 
+void open_segment_index_for_reading (const std::string& segment_index_path, size_t decompressor_file_read_buffer_capacity,
+                                     FileReader& segment_index_file_reader, streaming_compression::Decompressor& segment_index_decompressor)
+{
     segment_index_file_reader.open(segment_index_path);
     // Skip header
     segment_index_file_reader.seek_from_begin(sizeof(uint64_t));

--- a/components/core/src/dictionary_utils.hpp
+++ b/components/core/src/dictionary_utils.hpp
@@ -8,9 +8,11 @@
 #include "FileReader.hpp"
 #include "streaming_compression/Decompressor.hpp"
 
-void open_dictionary_for_reading (const std::string& dictionary_path, const std::string& segment_index_path, size_t decompressor_file_read_buffer_capacity,
-                                  FileReader& dictionary_file_reader, streaming_compression::Decompressor& dictionary_decompressor,
-                                  FileReader& segment_index_file_reader, streaming_compression::Decompressor& segment_index_decompressor);
+void open_dictionary_for_reading (const std::string& dictionary_path, size_t decompressor_file_read_buffer_capacity, FileReader& dictionary_file_reader,
+                                  streaming_compression::Decompressor& dictionary_decompressor);
+
+void open_segment_index_for_reading (const std::string& segment_index_path, size_t decompressor_file_read_buffer_capacity,
+                                     FileReader& segment_index_file_reader, streaming_compression::Decompressor& segment_index_decompressor);
 
 uint64_t read_dictionary_header (FileReader& file_reader);
 

--- a/components/core/src/streaming_archive/Constants.hpp
+++ b/components/core/src/streaming_archive/Constants.hpp
@@ -9,6 +9,7 @@ namespace streaming_archive {
     constexpr char cSegmentsDirname[] = "s";
     constexpr char cSegmentListFilename[] = "segment_list.txt";
     constexpr char cLogTypeDictFilename[] = "logtype.dict";
+    constexpr char cTsDictFilename[] = "ts.dict";
     constexpr char cVarDictFilename[] = "var.dict";
     constexpr char cLogTypeSegmentIndexFilename[] = "logtype.segindex";
     constexpr char cVarSegmentIndexFilename[] = "var.segindex";

--- a/components/core/src/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/streaming_archive/reader/Archive.cpp
@@ -85,6 +85,11 @@ namespace streaming_archive { namespace reader {
         var_segment_index_path += cVarSegmentIndexFilename;
         m_var_dictionary.open(var_dict_path, var_segment_index_path);
 
+        string ts_dict_path = m_path;
+        ts_dict_path += '/';
+        ts_dict_path += cTsDictFilename;
+        m_ts_dictionary.open(var_dict_path);
+
         // Open segment manager
         m_segments_dir_path = m_path;
         m_segments_dir_path += '/';
@@ -100,6 +105,7 @@ namespace streaming_archive { namespace reader {
     void Archive::close () {
         m_logtype_dictionary.close();
         m_var_dictionary.close();
+        m_ts_dictionary.close();
         m_segment_manager.close();
         m_segments_dir_path.clear();
         m_metadata_db.close();
@@ -109,10 +115,11 @@ namespace streaming_archive { namespace reader {
     void Archive::refresh_dictionaries () {
         m_logtype_dictionary.read_new_entries();
         m_var_dictionary.read_new_entries();
+        m_ts_dictionary.read_new_entries();
     }
 
     ErrorCode Archive::open_file (File& file, MetadataDB::FileIterator& file_metadata_ix) {
-        return file.open_me(m_logtype_dictionary, file_metadata_ix, m_segment_manager);
+        return file.open_me(m_logtype_dictionary, m_ts_dictionary, file_metadata_ix, m_segment_manager);
     }
 
     void Archive::close_file (File& file) {
@@ -129,6 +136,10 @@ namespace streaming_archive { namespace reader {
 
     const VariableDictionaryReader& Archive::get_var_dictionary () const {
         return m_var_dictionary;
+    }
+
+    const TimestampDictionaryReader& Archive::get_ts_dictionary () const {
+        return m_ts_dictionary;
     }
 
     bool Archive::find_message_in_time_range (File& file, epochtime_t search_begin_timestamp, epochtime_t search_end_timestamp, Message& msg) {

--- a/components/core/src/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/streaming_archive/reader/Archive.hpp
@@ -14,6 +14,7 @@
 #include "../../LogTypeDictionaryReader.hpp"
 #include "../../Query.hpp"
 #include "../../SQLiteDB.hpp"
+#include "../../TimestampDictionaryReader.hpp"
 #include "../../VariableDictionaryReader.hpp"
 #include "../MetadataDB.hpp"
 #include "File.hpp"
@@ -51,6 +52,7 @@ namespace streaming_archive { namespace reader {
         void refresh_dictionaries ();
         const LogTypeDictionaryReader& get_logtype_dictionary () const;
         const VariableDictionaryReader& get_var_dictionary () const;
+        const TimestampDictionaryReader& get_ts_dictionary () const;
 
         /**
          * Opens file with given path
@@ -117,6 +119,7 @@ namespace streaming_archive { namespace reader {
         std::string m_segments_dir_path;
         LogTypeDictionaryReader m_logtype_dictionary;
         VariableDictionaryReader m_var_dictionary;
+        TimestampDictionaryReader m_ts_dictionary;
 
         SegmentManager m_segment_manager;
 

--- a/components/core/src/streaming_archive/reader/File.hpp
+++ b/components/core/src/streaming_archive/reader/File.hpp
@@ -11,6 +11,7 @@
 #include "../../ErrorCode.hpp"
 #include "../../LogTypeDictionaryReader.hpp"
 #include "../../Query.hpp"
+#include "../../TimestampDictionaryReader.hpp"
 #include "../../TimestampPattern.hpp"
 #include "../MetadataDB.hpp"
 #include "Message.hpp"
@@ -75,9 +76,8 @@ namespace streaming_archive::reader {
          * @return Same as SegmentManager::try_read
          * @return ErrorCode_Success on success
          */
-        ErrorCode open_me (const LogTypeDictionaryReader& archive_logtype_dict,
-                           MetadataDB::FileIterator& file_metadata_ix,
-                           SegmentManager& segment_manager);
+        ErrorCode open_me (const LogTypeDictionaryReader& archive_logtype_dict, const TimestampDictionaryReader& ts_dict,
+                           MetadataDB::FileIterator& file_metadata_ix, SegmentManager& segment_manager);
         /**
          * Closes the file
          */

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -18,6 +18,7 @@
 #include "../../ErrorCode.hpp"
 #include "../../GlobalMetadataDB.hpp"
 #include "../../LogTypeDictionaryWriter.hpp"
+#include "../../TimestampDictionaryWriter.hpp"
 #include "../../VariableDictionaryWriter.hpp"
 #include "../../compressor_frontend/Token.hpp"
 #include "../ArchiveMetadata.hpp"
@@ -261,6 +262,7 @@ namespace streaming_archive { namespace writer {
         std::vector<encoded_variable_t> m_encoded_vars;
         std::vector<variable_dictionary_id_t> m_var_ids;
         VariableDictionaryWriter m_var_dict;
+        TimestampDictionaryWriter m_ts_dict;
 
         boost::uuids::random_generator m_uuid_generator;
 

--- a/components/core/src/streaming_archive/writer/File.cpp
+++ b/components/core/src/streaming_archive/writer/File.cpp
@@ -63,12 +63,8 @@ namespace streaming_archive { namespace writer {
         m_is_metadata_clean = false;
     }
 
-    void File::change_ts_pattern (const TimestampPattern* pattern) {
-        if (nullptr == pattern) {
-            m_timestamp_patterns.emplace_back(m_num_messages, TimestampPattern());
-        } else {
-            m_timestamp_patterns.emplace_back(m_num_messages, *pattern);
-        }
+    void File::change_ts_pattern (const timestamp_dictionary_id_t id) {
+        m_timestamp_patterns.emplace_back(m_num_messages, id);
         m_is_metadata_clean = false;
     }
 
@@ -96,9 +92,7 @@ namespace streaming_archive { namespace writer {
         for (const auto& timestamp_pattern : m_timestamp_patterns) {
             encoded_timestamp_pattern.assign(to_string(timestamp_pattern.first));
             encoded_timestamp_pattern += ':';
-            encoded_timestamp_pattern += to_string(timestamp_pattern.second.get_num_spaces_before_ts());
-            encoded_timestamp_pattern += ':';
-            encoded_timestamp_pattern += timestamp_pattern.second.get_format();
+            encoded_timestamp_pattern += to_string(timestamp_pattern.second);
             encoded_timestamp_pattern += '\n';
 
             encoded_timestamp_patterns += encoded_timestamp_pattern;

--- a/components/core/src/streaming_archive/writer/File.hpp
+++ b/components/core/src/streaming_archive/writer/File.hpp
@@ -86,7 +86,7 @@ namespace streaming_archive { namespace writer {
          * Changes timestamp pattern in use at current message in file
          * @param pattern
          */
-        void change_ts_pattern (const TimestampPattern* pattern);
+        void change_ts_pattern (const timestamp_dictionary_id_t id);
 
         /**
          * Returns whether the file contains any timestamp pattern
@@ -146,7 +146,7 @@ namespace streaming_archive { namespace writer {
         std::string get_id_as_string () const { return boost::uuids::to_string(m_id); }
         epochtime_t get_begin_ts () const { return m_begin_ts; }
         epochtime_t get_end_ts () const { return m_end_ts; }
-        const std::vector<std::pair<int64_t, TimestampPattern>>& get_timestamp_patterns () const { return m_timestamp_patterns; }
+        const std::vector<std::pair<int64_t, timestamp_dictionary_id_t>>& get_timestamp_patterns () const { return m_timestamp_patterns; }
         std::string get_encoded_timestamp_patterns () const;
         uint64_t get_num_messages () const { return m_num_messages; }
         uint64_t get_num_variables () const { return m_num_variables; }
@@ -187,7 +187,7 @@ namespace streaming_archive { namespace writer {
 
         epochtime_t m_begin_ts;
         epochtime_t m_end_ts;
-        std::vector<std::pair<int64_t, TimestampPattern>> m_timestamp_patterns;
+        std::vector<std::pair<int64_t, timestamp_dictionary_id_t>> m_timestamp_patterns;
 
         group_id_t m_group_id;
 


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
As we will use timestamp dictionaries for semi-structured logs later, we first introduce it to CLP and use it to store timestamp pattern formats.

# Validation performed
<!-- What tests and validation you performed on the change -->

