### PR TITLE
Library Inclusion in Archive.hpp

### DIFF
--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -22,6 +22,8 @@
 #include "../../compressor_frontend/Token.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
+#include <optional>
+
 
 namespace streaming_archive { namespace writer {
     class Archive {

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -2,27 +2,27 @@
 #define STREAMING_ARCHIVE_WRITER_ARCHIVE_HPP
 
 // C++ libraries
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <filesystem>
 
 // Boost libraries
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
 // Project headers
+#include "../ArchiveMetadata.hpp"
 #include "../../ArrayBackedPosIntSet.hpp"
+#include "../../compressor_frontend/Token.hpp"
 #include "../../ErrorCode.hpp"
 #include "../../GlobalMetadataDB.hpp"
 #include "../../LogTypeDictionaryWriter.hpp"
-#include "../../VariableDictionaryWriter.hpp"
-#include "../../compressor_frontend/Token.hpp"
-#include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
+#include "../../VariableDictionaryWriter.hpp"
 
 namespace streaming_archive { namespace writer {
     class Archive {

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -8,6 +8,7 @@
 #include <unordered_set>
 #include <vector>
 #include <filesystem>
+#include <optional>
 
 // Boost libraries
 #include <boost/uuid/random_generator.hpp>
@@ -22,7 +23,7 @@
 #include "../../compressor_frontend/Token.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
-#include <optional>
+
 
 
 namespace streaming_archive { namespace writer {

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -3,12 +3,13 @@
 
 // C++ libraries
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
 #include <filesystem>
-#include <optional>
+
 
 // Boost libraries
 #include <boost/uuid/random_generator.hpp>
@@ -23,8 +24,6 @@
 #include "../../compressor_frontend/Token.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
-
-
 
 namespace streaming_archive { namespace writer {
     class Archive {

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -16,12 +16,12 @@
 
 // Project headers
 #include "../ArchiveMetadata.hpp"
+#include "../MetadataDB.hpp"
 #include "../../ArrayBackedPosIntSet.hpp"
 #include "../../compressor_frontend/Token.hpp"
 #include "../../ErrorCode.hpp"
 #include "../../GlobalMetadataDB.hpp"
 #include "../../LogTypeDictionaryWriter.hpp"
-#include "../MetadataDB.hpp"
 #include "../../VariableDictionaryWriter.hpp"
 
 namespace streaming_archive { namespace writer {

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -10,7 +10,6 @@
 #include <vector>
 #include <filesystem>
 
-
 // Boost libraries
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -15,14 +15,14 @@
 #include <boost/uuid/uuid.hpp>
 
 // Project headers
-#include "../ArchiveMetadata.hpp"
-#include "../MetadataDB.hpp"
 #include "../../ArrayBackedPosIntSet.hpp"
 #include "../../compressor_frontend/Token.hpp"
 #include "../../ErrorCode.hpp"
 #include "../../GlobalMetadataDB.hpp"
 #include "../../LogTypeDictionaryWriter.hpp"
 #include "../../VariableDictionaryWriter.hpp"
+#include "../ArchiveMetadata.hpp"
+#include "../MetadataDB.hpp"
 
 namespace streaming_archive { namespace writer {
     class Archive {


### PR DESCRIPTION

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

-Added required headers for newer (GCC/G++)/Ubuntu versions in Archive.hpp
- GCC version 12.3.0
- Ubuntu 23.04
- path: core/src/streaming_archive/writer/Archive.hpp
![image](https://github.com/y-scope/clp/assets/116512923/c695566e-eb04-4d59-886d-3aa12e6a0e0b)



# Validation performed
<!-- What tests and validation you performed on the change -->

Ran with all 49 executable and unit tests in CLP
![image](https://github.com/y-scope/clp/assets/116512923/b7f7cc75-9021-4b52-9622-db3e635672d7)
