### PR TITLE
Apply clang-format to string_utils.*pp

### DIFF
--- a/components/core/src/string_utils.cpp
+++ b/components/core/src/string_utils.cpp
@@ -1,6 +1,5 @@
 #include "string_utils.hpp"
 
-// C++ standard libraries
 #include <algorithm>
 #include <charconv>
 #include <cstring>
@@ -8,11 +7,10 @@
 using std::string;
 using std::string_view;
 
-// Local function prototypes
 /**
- * Helper for ``wildcard_match_unsafe_case_sensitive`` to advance the pointer in tame to
- * the next character which matches wild. This method should be inlined for
- * performance.
+ * Helper for ``wildcard_match_unsafe_case_sensitive`` to advance the pointer in
+ * tame to the next character which matches wild. This method should be inlined
+ * for performance.
  * @param tame_current
  * @param tame_bookmark
  * @param tame_end
@@ -20,17 +18,20 @@ using std::string_view;
  * @param wild_bookmark
  * @return true on success, false if wild cannot match tame
  */
-static inline bool advance_tame_to_next_match (
-        const char*& tame_current,
-        const char*& tame_bookmark,
-        const char* tame_end,
-        const char*& wild_current,
-        const char*& wild_bookmark
+static inline bool advance_tame_to_next_match(
+        char const*& tame_current,
+        char const*& tame_bookmark,
+        char const* tame_end,
+        char const*& wild_current,
+        char const*& wild_bookmark
 );
 
-size_t find_first_of (const string& haystack, const char* needles, size_t search_start_pos,
-                      size_t& needle_ix)
-{
+size_t find_first_of(
+        string const& haystack,
+        char const* needles,
+        size_t search_start_pos,
+        size_t& needle_ix
+) {
     size_t haystack_length = haystack.length();
     size_t needles_length = strlen(needles);
     for (size_t i = search_start_pos; i < haystack_length; ++i) {
@@ -44,15 +45,18 @@ size_t find_first_of (const string& haystack, const char* needles, size_t search
     return string::npos;
 }
 
-string replace_characters (const char* characters_to_replace, const char* replacement_characters,
-                           const string& value, bool escape)
-{
+string replace_characters(
+        char const* characters_to_replace,
+        char const* replacement_characters,
+        string const& value,
+        bool escape
+) {
     string new_value;
     size_t search_start_pos = 0;
     while (true) {
         size_t replace_char_ix;
-        size_t char_to_replace_pos = find_first_of(value, characters_to_replace, search_start_pos,
-                                                   replace_char_ix);
+        size_t char_to_replace_pos
+                = find_first_of(value, characters_to_replace, search_start_pos, replace_char_ix);
         if (string::npos == char_to_replace_pos) {
             new_value.append(value, search_start_pos, string::npos);
             break;
@@ -68,13 +72,13 @@ string replace_characters (const char* characters_to_replace, const char* replac
     return new_value;
 }
 
-void to_lower (string& str) {
+void to_lower(string& str) {
     std::transform(str.cbegin(), str.cend(), str.begin(), [](unsigned char c) {
         return std::tolower(c);
     });
 }
 
-bool is_wildcard (char c) {
+bool is_wildcard(char c) {
     static constexpr char cWildcards[] = "?*";
     for (size_t i = 0; i < strlen(cWildcards); ++i) {
         if (cWildcards[i] == c) {
@@ -84,7 +88,7 @@ bool is_wildcard (char c) {
     return false;
 }
 
-string clean_up_wildcard_search_string (string_view str) {
+string clean_up_wildcard_search_string(string_view str) {
     string cleaned_str;
 
     bool is_escaped = false;
@@ -95,7 +99,8 @@ string clean_up_wildcard_search_string (string_view str) {
             is_escaped = false;
 
             if (is_wildcard(c) || '\\' == c) {
-                // Keep escaping if c is a wildcard character or an escape character
+                // Keep escaping if c is a wildcard character or an escape
+                // character
                 cleaned_str += '\\';
             }
             cleaned_str += c;
@@ -120,12 +125,12 @@ string clean_up_wildcard_search_string (string_view str) {
     return cleaned_str;
 }
 
-static inline bool advance_tame_to_next_match (
-        const char*& tame_current,
-        const char*& tame_bookmark,
-        const char* tame_end,
-        const char*& wild_current,
-        const char*& wild_bookmark
+static inline bool advance_tame_to_next_match(
+        char const*& tame_current,
+        char const*& tame_bookmark,
+        char const* tame_end,
+        char const*& wild_current,
+        char const*& wild_bookmark
 ) {
     auto w = *wild_current;
     if ('?' != w) {
@@ -135,16 +140,15 @@ static inline bool advance_tame_to_next_match (
         // Handle escaped characters
         if ('\\' == w) {
             ++wild_current;
-            // This is safe without a bounds check since this the caller
-            // ensures there are no dangling escape characters
+            // This is safe without a bounds check since this the caller ensures
+            // there are no dangling escape characters
             w = *wild_current;
         }
 
         // Advance tame_current until it matches wild_current
         while (true) {
             if (tame_end == tame_current) {
-                // Wild group is longer than last group in tame, so
-                // can't match
+                // Wild group is longer than last group in tame, so can't match
                 // e.g. "*abc" doesn't match "zab"
                 return false;
             }
@@ -161,7 +165,7 @@ static inline bool advance_tame_to_next_match (
     return true;
 }
 
-bool wildcard_match_unsafe (string_view tame, string_view wild, bool case_sensitive_match) {
+bool wildcard_match_unsafe(string_view tame, string_view wild, bool case_sensitive_match) {
     if (case_sensitive_match) {
         return wildcard_match_unsafe_case_sensitive(tame, wild);
     } else {
@@ -178,9 +182,9 @@ bool wildcard_match_unsafe (string_view tame, string_view wild, bool case_sensit
 /**
  * The algorithm basically works as follows:
  * Given a wild string "*abc*def*ghi*", it can be broken into groups of
- * characters delimited by one or more '*' characters. The goal of the
- * algorithm is then to determine whether the tame string contains each of
- * those groups in the same order.
+ * characters delimited by one or more '*' characters. The goal of the algorithm
+ * is then to determine whether the tame string contains each of those groups in
+ * the same order.
  *
  * Thus, the algorithm:
  * 1. searches for the start of one of these groups in wild,
@@ -188,15 +192,15 @@ bool wildcard_match_unsafe (string_view tame, string_view wild, bool case_sensit
  * 3. checks if the two match. If not, the search repeats with the next group in
  *    tame.
  */
-bool wildcard_match_unsafe_case_sensitive (string_view tame, string_view wild) {
-    const auto tame_length = tame.length();
-    const auto wild_length = wild.length();
-    const char* tame_current = tame.data();
-    const char* wild_current = wild.data();
-    const char* tame_bookmark = nullptr;
-    const char* wild_bookmark = nullptr;
-    const char* tame_end = tame_current + tame_length;
-    const char* wild_end = wild_current + wild_length;
+bool wildcard_match_unsafe_case_sensitive(string_view tame, string_view wild) {
+    auto const tame_length = tame.length();
+    auto const wild_length = wild.length();
+    char const* tame_current = tame.data();
+    char const* wild_current = wild.data();
+    char const* tame_bookmark = nullptr;
+    char const* wild_bookmark = nullptr;
+    char const* tame_end = tame_current + tame_length;
+    char const* wild_end = wild_current + wild_length;
 
     // Handle wild or tame being empty
     if (0 == wild_length) {
@@ -221,8 +225,14 @@ bool wildcard_match_unsafe_case_sensitive (string_view tame, string_view wild) {
 
             // Set wild and tame bookmarks
             wild_bookmark = wild_current;
-            if (false == advance_tame_to_next_match(tame_current, tame_bookmark, tame_end,
-                                                    wild_current, wild_bookmark))
+            if (false
+                == advance_tame_to_next_match(
+                        tame_current,
+                        tame_bookmark,
+                        tame_end,
+                        wild_current,
+                        wild_bookmark
+                ))
             {
                 return false;
             }
@@ -246,8 +256,14 @@ bool wildcard_match_unsafe_case_sensitive (string_view tame, string_view wild) {
 
                 wild_current = wild_bookmark;
                 tame_current = tame_bookmark + 1;
-                if (false == advance_tame_to_next_match(tame_current, tame_bookmark, tame_end,
-                                                        wild_current, wild_bookmark))
+                if (false
+                    == advance_tame_to_next_match(
+                            tame_current,
+                            tame_bookmark,
+                            tame_end,
+                            wild_current,
+                            wild_bookmark
+                    ))
                 {
                     return false;
                 }
@@ -259,8 +275,8 @@ bool wildcard_match_unsafe_case_sensitive (string_view tame, string_view wild) {
 
         // Handle reaching the end of tame or wild
         if (tame_end == tame_current) {
-            return (wild_end == wild_current ||
-                    ('*' == *wild_current && (wild_current + 1) == wild_end));
+            return (wild_end == wild_current
+                    || ('*' == *wild_current && (wild_current + 1) == wild_end));
         } else {
             if (wild_end == wild_current) {
                 if (nullptr == wild_bookmark) {
@@ -269,8 +285,14 @@ bool wildcard_match_unsafe_case_sensitive (string_view tame, string_view wild) {
                 } else {
                     wild_current = wild_bookmark;
                     tame_current = tame_bookmark + 1;
-                    if (false == advance_tame_to_next_match(tame_current, tame_bookmark, tame_end,
-                                                            wild_current, wild_bookmark))
+                    if (false
+                        == advance_tame_to_next_match(
+                                tame_current,
+                                tame_bookmark,
+                                tame_end,
+                                wild_current,
+                                wild_bookmark
+                        ))
                     {
                         return false;
                     }
@@ -280,13 +302,13 @@ bool wildcard_match_unsafe_case_sensitive (string_view tame, string_view wild) {
     }
 }
 
-bool convert_string_to_double (const std::string& raw, double& converted) {
+bool convert_string_to_double(std::string const& raw, double& converted) {
     if (raw.empty()) {
         // Can't convert an empty string
         return false;
     }
 
-    const char* c_str = raw.c_str();
+    char const* c_str = raw.c_str();
     char* end_ptr;
     // Reset errno so we can detect a new error
     errno = 0;
@@ -297,4 +319,3 @@ bool convert_string_to_double (const std::string& raw, double& converted) {
     converted = raw_as_double;
     return true;
 }
-

--- a/components/core/src/string_utils.hpp
+++ b/components/core/src/string_utils.hpp
@@ -1,7 +1,6 @@
 #ifndef STRING_UTILS_HPP
 #define STRING_UTILS_HPP
 
-// C++ standard libraries
 #include <string>
 
 /**
@@ -9,7 +8,7 @@
  * @param c
  * @return true if c is an alphabet, false otherwise
  */
-inline bool is_alphabet (char c) {
+inline bool is_alphabet(char c) {
     return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
 }
 
@@ -18,7 +17,7 @@ inline bool is_alphabet (char c) {
  * @param c
  * @return true if c is a decimal digit, false otherwise
  */
-inline bool is_decimal_digit (char c)  {
+inline bool is_decimal_digit(char c) {
     return '0' <= c && c <= '9';
 }
 
@@ -30,7 +29,12 @@ inline bool is_decimal_digit (char c)  {
  * @param needle_ix The index of the needle found
  * @return The position of the match or string::npos if none
  */
-size_t find_first_of (const std::string& haystack, const char* needles, size_t search_start_pos, size_t& needle_ix);
+size_t find_first_of(
+        std::string const& haystack,
+        char const* needles,
+        size_t search_start_pos,
+        size_t& needle_ix
+);
 
 /**
  * Replaces the given characters in the given value with the given replacements
@@ -41,15 +45,18 @@ size_t find_first_of (const std::string& haystack, const char* needles, size_t s
  * line-feed character is output as "\n")
  * @return The string with replacements
  */
-std::string replace_characters (const char* characters_to_escape,
-                                const char* replacement_characters, const std::string& value,
-                                bool escape);
+std::string replace_characters(
+        char const* characters_to_escape,
+        char const* replacement_characters,
+        std::string const& value,
+        bool escape
+);
 
 /**
  * Converts a string to lowercase
  * @param str
  */
-void to_lower (std::string& str);
+void to_lower(std::string& str);
 
 /**
  * Cleans wildcard search string
@@ -61,14 +68,14 @@ void to_lower (std::string& str);
  * @param str Wildcard search string to clean
  * @return Cleaned wildcard search string
  */
-std::string clean_up_wildcard_search_string (std::string_view str);
+std::string clean_up_wildcard_search_string(std::string_view str);
 
 /**
  * Checks if character is a wildcard
  * @param c
  * @return true if c is a wildcard, false otherwise
  */
-bool is_wildcard (char c);
+bool is_wildcard(char c);
 
 /**
  * Same as ``wildcard_match_unsafe_case_sensitive`` except this method allows
@@ -79,8 +86,11 @@ bool is_wildcard (char c);
  * @param case_sensitive_match Whether to consider case when matching
  * @return Whether the two strings match
  */
-bool wildcard_match_unsafe (std::string_view tame, std::string_view wild,
-                            bool case_sensitive_match = true);
+bool wildcard_match_unsafe(
+        std::string_view tame,
+        std::string_view wild,
+        bool case_sensitive_match = true
+);
 /**
  * Checks if a string matches a wildcard string. Two wildcards are currently
  * supported: '*' to match 0 or more characters, and '?' to match any single
@@ -100,7 +110,7 @@ bool wildcard_match_unsafe (std::string_view tame, std::string_view wild,
  * @param wild The wildcard string
  * @return Whether the two strings match
  */
-bool wildcard_match_unsafe_case_sensitive (std::string_view tame, std::string_view wild);
+bool wildcard_match_unsafe_case_sensitive(std::string_view tame, std::string_view wild);
 
 /**
  * Converts the given string to a 64-bit integer if possible
@@ -109,8 +119,8 @@ bool wildcard_match_unsafe_case_sensitive (std::string_view tame, std::string_vi
  * @param converted
  * @return true if the conversion was successful, false otherwise
  */
-template<typename integer_t>
-bool convert_string_to_int (std::string_view raw, integer_t& converted);
+template <typename integer_t>
+bool convert_string_to_int(std::string_view raw, integer_t& converted);
 
 /**
  * Converts the given string to a double if possible
@@ -118,8 +128,8 @@ bool convert_string_to_int (std::string_view raw, integer_t& converted);
  * @param converted
  * @return true if the conversion was successful, false otherwise
  */
-bool convert_string_to_double (const std::string& raw, double& converted);
+bool convert_string_to_double(std::string const& raw, double& converted);
 
 #include "string_utils.tpp"
 
-#endif // STRING_UTILS_HPP
+#endif  // STRING_UTILS_HPP

--- a/components/core/src/string_utils.tpp
+++ b/components/core/src/string_utils.tpp
@@ -1,11 +1,10 @@
 #ifndef STRING_UTILS_TPP
 #define STRING_UTILS_TPP
 
-// C++ standard libraries
 #include <charconv>
 
-template<typename integer_t>
-bool convert_string_to_int (std::string_view raw, integer_t& converted) {
+template <typename integer_t>
+bool convert_string_to_int(std::string_view raw, integer_t& converted) {
     auto raw_end = raw.cend();
     auto result = std::from_chars(raw.cbegin(), raw_end, converted);
     if (raw_end != result.ptr) {
@@ -15,4 +14,4 @@ bool convert_string_to_int (std::string_view raw, integer_t& converted) {
     }
 }
 
-#endif // STRING_UTILS_TPP
+#endif  // STRING_UTILS_TPP


### PR DESCRIPTION
# Description
Applies clang format to the string_utils files and also adjusts comments to be <= 80.

Removes header group comments (e.g. // Project headers) now that clang-format organizes them.

# Validation performed
unit tests passing

