### PR TITLE
[ffi] Fix clang warning by changing encoded_vars_length to size_t from int in wildcard query match.

### DIFF
--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -326,7 +326,7 @@ bool wildcard_query_matches_any_encoded_var(
         std::string_view wildcard_query,
         std::string_view logtype,
         encoded_variable_t* encoded_vars,
-        int encoded_vars_length
+        size_t encoded_vars_length
 );
 
 /**

--- a/components/core/src/ffi/encoding_methods.tpp
+++ b/components/core/src/ffi/encoding_methods.tpp
@@ -538,7 +538,7 @@ bool wildcard_query_matches_any_encoded_var(
         std::string_view wildcard_query,
         std::string_view logtype,
         encoded_variable_t* encoded_vars,
-        int encoded_vars_length
+        size_t encoded_vars_length
 ) {
     size_t encoded_vars_ix = 0;
     for (auto c : logtype) {


### PR DESCRIPTION
# Description
Building FFI libraries with clang 16 with `-Werror` will fail due to a signed-unsigned comparison in the wildcard query matching. Changing the encoded variable array length to `size_t` resolves this and is generally the expected type for container `.size()`  calls.

# Validation performed
Clp builds, unit tests pass, also works as expected with go ffi library.

