### PR TITLE
Switch boost-outcome's repo URL from ssh to https.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,4 +13,4 @@
 	url = https://github.com/jbeder/yaml-cpp.git
 [submodule "components/core/submodules/boost-outcome"]
 	path = components/core/submodules/boost-outcome
-	url = git@github.com:boostorg/outcome.git
+	url = https://github.com/boostorg/outcome.git


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

In #152, we mistakenly used an ssh URL for boost-outcome instead of https. This fixes it.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that the submodule can be downloaded with the new URL.