### PR TITLE
Fix archive metadata db related bugs

### DIFF
--- a/components/core/src/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/streaming_archive/MetadataDB.cpp
@@ -342,6 +342,7 @@ namespace streaming_archive {
                        streaming_archive::cMetadataDB::EmptyDirectory::Path);
         SPDLOG_DEBUG("{:.{}}", statement_buffer.data(), statement_buffer.size());
         m_insert_empty_directories_statement = make_unique<SQLitePreparedStatement>(m_db.prepare_statement(statement_buffer.data(), statement_buffer.size()));
+        m_is_open = true;
     }
 
     void MetadataDB::close () {

--- a/components/core/src/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/streaming_archive/reader/Archive.cpp
@@ -65,6 +65,10 @@ namespace streaming_archive { namespace reader {
         }
 
         auto metadata_db_path = boost::filesystem::path(path) / cMetadataDBFileName;
+        if (false == boost::filesystem::exists(metadata_db_path)) {
+            SPDLOG_ERROR("streaming_archive::reader::Archive: Metadata DB not found: {}", metadata_db_path.string());
+            throw OperationFailed(ErrorCode_FileNotFound, __FILENAME__, __LINE__);
+        }
         m_metadata_db.open(metadata_db_path.string());
 
         // Open log-type dictionary


### PR DESCRIPTION
# Description
There are two minor bugs found in the current metadata database, and this PR is to address these two bugs:
1. The archive reader should raise an exception if the metadata db is not found in the archive instead of silencing the error.
2. After the metadata data base is successfully opened, the `m_is_open` flag should be set to true.

