### PR TITLE
Default __FILENAME__ to __FILE__ when the source path size has not been defined.

### DIFF
--- a/components/core/src/TraceableException.hpp
+++ b/components/core/src/TraceableException.hpp
@@ -10,29 +10,25 @@
 class TraceableException : public std::exception {
 public:
     // Constructors
-    TraceableException(ErrorCode error_code, char const* const filename, int const line_number)
-            : m_error_code(error_code),
-              m_filename(filename),
-              m_line_number(line_number) {}
+    TraceableException (ErrorCode error_code, const char* const filename, const int line_number) : m_error_code(error_code), m_filename(filename),
+            m_line_number(line_number) {}
 
     // Copy constructor / assignment operators
-    TraceableException(TraceableException const&) = default;
-    TraceableException& operator=(TraceableException const&) = default;
+    TraceableException (const TraceableException&) = default;
+    TraceableException& operator= (const TraceableException&) = default;
 
     // Methods
-    ErrorCode get_error_code() const { return m_error_code; }
-
-    char const* get_filename() const { return m_filename; }
-
-    int get_line_number() const { return m_line_number; }
+    ErrorCode get_error_code () const { return m_error_code; }
+    const char* get_filename () const { return m_filename; }
+    int get_line_number () const { return m_line_number; }
 
     // NOTE: We make what() abstract to make the entire class abstract
-    virtual char const* what() const noexcept = 0;
+    virtual const char* what () const noexcept = 0;
 
 private:
     // Variables
     ErrorCode m_error_code;
-    char const* m_filename;
+    const char* m_filename;
     int m_line_number;
 };
 
@@ -45,4 +41,4 @@ private:
     #define __FILENAME__ __FILE__
 #endif
 
-#endif  // TRACEABLEEXCEPTION
+#endif // TRACEABLEEXCEPTION

--- a/components/core/src/TraceableException.hpp
+++ b/components/core/src/TraceableException.hpp
@@ -10,30 +10,39 @@
 class TraceableException : public std::exception {
 public:
     // Constructors
-    TraceableException (ErrorCode error_code, const char* const filename, const int line_number) : m_error_code(error_code), m_filename(filename),
-            m_line_number(line_number) {}
+    TraceableException(ErrorCode error_code, char const* const filename, int const line_number)
+            : m_error_code(error_code),
+              m_filename(filename),
+              m_line_number(line_number) {}
 
     // Copy constructor / assignment operators
-    TraceableException (const TraceableException&) = default;
-    TraceableException& operator= (const TraceableException&) = default;
+    TraceableException(TraceableException const&) = default;
+    TraceableException& operator=(TraceableException const&) = default;
 
     // Methods
-    ErrorCode get_error_code () const { return m_error_code; }
-    const char* get_filename () const { return m_filename; }
-    int get_line_number () const { return m_line_number; }
+    ErrorCode get_error_code() const { return m_error_code; }
+
+    char const* get_filename() const { return m_filename; }
+
+    int get_line_number() const { return m_line_number; }
 
     // NOTE: We make what() abstract to make the entire class abstract
-    virtual const char* what () const noexcept = 0;
+    virtual char const* what() const noexcept = 0;
 
 private:
     // Variables
     ErrorCode m_error_code;
-    const char* m_filename;
+    char const* m_filename;
     int m_line_number;
 };
 
 // Macros
-// Relative version of __FILE__
-#define __FILENAME__ ((__FILE__) + SOURCE_PATH_SIZE)
+// Define a version of __FILE__ that's relative to the source directory
+#ifdef SOURCE_PATH_SIZE
+    #define __FILENAME__ ((__FILE__) + SOURCE_PATH_SIZE)
+#else
+    // We don't know the source path size, so just default to __FILE__
+    #define __FILENAME__ __FILE__
+#endif
 
-#endif // TRACEABLEEXCEPTION
+#endif  // TRACEABLEEXCEPTION


### PR DESCRIPTION
# Description
Without `SOURCE_PATH_SIZE` defined compilation fails as `__FILENAME__` (a relative path version of `__FILE__`) fails to be defined. However, a relative file path should not be a hard requirement for building/running CLP. Therefore, we default back to `__FILE__` when `SOURCE_PATH_SIZE` is not defined.

# Validation performed
All unit tests passing with or without `SOURCE_PATH_SIZE` defined.

