### PR TITLE
Add missing parameter to log statement.

### DIFF
--- a/components/core/src/clp/FileCompressor.cpp
+++ b/components/core/src/clp/FileCompressor.cpp
@@ -382,6 +382,7 @@ namespace clp {
             if (0 != error_code.value()) {
                 SPDLOG_ERROR(
                         "Failed to compress {} - {}:{}",
+                        path,
                         error_code.category().name(),
                         error_code.message()
                 );


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Missed a parameter in the log statement introduced in 03cedcdf391ddbe409196a627dc8e0a128941207. This PR fixes it.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Created an IR file with only a magic number.
* Attempted to compress it with clp and validated that it printed the error log *with* the path.