### PR TITLE
Add support for the 8-byte long timestamp delta encoding

### DIFF
--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -251,6 +251,12 @@ parse_timestamp(ReaderInterface& reader, encoded_tag_t encoded_tag, epoch_time_m
                 return IRErrorCode_Incomplete_IR;
             }
             ts = ts_delta;
+        } else if (cProtocol::Payload::TimestampDeltaLong == encoded_tag) {
+            int64_t ts_delta;
+            if (false == decode_int(reader, ts_delta)) {
+                return IRErrorCode_Incomplete_IR;
+            }
+            ts = ts_delta;
         } else {
             return IRErrorCode_Corrupted_IR;
         }

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -150,7 +150,7 @@ typedef enum {
 
 /**
  * Validates whether the given protocol version can be supported by the current
- * decoding method implementations.
+ * build.
  * @param protocol_version Protocol version to be validate.
  * @return IRProtocolErrorCode_Supported if the protocol version is supported.
  * @return IRProtocolErrorCode_Unsupported if the protocol version cannot be

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -18,6 +18,13 @@ typedef enum {
     IRErrorCode_Incomplete_IR,
 } IRErrorCode;
 
+typedef enum {
+    IRProtocolErrorCode_Supported,
+    IRProtocolErrorCode_Too_Old,
+    IRProtocolErrorCode_Too_New,
+    IRProtocolErrorCode_Invalid,
+} IRProtocolErrorCode;
+
 class DecodingException : public TraceableException {
 public:
     // Constructors
@@ -142,23 +149,19 @@ IRErrorCode decode_preamble(
         std::vector<int8_t>& metadata
 );
 
-typedef enum {
-    IRProtocolErrorCode_Supported,
-    IRProtocolErrorCode_Unsupported,
-    IRProtocolErrorCode_Unknown,
-} IRProtocolErrorCode;
-
 /**
  * Validates whether the given protocol version can be supported by the current
  * build.
- * @param protocol_version Protocol version to be validate.
+ * @param protocol_version
  * @return IRProtocolErrorCode_Supported if the protocol version is supported.
- * @return IRProtocolErrorCode_Unsupported if the protocol version cannot be
- * supported.
- * @return IRProtocolErrorCode_Unknow if the protocol version does not follow
- * the form specified by SemVer.
+ * @return IRProtocolErrorCode_Too_Old if the protocol version is no longer
+ * supported by the current build version.
+ * @return IRProtocolErrorCode_Too_New if the protocol version is newer than the
+ * build version.
+ * @return IRProtocolErrorCode_Invalid if the protocol version does not follow
+ * the SemVer specification.
  */
-IRProtocolErrorCode validate_protocol_version(std::string const& protocol_version);
+IRProtocolErrorCode validate_protocol_version(std::string_view protocol_version);
 
 namespace eight_byte_encoding {
     /**

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -142,6 +142,24 @@ IRErrorCode decode_preamble(
         std::vector<int8_t>& metadata
 );
 
+typedef enum {
+    IRProtocolErrorCode_Supported,
+    IRProtocolErrorCode_Unsupported,
+    IRProtocolErrorCode_Unknown,
+} IRProtocolErrorCode;
+
+/**
+ * Validates whether the given protocol version can be supported by the current
+ * decoding method implementations.
+ * @param protocol_version Protocol version to be validate.
+ * @return IRProtocolErrorCode_Supported if the protocol version is supported.
+ * @return IRProtocolErrorCode_Unsupported if the protocol version cannot be
+ * supported.
+ * @return IRProtocolErrorCode_Unknow if the protocol version does not follow
+ * the form specified by SemVer.
+ */
+IRProtocolErrorCode validate_protocol_version(std::string const& protocol_version);
+
 namespace eight_byte_encoding {
     /**
      * Decodes the next message for the eight-byte encoding IR stream.

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -155,9 +155,9 @@ IRErrorCode decode_preamble(
  * @param protocol_version
  * @return IRProtocolErrorCode_Supported if the protocol version is supported.
  * @return IRProtocolErrorCode_Too_Old if the protocol version is no longer
- * supported by the current build version.
- * @return IRProtocolErrorCode_Too_New if the protocol version is newer than the
- * build version.
+ * supported by this build's protocol version.
+ * @return IRProtocolErrorCode_Too_New if the protocol version is newer than this
+ * build's protocol version.
  * @return IRProtocolErrorCode_Invalid if the protocol version does not follow
  * the SemVer specification.
  */

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -308,8 +308,11 @@ namespace four_byte_encoding {
         } else if (INT32_MIN <= timestamp_delta && timestamp_delta <= INT32_MAX) {
             ir_buf.push_back(cProtocol::Payload::TimestampDeltaInt);
             encode_int(static_cast<int32_t>(timestamp_delta), ir_buf);
+        } else if (INT64_MIN <= timestamp_delta && timestamp_delta <= INT64_MAX) {
+            ir_buf.push_back(cProtocol::Payload::TimestampDeltaLong);
+            encode_int(static_cast<int64_t>(timestamp_delta), ir_buf);
         } else {
-            // Delta exceeds maximum representable by an int (24.86 days)
+            // Delta exceeds maximum representable by a 64-bit int
             return false;
         }
 

--- a/components/core/src/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.cpp
@@ -57,10 +57,7 @@ static void add_base_metadata_fields(
  * @param logtype
  * @return true
  */
-static bool append_constant_to_logtype(
-        string_view constant,
-        string& logtype
-);
+static bool append_constant_to_logtype(string_view constant, string& logtype);
 
 /**
  * A functor for encoding dictionary variables in a message

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -12,7 +12,7 @@ namespace Metadata {
     constexpr int8_t LengthUShort = 0x12;
 
     constexpr char VersionKey[] = "VERSION";
-    constexpr char VersionValue[] = "v0.0.0";
+    constexpr char VersionValue[] = "v0.0.1";
 
     constexpr char TimestampPatternKey[] = "TIMESTAMP_PATTERN";
     constexpr char TimestampPatternSyntaxKey[] = "TIMESTAMP_PATTERN_SYNTAX";

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -39,6 +39,7 @@ namespace Payload {
     constexpr int8_t TimestampDeltaByte = 0x31;
     constexpr int8_t TimestampDeltaShort = 0x32;
     constexpr int8_t TimestampDeltaInt = 0x33;
+    constexpr int8_t TimestampDeltaLong = 0x34;
 }  // namespace Payload
 
 constexpr int8_t FourByteEncodingMagicNumber[]

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -3,7 +3,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <regex>
 #include <type_traits>
 
 namespace ffi::ir_stream::cProtocol {
@@ -13,12 +12,14 @@ namespace Metadata {
     constexpr int8_t LengthUShort = 0x12;
 
     constexpr char VersionKey[] = "VERSION";
-    constexpr char VersionValue[] = "v0.0.1";
-    constexpr char VersionRegex[] =
-            "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
-            "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-            "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
-            "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
+    constexpr char VersionValue[] = "0.0.1";
+
+    // The following regex can be used to validate a Semantic Versioning string.
+    // The source of the regex can be found here: https://semver.org/
+    constexpr char VersionRegex[] = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
+                                    "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+                                    "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+                                    "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
 
     constexpr char TimestampPatternKey[] = "TIMESTAMP_PATTERN";
     constexpr char TimestampPatternSyntaxKey[] = "TIMESTAMP_PATTERN_SYNTAX";

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <regex>
 #include <type_traits>
 
 namespace ffi::ir_stream::cProtocol {
@@ -13,6 +14,11 @@ namespace Metadata {
 
     constexpr char VersionKey[] = "VERSION";
     constexpr char VersionValue[] = "v0.0.1";
+    constexpr char VersionRegex[] =
+            "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
+            "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+            "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+            "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
 
     constexpr char TimestampPatternKey[] = "TIMESTAMP_PATTERN";
     constexpr char TimestampPatternSyntaxKey[] = "TIMESTAMP_PATTERN_SYNTAX";

--- a/components/core/src/ir/LogEventDeserializer.cpp
+++ b/components/core/src/ir/LogEventDeserializer.cpp
@@ -37,8 +37,8 @@ auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader)
         return std::errc::protocol_error;
     }
     auto metadata_version = version_iter->get_ref<nlohmann::json::string_t&>();
-    if (static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::VersionValue)
-        != metadata_version)
+    if (ffi::ir_stream::IRProtocolErrorCode_Supported
+        != ffi::ir_stream::validate_protocol_version(metadata_version))
     {
         return std::errc::protocol_not_supported;
     }

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -28,6 +28,7 @@ using ffi::ir_stream::decode_preamble;
 using ffi::ir_stream::encoded_tag_t;
 using ffi::ir_stream::get_encoding_type;
 using ffi::ir_stream::IRErrorCode;
+using ffi::ir_stream::validate_protocol_version;
 using ffi::wildcard_query_matches_any_encoded_var;
 using ir::VariablePlaceholder;
 using std::chrono::duration_cast;
@@ -329,8 +330,10 @@ TEMPLATE_TEST_CASE(
     string_view json_metadata{metadata_ptr, metadata_size};
 
     auto metadata_json = nlohmann::json::parse(json_metadata);
-    REQUIRE(ffi::ir_stream::cProtocol::Metadata::VersionValue
-            == metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey));
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported
+            == validate_protocol_version(
+                    metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey)
+            ));
     REQUIRE(ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type);
     set_timestamp_info(metadata_json, ts_info);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
@@ -471,7 +474,7 @@ TEST_CASE("message_decode_error", "[ffi][decode_next_message]") {
 
 TEST_CASE("decode_next_message_four_byte_timestamp_delta", "[ffi][decode_next_message]") {
     string const message = "Static <\text>, dictVar1, 123, 456345232.7234223, "
-                     "dictVar2, 987, 654.3, end of static text";
+                           "dictVar2, 987, 654.3, end of static text";
     auto test_timestamp_delta = [&](epoch_time_ms_t ref_ts_delta) {
         vector<int8_t> ir_buf;
         string logtype;
@@ -582,8 +585,10 @@ TEMPLATE_TEST_CASE(
     auto* json_metadata_ptr{size_checked_pointer_cast<char>(ir_buf.data() + metadata_pos)};
     string_view json_metadata{json_metadata_ptr, metadata_size};
     auto metadata_json = nlohmann::json::parse(json_metadata);
-    REQUIRE(ffi::ir_stream::cProtocol::Metadata::VersionValue
-            == metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey));
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported
+            == validate_protocol_version(
+                    metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey)
+            ));
     REQUIRE(ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type);
     set_timestamp_info(metadata_json, ts_info);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -514,8 +514,7 @@ TEST_CASE("decode_next_message_four_byte_timestamp_delta", "[ffi][decode_next_me
     );
     vector<int8_t> ir_buf;
     string logtype;
-    REQUIRE(true == encode_message<four_byte_encoded_variable_t>(ts_delta, message, logtype, ir_buf)
-    );
+    REQUIRE(encode_message<four_byte_encoded_variable_t>(ts_delta, message, logtype, ir_buf));
 
     BufferReader ir_buffer{size_checked_pointer_cast<char const>(ir_buf.data()), ir_buf.size()};
     string decoded_message;

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -130,7 +130,10 @@ static epoch_time_ms_t get_current_ts() {
 
 template <typename encoded_variable_t>
 bool match_encoding_type(bool is_four_bytes_encoding) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(
+            (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>)
+            || (is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return false == is_four_bytes_encoding;
@@ -141,7 +144,10 @@ bool match_encoding_type(bool is_four_bytes_encoding) {
 
 template <typename encoded_variable_t>
 epoch_time_ms_t get_next_timestamp_for_test() {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(
+            (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>)
+            || (is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
 
     // We return an absolute timestamp for the eight-byte encoding and a mocked
     // timestamp delta for the four-byte encoding
@@ -164,7 +170,10 @@ bool encode_preamble(
         epoch_time_ms_t reference_timestamp,
         vector<int8_t>& ir_buf
 ) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(
+            (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>)
+            || (is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::encode_preamble(
@@ -191,7 +200,10 @@ bool encode_message(
         string& logtype,
         vector<int8_t>& ir_buf
 ) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(
+            (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>)
+            || (is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::encode_message(
@@ -213,7 +225,10 @@ bool encode_message(
 template <typename encoded_variable_t>
 IRErrorCode
 decode_next_message(BufferReader& reader, string& message, epoch_time_ms_t& decoded_ts) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(
+            (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>)
+            || (is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::decode_next_message(

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -495,45 +495,39 @@ TEST_CASE("message_decode_error", "[ffi][decode_next_message]") {
 TEST_CASE("decode_next_message_four_byte_timestamp_delta", "[ffi][decode_next_message]") {
     string const message = "Static <\text>, dictVar1, 123, 456345232.7234223, "
                            "dictVar2, 987, 654.3, end of static text";
-    auto test_timestamp_delta = [&](epoch_time_ms_t ts_delta) {
-        vector<int8_t> ir_buf;
-        string logtype;
-        REQUIRE(true
-                == encode_message<four_byte_encoded_variable_t>(ts_delta, message, logtype, ir_buf)
-        );
-
-        BufferReader ir_buffer{size_checked_pointer_cast<char const>(ir_buf.data()), ir_buf.size()};
-        string decoded_message;
-        epoch_time_ms_t decoded_delta_ts{};
-        REQUIRE(IRErrorCode::IRErrorCode_Success
-                == decode_next_message<four_byte_encoded_variable_t>(
-                        ir_buffer,
-                        decoded_message,
-                        decoded_delta_ts
-                ));
-        REQUIRE(message == decoded_message);
-        REQUIRE(decoded_delta_ts == ts_delta);
-        return true;
-    };
-
-    auto timestamp_deltas = GENERATE(
-            0,
-            INT8_MIN,
-            INT8_MIN + 1,
-            INT8_MAX - 1,
-            INT8_MAX,
-            INT16_MIN,
-            INT16_MIN + 1,
-            INT16_MAX - 1,
-            INT16_MAX,
-            INT32_MIN,
-            INT32_MIN + 1,
-            INT32_MAX - 1,
-            INT32_MAX,
-            INT64_MIN,
-            INT64_MAX
+    auto ts_delta = GENERATE(
+            static_cast<ffi::epoch_time_ms_t>(0),
+            static_cast<ffi::epoch_time_ms_t>(INT8_MIN),
+            static_cast<ffi::epoch_time_ms_t>(INT8_MIN + 1),
+            static_cast<ffi::epoch_time_ms_t>(INT8_MAX - 1),
+            static_cast<ffi::epoch_time_ms_t>(INT8_MAX),
+            static_cast<ffi::epoch_time_ms_t>(INT16_MIN),
+            static_cast<ffi::epoch_time_ms_t>(INT16_MIN + 1),
+            static_cast<ffi::epoch_time_ms_t>(INT16_MAX - 1),
+            static_cast<ffi::epoch_time_ms_t>(INT16_MAX),
+            static_cast<ffi::epoch_time_ms_t>(INT32_MIN),
+            static_cast<ffi::epoch_time_ms_t>(INT32_MIN + 1),
+            static_cast<ffi::epoch_time_ms_t>(INT32_MAX - 1),
+            static_cast<ffi::epoch_time_ms_t>(INT32_MAX),
+            static_cast<ffi::epoch_time_ms_t>(INT64_MIN),
+            static_cast<ffi::epoch_time_ms_t>(INT64_MAX)
     );
-    REQUIRE(test_timestamp_delta(timestamp_deltas));
+    vector<int8_t> ir_buf;
+    string logtype;
+    REQUIRE(true == encode_message<four_byte_encoded_variable_t>(ts_delta, message, logtype, ir_buf)
+    );
+
+    BufferReader ir_buffer{size_checked_pointer_cast<char const>(ir_buf.data()), ir_buf.size()};
+    string decoded_message;
+    epoch_time_ms_t decoded_delta_ts{};
+    REQUIRE(IRErrorCode::IRErrorCode_Success
+            == decode_next_message<four_byte_encoded_variable_t>(
+                    ir_buffer,
+                    decoded_message,
+                    decoded_delta_ts
+            ));
+    REQUIRE(message == decoded_message);
+    REQUIRE(decoded_delta_ts == ts_delta);
 }
 
 TEST_CASE("validate_protocol_version", "[ffi][validate_version_protocol]") {

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -130,8 +130,7 @@ static epoch_time_ms_t get_current_ts() {
 
 template <typename encoded_variable_t>
 bool match_encoding_type(bool is_four_bytes_encoding) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return false == is_four_bytes_encoding;
@@ -142,8 +141,7 @@ bool match_encoding_type(bool is_four_bytes_encoding) {
 
 template <typename encoded_variable_t>
 epoch_time_ms_t get_next_timestamp_for_test() {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     // We return an absolute timestamp for the eight-byte encoding and a mocked
     // timestamp delta for the four-byte encoding
@@ -166,8 +164,7 @@ bool encode_preamble(
         epoch_time_ms_t reference_timestamp,
         vector<int8_t>& ir_buf
 ) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::encode_preamble(
@@ -194,8 +191,7 @@ bool encode_message(
         string& logtype,
         vector<int8_t>& ir_buf
 ) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::encode_message(
@@ -217,8 +213,7 @@ bool encode_message(
 template <typename encoded_variable_t>
 IRErrorCode
 decode_next_message(BufferReader& reader, string& message, epoch_time_ms_t& decoded_ts) {
-    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> ||
-                  is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
+    static_assert(is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || is_same_v<encoded_variable_t, four_byte_encoded_variable_t>);
 
     if constexpr (is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>) {
         return ffi::ir_stream::eight_byte_encoding::decode_next_message(
@@ -245,11 +240,13 @@ TEST_CASE("get_encoding_type", "[ffi][get_encoding_type]") {
     // Test eight-byte encoding
     vector<int8_t> eight_byte_encoding_vec{
             EightByteEncodingMagicNumber,
-            EightByteEncodingMagicNumber + MagicNumberLength};
+            EightByteEncodingMagicNumber + MagicNumberLength
+    };
 
     BufferReader eight_byte_ir_buffer{
             size_checked_pointer_cast<char const>(eight_byte_encoding_vec.data()),
-            eight_byte_encoding_vec.size()};
+            eight_byte_encoding_vec.size()
+    };
     REQUIRE(get_encoding_type(eight_byte_ir_buffer, is_four_bytes_encoding)
             == IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<eight_byte_encoded_variable_t>(is_four_bytes_encoding));
@@ -257,11 +254,13 @@ TEST_CASE("get_encoding_type", "[ffi][get_encoding_type]") {
     // Test four-byte encoding
     vector<int8_t> four_byte_encoding_vec{
             FourByteEncodingMagicNumber,
-            FourByteEncodingMagicNumber + MagicNumberLength};
+            FourByteEncodingMagicNumber + MagicNumberLength
+    };
 
     BufferReader four_byte_ir_buffer{
             size_checked_pointer_cast<char const>(four_byte_encoding_vec.data()),
-            four_byte_encoding_vec.size()};
+            four_byte_encoding_vec.size()
+    };
     REQUIRE(get_encoding_type(four_byte_ir_buffer, is_four_bytes_encoding)
             == IRErrorCode::IRErrorCode_Success);
     REQUIRE(match_encoding_type<four_byte_encoded_variable_t>(is_four_bytes_encoding));
@@ -276,7 +275,8 @@ TEST_CASE("get_encoding_type", "[ffi][get_encoding_type]") {
 
     BufferReader incomplete_buffer{
             size_checked_pointer_cast<char const>(four_byte_encoding_vec.data()),
-            four_byte_encoding_vec.size() - 1};
+            four_byte_encoding_vec.size() - 1
+    };
     REQUIRE(get_encoding_type(incomplete_buffer, is_four_bytes_encoding)
             == IRErrorCode::IRErrorCode_Incomplete_IR);
 
@@ -284,7 +284,8 @@ TEST_CASE("get_encoding_type", "[ffi][get_encoding_type]") {
     vector<int8_t> const invalid_ir_vec{0x02, 0x43, 0x24, 0x34};
     BufferReader invalid_ir_buffer{
             size_checked_pointer_cast<char const>(invalid_ir_vec.data()),
-            invalid_ir_vec.size()};
+            invalid_ir_vec.size()
+    };
     REQUIRE(get_encoding_type(invalid_ir_buffer, is_four_bytes_encoding)
             == IRErrorCode::IRErrorCode_Corrupted_IR);
 }
@@ -330,10 +331,8 @@ TEMPLATE_TEST_CASE(
     string_view json_metadata{metadata_ptr, metadata_size};
 
     auto metadata_json = nlohmann::json::parse(json_metadata);
-    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported
-            == validate_protocol_version(
-                    metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey)
-            ));
+    std::string const version = metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey);
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported == validate_protocol_version(version));
     REQUIRE(ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type);
     set_timestamp_info(metadata_json, ts_info);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);
@@ -356,7 +355,8 @@ TEMPLATE_TEST_CASE(
             == IRErrorCode::IRErrorCode_Success);
     string_view json_metadata_copied{
             size_checked_pointer_cast<char const>(json_metadata_vec.data()),
-            json_metadata_vec.size()};
+            json_metadata_vec.size()
+    };
     // Crosscheck with the json_metadata decoded previously
     REQUIRE(json_metadata_copied == json_metadata);
 
@@ -364,7 +364,8 @@ TEMPLATE_TEST_CASE(
     ir_buf.resize(encoded_preamble_end_pos - 1);
     BufferReader incomplete_preamble_buffer{
             size_checked_pointer_cast<char const>(ir_buf.data()),
-            ir_buf.size()};
+            ir_buf.size()
+    };
     incomplete_preamble_buffer.seek_from_begin(MagicNumberLength);
     REQUIRE(decode_preamble(incomplete_preamble_buffer, metadata_type, metadata_pos, metadata_size)
             == IRErrorCode::IRErrorCode_Incomplete_IR);
@@ -373,7 +374,8 @@ TEMPLATE_TEST_CASE(
     ir_buf[MagicNumberLength] = 0x23;
     BufferReader corrupted_preamble_buffer{
             size_checked_pointer_cast<char const>(ir_buf.data()),
-            ir_buf.size()};
+            ir_buf.size()
+    };
     REQUIRE(decode_preamble(corrupted_preamble_buffer, metadata_type, metadata_pos, metadata_size)
             == IRErrorCode::IRErrorCode_Corrupted_IR);
 }
@@ -415,7 +417,8 @@ TEMPLATE_TEST_CASE(
     ir_buf.resize(encoded_message_end_pos - 4);
     BufferReader incomplete_preamble_buffer{
             size_checked_pointer_cast<char const>(ir_buf.data()),
-            ir_buf.size()};
+            ir_buf.size()
+    };
     REQUIRE(IRErrorCode::IRErrorCode_Incomplete_IR
             == decode_next_message<TestType>(incomplete_preamble_buffer, message, timestamp));
 }
@@ -449,7 +452,8 @@ TEST_CASE("message_decode_error", "[ffi][decode_next_message]") {
     ir_with_extra_escape.at(logtype_end_pos - 1) = ir::cVariablePlaceholderEscapeCharacter;
     BufferReader ir_with_extra_escape_buffer{
             size_checked_pointer_cast<char const>(ir_with_extra_escape.data()),
-            ir_with_extra_escape.size()};
+            ir_with_extra_escape.size()
+    };
     REQUIRE(IRErrorCode::IRErrorCode_Decode_Error
             == decode_next_message<eight_byte_encoded_variable_t>(
                     ir_with_extra_escape_buffer,
@@ -463,7 +467,8 @@ TEST_CASE("message_decode_error", "[ffi][decode_next_message]") {
             = enum_to_underlying_type(VariablePlaceholder::Dictionary);
     BufferReader ir_with_extra_placeholder_buffer{
             size_checked_pointer_cast<char const>(ir_with_extra_placeholder.data()),
-            ir_with_extra_placeholder.size()};
+            ir_with_extra_placeholder.size()
+    };
     REQUIRE(IRErrorCode::IRErrorCode_Decode_Error
             == decode_next_message<eight_byte_encoded_variable_t>(
                     ir_with_extra_placeholder_buffer,
@@ -475,51 +480,56 @@ TEST_CASE("message_decode_error", "[ffi][decode_next_message]") {
 TEST_CASE("decode_next_message_four_byte_timestamp_delta", "[ffi][decode_next_message]") {
     string const message = "Static <\text>, dictVar1, 123, 456345232.7234223, "
                            "dictVar2, 987, 654.3, end of static text";
-    auto test_timestamp_delta = [&](epoch_time_ms_t ref_ts_delta) {
+    auto test_timestamp_delta = [&](epoch_time_ms_t ts_delta) {
         vector<int8_t> ir_buf;
         string logtype;
         REQUIRE(true
-                == encode_message<four_byte_encoded_variable_t>(
-                        ref_ts_delta,
-                        message,
-                        logtype,
-                        ir_buf
-                ));
+                == encode_message<four_byte_encoded_variable_t>(ts_delta, message, logtype, ir_buf)
+        );
 
         BufferReader ir_buffer{size_checked_pointer_cast<char const>(ir_buf.data()), ir_buf.size()};
         string decoded_message;
-        epoch_time_ms_t delta_ts;
+        epoch_time_ms_t decoded_delta_ts{};
         REQUIRE(IRErrorCode::IRErrorCode_Success
                 == decode_next_message<four_byte_encoded_variable_t>(
                         ir_buffer,
                         decoded_message,
-                        delta_ts
+                        decoded_delta_ts
                 ));
         REQUIRE(message == decoded_message);
-        REQUIRE(delta_ts == ref_ts_delta);
+        REQUIRE(decoded_delta_ts == ts_delta);
+        return true;
     };
 
-    test_timestamp_delta(0);
+    auto timestamp_deltas = GENERATE(
+            0,
+            INT8_MIN,
+            INT8_MIN + 1,
+            INT8_MAX - 1,
+            INT8_MAX,
+            INT16_MIN,
+            INT16_MIN + 1,
+            INT16_MAX - 1,
+            INT16_MAX,
+            INT32_MIN,
+            INT32_MIN + 1,
+            INT32_MAX - 1,
+            INT32_MAX,
+            INT64_MIN,
+            INT64_MAX
+    );
+    REQUIRE(test_timestamp_delta(timestamp_deltas));
+}
 
-    test_timestamp_delta(INT8_MIN);
-    test_timestamp_delta(INT8_MIN + 1);
-    test_timestamp_delta(INT8_MAX - 1);
-    test_timestamp_delta(INT8_MAX);
+TEST_CASE("validate_protocol_version", "[ffi][validate_version_protocol]") {
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Invalid == validate_protocol_version("v0.0.1"));
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Invalid == validate_protocol_version("0.1"));
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Invalid == validate_protocol_version("0.a.1"));
 
-    test_timestamp_delta(INT16_MIN);
-    test_timestamp_delta(INT16_MIN + 1);
-    test_timestamp_delta(INT16_MAX - 1);
-    test_timestamp_delta(INT16_MAX);
-
-    test_timestamp_delta(INT32_MIN);
-    test_timestamp_delta(INT32_MIN + 1);
-    test_timestamp_delta(INT32_MAX - 1);
-    test_timestamp_delta(INT32_MAX);
-
-    test_timestamp_delta(INT64_MIN);
-    test_timestamp_delta(INT64_MIN + 1);
-    test_timestamp_delta(INT64_MAX - 1);
-    test_timestamp_delta(INT64_MAX);
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Too_New == validate_protocol_version("1000.0.0"));
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported
+            == validate_protocol_version(ffi::ir_stream::cProtocol::Metadata::VersionValue));
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported == validate_protocol_version("v0.0.0"));
 }
 
 TEMPLATE_TEST_CASE(
@@ -566,7 +576,8 @@ TEMPLATE_TEST_CASE(
 
     BufferReader complete_ir_buffer{
             size_checked_pointer_cast<char const>(ir_buf.data()),
-            ir_buf.size()};
+            ir_buf.size()
+    };
 
     bool is_four_bytes_encoding;
     REQUIRE(get_encoding_type(complete_ir_buffer, is_four_bytes_encoding)
@@ -585,10 +596,8 @@ TEMPLATE_TEST_CASE(
     auto* json_metadata_ptr{size_checked_pointer_cast<char>(ir_buf.data() + metadata_pos)};
     string_view json_metadata{json_metadata_ptr, metadata_size};
     auto metadata_json = nlohmann::json::parse(json_metadata);
-    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported
-            == validate_protocol_version(
-                    metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey)
-            ));
+    string const version = metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey);
+    REQUIRE(ffi::ir_stream::IRProtocolErrorCode_Supported == validate_protocol_version(version));
     REQUIRE(ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type);
     set_timestamp_info(metadata_json, ts_info);
     REQUIRE(timestamp_pattern_syntax == ts_info.timestamp_pattern_syntax);


### PR DESCRIPTION
# Description
The current IR encoding protocol doesn't support 8-byte timestamp delta encoding. This means the current four-byte encoding IR stream cannot contain a timestamp delta of more than +/- 24.86 days. This PR resolves this problem by introducing an 8-byte timestamp delta encoding.
The protocol version number is bumped to "v0.0.1". As a result, the version of the decoder must have been up-to-date to decode an 8-byte encoded timestamp delta properly.
To validate the version, a validation function is added to check whether the built protocol version number is greater or equal to the input protocol version number. The current version validation relies on the SemVar [https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions](url) convention.

# Validation performed
- Added unit tests to cover the timestamp delta encoding for all integer sizes we support. Negative timestamp deltas are also tested.
- Tested the version number validation:
  - Ensured the old version (v0.0.0) can be compressed successfully.
  - Ensured the version that doesn't follow the SemVer convention will be caught.