### PR TITLE
webui: separate search results by job ids

### DIFF
--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_method.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_method.py
@@ -113,7 +113,7 @@ def search(
         search_cmd.append("--mongodb-database")
         search_cmd.append(str(output_config["db_name"]))
         search_cmd.append("--mongodb-collection")
-        search_cmd.append(str(query['results_collection_name']))
+        search_cmd.append(f"{output_config['results_collection_name']}_{job_id_str}")
 
     # Start compression
     logger.info("Searching...")

--- a/components/webui/imports/api/search/publications.js
+++ b/components/webui/imports/api/search/publications.js
@@ -2,3 +2,4 @@ import {Mongo} from "meteor/mongo";
 
 export const SEARCH_SERVER_STATE_COLLECTION_NAME = "search-server-state";
 export const SearchServerStateCollection = new Mongo.Collection(SEARCH_SERVER_STATE_COLLECTION_NAME);
+export const SearchResultsMetadataCollection = new Mongo.Collection(Meteor.settings.public.SearchResultsMetadataCollectionName);

--- a/components/webui/imports/api/search/server/query_handler_mediator.js
+++ b/components/webui/imports/api/search/server/query_handler_mediator.js
@@ -88,6 +88,7 @@ class WebUiQueryHandlerWebsocket {
             case ServerMessageType.QUERY_STARTED:
                 if (SearchState.WAITING_FOR_QUERY_TO_START === currentServerStateList[this.__sessionId].state) {
                     currentServerStateList[this.__sessionId].state = SearchState.QUERY_IN_PROGRESS;
+                    currentServerStateList[this.__sessionId].jobID = message['value']['jobID']
                 } else {
                     // Should not be possible, so disconnect
                     console.error("Got QUERY_STARTED while in impossible state.");
@@ -118,7 +119,7 @@ class WebUiQueryHandlerWebsocket {
 
 export function initCurrentServerState(sessionId) {
     if (currentServerStateList[sessionId] === undefined) {
-        currentServerStateList[sessionId] = {state: null, errorMessage: ""};
+        currentServerStateList[sessionId] = {state: null, errorMessage: "", jobID: null};
     }
 }
 


### PR DESCRIPTION
# References
Kirk reported that race conditions in search results and/or metadata were discovered when the server was undergoing high load.

# Description
1. Create a single search metadata collection for all and store each job's results metadata per document.
2. Instead of storing search results per session, store those per job with the collection name being `results_${job_id}`.
3. In the webui-query-handler, pass `job_id` as part of the state reporting back to the meteor server, which is later propagated to the meteor client side.
4. For each search / timeline update, pull results from `results_${job_id}` and metadata from `results-metadata`'s document `meta-job-${job_id}`.

# Validation performed
Manual integration test. Steps include:
1. Rebuild `clp-package`.
2. Start `clp-package`.
3. Session A: In the Chromium-based Microsoft Edge browser, visit `http://localhost:4000` and start a search query.
4. Session B: Open a "New InPrivate Window" in Microsoft Edge and visit `http://localhost:4000`, effectively emulating another user visiting the same site. Start a search query.
5. Keep both Session A and B open, adjust pipeline strings (search keywords) in both Session A and B, and observe search results showing up independently in each session.
6. Keep both Session A and B open, adjust the timeline in both Session A and B, and observe updated search results showing up independently in each session.
