### PR TITLE
Fix four-byte float encoding methods to properly handle cases where the input float exceeds the representable range.

### DIFF
--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -83,10 +83,9 @@ eight_byte_encoded_variable_t encode_four_byte_float_as_eight_byte(
 );
 
 /**
- * Encodes a float value with the given properties into an encoded variable. It
- * does not check whether the input can be safely encoded with the given
- * encoding type. It is the caller's responsibility to validate whether the
- * input is a representable float.
+ * Encodes a float value with the given properties into an encoded variable.
+ * NOTE: It's the caller's responsibility to validate that the input is a
+ * representable float.
  * @tparam encoded_variable_t Type of the encoded variable
  * @param is_negative
  * @param digits The digits of the float, ignoring the decimal, as an

--- a/components/core/src/ffi/encoding_methods.hpp
+++ b/components/core/src/ffi/encoding_methods.hpp
@@ -83,7 +83,10 @@ eight_byte_encoded_variable_t encode_four_byte_float_as_eight_byte(
 );
 
 /**
- * Encodes a float value with the given properties into an encoded variable
+ * Encodes a float value with the given properties into an encoded variable. It
+ * does not check whether the input can be safely encoded with the given
+ * encoding type. It is the caller's responsibility to validate whether the
+ * input is a representable float.
  * @tparam encoded_variable_t Type of the encoded variable
  * @param is_negative
  * @param digits The digits of the float, ignoring the decimal, as an

--- a/components/core/src/ffi/encoding_methods.inc
+++ b/components/core/src/ffi/encoding_methods.inc
@@ -66,6 +66,13 @@ bool encode_float_string(std::string_view str, encoded_variable_t& encoded_var) 
         return false;
     }
 
+    if constexpr (std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>) {
+        if (cFourByteEncodedFloatDigitsBitMask < digits) {
+            // digits is larger than maximum representable
+            return false;
+        }
+    }
+
     encoded_var = encode_float_properties<encoded_variable_t>(
             is_negative,
             digits,
@@ -127,10 +134,6 @@ encoded_variable_t encode_float_properties(
         return bit_cast<encoded_variable_t>(encoded_float);
     } else {
         // std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>
-        if (digits > cFourByteEncodedFloatDigitsBitMask) {
-            // digits is larger than maximum representable
-            return false;
-        }
 
         // Encode into 32 bits with the following format (from MSB to LSB):
         // -  1 bit : is negative

--- a/components/core/src/ffi/encoding_methods.inc
+++ b/components/core/src/ffi/encoding_methods.inc
@@ -65,7 +65,6 @@ bool encode_float_string(std::string_view str, encoded_variable_t& encoded_var) 
         // digits found
         return false;
     }
-
     if constexpr (std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>) {
         if (cFourByteEncodedFloatDigitsBitMask < digits) {
             // digits is larger than maximum representable

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -228,7 +228,7 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
 
     SECTION("Test unrepresentable floats") {
         if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
-            std::string const unrepresentable_values = GENERATE(
+            string const unrepresentable_values = GENERATE(
                     "0.33554431",
                     "-0.33554431",
                     "3.3554432",
@@ -241,7 +241,7 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     }
 
     SECTION("Test non-floats") {
-        std::string const non_floating_values = GENERATE(
+        string const non_floating_values = GENERATE(
                 "",
                 "a",
                 "-",

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -260,7 +260,7 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
             "1.0F",
             "1.0l",
             "1.0L",
-            // "1.0.0"
+            "1.0.0"
     );
     REQUIRE(false == encode_float_string(non_floating_values, encoded_var));
 }

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -226,6 +226,20 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     decoded_value = decode_float_var(encoded_var);
     REQUIRE(decoded_value == value);
 
+    // Test out of range
+    if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
+        four_byte_encoded_variable_t encoded_var;
+        auto float_out_of_range = GENERATE(
+                std::string("0.33554431"),
+                std::string("-0.33554431"),
+                std::string("3.3554432"),
+                std::string("-3.3554432"),
+                std::string("60.000004"),
+                std::string("-60.000004")
+        );
+        REQUIRE(false == ffi::encode_float_string(float_out_of_range, encoded_var));
+    }
+
     // Test non-floats
     value = "";
     REQUIRE(!encode_float_string(value, encoded_var));

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -226,75 +226,43 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     decoded_value = decode_float_var(encoded_var);
     REQUIRE(decoded_value == value);
 
-    // Test out of range
+    // Test unrepresentable floating values
     if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
         four_byte_encoded_variable_t encoded_var;
-        auto float_out_of_range = GENERATE(
-                std::string("0.33554431"),
-                std::string("-0.33554431"),
-                std::string("3.3554432"),
-                std::string("-3.3554432"),
-                std::string("60.000004"),
-                std::string("-60.000004")
+        std::string unrepresentable_values = GENERATE(
+                "0.33554431",
+                "-0.33554431",
+                "3.3554432",
+                "-3.3554432",
+                "60.000004",
+                "-60.000004"
         );
-        REQUIRE(false == ffi::encode_float_string(float_out_of_range, encoded_var));
+        REQUIRE(false == ffi::encode_float_string(unrepresentable_values, encoded_var));
     }
 
     // Test non-floats
-    value = "";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "a";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "-";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "+";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "-a";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "+a";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "--";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "++";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    // Test unrepresentable values
-    value = ".";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "1.";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = " 1.0";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "- 1.0";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "1.0 ";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "+1.0";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "1.0f";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "1.0F";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "1.0l";
-    REQUIRE(!encode_float_string(value, encoded_var));
-
-    value = "1.0L";
-    REQUIRE(!encode_float_string(value, encoded_var));
+    std::string non_floating_values = GENERATE(
+            "",
+            "a",
+            "-",
+            "+",
+            "-a",
+            "+a",
+            "--",
+            "++",
+            ".",
+            "1.",
+            " 1.0",
+            "1.0 ",
+            "- 1.0",
+            "+1.0",
+            "1.0f"
+            "1.0F",
+            "1.0l",
+            "1.0L",
+            // "1.0.0"
+    );
+    REQUIRE(false == encode_float_string(non_floating_values, encoded_var));
 }
 
 TEMPLATE_TEST_CASE("encode_float_properties", "[ffi][encode-float]", eight_byte_encoded_variable_t,

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -226,43 +226,44 @@ TEMPLATE_TEST_CASE("Encoding floats", "[ffi][encode-float]", eight_byte_encoded_
     decoded_value = decode_float_var(encoded_var);
     REQUIRE(decoded_value == value);
 
-    // Test unrepresentable floating values
-    if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
-        four_byte_encoded_variable_t encoded_var;
-        std::string unrepresentable_values = GENERATE(
-                "0.33554431",
-                "-0.33554431",
-                "3.3554432",
-                "-3.3554432",
-                "60.000004",
-                "-60.000004"
-        );
-        REQUIRE(false == ffi::encode_float_string(unrepresentable_values, encoded_var));
+    SECTION("Test unrepresentable floats") {
+        if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
+            std::string const unrepresentable_values = GENERATE(
+                    "0.33554431",
+                    "-0.33554431",
+                    "3.3554432",
+                    "-3.3554432",
+                    "60.000004",
+                    "-60.000004"
+            );
+            REQUIRE(false == ffi::encode_float_string(unrepresentable_values, encoded_var));
+        }
     }
 
-    // Test non-floats
-    std::string non_floating_values = GENERATE(
-            "",
-            "a",
-            "-",
-            "+",
-            "-a",
-            "+a",
-            "--",
-            "++",
-            ".",
-            "1.",
-            " 1.0",
-            "1.0 ",
-            "- 1.0",
-            "+1.0",
-            "1.0f"
-            "1.0F",
-            "1.0l",
-            "1.0L",
-            "1.0.0"
-    );
-    REQUIRE(false == encode_float_string(non_floating_values, encoded_var));
+    SECTION("Test non-floats") {
+        std::string const non_floating_values = GENERATE(
+                "",
+                "a",
+                "-",
+                "+",
+                "-a",
+                "+a",
+                "--",
+                "++",
+                ".",
+                "1.",
+                " 1.0",
+                "1.0 ",
+                "- 1.0",
+                "+1.0",
+                "1.0f"
+                "1.0F",
+                "1.0l",
+                "1.0L",
+                "1.0.0"
+        );
+        REQUIRE(false == encode_float_string(non_floating_values, encoded_var));
+    }
 }
 
 TEMPLATE_TEST_CASE("encode_float_properties", "[ffi][encode-float]", eight_byte_encoded_variable_t,


### PR DESCRIPTION
# References
https://github.com/y-scope/clp/issues/172

# Description
The `encode_float_properties` method doesn't correctly handle cases where the given input exceeds the representable range for four-byte encoding. When it happens, it will return `false` which is interpreted as encoded `.0`. This PR fixes this bug by moving the range check to the `encode_float_string` method to ensure the input to the `encode_float_properties` is always in-bound.

# Validation performed
1. Passed all the existing unit tests.
2. Added unit test cases to cover the out-of-range scenarios.
3. Validated on the incorrect user logs to ensure it can now generate the correct output.

