### PR TITLE
Add log-surgeon to dependencies downloadable without git.

### DIFF
--- a/components/core/tools/scripts/deps-download/download-all.sh
+++ b/components/core/tools/scripts/deps-download/download-all.sh
@@ -25,5 +25,6 @@ else
   python3 "${script_dir}/download-dep.py" "${script_dir}/Catch2.json"
   python3 "${script_dir}/download-dep.py" "${script_dir}/date.json"
   python3 "${script_dir}/download-dep.py" "${script_dir}/json.json"
+  python3 "${script_dir}/download-dep.py" "${script_dir}/log-surgeon.json"
   python3 "${script_dir}/download-dep.py" "${script_dir}/yaml-cpp.json"
 fi

--- a/components/core/tools/scripts/deps-download/log-surgeon.json
+++ b/components/core/tools/scripts/deps-download/log-surgeon.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/y-scope/log-surgeon/archive/895f464.zip",
+  "unzip": true,
+  "targets": [
+    {
+      "source": "log-surgeon-895f46489b1911ab3b3aac3202afd56c96e8cd98",
+      "destination": "submodules/log-surgeon"
+    }
+  ]
+}


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

We added log-surgeon as a submodule in #131 but didn't add it to the dependencies that can be downloaded when git is unavailable (e.g., when building CLP from a release where the `.git` directory doesn't exist). This PR adds it.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that log-surgeon was downloaded when building `core` from a source-only (no `.git` directory) release.