### PR TITLE
Fix a memory bug related to m_relevant_sub_queries

### DIFF
--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -558,7 +558,7 @@ std::optional<Query> Grep::process_raw_query(
     // - (token1 as logtype) (token2 as var)
     // - (token1 as var) (token2 as logtype)
     // - (token1 as var) (token2 as var)
-    std::vector<SubQuery> sub_queries;
+    vector<SubQuery> sub_queries;
     string logtype;
     bool type_of_one_token_changed = true;
     while (type_of_one_token_changed) {
@@ -603,7 +603,7 @@ std::optional<Query> Grep::process_raw_query(
         return std::nullopt;
     }
 
-    query.add_sub_queries(sub_queries);
+    query.set_sub_queries(std::move(sub_queries));
     return query;
 }
 

--- a/components/core/src/Grep.hpp
+++ b/components/core/src/Grep.hpp
@@ -1,6 +1,7 @@
 #ifndef GREP_HPP
 #define GREP_HPP
 
+#include <optional>
 #include <string>
 
 #include <log_surgeon/Lexer.hpp>

--- a/components/core/src/Grep.hpp
+++ b/components/core/src/Grep.hpp
@@ -41,13 +41,12 @@ public:
      * @param use_heuristic
      * @return true if query may match messages, false otherwise
      */
-    static bool process_raw_query(
+    static std::optional<Query> process_raw_query(
             streaming_archive::reader::Archive const& archive,
             std::string const& search_string,
             epochtime_t search_begin_ts,
             epochtime_t search_end_ts,
             bool ignore_case,
-            Query& query,
             log_surgeon::lexers::ByteLexer& forward_lexer,
             log_surgeon::lexers::ByteLexer& reverse_lexer,
             bool use_heuristic

--- a/components/core/src/Grep.hpp
+++ b/components/core/src/Grep.hpp
@@ -36,11 +36,10 @@ public:
      * @param search_begin_ts
      * @param search_end_ts
      * @param ignore_case
-     * @param query
      * @param forward_lexer DFA for determining if input is in the schema
      * @param reverse_lexer DFA for determining if reverse of input is in the schema
      * @param use_heuristic
-     * @return true if query may match messages, false otherwise
+     * @return Query if it may match a message, std::nullopt otherwise
      */
     static std::optional<Query> process_raw_query(
             streaming_archive::reader::Archive const& archive,

--- a/components/core/src/Query.cpp
+++ b/components/core/src/Query.cpp
@@ -176,12 +176,14 @@ void Query::set_search_string(string const& search_string) {
     m_search_string_matches_all = (m_search_string.empty() || "*" == m_search_string);
 }
 
-void Query::add_sub_query(SubQuery const& sub_query) {
-    m_sub_queries.push_back(sub_query);
+void Query::add_sub_queries(std::vector<SubQuery>& sub_queries) {
+    m_sub_queries = std::move(sub_queries);
 
-    // Add to relevant sub-queries if necessary
-    if (sub_query.get_ids_of_matching_segments().count(m_prev_segment_id)) {
-        m_relevant_sub_queries.push_back(&m_sub_queries.back());
+    for (auto& sub_query : m_sub_queries) {
+        // Add to relevant sub-queries if necessary
+        if (sub_query.get_ids_of_matching_segments().count(m_prev_segment_id)) {
+            m_relevant_sub_queries.push_back(&m_sub_queries.back());
+        }
     }
 }
 

--- a/components/core/src/Query.cpp
+++ b/components/core/src/Query.cpp
@@ -176,13 +176,13 @@ void Query::set_search_string(string const& search_string) {
     m_search_string_matches_all = (m_search_string.empty() || "*" == m_search_string);
 }
 
-void Query::add_sub_queries(std::vector<SubQuery>& sub_queries) {
+void Query::set_sub_queries(std::vector<SubQuery> sub_queries) {
     m_sub_queries = std::move(sub_queries);
 
     for (auto& sub_query : m_sub_queries) {
         // Add to relevant sub-queries if necessary
         if (sub_query.get_ids_of_matching_segments().count(m_prev_segment_id)) {
-            m_relevant_sub_queries.push_back(&m_sub_queries.back());
+            m_relevant_sub_queries.push_back(&sub_query);
         }
     }
 }

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -172,7 +172,7 @@ public:
     void set_ignore_case(bool ignore_case) { m_ignore_case = ignore_case; }
 
     void set_search_string(std::string const& search_string);
-    void add_sub_query(SubQuery const& sub_query);
+    void add_sub_queries(std::vector<SubQuery>& sub_query);
     void clear_sub_queries();
     /**
      * Populates the set of relevant sub-queries with only those that match the given segment

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -172,7 +172,7 @@ public:
     void set_ignore_case(bool ignore_case) { m_ignore_case = ignore_case; }
 
     void set_search_string(std::string const& search_string);
-    void add_sub_queries(std::vector<SubQuery>& sub_query);
+    void set_sub_queries(std::vector<SubQuery> sub_queries);
     void clear_sub_queries();
     /**
      * Populates the set of relevant sub-queries with only those that match the given segment

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -216,7 +216,7 @@ static bool search(
                     reverse_lexer,
                     use_heuristic
             );
-            if (false == query_processing_result.has_value()) {
+            if (query_processing_result.has_value()) {
                 auto& query = query_processing_result.value();
                 no_queries_match = false;
 

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -206,7 +206,7 @@ static bool search(
         std::set<segment_id_t> ids_of_segments_to_search;
         bool is_superseding_query = false;
         for (auto const& search_string : search_strings) {
-            std::optional<Query> query_result = Grep::process_raw_query(
+            auto query_processing_result = Grep::process_raw_query(
                     archive,
                     search_string,
                     search_begin_ts,
@@ -216,11 +216,11 @@ static bool search(
                     reverse_lexer,
                     use_heuristic
             );
-            if (query_result) {
-                Query& query = query_result.value();
+            if (false == query_processing_result.has_value()) {
+                auto& query = query_processing_result.value();
                 no_queries_match = false;
 
-                if (query.contains_sub_queries() == false) {
+                if (false == query.contains_sub_queries()) {
                     // Search string supersedes all other possible search strings
                     is_superseding_query = true;
                     // Remove existing queries since they are superseded by this one

--- a/components/core/src/clg/clg.cpp
+++ b/components/core/src/clg/clg.cpp
@@ -206,19 +206,18 @@ static bool search(
         std::set<segment_id_t> ids_of_segments_to_search;
         bool is_superseding_query = false;
         for (auto const& search_string : search_strings) {
-            Query query;
-            if (Grep::process_raw_query(
-                        archive,
-                        search_string,
-                        search_begin_ts,
-                        search_end_ts,
-                        command_line_args.ignore_case(),
-                        query,
-                        forward_lexer,
-                        reverse_lexer,
-                        use_heuristic
-                ))
-            {
+            std::optional<Query> query_result = Grep::process_raw_query(
+                    archive,
+                    search_string,
+                    search_begin_ts,
+                    search_end_ts,
+                    command_line_args.ignore_case(),
+                    forward_lexer,
+                    reverse_lexer,
+                    use_heuristic
+            );
+            if (query_result) {
+                Query& query = query_result.value();
                 no_queries_match = false;
 
                 if (query.contains_sub_queries() == false) {

--- a/components/core/src/clo/clo.cpp
+++ b/components/core/src/clo/clo.cpp
@@ -260,7 +260,7 @@ static bool search_archive(
     auto search_begin_ts = command_line_args.get_search_begin_ts();
     auto search_end_ts = command_line_args.get_search_end_ts();
 
-    std::optional<Query> query_result = Grep::process_raw_query(
+    auto query_processing_result = Grep::process_raw_query(
             archive_reader,
             command_line_args.get_search_string(),
             search_begin_ts,
@@ -270,11 +270,11 @@ static bool search_archive(
             *reverse_lexer,
             use_heuristic
     );
-    if (query_result) {
+    if (false == query_processing_result.has_value()) {
         return true;
     }
 
-    Query& query = query_result.value();
+    Query& query = query_processing_result.value();
     // Get all segments potentially containing query results
     std::set<segment_id_t> ids_of_segments_to_search;
     for (auto& sub_query : query.get_sub_queries()) {

--- a/components/core/src/clo/clo.cpp
+++ b/components/core/src/clo/clo.cpp
@@ -274,7 +274,7 @@ static bool search_archive(
         return true;
     }
 
-    Query& query = query_processing_result.value();
+    auto& query = query_processing_result.value();
     // Get all segments potentially containing query results
     std::set<segment_id_t> ids_of_segments_to_search;
     for (auto& sub_query : query.get_sub_queries()) {

--- a/components/core/src/clo/clo.cpp
+++ b/components/core/src/clo/clo.cpp
@@ -260,23 +260,21 @@ static bool search_archive(
     auto search_begin_ts = command_line_args.get_search_begin_ts();
     auto search_end_ts = command_line_args.get_search_end_ts();
 
-    Query query;
-    if (false
-        == Grep::process_raw_query(
-                archive_reader,
-                command_line_args.get_search_string(),
-                search_begin_ts,
-                search_end_ts,
-                command_line_args.ignore_case(),
-                query,
-                *forward_lexer,
-                *reverse_lexer,
-                use_heuristic
-        ))
-    {
+    std::optional<Query> query_result = Grep::process_raw_query(
+            archive_reader,
+            command_line_args.get_search_string(),
+            search_begin_ts,
+            search_end_ts,
+            command_line_args.ignore_case(),
+            *forward_lexer,
+            *reverse_lexer,
+            use_heuristic
+    );
+    if (query_result) {
         return true;
     }
 
+    Query& query = query_result.value();
     // Get all segments potentially containing query results
     std::set<segment_id_t> ids_of_segments_to_search;
     for (auto& sub_query : query.get_sub_queries()) {


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Previously, when we push new elements into `m_relevant_sub_queries`, we use 
`m_relevant_sub_queries.push_back(&m_sub_queries.back());`. However, `m_sub_queries` is a vector and the memory is dynamically allocated. Upon resizing, it may use new addresses and pointers stored in `m_relevant_sub_queries` are no longer valid.

# Validation performed
<!-- What tests and validation you performed on the change -->
Passed unit test and clang-format check. Also ran queries which cover the affected code and got expected results
