### PR TITLE
Add workflow to validate clang-format was applied to core's sources

### DIFF
--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -26,15 +26,22 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: "Install and run clang-format on all of core's source files"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.11"
+
+      - name: "Install clang-format"
+        shell: "bash"
+        run: |
+          pip3 install --upgrade pip
+          pip3 install --upgrade clang-format
+
+      - name: "Run clang-format on all of core's source files"
         shell: "bash"
         working-directory: "./components/core"
         run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          pip3 install -U clang-format
           find src tests \
             -type f \
-            \( -iname "*.cpp" -o -iname "*.hpp" -o -iname "*.h" -o -iname "*.inc" \) \
+            \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
             -print0 | \
               xargs -0 clang-format --dry-run -Werror

--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -1,0 +1,38 @@
+name: clp-core-lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/clp-core-lint.yaml"
+      - "components/core/src/**"
+      - "components/core/tests/**"
+  push:
+    paths:
+      - ".github/workflows/clp-core-lint.yaml"
+      - "components/core/src/**"
+      - "components/core/tests/**"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  clang-format:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+        with:
+          submodules: "recursive"
+
+      - name: "Install and run clang-format on all of core's source files"
+        shell: "bash"
+        working-directory: "./components/core"
+        run: |
+          python3 -m venv venv
+          . venv/bin/activate
+          pip3 install -U clang-format
+          find src tests -type f \
+            \( -iname "*.cpp" -o -iname "*.hpp" -o -iname "*.h" -o -iname "*.inc" \) \
+            -exec clang-format --dry-run -Werror {} \;

--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -33,6 +33,8 @@ jobs:
           python3 -m venv venv
           . venv/bin/activate
           pip3 install -U clang-format
-          find src tests -type f \
+          find src tests \
+            -type f \
             \( -iname "*.cpp" -o -iname "*.hpp" -o -iname "*.h" -o -iname "*.inc" \) \
-            -exec clang-format --dry-run -Werror {} \;
+            -print0 | \
+              xargs -0 clang-format --dry-run -Werror

--- a/components/core/src/clp/clp.cpp
+++ b/components/core/src/clp/clp.cpp
@@ -10,5 +10,5 @@ int main(int argc, char const* argv[]) {
     } catch (std::string const err) {
         SPDLOG_ERROR(err.c_str());
         return 1;
-     }
+    }
 }

--- a/components/core/src/clp/clp.cpp
+++ b/components/core/src/clp/clp.cpp
@@ -10,5 +10,5 @@ int main(int argc, char const* argv[]) {
     } catch (std::string const err) {
         SPDLOG_ERROR(err.c_str());
         return 1;
-    }
+     }
 }


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Adds a workflow to validate that clang-format was applied to all of core's source files.

NOTE: There is an argument to be made that failure of this workflow should prevent the build workflows from running, but we have multiple build jobs and creating dependencies between workflows is complicated and not well supported.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that the workflow runs on changes to source files and that incorrectly formatted files cause the workflow to fail.
