### PR TITLE
Use apt package for MariaDB C connector on Ubuntu Focal.

### DIFF
--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
@@ -3,7 +3,6 @@
 ./tools/scripts/lib_install/fmtlib.sh 8.0.1
 ./tools/scripts/lib_install/libarchive.sh 3.5.1
 ./tools/scripts/lib_install/lz4.sh 1.8.2
-./tools/scripts/lib_install/mariadb-connector-c.sh 3.2.3
 ./tools/scripts/lib_install/msgpack.sh 6.0.0
 ./tools/scripts/lib_install/spdlog.sh 1.9.2
 ./tools/scripts/lib_install/zstandard.sh 1.4.9

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -13,6 +13,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   libboost-filesystem-dev \
   libboost-iostreams-dev \
   libboost-program-options-dev \
+  libmariadb-dev \
   libssl-dev \
   openjdk-11-jdk \
   pkg-config \


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

In the script to install `core`'s dependencies on Ubuntu Focal, we're using a prebuilt package for the MariaDB C connector; but it's downloaded directly from mariadb.com rather than the default apt repositories. If a user already has the package from apt installed, the prebuilt package used in the script would unnecessarily replace their existing one.

This PR changes the Focal install script to use the apt package instead.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated the core build workflows passed.