### PR TITLE
Convert repository names to lowercase before using them in docker image names.

### DIFF
--- a/.github/actions/clp-core-build-containers/action.yaml
+++ b/.github/actions/clp-core-build-containers/action.yaml
@@ -45,17 +45,14 @@ runs:
           echo "REGISTRY=localhost:${{inputs.local_registry_port}}" >> "$GITHUB_OUTPUT"
           echo "BRANCH=latest" >> "$GITHUB_OUTPUT"
         fi
-
-    - id: "generate_id"
-      shell: "bash"
-      run: |
-        echo "ID=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+        echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
+          >> "$GITHUB_OUTPUT"
 
     - id: "deps_image_meta"
       uses: "docker/metadata-action@v5"
       with:
         images: "${{steps.get_deps_image_props.outputs.REGISTRY}}\
-          /${{steps.generate_id.outputs.ID}}\
+          /${{steps.get_deps_image_props.outputs.REPOSITORY}}\
           /clp-core-dependencies-x86-${{inputs.os_name}}"
         tags: |
           type=raw,value=${{steps.get_deps_image_props.outputs.BRANCH}}
@@ -78,7 +75,7 @@ runs:
       uses: "docker/metadata-action@v5"
       with:
         images: "${{steps.get_deps_image_props.outputs.REGISTRY}}\
-          /${{steps.generate_id.outputs.ID}}\
+          /${{steps.get_deps_image_props.outputs.REPOSITORY}}\
           /clp-core-x86-${{inputs.os_name}}"
         tags: |
           type=raw,value=${{steps.get_deps_image_props.outputs.BRANCH}}

--- a/.github/actions/clp-core-build-containers/action.yaml
+++ b/.github/actions/clp-core-build-containers/action.yaml
@@ -45,6 +45,8 @@ runs:
           echo "REGISTRY=localhost:${{inputs.local_registry_port}}" >> "$GITHUB_OUTPUT"
           echo "BRANCH=latest" >> "$GITHUB_OUTPUT"
         fi
+        # Docker doesn't support repository names with uppercase characters, so we convert to
+        # lowercase here.
         echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
           >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/clp-core-build-containers/action.yaml
+++ b/.github/actions/clp-core-build-containers/action.yaml
@@ -46,11 +46,16 @@ runs:
           echo "BRANCH=latest" >> "$GITHUB_OUTPUT"
         fi
 
+    - id: "generate_id"
+      shell: "bash"
+      run: |
+        echo "ID=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
     - id: "deps_image_meta"
       uses: "docker/metadata-action@v5"
       with:
         images: "${{steps.get_deps_image_props.outputs.REGISTRY}}\
-          /${{github.repository}}\
+          /${{steps.generate_id.outputs.ID}}\
           /clp-core-dependencies-x86-${{inputs.os_name}}"
         tags: |
           type=raw,value=${{steps.get_deps_image_props.outputs.BRANCH}}
@@ -73,7 +78,7 @@ runs:
       uses: "docker/metadata-action@v5"
       with:
         images: "${{steps.get_deps_image_props.outputs.REGISTRY}}\
-          /${{github.repository}}\
+          /${{steps.generate_id.outputs.ID}}\
           /clp-core-x86-${{inputs.os_name}}"
         tags: |
           type=raw,value=${{steps.get_deps_image_props.outputs.BRANCH}}


### PR DESCRIPTION
# Description
The current workflow will use the GitHub id+repository name to generate an ID to name the build container. However, if the user's GitHub ID contains uppercase letters, the docker would fail to initiate (this was uncovered when I tried to run CLP workflow in my forked repo). This PR fixes this problem by introducing an additional step to lowercase the repository name.

# Validation performed
1. GitHub actions all passed in the forked repo.
2. Manually checked the generated docker ID doesn't contain uppercase letters (LinZhihao-723 -> linzhihao-723):
![Screen Shot 2023-12-18 at 3 22 05 PM](https://github.com/y-scope/clp/assets/59785146/f8a9c5c0-ff4e-4b97-ab60-5b9b8e19ecf4)

