### PR TITLE
Remove unnecessary calls of getting the original path from the file iterator.

### DIFF
--- a/components/core/src/clp/FileDecompressor.cpp
+++ b/components/core/src/clp/FileDecompressor.cpp
@@ -9,7 +9,7 @@ using std::string;
 
 namespace clp {
 bool FileDecompressor::decompress_file(
-        streaming_archive::MetadataDB::FileIterator& file_metadata_ix,
+        streaming_archive::MetadataDB::FileIterator const& file_metadata_ix,
         string const& output_dir,
         streaming_archive::reader::Archive& archive_reader,
         std::unordered_map<string, string>& temp_path_to_final_path

--- a/components/core/src/clp/FileDecompressor.hpp
+++ b/components/core/src/clp/FileDecompressor.hpp
@@ -18,7 +18,7 @@ class FileDecompressor {
 public:
     // Methods
     bool decompress_file(
-            streaming_archive::MetadataDB::FileIterator& file_metadata_ix,
+            streaming_archive::MetadataDB::FileIterator const& file_metadata_ix,
             std::string const& output_dir,
             streaming_archive::reader::Archive& archive_reader,
             std::unordered_map<std::string, std::string>& temp_path_to_final_path

--- a/components/core/src/clp/decompression.cpp
+++ b/components/core/src/clp/decompression.cpp
@@ -102,8 +102,6 @@ bool decompress(
                 for (auto& file_metadata_ix = *file_metadata_ix_ptr; file_metadata_ix.has_next();
                      file_metadata_ix.next())
                 {
-                    file_metadata_ix.get_path(orig_path);
-
                     // Decompress file
                     if (false
                         == file_decompressor.decompress_file(
@@ -140,8 +138,6 @@ bool decompress(
                 for (auto& file_metadata_ix = *file_metadata_ix_ptr; file_metadata_ix.has_next();
                      file_metadata_ix.next())
                 {
-                    file_metadata_ix.get_path(orig_path);
-
                     // Decompress file
                     if (false
                         == file_decompressor.decompress_file(
@@ -193,7 +189,6 @@ bool decompress(
                     {
                         return false;
                     }
-                    file_metadata_ix.get_path(orig_path);
                     decompressed_files.insert(orig_path);
                 }
                 file_metadata_ix_ptr.reset(nullptr);

--- a/components/core/src/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/streaming_archive/reader/Archive.cpp
@@ -126,7 +126,7 @@ namespace streaming_archive { namespace reader {
         m_var_dictionary.read_new_entries();
     }
 
-    ErrorCode Archive::open_file(File& file, MetadataDB::FileIterator& file_metadata_ix) {
+    ErrorCode Archive::open_file(File& file, MetadataDB::FileIterator const& file_metadata_ix) {
         return file.open_me(m_logtype_dictionary, file_metadata_ix, m_segment_manager);
     }
 

--- a/components/core/src/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/streaming_archive/reader/Archive.hpp
@@ -58,7 +58,7 @@ namespace streaming_archive { namespace reader {
          * @param file_metadata_ix
          * @return Same as streaming_archive::reader::File::open_me
          */
-        ErrorCode open_file(File& file, MetadataDB::FileIterator& file_metadata_ix);
+        ErrorCode open_file(File& file, MetadataDB::FileIterator const& file_metadata_ix);
         /**
          * Wrapper for streaming_archive::reader::File::close_me
          * @param file

--- a/components/core/src/streaming_archive/reader/File.cpp
+++ b/components/core/src/streaming_archive/reader/File.cpp
@@ -21,7 +21,7 @@ epochtime_t File::get_end_ts() const {
 
 ErrorCode File::open_me(
         LogTypeDictionaryReader const& archive_logtype_dict,
-        MetadataDB::FileIterator& file_metadata_ix,
+        MetadataDB::FileIterator const& file_metadata_ix,
         SegmentManager& segment_manager
 ) {
     m_archive_logtype_dict = &archive_logtype_dict;

--- a/components/core/src/streaming_archive/reader/File.hpp
+++ b/components/core/src/streaming_archive/reader/File.hpp
@@ -79,7 +79,7 @@ private:
      */
     ErrorCode open_me(
             LogTypeDictionaryReader const& archive_logtype_dict,
-            MetadataDB::FileIterator& file_metadata_ix,
+            MetadataDB::FileIterator const& file_metadata_ix,
             SegmentManager& segment_manager
     );
     /**


### PR DESCRIPTION
# Description
The current decompression code has unnecessary calls of getting the original file path from the DB file iterator during the decompression. This PR cleans up all the unnecessary calls. In addition, it turned to be confusing when I first saw them since the iterator was passed into the decompressor without `const` decoration. This misled me to consider whether the iterator was modified through the decompression process. To clarify the behavior, `const` is added all the way down from the archive reader to the file reader to indicate it is immutable through the file decompression.