### PR TITLE
Initialize the Query class through its constructor rather than separate setter methods.

### DIFF
--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -512,7 +512,7 @@ std::optional<Query> Grep::process_raw_query(
     if (use_heuristic) {
         // Replace '?' wildcards with '*' wildcards since we currently have no support for
         // generating sub-queries with '?' wildcards. The final wildcard match on the decompressed
-        // message makes this a non-issue.
+        // message uses the original wildcards, so correctness will be maintained.
         std::replace(
                 search_string_for_sub_queries.begin(),
                 search_string_for_sub_queries.end(),

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -497,40 +497,43 @@ std::optional<Query> Grep::process_raw_query(
         log_surgeon::lexers::ByteLexer& reverse_lexer,
         bool use_heuristic
 ) {
-    Query query;
-    // Set properties which require no processing
-    query.set_search_begin_timestamp(search_begin_ts);
-    query.set_search_end_timestamp(search_end_ts);
-    query.set_ignore_case(ignore_case);
-
     // Add prefix and suffix '*' to make the search a sub-string match
     string processed_search_string = "*";
     processed_search_string += search_string;
     processed_search_string += '*';
-
-    // Clean-up search string
     processed_search_string = clean_up_wildcard_search_string(processed_search_string);
-    query.set_search_string(processed_search_string);
 
     // Split search_string into tokens with wildcards
     vector<QueryToken> query_tokens;
     size_t begin_pos = 0;
     size_t end_pos = 0;
     bool is_var;
+    string search_string_for_sub_queries{processed_search_string};
     if (use_heuristic) {
         // Replace non-greedy wildcards with greedy wildcards since we currently have no support for
-        // searching compressed files with non-greedy wildcards
-        std::replace(processed_search_string.begin(), processed_search_string.end(), '?', '*');
+        // generating subqueries with '?' wildcards. The wildcard match on the decompressed message
+        // mitigates this limitation.
+        std::replace(
+                search_string_for_sub_queries.begin(),
+                search_string_for_sub_queries.end(),
+                '?',
+                '*'
+        );
         // Clean-up in case any instances of "?*" or "*?" were changed into "**"
-        processed_search_string = clean_up_wildcard_search_string(processed_search_string);
-        while (get_bounds_of_next_potential_var(processed_search_string, begin_pos, end_pos, is_var)
-        )
+        search_string_for_sub_queries
+                = clean_up_wildcard_search_string(search_string_for_sub_queries);
+        while (get_bounds_of_next_potential_var(
+                search_string_for_sub_queries,
+                begin_pos,
+                end_pos,
+                is_var
+        ))
         {
-            query_tokens.emplace_back(processed_search_string, begin_pos, end_pos, is_var);
+            query_tokens.emplace_back(search_string_for_sub_queries, begin_pos, end_pos, is_var);
         }
     } else {
         while (get_bounds_of_next_potential_var(
-                processed_search_string,
+                search_string_for_sub_queries,
                 begin_pos,
                 end_pos,
                 is_var,
@@ -538,7 +541,7 @@ std::optional<Query> Grep::process_raw_query(
                 reverse_lexer
         ))
         {
-            query_tokens.emplace_back(processed_search_string, begin_pos, end_pos, is_var);
+            query_tokens.emplace_back(search_string_for_sub_queries, begin_pos, end_pos, is_var);
         }
     }
 
@@ -567,19 +570,22 @@ std::optional<Query> Grep::process_raw_query(
         // Compute logtypes and variables for query
         auto matchability = generate_logtypes_and_vars_for_subquery(
                 archive,
-                processed_search_string,
+                search_string_for_sub_queries,
                 query_tokens,
-                query.get_ignore_case(),
+                ignore_case,
                 sub_query
         );
         switch (matchability) {
             case SubQueryMatchabilityResult::SupercedesAllSubQueries:
-                // Clear all sub-queries since they will be superceded by this sub-query
-                query.clear_sub_queries();
-
                 // Since other sub-queries will be superceded by this one, we can stop processing
                 // now
-                return query;
+                return Query{
+                        search_begin_ts,
+                        search_end_ts,
+                        ignore_case,
+                        processed_search_string,
+                        {}
+                };
             case SubQueryMatchabilityResult::MayMatch:
                 sub_queries.push_back(std::move(sub_query));
                 break;
@@ -603,8 +609,13 @@ std::optional<Query> Grep::process_raw_query(
         return std::nullopt;
     }
 
-    query.set_sub_queries(std::move(sub_queries));
-    return query;
+    return Query{
+            search_begin_ts,
+            search_end_ts,
+            ignore_case,
+            processed_search_string,
+            std::move(sub_queries)
+    };
 }
 
 bool Grep::get_bounds_of_next_potential_var(

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -510,9 +510,9 @@ std::optional<Query> Grep::process_raw_query(
     bool is_var;
     string search_string_for_sub_queries{processed_search_string};
     if (use_heuristic) {
-        // Replace non-greedy wildcards with greedy wildcards since we currently have no support for
-        // generating subqueries with '?' wildcards. The wildcard match on the decompressed message
-        // mitigates this limitation.
+        // Replace '?' wildcards with '*' wildcards since we currently have no support for
+        // generating sub-queries with '?' wildcards. The final wildcard match on the decompressed
+        // message makes this a non-issue.
         std::replace(
                 search_string_for_sub_queries.begin(),
                 search_string_for_sub_queries.end(),

--- a/components/core/src/Query.cpp
+++ b/components/core/src/Query.cpp
@@ -171,25 +171,19 @@ bool SubQuery::matches_vars(std::vector<encoded_variable_t> const& vars) const {
     return (num_possible_vars == possible_vars_ix);
 }
 
-void Query::set_search_string(string const& search_string) {
-    m_search_string = search_string;
+Query::Query(
+        epochtime_t search_begin_timestamp,
+        epochtime_t search_end_timestamp,
+        bool ignore_case,
+        std::string search_string,
+        std::vector<SubQuery> sub_queries
+)
+        : m_search_begin_timestamp{search_begin_timestamp},
+          m_search_end_timestamp{search_end_timestamp},
+          m_ignore_case{ignore_case},
+          m_search_string{std::move(search_string)},
+          m_sub_queries{std::move(sub_queries)} {
     m_search_string_matches_all = (m_search_string.empty() || "*" == m_search_string);
-}
-
-void Query::set_sub_queries(std::vector<SubQuery> sub_queries) {
-    m_sub_queries = std::move(sub_queries);
-
-    for (auto& sub_query : m_sub_queries) {
-        // Add to relevant sub-queries if necessary
-        if (sub_query.get_ids_of_matching_segments().count(m_prev_segment_id)) {
-            m_relevant_sub_queries.push_back(&sub_query);
-        }
-    }
-}
-
-void Query::clear_sub_queries() {
-    m_sub_queries.clear();
-    m_relevant_sub_queries.clear();
 }
 
 void Query::make_sub_queries_relevant_to_segment(segment_id_t segment_id) {

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -206,12 +206,12 @@ public:
 private:
     // Variables
     // Start of search time range (inclusive)
-    epochtime_t m_search_begin_timestamp;
+    epochtime_t m_search_begin_timestamp{cEpochTimeMin};
     // End of search time range (inclusive)
-    epochtime_t m_search_end_timestamp;
-    bool m_ignore_case;
+    epochtime_t m_search_end_timestamp{cEpochTimeMax};
+    bool m_ignore_case{false};
     std::string m_search_string;
-    bool m_search_string_matches_all;
+    bool m_search_string_matches_all{true};
     std::vector<SubQuery> m_sub_queries;
     std::vector<SubQuery const*> m_relevant_sub_queries;
     segment_id_t m_prev_segment_id{cInvalidSegmentId};

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -157,23 +157,13 @@ private:
 class Query {
 public:
     // Constructors
-    Query()
-            : m_search_begin_timestamp(cEpochTimeMin),
-              m_search_end_timestamp(cEpochTimeMax),
-              m_ignore_case(false),
-              m_search_string_matches_all(true),
-              m_prev_segment_id(cInvalidSegmentId) {}
+    Query(epochtime_t search_begin_timestamp,
+          epochtime_t search_end_timestamp,
+          bool ignore_case,
+          std::string search_string,
+          std::vector<SubQuery> sub_queries);
 
     // Methods
-    void set_search_begin_timestamp(epochtime_t timestamp) { m_search_begin_timestamp = timestamp; }
-
-    void set_search_end_timestamp(epochtime_t timestamp) { m_search_end_timestamp = timestamp; }
-
-    void set_ignore_case(bool ignore_case) { m_ignore_case = ignore_case; }
-
-    void set_search_string(std::string const& search_string);
-    void set_sub_queries(std::vector<SubQuery> sub_queries);
-    void clear_sub_queries();
     /**
      * Populates the set of relevant sub-queries with only those that match the given segment
      * @param segment_id
@@ -224,7 +214,7 @@ private:
     bool m_search_string_matches_all;
     std::vector<SubQuery> m_sub_queries;
     std::vector<SubQuery const*> m_relevant_sub_queries;
-    segment_id_t m_prev_segment_id;
+    segment_id_t m_prev_segment_id{cInvalidSegmentId};
 };
 
 #endif  // QUERY_HPP


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The `Query` class had setter methods for its members but they were only used in one method (`Grep::process_raw_query`). This PR simplifies `Query` so it takes its parameters in the constructor rather than through setters.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Compressed some logs using the parsing heuristics.
* Validated a query returned the same results as grep.
* Compressed some logs using the schema-based parser.
* Repeated the validation step.