### PR TITLE
Add taskfile to simplify linting the core component.

### DIFF
--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -30,13 +30,9 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: "Setup Homebrew"
-        shell: "bash"
-        run: "eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
-
       - name: "Install task"
         shell: "bash"
-        run: "brew install go-task/tap/go-task"
+        run: "npm install -g @go-task/cli"
 
       - name: "Run lint task"
         shell: "bash"

--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -30,6 +30,10 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: "Setup Homebrew"
+        shell: "bash"
+        run: "eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
+
       - name: "Install task"
         shell: "bash"
         run: "brew install go-task/tap/go-task"

--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -5,11 +5,13 @@ on:
     paths:
       - ".github/workflows/clp-core-lint.yaml"
       - "components/core/src/**"
+      - "components/core/Taskfile.yml"
       - "components/core/tests/**"
   push:
     paths:
       - ".github/workflows/clp-core-lint.yaml"
       - "components/core/src/**"
+      - "components/core/Taskfile.yml"
       - "components/core/tests/**"
   workflow_dispatch:
 

--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -30,18 +30,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: "Install clang-format"
+      - name: "Install task"
         shell: "bash"
-        run: |
-          pip3 install --upgrade pip
-          pip3 install --upgrade clang-format
+        run: "brew install go-task/tap/go-task"
 
-      - name: "Run clang-format on all of core's source files"
+      - name: "Run lint task"
         shell: "bash"
         working-directory: "./components/core"
-        run: |
-          find src tests \
-            -type f \
-            \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
-            -print0 | \
-              xargs -0 clang-format --dry-run -Werror
+        run: "task lint"

--- a/components/core/.gitignore
+++ b/components/core/.gitignore
@@ -1,3 +1,3 @@
+build/**
 submodules/sqlite3/*
 third-party/**
-

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -28,12 +28,11 @@ tasks:
 
   lint_venv:
     cmds:
+      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       - |
-        python3 -m venv '{{.LINT_VENV_DIR}}'
+        hash -r 2> /dev/null
+        set -x
         . {{.LINT_VENV_DIR}}/bin/activate
-      - |
-        . {{.LINT_VENV_DIR}}/bin/activate
-        pip3 list
         pip3 install --upgrade pip
         pip3 install --upgrade clang-format
     sources:

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -32,7 +32,7 @@ tasks:
       # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.
-      - sed -i 's/.* hash .*//g' "{{.LINT_VENV_DIR}}/bin/activate"
+      - sed -i 's/\s\+hash\s\+.*//g' "{{.LINT_VENV_DIR}}/bin/activate"
       - |
         . "{{.LINT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade pip

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -28,7 +28,7 @@ tasks:
 
   lint_venv:
     cmds:
-      - "python3.11 -m venv '{{.LINT_VENV_DIR}}'"
+      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -29,12 +29,12 @@ tasks:
   lint_venv:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
-      - "hash -r 2> /dev/null"
       - |
-        set -x
-        . {{.LINT_VENV_DIR}}/bin/activate
-        pip3 install --upgrade pip
-        pip3 install --upgrade clang-format
+        echo $0
+        bash -c " \
+          . {{.LINT_VENV_DIR}}/bin/activate \
+          pip3 install --upgrade pip \
+          pip3 install --upgrade clang-format"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -30,10 +30,7 @@ tasks:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       - |
-        source {{.LINT_VENV_DIR}}/bin/activate
-        pip3 list
-        pip3 install --upgrade pip
-        pip3 install --upgrade clang-format
+        . {{.LINT_VENV_DIR}}/bin/activate
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -28,11 +28,11 @@ tasks:
 
   lint_venv:
     cmds:
-      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
+      - "python3.11 -m venv '{{.LINT_VENV_DIR}}'"
       # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.
-      - sed -i 's/\s\+hash\s\+.*//g' "{{.LINT_VENV_DIR}}/bin/activate"
+      - sed -i 's/^\s*hash\s\+.*//g' "{{.LINT_VENV_DIR}}/bin/activate"
       - |
         . "{{.LINT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade pip

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -29,7 +29,7 @@ tasks:
   lint_venv:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
-      - "ls -l {{.LINT_VENV_DIR}}"
+      - "cat {{.LINT_VENV_DIR}}/bin/activate"
       - |
         . {{.LINT_VENV_DIR}}/bin/activate
         pip3 list

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -32,7 +32,7 @@ tasks:
       # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.
-      - sed -i 's/hash.*//g' "{{.LINT_VENV_DIR}}/bin/activate"
+      - sed -i 's/.* hash .*//g' "{{.LINT_VENV_DIR}}/bin/activate"
       - |
         . "{{.LINT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade pip

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -31,8 +31,8 @@ tasks:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       - |
         . {{.LINT_VENV_DIR}}/bin/activate
-        pip3 install --upgrade pip
-        pip3 install --upgrade clang-format
+        pip install --upgrade pip
+        pip install --upgrade clang-format
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -1,0 +1,40 @@
+version: "3"
+
+vars:
+  BUILD_DIR: "{{.TASKFILE_DIR}}/build"
+  LINT_VENV_DIR: "{{.BUILD_DIR}}/venv"
+  PYTHON_VERSION:
+    sh: "python3 -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\""
+
+tasks:
+  clean:
+    cmds:
+      - "rm -rf {{.BUILD_DIR}}"
+
+  lint:
+    deps: [ "lint_venv" ]
+    dir: "{{.TASKFILE_DIR}}"
+    cmds:
+      - |
+        . {{.LINT_VENV_DIR}}/bin/activate
+        find src tests \
+          -type f \
+          \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
+          -print0 | \
+            xargs -0 clang-format --dry-run -Werror
+    sources:
+      - "src/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"
+      - "tests/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"
+
+  lint_venv:
+    cmds:
+      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
+      - |
+        . {{.LINT_VENV_DIR}}/bin/activate
+        pip3 install --upgrade pip
+        pip3 install --upgrade clang-format
+    sources:
+      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+    generates:
+      # For performance, we only mark a subset of all files in the venv as generated
+      - "{{.LINT_VENV_DIR}}/lib/python{{.PYTHON_VERSION}}/site-packages/*.dist-info/*"

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -30,7 +30,8 @@ tasks:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       - |
-        echo $0
+        python3 --version
+        python3 -m pip --version
         bash -c " \
           . {{.LINT_VENV_DIR}}/bin/activate \
           pip3 install --upgrade pip \

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -31,8 +31,9 @@ tasks:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       - |
         . {{.LINT_VENV_DIR}}/bin/activate
-        pip install --upgrade pip
-        pip install --upgrade clang-format
+        pip3 list
+        pip3 install --upgrade pip
+        pip3 install --upgrade clang-format
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -29,7 +29,7 @@ tasks:
   lint_venv:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
-      - "hash -r 2> /dev/null""
+      - "hash -r 2> /dev/null"
       - |
         set -x
         . {{.LINT_VENV_DIR}}/bin/activate

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -29,8 +29,8 @@ tasks:
   lint_venv:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
+      - "hash -r 2> /dev/null""
       - |
-        hash -r 2> /dev/null
         set -x
         . {{.LINT_VENV_DIR}}/bin/activate
         pip3 install --upgrade pip

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -29,8 +29,12 @@ tasks:
   lint_venv:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
+      - "ls -l {{.LINT_VENV_DIR}}"
       - |
         . {{.LINT_VENV_DIR}}/bin/activate
+        pip3 list
+        pip3 install --upgrade pip
+        pip3 install --upgrade clang-format
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -28,8 +28,9 @@ tasks:
 
   lint_venv:
     cmds:
-      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
-      - "cat {{.LINT_VENV_DIR}}/bin/activate"
+      - |
+        python3 -m venv '{{.LINT_VENV_DIR}}'
+        . {{.LINT_VENV_DIR}}/bin/activate
       - |
         . {{.LINT_VENV_DIR}}/bin/activate
         pip3 list

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       - |
-        . {{.LINT_VENV_DIR}}/bin/activate
+        source {{.LINT_VENV_DIR}}/bin/activate
         pip3 list
         pip3 install --upgrade pip
         pip3 install --upgrade clang-format

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -16,7 +16,7 @@ tasks:
     dir: "{{.TASKFILE_DIR}}"
     cmds:
       - |
-        . {{.LINT_VENV_DIR}}/bin/activate
+        . "{{.LINT_VENV_DIR}}/bin/activate"
         find src tests \
           -type f \
           \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
@@ -29,13 +29,14 @@ tasks:
   lint_venv:
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
+      # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
+      # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
+      # shell was one that had the command, but that's not the case in newer versions.
+      - sed -i 's/hash.*//g' "{{.LINT_VENV_DIR}}/bin/activate"
       - |
-        python3 --version
-        python3 -m pip --version
-        bash -c " \
-          . {{.LINT_VENV_DIR}}/bin/activate \
-          pip3 install --upgrade pip \
-          pip3 install --upgrade clang-format"
+        . "{{.LINT_VENV_DIR}}/bin/activate"
+        pip3 install --upgrade pip
+        pip3 install --upgrade clang-format
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -220,7 +220,7 @@ private:
     // End of search time range (inclusive)
     epochtime_t m_search_end_timestamp;
     bool m_ignore_case;
-    std::string m_search_string;
+     std::string m_search_string;
     bool m_search_string_matches_all;
     std::vector<SubQuery> m_sub_queries;
     std::vector<SubQuery const*> m_relevant_sub_queries;

--- a/components/core/src/Query.hpp
+++ b/components/core/src/Query.hpp
@@ -220,7 +220,7 @@ private:
     // End of search time range (inclusive)
     epochtime_t m_search_end_timestamp;
     bool m_ignore_case;
-     std::string m_search_string;
+    std::string m_search_string;
     bool m_search_string_matches_all;
     std::vector<SubQuery> m_sub_queries;
     std::vector<SubQuery const*> m_relevant_sub_queries;


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Linting can now be performed by running `task lint` (assuming the user has `task` installed).

For now, this remains undocumented; we could document it as a contribution guideline in the README but since our other guidelines are not documented, it would be confusing for new contributors why we have one guideline documented but not others. We will document the others soon.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated that linting worked through the lint workflow (which now calls the lint task).
* Validated that linting worked locally.