### PR TITLE
Add support for filtering by timestamp to the CLP package.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -36,6 +36,12 @@ def main(argv):
     args_parser.add_argument('--config', '-c', default=str(default_config_file_path),
                              help="CLP package configuration file.")
     args_parser.add_argument('wildcard_query', help="Wildcard query.")
+    args_parser.add_argument('--begin-time', type=int,
+                             help="Time range filter lower-bound (inclusive) as milliseconds"
+                                  " from the UNIX epoch.")
+    args_parser.add_argument('--end-time', type=int,
+                             help="Time range filter upper-bound (inclusive) as milliseconds"
+                                  " from the UNIX epoch.")
     args_parser.add_argument('--file-path', help="File to search.")
     parsed_args = args_parser.parse_args(argv[1:])
 
@@ -87,6 +93,12 @@ def main(argv):
         '--config', str(container_clp_config.logs_directory / container_config_filename),
         parsed_args.wildcard_query,
     ]
+    if parsed_args.begin_time is not None:
+        search_cmd.append('--begin-time')
+        search_cmd.append(str(parsed_args.begin_time))
+    if parsed_args.end_time is not None:
+        search_cmd.append('--end-time')
+        search_cmd.append(str(parsed_args.end_time))
     if parsed_args.file_path:
         search_cmd.append('--file-path')
         search_cmd.append(parsed_args.file_path)

--- a/components/job-orchestration/job_orchestration/job_config.py
+++ b/components/job-orchestration/job_orchestration/job_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 
 from pydantic import BaseModel
@@ -31,6 +33,6 @@ class SearchConfig(BaseModel):
     search_controller_host: str
     search_controller_port: int
     wildcard_query: str
-    begin_timestamp: int = None
-    end_timestamp: int = None
-    path_filter: str = None
+    begin_timestamp: int | None = None
+    end_timestamp: int | None = None
+    path_filter: str | None = None

--- a/components/job-orchestration/job_orchestration/job_config.py
+++ b/components/job-orchestration/job_orchestration/job_config.py
@@ -31,4 +31,6 @@ class SearchConfig(BaseModel):
     search_controller_host: str
     search_controller_port: int
     wildcard_query: str
+    begin_timestamp: int = None
+    end_timestamp: int = None
     path_filter: str = None


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The CLP package doesn't currently support filtering by timestamp (although the `clg` binary does). We do have support in the package on the [v0.5-prototype](https://github.com/y-scope/clp/tree/v0.5-prototype) branch, but that's still being merged to main. Since a user asked about the feature in #191, this PR adds support for it as a holdover until we finish merging v0.5-prototype.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Compressed the [hive-24hr](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset with the package.
* Validated that a search for a begin-timestamp outside the range of the archives returns no results:
  ```shell
  sbin/search.sh --begin-time 1427169541159  " INFO "
  ```
  * Also validated that no search tasks were generated in the database.
* Validated that a search for a begin-timestamp one less than the one above returns results.
* Validated that a search for an end-timestamp outside the range of messages returns no results:
  ```shell
  sbin/search.sh --end-time 1427088179022 " INFO "
  ```
  * In this case, search tasks are still generated since all the archives have a begin-timestamp of `0`.
* Validated that a search for an end-timestamp one more than the one above returns results.
* Validated that a search for a begin-timestamp and end-timestamp of a single message returns a single result:
  ```shell
  sbin/search.sh --begin-time 1427169541158 --end-time 1427169541158 " INFO "
  ```
* Validated that searches without a timestamp range still return results.