### PR TITLE
Linting improvements for core component:

### DIFF
--- a/.github/workflows/clp-core-lint.yaml
+++ b/.github/workflows/clp-core-lint.yaml
@@ -39,4 +39,4 @@ jobs:
       - name: "Run lint task"
         shell: "bash"
         working-directory: "./components/core"
-        run: "task lint"
+        run: "task lint_check"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,11 @@
 extends: "default"
 
+yaml-files:
+  - ".clang-format"
+  - ".yamllint"
+  - "*.yaml"
+  - "*.yml"
+
 ignore: |
   components/core/build/
   components/core/cmake-build-debug/

--- a/components/core/.clang-format
+++ b/components/core/.clang-format
@@ -1,37 +1,40 @@
+# yamllint disable-line rule:document-start
 ---
 ColumnLimit: 100
 IndentWidth: 4
+# yamllint disable-line rule:document-start
 ---
-Language: Cpp
+Language: "Cpp"
 AccessModifierOffset: -4
-AlignAfterOpenBracket: BlockIndent
-AlignArrayOfStructures: None
-AlignConsecutiveAssignments: None
-AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: None
-AlignConsecutiveMacros: None
-AlignEscapedNewlines: DontAlign
-AlignOperands: Align
-AlignTrailingComments: Never
+AlignAfterOpenBracket: "BlockIndent"
+AlignArrayOfStructures: "None"
+AlignConsecutiveAssignments: "None"
+AlignConsecutiveBitFields: "None"
+AlignConsecutiveDeclarations: "None"
+AlignConsecutiveMacros: "None"
+AlignEscapedNewlines: "DontAlign"
+AlignOperands: "Align"
+AlignTrailingComments:
+  Kind: "Never"
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: Always
+AllowShortBlocksOnASingleLine: "Always"
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: Never
-AllowShortLambdasOnASingleLine: All
+AllowShortFunctionsOnASingleLine: "Inline"
+AllowShortIfStatementsOnASingleLine: "Never"
+AllowShortLambdasOnASingleLine: "All"
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: None
+AlwaysBreakAfterReturnType: "None"
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
+AlwaysBreakTemplateDeclarations: "Yes"
 BinPackArguments: false
 BinPackParameters: false
-BitFieldColonSpacing: Both
+BitFieldColonSpacing: "Both"
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false
-  AfterControlStatement: MultiLine
+  AfterControlStatement: "MultiLine"
   AfterEnum: false
   AfterFunction: false
   AfterNamespace: false
@@ -46,14 +49,14 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyNamespace: false
   SplitEmptyRecord: false
-BreakAfterAttributes: Never
-BreakBeforeBinaryOperators: All
-BreakBeforeBraces: Custom
-BreakBeforeConceptDeclarations: Always
-BreakBeforeInlineASMColon: OnlyMultiline
+BreakAfterAttributes: "Never"
+BreakBeforeBinaryOperators: "All"
+BreakBeforeBraces: "Custom"
+BreakBeforeConceptDeclarations: "Always"
+BreakBeforeInlineASMColon: "OnlyMultiline"
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
-BreakInheritanceList: BeforeColon
+BreakConstructorInitializers: "BeforeColon"
+BreakInheritanceList: "BeforeColon"
 BreakStringLiterals: true
 CompactNamespaces: true
 ConstructorInitializerIndentWidth: 8
@@ -61,30 +64,30 @@ ContinuationIndentWidth: 8
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat: false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
+EmptyLineAfterAccessModifier: "Never"
+EmptyLineBeforeAccessModifier: "LogicalBlock"
 FixNamespaceComments: true
-IncludeBlocks: Regroup
+IncludeBlocks: "Regroup"
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
   # Third-party headers. Update when adding new third-party libraries.
-  - Regex: '^<(archive|boost|catch2|date|fmt|json|log_surgeon|mariadb|spdlog|sqlite3|yaml-cpp|zstd)'
+  - Regex: "^<(archive|boost|catch2|date|fmt|json|log_surgeon|mariadb|spdlog|sqlite3|yaml-cpp|zstd)"
     Priority: 3
   # C system headers
-  - Regex: '^<.+.h>'
+  - Regex: "^<.+.h>"
     Priority: 1
   # C++ standard libraries
-  - Regex: '^<.+>'
+  - Regex: "^<.+>"
     Priority: 2
   # Project headers
-  - Regex: '^".+"'
+  - Regex: "^\".+\""
     Priority: 4
 IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: true
-IndentExternBlock: Indent
+IndentExternBlock: "Indent"
 IndentGotoLabels: false
-IndentPPDirectives: BeforeHash
+IndentPPDirectives: "BeforeHash"
 IndentRequiresClause: false
 IndentWrappedFunctionNames: false
 InsertBraces: true
@@ -97,46 +100,46 @@ IntegerLiteralSeparator:
   Hex: 4
   HexMinDigits: 4
 KeepEmptyLinesAtTheStartOfBlocks: false
-LambdaBodyIndentation: Signature
-LineEnding: LF
+LambdaBodyIndentation: "Signature"
+LineEnding: "LF"
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: Inner
+NamespaceIndentation: "Inner"
 PPIndentWidth: -1
-PackConstructorInitializers: CurrentLine
+PackConstructorInitializers: "CurrentLine"
 PenaltyBreakOpenParenthesis: 25
 PenaltyBreakBeforeFirstCallParameter: 25
 PenaltyReturnTypeOnItsOwnLine: 100
-PointerAlignment: Left
-QualifierAlignment: Custom
+PointerAlignment: "Left"
+QualifierAlignment: "Custom"
 QualifierOrder:
-  - static
-  - friend
-  - inline
+  - "static"
+  - "friend"
+  - "inline"
   # constexpr west as explained in https://www.youtube.com/watch?v=z6s6bacI424
-  - constexpr
-  - type
-  - const
-  - volatile
-ReferenceAlignment: Pointer
+  - "constexpr"
+  - "type"
+  - "const"
+  - "volatile"
+ReferenceAlignment: "Pointer"
 ReflowComments: true
 RemoveBracesLLVM: false
 RemoveSemicolon: true
-RequiresClausePosition: OwnLine
-RequiresExpressionIndentation: OuterScope
-SeparateDefinitionBlocks: Always
+RequiresClausePosition: "OwnLine"
+RequiresExpressionIndentation: "OuterScope"
+SeparateDefinitionBlocks: "Always"
 ShortNamespaceLines: 0
-SortIncludes: CaseInsensitive
-SortUsingDeclarations: Lexicographic
+SortIncludes: "CaseInsensitive"
+SortUsingDeclarations: "Lexicographic"
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
-SpaceAroundPointerQualifiers: Default
+SpaceAroundPointerQualifiers: "Default"
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
+SpaceBeforeParens: "ControlStatements"
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
@@ -151,6 +154,6 @@ SpacesInLineCommentPrefix:
   Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Latest
+Standard: "Latest"
 TabWidth: 4
-UseTab: Never
+UseTab: "Never"

--- a/components/core/.clang-format
+++ b/components/core/.clang-format
@@ -74,7 +74,7 @@ IncludeCategories:
   - Regex: "^<(archive|boost|catch2|date|fmt|json|log_surgeon|mariadb|spdlog|sqlite3|yaml-cpp|zstd)"
     Priority: 3
   # C system headers
-  - Regex: "^<.+.h>"
+  - Regex: "^<.+\\.h>"
     Priority: 1
   # C++ standard libraries
   - Regex: "^<.+>"

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -11,7 +11,29 @@ tasks:
     cmds:
       - "rm -rf {{.BUILD_DIR}}"
 
+  lint_check:
+    dir: "{{.TASKFILE_DIR}}"
+    cmds:
+      - task: "lint"
+        vars:
+          FLAGS: "--dry-run"
+    sources: &lint_source_files
+      - "src/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"
+      - "Taskfile.yml"
+      - "tests/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"
+
+  lint_fix:
+    dir: "{{.TASKFILE_DIR}}"
+    cmds:
+      - task: "lint"
+        vars:
+          FLAGS: "-i"
+    sources: *lint_source_files
+
   lint:
+    internal: true
+    requires:
+      vars: ["FLAGS"]
     deps: ["lint_venv"]
     dir: "{{.TASKFILE_DIR}}"
     cmds:
@@ -21,12 +43,10 @@ tasks:
           -type f \
           \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
           -print0 | \
-            xargs -0 clang-format --dry-run -Werror
-    sources:
-      - "src/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"
-      - "tests/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"
+            xargs -0 clang-format {{.FLAGS}} -Werror
 
   lint_venv:
+    internal: true
     cmds:
       - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       # Remove calls to `hash` since Task uses `gosh` rather than `bash`.

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -53,7 +53,7 @@ tasks:
       # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.
-      - "sed -i 's/^\\s*hash\\s\\+.*//g' \"{{.LINT_VENV_DIR}}/bin/activate\""
+      - "sed -i 's/^\\s*hash\\s\\+.*/true/g' \"{{.LINT_VENV_DIR}}/bin/activate\""
       - |
         . "{{.LINT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade pip

--- a/components/core/Taskfile.yml
+++ b/components/core/Taskfile.yml
@@ -18,6 +18,7 @@ tasks:
         vars:
           FLAGS: "--dry-run"
     sources: &lint_source_files
+      - ".clang-format"
       - "src/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"
       - "Taskfile.yml"
       - "tests/{**/*.cpp,**/*.h,**/*.hpp,**/*.inc}"

--- a/components/core/src/EncodedVariableInterpreter.cpp
+++ b/components/core/src/EncodedVariableInterpreter.cpp
@@ -1,8 +1,7 @@
 #include "EncodedVariableInterpreter.hpp"
 
-#include <cmath>
-
 #include <cassert>
+#include <cmath>
 
 #include "Defs.h"
 #include "ffi/ir_stream/decoding_methods.hpp"

--- a/components/core/src/streaming_archive/writer/Segment.cpp
+++ b/components/core/src/streaming_archive/writer/Segment.cpp
@@ -1,9 +1,9 @@
 #include "Segment.hpp"
 
-#include <cmath>
 #include <sys/stat.h>
 
 #include <climits>
+#include <cmath>
 #include <cstring>
 
 #include "../../ErrorCode.hpp"


### PR DESCRIPTION
- Add Taskfile rule to apply lint fixes.
- Add .clang-format to list of files for yamllint to check.
- Fix .clang-format's yamllint violations.
- Fix .clang-format rule error.
- Fix .clang-format regex for C standard library headers.
- Fix venv generation so `activate` remains valid.

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR mainly adds a convenient rule to apply core's lint fixes and reformats the `.clang-format` file.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated the fix and check rules work.
* Validated the lint workflow still works.
