### PR TITLE
Replace instances of using namespace with using <symbol>.

### DIFF
--- a/components/core/src/streaming_archive/reader/File.cpp
+++ b/components/core/src/streaming_archive/reader/File.cpp
@@ -8,7 +8,7 @@
 #include "../Constants.hpp"
 #include "SegmentManager.hpp"
 
-using namespace std;
+using std::string;
 
 namespace streaming_archive::reader {
 epochtime_t File::get_begin_ts() const {
@@ -87,8 +87,8 @@ ErrorCode File::open_me(
     if (m_num_messages > 0) {
         if (m_num_messages > m_num_segment_msgs) {
             // Buffers too small, so increase size to required amount
-            m_segment_timestamps = make_unique<epochtime_t[]>(m_num_messages);
-            m_segment_logtypes = make_unique<logtype_dictionary_id_t[]>(m_num_messages);
+            m_segment_timestamps = std::make_unique<epochtime_t[]>(m_num_messages);
+            m_segment_logtypes = std::make_unique<logtype_dictionary_id_t[]>(m_num_messages);
             m_num_segment_msgs = m_num_messages;
         }
 
@@ -122,7 +122,7 @@ ErrorCode File::open_me(
     if (m_num_variables > 0) {
         if (m_num_variables > m_num_segment_vars) {
             // Buffer too small, so increase size to required amount
-            m_segment_variables = make_unique<encoded_variable_t[]>(m_num_variables);
+            m_segment_variables = std::make_unique<encoded_variable_t[]>(m_num_variables);
             m_num_segment_vars = m_num_variables;
         }
         num_bytes_to_read = m_num_variables * sizeof(encoded_variable_t);
@@ -182,7 +182,7 @@ string const& File::get_orig_path() const {
     return m_orig_path;
 }
 
-vector<pair<uint64_t, TimestampPattern>> const& File::get_timestamp_patterns() const {
+std::vector<std::pair<uint64_t, TimestampPattern>> const& File::get_timestamp_patterns() const {
     return m_timestamp_patterns;
 }
 

--- a/components/core/tests/test-Segment.cpp
+++ b/components/core/tests/test-Segment.cpp
@@ -7,8 +7,7 @@
 #include "../src/streaming_archive/writer/Segment.hpp"
 #include "../src/Utils.hpp"
 
-using namespace std;
-using namespace streaming_archive;
+using std::string;
 
 TEST_CASE("Test writing and reading a segment", "[Segment]") {
     ErrorCode error_code;
@@ -29,7 +28,7 @@ TEST_CASE("Test writing and reading a segment", "[Segment]") {
     REQUIRE(ErrorCode_Success == error_code);
 
     // Test segment writing
-    writer::Segment writer_segment;
+    streaming_archive::writer::Segment writer_segment;
 
     writer_segment.open(segments_dir_path, 0, 0);
     auto segment_id = writer_segment.get_id();
@@ -40,7 +39,7 @@ TEST_CASE("Test writing and reading a segment", "[Segment]") {
     writer_segment.close();
 
     // Test reading
-    reader::Segment reader_segment;
+    streaming_archive::reader::Segment reader_segment;
 
     error_code = reader_segment.try_open(segments_dir_path, segment_id);
     REQUIRE(ErrorCode_Success == error_code);

--- a/components/core/tests/test-Utils.cpp
+++ b/components/core/tests/test-Utils.cpp
@@ -12,7 +12,7 @@
 
 #include "../src/Utils.hpp"
 
-using namespace std;
+using std::string;
 
 TEST_CASE("create_directory_structure", "[create_directory_structure]") {
     struct stat s = {};

--- a/components/core/tests/test-string_utils.cpp
+++ b/components/core/tests/test-string_utils.cpp
@@ -5,6 +5,8 @@
 #include <Catch2/single_include/catch2/catch.hpp>
 #include <string_utils/string_utils.hpp>
 
+using std::chrono::duration;
+using std::chrono::high_resolution_clock;
 using std::cout;
 using std::endl;
 using std::string;
@@ -453,7 +455,6 @@ SCENARIO("Test wild card performance", "[wildcard performance]") {
     // This test is to ensure there is no performance regression
     // We use our current implementation vs the next best implementation as a reference
     // If performance becomes slower than our next best implementation, then it is considered a fail
-    using namespace std::chrono;
 
     high_resolution_clock::time_point t1, t2;
     string tameStr, wildStr;


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The [style guide](https://google.github.io/styleguide/cppguide.html#Namespaces) prohibits the use of `using` declarations to include all symbols from a namespace.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Built successfully.
* Unit tests pass.
