### PR TITLE
Move global metadata DB sources into the clp namespace.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -186,6 +186,13 @@ set(SOURCE_FILES_unitTest
         src/clp/clp/run.hpp
         src/clp/clp/utils.cpp
         src/clp/clp/utils.hpp
+        src/clp/GlobalMetadataDB.hpp
+        src/clp/GlobalMetadataDBConfig.cpp
+        src/clp/GlobalMetadataDBConfig.hpp
+        src/clp/GlobalMySQLMetadataDB.cpp
+        src/clp/GlobalMySQLMetadataDB.hpp
+        src/clp/GlobalSQLiteMetadataDB.cpp
+        src/clp/GlobalSQLiteMetadataDB.hpp
         src/database_utils.cpp
         src/database_utils.hpp
         src/Defs.h
@@ -225,13 +232,6 @@ set(SOURCE_FILES_unitTest
         src/FileReader.hpp
         src/FileWriter.cpp
         src/FileWriter.hpp
-        src/GlobalMetadataDB.hpp
-        src/GlobalMetadataDBConfig.cpp
-        src/GlobalMetadataDBConfig.hpp
-        src/GlobalMySQLMetadataDB.cpp
-        src/GlobalMySQLMetadataDB.hpp
-        src/GlobalSQLiteMetadataDB.cpp
-        src/GlobalSQLiteMetadataDB.hpp
         src/Grep.cpp
         src/Grep.hpp
         src/ir/LogEvent.hpp

--- a/components/core/src/clp/GlobalMetadataDB.hpp
+++ b/components/core/src/clp/GlobalMetadataDB.hpp
@@ -1,12 +1,13 @@
-#ifndef GLOBALMETADATADB_HPP
-#define GLOBALMETADATADB_HPP
+#ifndef CLP_GLOBALMETADATADB_HPP
+#define CLP_GLOBALMETADATADB_HPP
 
 #include <string>
 #include <vector>
 
-#include "streaming_archive/ArchiveMetadata.hpp"
-#include "streaming_archive/writer/File.hpp"
+#include "../streaming_archive/ArchiveMetadata.hpp"
+#include "../streaming_archive/writer/File.hpp"
 
+namespace clp {
 /**
  * Base class for a representation of the global metadata database
  */
@@ -93,5 +94,6 @@ protected:
     // Variables
     bool m_is_open;
 };
+}  // namespace clp
 
-#endif  // GLOBALMETADATADB_HPP
+#endif  // CLP_GLOBALMETADATADB_HPP

--- a/components/core/src/clp/GlobalMetadataDBConfig.cpp
+++ b/components/core/src/clp/GlobalMetadataDBConfig.cpp
@@ -18,6 +18,7 @@ get_yaml_unconvertable_value_exception(string const& key_name, string const& des
     );
 }
 
+namespace clp {
 void GlobalMetadataDBConfig::parse_config_file(string const& config_file_path) {
     YAML::Node config = YAML::LoadFile(config_file_path);
 
@@ -106,3 +107,4 @@ void GlobalMetadataDBConfig::parse_config_file(string const& config_file_path) {
         throw invalid_argument("Unknown type");
     }
 }
+}  // namespace clp

--- a/components/core/src/clp/GlobalMetadataDBConfig.hpp
+++ b/components/core/src/clp/GlobalMetadataDBConfig.hpp
@@ -1,8 +1,9 @@
-#ifndef GLOBALMETADATADBCONFIG_HPP
-#define GLOBALMETADATADBCONFIG_HPP
+#ifndef CLP_GLOBALMETADATADBCONFIG_HPP
+#define CLP_GLOBALMETADATADBCONFIG_HPP
 
 #include <string>
 
+namespace clp {
 /**
  * Class encapsulating the global metadata database's configuration details
  */
@@ -50,5 +51,6 @@ private:
 
     std::string m_metadata_table_prefix;
 };
+}  // namespace clp
 
-#endif  // GLOBALMETADATADBCONFIG_HPP
+#endif  // CLP_GLOBALMETADATADBCONFIG_HPP

--- a/components/core/src/clp/GlobalMySQLMetadataDB.cpp
+++ b/components/core/src/clp/GlobalMySQLMetadataDB.cpp
@@ -2,9 +2,9 @@
 
 #include <fmt/core.h>
 
-#include "database_utils.hpp"
-#include "streaming_archive/Constants.hpp"
-#include "type_utils.hpp"
+#include "../database_utils.hpp"
+#include "../streaming_archive/Constants.hpp"
+#include "../type_utils.hpp"
 
 using std::pair;
 using std::string;
@@ -40,6 +40,7 @@ enum class FilesTableFieldIndexes : uint16_t {
     Length,
 };
 
+namespace clp {
 void GlobalMySQLMetadataDB::ArchiveIterator::get_id(string& id) const {
     m_db_iterator->get_field_as_string(enum_to_underlying_type(ArchivesTableFieldIndexes::Id), id);
 }
@@ -439,3 +440,4 @@ GlobalMetadataDB::ArchiveIterator* GlobalMySQLMetadataDB::get_archive_iterator_f
 
     return new ArchiveIterator(m_db.get_iterator());
 }
+}  // namespace clp

--- a/components/core/src/clp/GlobalMySQLMetadataDB.hpp
+++ b/components/core/src/clp/GlobalMySQLMetadataDB.hpp
@@ -1,11 +1,12 @@
-#ifndef GLOBALMYSQLMETADATADB_HPP
-#define GLOBALMYSQLMETADATADB_HPP
+#ifndef CLP_GLOBALMYSQLMETADATADB_HPP
+#define CLP_GLOBALMYSQLMETADATADB_HPP
 
-#include "ErrorCode.hpp"
+#include "../ErrorCode.hpp"
+#include "../MySQLDB.hpp"
+#include "../TraceableException.hpp"
 #include "GlobalMetadataDB.hpp"
-#include "MySQLDB.hpp"
-#include "TraceableException.hpp"
 
+namespace clp {
 /**
  * Class representing a MySQL global metadata database
  */
@@ -108,5 +109,6 @@ private:
     std::unique_ptr<MySQLPreparedStatement> m_update_archive_size_statement;
     std::unique_ptr<MySQLPreparedStatement> m_upsert_file_statement;
 };
+}  // namespace clp
 
-#endif  // GLOBALMYSQLMETADATADB_HPP
+#endif  // CLP_GLOBALMYSQLMETADATADB_HPP

--- a/components/core/src/clp/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/clp/GlobalSQLiteMetadataDB.cpp
@@ -5,10 +5,10 @@
 
 #include <fmt/core.h>
 
-#include "database_utils.hpp"
-#include "spdlog_with_specializations.hpp"
-#include "streaming_archive/Constants.hpp"
-#include "type_utils.hpp"
+#include "../database_utils.hpp"
+#include "../spdlog_with_specializations.hpp"
+#include "../streaming_archive/Constants.hpp"
+#include "../type_utils.hpp"
 
 // Types
 enum class ArchivesTableFieldIndexes : uint16_t {
@@ -174,6 +174,7 @@ get_archives_for_file_select_statement(SQLiteDB& db, string const& file_path) {
     return statement;
 }
 
+namespace clp {
 GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator(SQLiteDB& db)
         : m_statement(get_archives_select_statement(db)) {
     m_statement.step();
@@ -529,3 +530,4 @@ void GlobalSQLiteMetadataDB::update_metadata_for_files(
     m_upsert_files_transaction_begin_statement->reset();
     m_upsert_files_transaction_end_statement->reset();
 }
+}  // namespace clp

--- a/components/core/src/clp/GlobalSQLiteMetadataDB.hpp
+++ b/components/core/src/clp/GlobalSQLiteMetadataDB.hpp
@@ -1,16 +1,17 @@
-#ifndef GLOBALSQLITEMETADATADB_HPP
-#define GLOBALSQLITEMETADATADB_HPP
+#ifndef CLP_GLOBALSQLITEMETADATADB_HPP
+#define CLP_GLOBALSQLITEMETADATADB_HPP
 
 #include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "ErrorCode.hpp"
+#include "../ErrorCode.hpp"
+#include "../SQLiteDB.hpp"
+#include "../TraceableException.hpp"
 #include "GlobalMetadataDB.hpp"
-#include "SQLiteDB.hpp"
-#include "TraceableException.hpp"
 
+namespace clp {
 /**
  * Class representing a MySQL global metadata database
  */
@@ -105,5 +106,6 @@ private:
     std::unique_ptr<SQLitePreparedStatement> m_upsert_files_transaction_begin_statement;
     std::unique_ptr<SQLitePreparedStatement> m_upsert_files_transaction_end_statement;
 };
+}  // namespace clp
 
-#endif  // GLOBALSQLITEMETADATADB_HPP
+#endif  // CLP_GLOBALSQLITEMETADATADB_HPP

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -1,5 +1,12 @@
 set(
         CLG_SOURCES
+        ../GlobalMetadataDB.hpp
+        ../GlobalMetadataDBConfig.cpp
+        ../GlobalMetadataDBConfig.hpp
+        ../GlobalMySQLMetadataDB.cpp
+        ../GlobalMySQLMetadataDB.hpp
+        ../GlobalSQLiteMetadataDB.cpp
+        ../GlobalSQLiteMetadataDB.hpp
         "${PROJECT_SOURCE_DIR}/src/BufferReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.cpp"
@@ -22,13 +29,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/FileReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.cpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMetadataDB.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMetadataDBConfig.cpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMetadataDBConfig.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMySQLMetadataDB.cpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMySQLMetadataDB.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalSQLiteMetadataDB.cpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalSQLiteMetadataDB.hpp"
         "${PROJECT_SOURCE_DIR}/src/Grep.cpp"
         "${PROJECT_SOURCE_DIR}/src/Grep.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/LogEvent.hpp"

--- a/components/core/src/clp/clg/CommandLineArguments.hpp
+++ b/components/core/src/clp/clg/CommandLineArguments.hpp
@@ -8,7 +8,7 @@
 
 #include "../../CommandLineArgumentsBase.hpp"
 #include "../../Defs.h"
-#include "../../GlobalMetadataDBConfig.hpp"
+#include "../GlobalMetadataDBConfig.hpp"
 
 namespace clp::clg {
 class CommandLineArguments : public CommandLineArgumentsBase {

--- a/components/core/src/clp/clg/clg.cpp
+++ b/components/core/src/clp/clg/clg.cpp
@@ -7,16 +7,18 @@
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "../../Defs.h"
-#include "../../GlobalMySQLMetadataDB.hpp"
-#include "../../GlobalSQLiteMetadataDB.hpp"
 #include "../../Grep.hpp"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../streaming_archive/Constants.hpp"
 #include "../../Utils.hpp"
+#include "../GlobalMySQLMetadataDB.hpp"
+#include "../GlobalSQLiteMetadataDB.hpp"
 #include "CommandLineArguments.hpp"
 
 using clp::clg::CommandLineArguments;
+using clp::GlobalMetadataDB;
+using clp::GlobalMetadataDBConfig;
 using std::cerr;
 using std::cout;
 using std::endl;
@@ -511,11 +513,12 @@ int main(int argc, char const* argv[]) {
         case GlobalMetadataDBConfig::MetadataDBType::SQLite: {
             auto global_metadata_db_path = archives_dir / streaming_archive::cMetadataDBFileName;
             global_metadata_db
-                    = std::make_unique<GlobalSQLiteMetadataDB>(global_metadata_db_path.string());
+                    = std::make_unique<clp::GlobalSQLiteMetadataDB>(global_metadata_db_path.string()
+                    );
             break;
         }
         case GlobalMetadataDBConfig::MetadataDBType::MySQL:
-            global_metadata_db = std::make_unique<GlobalMySQLMetadataDB>(
+            global_metadata_db = std::make_unique<clp::GlobalMySQLMetadataDB>(
                     global_metadata_db_config.get_metadata_db_host(),
                     global_metadata_db_config.get_metadata_db_port(),
                     global_metadata_db_config.get_metadata_db_username(),

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -1,5 +1,12 @@
 set(
         CLP_SOURCES
+        ../GlobalMetadataDB.hpp
+        ../GlobalMetadataDBConfig.cpp
+        ../GlobalMetadataDBConfig.hpp
+        ../GlobalMySQLMetadataDB.cpp
+        ../GlobalMySQLMetadataDB.hpp
+        ../GlobalSQLiteMetadataDB.cpp
+        ../GlobalSQLiteMetadataDB.hpp
         "${PROJECT_SOURCE_DIR}/src/ArrayBackedPosIntSet.hpp"
         "${PROJECT_SOURCE_DIR}/src/BufferedFileReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferedFileReader.hpp"
@@ -29,13 +36,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/FileReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.cpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMetadataDB.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMetadataDBConfig.cpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMetadataDBConfig.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMySQLMetadataDB.cpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalMySQLMetadataDB.hpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalSQLiteMetadataDB.cpp"
-        "${PROJECT_SOURCE_DIR}/src/GlobalSQLiteMetadataDB.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/LogEvent.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/LogEventDeserializer.cpp"
         "${PROJECT_SOURCE_DIR}/src/ir/LogEventDeserializer.hpp"

--- a/components/core/src/clp/clp/CommandLineArguments.hpp
+++ b/components/core/src/clp/clp/CommandLineArguments.hpp
@@ -7,7 +7,7 @@
 #include <boost/asio.hpp>
 
 #include "../../CommandLineArgumentsBase.hpp"
-#include "../../GlobalMetadataDBConfig.hpp"
+#include "../GlobalMetadataDBConfig.hpp"
 
 namespace clp::clp {
 class CommandLineArguments : public CommandLineArgumentsBase {

--- a/components/core/src/clp/clp/compression.cpp
+++ b/components/core/src/clp/clp/compression.cpp
@@ -6,12 +6,12 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/uuid/random_generator.hpp>
 
-#include "../../GlobalMySQLMetadataDB.hpp"
-#include "../../GlobalSQLiteMetadataDB.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../streaming_archive/writer/Archive.hpp"
 #include "../../streaming_archive/writer/utils.hpp"
 #include "../../Utils.hpp"
+#include "../GlobalMySQLMetadataDB.hpp"
+#include "../GlobalSQLiteMetadataDB.hpp"
 #include "FileCompressor.hpp"
 #include "utils.hpp"
 

--- a/components/core/src/clp/clp/decompression.cpp
+++ b/components/core/src/clp/clp/decompression.cpp
@@ -7,12 +7,12 @@
 
 #include "../../ErrorCode.hpp"
 #include "../../FileWriter.hpp"
-#include "../../GlobalMySQLMetadataDB.hpp"
-#include "../../GlobalSQLiteMetadataDB.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../streaming_archive/reader/Archive.hpp"
 #include "../../TraceableException.hpp"
 #include "../../Utils.hpp"
+#include "../GlobalMySQLMetadataDB.hpp"
+#include "../GlobalSQLiteMetadataDB.hpp"
 #include "FileDecompressor.hpp"
 
 using std::cerr;

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -15,8 +15,8 @@
 #include <log_surgeon/ReaderParser.hpp>
 
 #include "../../ArrayBackedPosIntSet.hpp"
+#include "../../clp/GlobalMetadataDB.hpp"
 #include "../../ErrorCode.hpp"
-#include "../../GlobalMetadataDB.hpp"
 #include "../../ir/LogEvent.hpp"
 #include "../../LogTypeDictionaryWriter.hpp"
 #include "../../VariableDictionaryWriter.hpp"
@@ -46,7 +46,7 @@ namespace streaming_archive { namespace writer {
             size_t target_segment_uncompressed_size;
             int compression_level;
             std::string output_dir;
-            GlobalMetadataDB* global_metadata_db;
+            clp::GlobalMetadataDB* global_metadata_db;
             bool print_archive_stats_progress;
         };
 
@@ -338,7 +338,7 @@ namespace streaming_archive { namespace writer {
         std::optional<ArchiveMetadata> m_local_metadata;
         FileWriter m_metadata_file_writer;
 
-        GlobalMetadataDB* m_global_metadata_db;
+        clp::GlobalMetadataDB* m_global_metadata_db;
 
         bool m_print_archive_stats_progress;
     };

--- a/components/core/tests/test-ParserWithUserSchema.cpp
+++ b/components/core/tests/test-ParserWithUserSchema.cpp
@@ -11,7 +11,7 @@
 #include <log_surgeon/LogParser.hpp>
 
 #include "../src/clp/clp/run.hpp"
-#include "../src/GlobalMySQLMetadataDB.hpp"
+#include "../src/clp/GlobalMySQLMetadataDB.hpp"
 #include "../src/LogSurgeonReader.hpp"
 #include "../src/Utils.hpp"
 


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR moves the sources for CLP's global metadata DB classes into the `clp` namespace. Ideally, we'd turn this into a library but we need to clean-up its dependencies first, so we're deferring the library to another PR.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated unit tests pass.
* Validated compression and decompression with the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset.
* Validated a search `"DESERIALIZE_ERRORS"` returns the same (after sorting) results as `grep`.
