### PR TITLE
Move networking sources into the clp namespace.

### DIFF
--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(
         CLO_SOURCES
+        ../networking/socket_utils.cpp
+        ../networking/socket_utils.hpp
+        ../networking/SocketOperationFailed.hpp
         "${PROJECT_SOURCE_DIR}/src/BufferReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.cpp"
@@ -34,9 +37,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/networking/socket_utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/networking/socket_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/networking/SocketOperationFailed.hpp"
         "${PROJECT_SOURCE_DIR}/src/PageAllocatedVector.hpp"
         "${PROJECT_SOURCE_DIR}/src/ParsedMessage.cpp"
         "${PROJECT_SOURCE_DIR}/src/ParsedMessage.hpp"

--- a/components/core/src/clp/clo/ControllerMonitoringThread.cpp
+++ b/components/core/src/clp/clo/ControllerMonitoringThread.cpp
@@ -2,8 +2,8 @@
 
 #include <unistd.h>
 
-#include "../../networking/socket_utils.hpp"
 #include "../../spdlog_with_specializations.hpp"
+#include "../networking/socket_utils.hpp"
 
 namespace clp::clo {
 void ControllerMonitoringThread::thread_method() {

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -9,11 +9,11 @@
 
 #include "../../Defs.h"
 #include "../../Grep.hpp"
-#include "../../networking/socket_utils.hpp"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../streaming_archive/Constants.hpp"
 #include "../../Utils.hpp"
+#include "../networking/socket_utils.hpp"
 #include "CommandLineArguments.hpp"
 #include "ControllerMonitoringThread.hpp"
 
@@ -155,7 +155,7 @@ static ErrorCode send_result(
     );
     msgpack::sbuffer m;
     msgpack::pack(m, src);
-    return networking::try_send(controller_socket_fd, m.data(), m.size());
+    return clp::networking::try_send(controller_socket_fd, m.data(), m.size());
 }
 
 static SearchFilesResult search_files(

--- a/components/core/src/clp/networking/SocketOperationFailed.hpp
+++ b/components/core/src/clp/networking/SocketOperationFailed.hpp
@@ -1,10 +1,10 @@
-#ifndef NETWORKING_SOCKETOPERATIONFAILED_HPP
-#define NETWORKING_SOCKETOPERATIONFAILED_HPP
+#ifndef CLP_NETWORKING_SOCKETOPERATIONFAILED_HPP
+#define CLP_NETWORKING_SOCKETOPERATIONFAILED_HPP
 
-#include "../ErrorCode.hpp"
-#include "../TraceableException.hpp"
+#include "../../ErrorCode.hpp"
+#include "../../TraceableException.hpp"
 
-namespace networking {
+namespace clp::networking {
 class SocketOperationFailed : public TraceableException {
 public:
     // Constructors
@@ -14,6 +14,6 @@ public:
     // Methods
     [[nodiscard]] char const* what() const noexcept override { return "Socket operation failed"; }
 };
-}  // namespace networking
+}  // namespace clp::networking
 
-#endif  // NETWORKING_SOCKETOPERATIONFAILED_HPP
+#endif  // CLP_NETWORKING_SOCKETOPERATIONFAILED_HPP

--- a/components/core/src/clp/networking/socket_utils.cpp
+++ b/components/core/src/clp/networking/socket_utils.cpp
@@ -4,10 +4,10 @@
 
 #include <cstdio>
 
-#include "../Defs.h"
+#include "../../Defs.h"
 #include "SocketOperationFailed.hpp"
 
-namespace networking {
+namespace clp::networking {
 ErrorCode try_send(int fd, char const* buf, size_t buf_len) {
     if (fd < 0 || nullptr == buf) {
         return ErrorCode_BadParam;
@@ -51,4 +51,4 @@ void receive(int fd, char* buf, size_t buf_len, size_t& num_bytes_received) {
         throw SocketOperationFailed(error_code, __FILENAME__, __LINE__);
     }
 }
-}  // namespace networking
+}  // namespace clp::networking

--- a/components/core/src/clp/networking/socket_utils.hpp
+++ b/components/core/src/clp/networking/socket_utils.hpp
@@ -1,11 +1,11 @@
-#ifndef NETWORKING_SOCKET_UTILS_HPP
-#define NETWORKING_SOCKET_UTILS_HPP
+#ifndef CLP_NETWORKING_SOCKET_UTILS_HPP
+#define CLP_NETWORKING_SOCKET_UTILS_HPP
 
 #include <cstddef>
 
-#include "../ErrorCode.hpp"
+#include "../../ErrorCode.hpp"
 
-namespace networking {
+namespace clp::networking {
 // Methods
 /**
  * Tries to send a buffer of data over the socket
@@ -41,6 +41,6 @@ ErrorCode try_receive(int fd, char* buf, size_t buf_len, size_t& num_bytes_recei
  * @param buf_len Number of bytes to receive
  */
 void receive(int fd, char* buf, size_t buf_len, size_t& num_bytes_received);
-}  // namespace networking
+}  // namespace clp::networking
 
-#endif  // NETWORKING_SOCKET_UTILS_HPP
+#endif  // CLP_NETWORKING_SOCKET_UTILS_HPP


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR moves the networking sources into the `clp` namespace.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated unit tests pass.
* Validated compression and decompression with the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset.
* Validated a search `"DESERIALIZE_ERRORS"` returns the same (after sorting) results as `grep`.
