### PR TITLE
Join nested namespace names to reduce indentation; Don't indent inner namespaces.

### DIFF
--- a/components/core/.clang-format
+++ b/components/core/.clang-format
@@ -105,7 +105,7 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 LambdaBodyIndentation: "Signature"
 LineEnding: "LF"
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: "Inner"
+NamespaceIndentation: "None"
 PPIndentWidth: -1
 PackConstructorInitializers: "CurrentLine"
 PenaltyBreakOpenParenthesis: 25

--- a/components/core/src/ffi/ir_stream/decoding_methods.cpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.cpp
@@ -504,28 +504,21 @@ IRProtocolErrorCode validate_protocol_version(std::string_view protocol_version)
 }
 
 namespace four_byte_encoding {
-    IRErrorCode deserialize_log_event(
-            ReaderInterface& reader,
-            string& message,
-            epoch_time_ms_t& timestamp_delta
-    ) {
-        return generic_deserialize_log_event<four_byte_encoded_variable_t>(
-                reader,
-                message,
-                timestamp_delta
-        );
-    }
+IRErrorCode
+deserialize_log_event(ReaderInterface& reader, string& message, epoch_time_ms_t& timestamp_delta) {
+    return generic_deserialize_log_event<four_byte_encoded_variable_t>(
+            reader,
+            message,
+            timestamp_delta
+    );
+}
 }  // namespace four_byte_encoding
 
 namespace eight_byte_encoding {
-    IRErrorCode
-    deserialize_log_event(ReaderInterface& reader, string& message, epoch_time_ms_t& timestamp) {
-        return generic_deserialize_log_event<eight_byte_encoded_variable_t>(
-                reader,
-                message,
-                timestamp
-        );
-    }
+IRErrorCode
+deserialize_log_event(ReaderInterface& reader, string& message, epoch_time_ms_t& timestamp) {
+    return generic_deserialize_log_event<eight_byte_encoded_variable_t>(reader, message, timestamp);
+}
 }  // namespace eight_byte_encoding
 
 // Explicitly declare specializations

--- a/components/core/src/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/decoding_methods.hpp
@@ -163,41 +163,41 @@ IRErrorCode deserialize_preamble(
 IRProtocolErrorCode validate_protocol_version(std::string_view protocol_version);
 
 namespace eight_byte_encoding {
-    /**
-     * Deserializes the next log event from an eight-byte encoding IR stream.
-     * @param reader
-     * @param message Returns the deserialized message
-     * @param timestamp Returns the deserialized timestamp
-     * @return ErrorCode_Success on success
-     * @return ErrorCode_Corrupted_IR if reader contains invalid IR
-     * @return ErrorCode_Decode_Error if the log event cannot be properly deserialized
-     * @return ErrorCode_Incomplete_IR if reader doesn't contain enough data to deserialize
-     * @return ErrorCode_End_of_IR if the IR ends
-     */
-    IRErrorCode deserialize_log_event(
-            ReaderInterface& reader,
-            std::string& message,
-            ir::epoch_time_ms_t& timestamp
-    );
+/**
+ * Deserializes the next log event from an eight-byte encoding IR stream.
+ * @param reader
+ * @param message Returns the deserialized message
+ * @param timestamp Returns the deserialized timestamp
+ * @return ErrorCode_Success on success
+ * @return ErrorCode_Corrupted_IR if reader contains invalid IR
+ * @return ErrorCode_Decode_Error if the log event cannot be properly deserialized
+ * @return ErrorCode_Incomplete_IR if reader doesn't contain enough data to deserialize
+ * @return ErrorCode_End_of_IR if the IR ends
+ */
+IRErrorCode deserialize_log_event(
+        ReaderInterface& reader,
+        std::string& message,
+        ir::epoch_time_ms_t& timestamp
+);
 }  // namespace eight_byte_encoding
 
 namespace four_byte_encoding {
-    /**
-     * Deserializes the next log event from a four-byte encoding IR stream.
-     * @param reader
-     * @param message Returns the deserialized message
-     * @param timestamp_delta Returns the deserialized timestamp delta
-     * @return ErrorCode_Success on success
-     * @return ErrorCode_Corrupted_IR if reader contains invalid IR
-     * @return ErrorCode_Decode_Error if the log event cannot be properly deserialized
-     * @return ErrorCode_Incomplete_IR if reader doesn't contain enough data to deserialize
-     * @return ErrorCode_End_of_IR if the IR ends
-     */
-    IRErrorCode deserialize_log_event(
-            ReaderInterface& reader,
-            std::string& message,
-            ir::epoch_time_ms_t& timestamp_delta
-    );
+/**
+ * Deserializes the next log event from a four-byte encoding IR stream.
+ * @param reader
+ * @param message Returns the deserialized message
+ * @param timestamp_delta Returns the deserialized timestamp delta
+ * @return ErrorCode_Success on success
+ * @return ErrorCode_Corrupted_IR if reader contains invalid IR
+ * @return ErrorCode_Decode_Error if the log event cannot be properly deserialized
+ * @return ErrorCode_Incomplete_IR if reader doesn't contain enough data to deserialize
+ * @return ErrorCode_End_of_IR if the IR ends
+ */
+IRErrorCode deserialize_log_event(
+        ReaderInterface& reader,
+        std::string& message,
+        ir::epoch_time_ms_t& timestamp_delta
+);
 }  // namespace four_byte_encoding
 }  // namespace ffi::ir_stream
 

--- a/components/core/src/ffi/ir_stream/encoding_methods.hpp
+++ b/components/core/src/ffi/ir_stream/encoding_methods.hpp
@@ -9,88 +9,87 @@
 
 namespace ffi::ir_stream {
 namespace eight_byte_encoding {
-    /**
-     * Serializes the preamble for the eight-byte encoding IR stream
-     * @param timestamp_pattern
-     * @param timestamp_pattern_syntax
-     * @param time_zone_id
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    bool serialize_preamble(
-            std::string_view timestamp_pattern,
-            std::string_view timestamp_pattern_syntax,
-            std::string_view time_zone_id,
-            std::vector<int8_t>& ir_buf
-    );
+/**
+ * Serializes the preamble for the eight-byte encoding IR stream
+ * @param timestamp_pattern
+ * @param timestamp_pattern_syntax
+ * @param time_zone_id
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+bool serialize_preamble(
+        std::string_view timestamp_pattern,
+        std::string_view timestamp_pattern_syntax,
+        std::string_view time_zone_id,
+        std::vector<int8_t>& ir_buf
+);
 
-    /**
-     * Serializes the given log event into the eight-byte encoding IR stream
-     * @param timestamp
-     * @param message
-     * @param logtype
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    bool serialize_log_event(
-            ir::epoch_time_ms_t timestamp,
-            std::string_view message,
-            std::string& logtype,
-            std::vector<int8_t>& ir_buf
-    );
+/**
+ * Serializes the given log event into the eight-byte encoding IR stream
+ * @param timestamp
+ * @param message
+ * @param logtype
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+bool serialize_log_event(
+        ir::epoch_time_ms_t timestamp,
+        std::string_view message,
+        std::string& logtype,
+        std::vector<int8_t>& ir_buf
+);
 }  // namespace eight_byte_encoding
 
 namespace four_byte_encoding {
-    /**
-     * Serializes the preamble for the four-byte encoding IR stream
-     * @param timestamp_pattern
-     * @param timestamp_pattern_syntax
-     * @param time_zone_id
-     * @param reference_timestamp
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    bool serialize_preamble(
-            std::string_view timestamp_pattern,
-            std::string_view timestamp_pattern_syntax,
-            std::string_view time_zone_id,
-            ir::epoch_time_ms_t reference_timestamp,
-            std::vector<int8_t>& ir_buf
-    );
+/**
+ * Serializes the preamble for the four-byte encoding IR stream
+ * @param timestamp_pattern
+ * @param timestamp_pattern_syntax
+ * @param time_zone_id
+ * @param reference_timestamp
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+bool serialize_preamble(
+        std::string_view timestamp_pattern,
+        std::string_view timestamp_pattern_syntax,
+        std::string_view time_zone_id,
+        ir::epoch_time_ms_t reference_timestamp,
+        std::vector<int8_t>& ir_buf
+);
 
-    /**
-     * Serializes the given log event into the four-byte encoding IR stream
-     * @param timestamp_delta
-     * @param message
-     * @param logtype
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    bool serialize_log_event(
-            ir::epoch_time_ms_t timestamp_delta,
-            std::string_view message,
-            std::string& logtype,
-            std::vector<int8_t>& ir_buf
-    );
+/**
+ * Serializes the given log event into the four-byte encoding IR stream
+ * @param timestamp_delta
+ * @param message
+ * @param logtype
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+bool serialize_log_event(
+        ir::epoch_time_ms_t timestamp_delta,
+        std::string_view message,
+        std::string& logtype,
+        std::vector<int8_t>& ir_buf
+);
 
-    /**
-     * Serializes the given message into the four-byte encoding IR stream
-     * delta
-     * @param message
-     * @param logtype
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    bool
-    serialize_message(std::string_view message, std::string& logtype, std::vector<int8_t>& ir_buf);
+/**
+ * Serializes the given message into the four-byte encoding IR stream
+ * delta
+ * @param message
+ * @param logtype
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+bool serialize_message(std::string_view message, std::string& logtype, std::vector<int8_t>& ir_buf);
 
-    /**
-     * Serializes the given timestamp delta into the four-byte encoding IR stream
-     * @param timestamp_delta
-     * @param ir_buf
-     * @return true on success, false otherwise
-     */
-    bool serialize_timestamp(ir::epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf);
+/**
+ * Serializes the given timestamp delta into the four-byte encoding IR stream
+ * @param timestamp_delta
+ * @param ir_buf
+ * @return true on success, false otherwise
+ */
+bool serialize_timestamp(ir::epoch_time_ms_t timestamp_delta, std::vector<int8_t>& ir_buf);
 }  // namespace four_byte_encoding
 }  // namespace ffi::ir_stream
 

--- a/components/core/src/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/ffi/ir_stream/protocol_constants.hpp
@@ -7,46 +7,46 @@
 
 namespace ffi::ir_stream::cProtocol {
 namespace Metadata {
-    constexpr int8_t EncodingJson = 0x1;
-    constexpr int8_t LengthUByte = 0x11;
-    constexpr int8_t LengthUShort = 0x12;
+constexpr int8_t EncodingJson = 0x1;
+constexpr int8_t LengthUByte = 0x11;
+constexpr int8_t LengthUShort = 0x12;
 
-    constexpr char VersionKey[] = "VERSION";
-    constexpr char VersionValue[] = "0.0.1";
+constexpr char VersionKey[] = "VERSION";
+constexpr char VersionValue[] = "0.0.1";
 
-    // The following regex can be used to validate a Semantic Versioning string. The source of the
-    // regex can be found here: https://semver.org/
-    constexpr char VersionRegex[] = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
-                                    "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-                                    "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
-                                    "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
+// The following regex can be used to validate a Semantic Versioning string. The source of the
+// regex can be found here: https://semver.org/
+constexpr char VersionRegex[] = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
+                                "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+                                "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+                                "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
 
-    constexpr char TimestampPatternKey[] = "TIMESTAMP_PATTERN";
-    constexpr char TimestampPatternSyntaxKey[] = "TIMESTAMP_PATTERN_SYNTAX";
-    constexpr char TimeZoneIdKey[] = "TZ_ID";
-    constexpr char ReferenceTimestampKey[] = "REFERENCE_TIMESTAMP";
+constexpr char TimestampPatternKey[] = "TIMESTAMP_PATTERN";
+constexpr char TimestampPatternSyntaxKey[] = "TIMESTAMP_PATTERN_SYNTAX";
+constexpr char TimeZoneIdKey[] = "TZ_ID";
+constexpr char ReferenceTimestampKey[] = "REFERENCE_TIMESTAMP";
 
-    constexpr char VariablesSchemaIdKey[] = "VARIABLES_SCHEMA_ID";
-    constexpr char VariableEncodingMethodsIdKey[] = "VARIABLE_ENCODING_METHODS_ID";
+constexpr char VariablesSchemaIdKey[] = "VARIABLES_SCHEMA_ID";
+constexpr char VariableEncodingMethodsIdKey[] = "VARIABLE_ENCODING_METHODS_ID";
 }  // namespace Metadata
 
 namespace Payload {
-    constexpr int8_t VarFourByteEncoding = 0x18;
-    constexpr int8_t VarEightByteEncoding = 0x19;
+constexpr int8_t VarFourByteEncoding = 0x18;
+constexpr int8_t VarEightByteEncoding = 0x19;
 
-    constexpr int8_t VarStrLenUByte = 0x11;
-    constexpr int8_t VarStrLenUShort = 0x12;
-    constexpr int8_t VarStrLenInt = 0x13;
+constexpr int8_t VarStrLenUByte = 0x11;
+constexpr int8_t VarStrLenUShort = 0x12;
+constexpr int8_t VarStrLenInt = 0x13;
 
-    constexpr int8_t LogtypeStrLenUByte = 0x21;
-    constexpr int8_t LogtypeStrLenUShort = 0x22;
-    constexpr int8_t LogtypeStrLenInt = 0x23;
+constexpr int8_t LogtypeStrLenUByte = 0x21;
+constexpr int8_t LogtypeStrLenUShort = 0x22;
+constexpr int8_t LogtypeStrLenInt = 0x23;
 
-    constexpr int8_t TimestampVal = 0x30;
-    constexpr int8_t TimestampDeltaByte = 0x31;
-    constexpr int8_t TimestampDeltaShort = 0x32;
-    constexpr int8_t TimestampDeltaInt = 0x33;
-    constexpr int8_t TimestampDeltaLong = 0x34;
+constexpr int8_t TimestampVal = 0x30;
+constexpr int8_t TimestampDeltaByte = 0x31;
+constexpr int8_t TimestampDeltaShort = 0x32;
+constexpr int8_t TimestampDeltaInt = 0x33;
+constexpr int8_t TimestampDeltaLong = 0x34;
 }  // namespace Payload
 
 constexpr int8_t FourByteEncodingMagicNumber[]

--- a/components/core/src/streaming_archive/Constants.hpp
+++ b/components/core/src/streaming_archive/Constants.hpp
@@ -16,42 +16,42 @@ constexpr char cMetadataDBFileName[] = "metadata.db";
 constexpr char cSchemaFileName[] = "schema.txt";
 
 namespace cMetadataDB {
-    constexpr char ArchivesTableName[] = "archives";
-    constexpr char FilesTableName[] = "files";
-    constexpr char EmptyDirectoriesTableName[] = "empty_directories";
+constexpr char ArchivesTableName[] = "archives";
+constexpr char FilesTableName[] = "files";
+constexpr char EmptyDirectoriesTableName[] = "empty_directories";
 
-    namespace Archive {
-        constexpr char Id[] = "id";
-        constexpr char BeginTimestamp[] = "begin_timestamp";
-        constexpr char EndTimestamp[] = "end_timestamp";
-        constexpr char UncompressedSize[] = "uncompressed_size";
-        constexpr char Size[] = "size";
-        constexpr char CreatorId[] = "creator_id";
-        constexpr char CreationIx[] = "creation_ix";
-    }  // namespace Archive
+namespace Archive {
+constexpr char Id[] = "id";
+constexpr char BeginTimestamp[] = "begin_timestamp";
+constexpr char EndTimestamp[] = "end_timestamp";
+constexpr char UncompressedSize[] = "uncompressed_size";
+constexpr char Size[] = "size";
+constexpr char CreatorId[] = "creator_id";
+constexpr char CreationIx[] = "creation_ix";
+}  // namespace Archive
 
-    namespace File {
-        constexpr char Id[] = "id";
-        constexpr char OrigFileId[] = "orig_file_id";
-        constexpr char Path[] = "path";
-        constexpr char BeginTimestamp[] = "begin_timestamp";
-        constexpr char EndTimestamp[] = "end_timestamp";
-        constexpr char TimestampPatterns[] = "timestamp_patterns";
-        constexpr char NumUncompressedBytes[] = "num_uncompressed_bytes";
-        constexpr char NumMessages[] = "num_messages";
-        constexpr char NumVariables[] = "num_variables";
-        constexpr char IsSplit[] = "is_split";
-        constexpr char SplitIx[] = "split_ix";
-        constexpr char SegmentId[] = "segment_id";
-        constexpr char SegmentTimestampsPosition[] = "segment_timestamps_position";
-        constexpr char SegmentLogtypesPosition[] = "segment_logtypes_position";
-        constexpr char SegmentVariablesPosition[] = "segment_variables_position";
-        constexpr char ArchiveId[] = "archive_id";
-    }  // namespace File
+namespace File {
+constexpr char Id[] = "id";
+constexpr char OrigFileId[] = "orig_file_id";
+constexpr char Path[] = "path";
+constexpr char BeginTimestamp[] = "begin_timestamp";
+constexpr char EndTimestamp[] = "end_timestamp";
+constexpr char TimestampPatterns[] = "timestamp_patterns";
+constexpr char NumUncompressedBytes[] = "num_uncompressed_bytes";
+constexpr char NumMessages[] = "num_messages";
+constexpr char NumVariables[] = "num_variables";
+constexpr char IsSplit[] = "is_split";
+constexpr char SplitIx[] = "split_ix";
+constexpr char SegmentId[] = "segment_id";
+constexpr char SegmentTimestampsPosition[] = "segment_timestamps_position";
+constexpr char SegmentLogtypesPosition[] = "segment_logtypes_position";
+constexpr char SegmentVariablesPosition[] = "segment_variables_position";
+constexpr char ArchiveId[] = "archive_id";
+}  // namespace File
 
-    namespace EmptyDirectory {
-        constexpr char Path[] = "path";
-    }  // namespace EmptyDirectory
+namespace EmptyDirectory {
+constexpr char Path[] = "path";
+}  // namespace EmptyDirectory
 }  // namespace cMetadataDB
 }  // namespace streaming_archive
 

--- a/components/core/src/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/streaming_archive/reader/Archive.cpp
@@ -18,222 +18,221 @@ using std::string;
 using std::unordered_set;
 using std::vector;
 
-namespace streaming_archive { namespace reader {
-    void Archive::open(string const& path) {
-        // Determine whether path is file or directory
-        struct stat path_stat = {};
-        char const* path_c_str = path.c_str();
-        if (0 != stat(path_c_str, &path_stat)) {
-            SPDLOG_ERROR("Failed to stat {}, errno={}", path_c_str, errno);
-            throw OperationFailed(ErrorCode_errno, __FILENAME__, __LINE__);
-        }
-        if (!S_ISDIR(path_stat.st_mode)) {
-            SPDLOG_ERROR("{} is not a directory", path_c_str);
-            throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
-        }
-        m_path = path;
+namespace streaming_archive::reader {
+void Archive::open(string const& path) {
+    // Determine whether path is file or directory
+    struct stat path_stat = {};
+    char const* path_c_str = path.c_str();
+    if (0 != stat(path_c_str, &path_stat)) {
+        SPDLOG_ERROR("Failed to stat {}, errno={}", path_c_str, errno);
+        throw OperationFailed(ErrorCode_errno, __FILENAME__, __LINE__);
+    }
+    if (!S_ISDIR(path_stat.st_mode)) {
+        SPDLOG_ERROR("{} is not a directory", path_c_str);
+        throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+    }
+    m_path = path;
 
-        // Read the metadata file
-        string metadata_file_path = path + '/' + cMetadataFileName;
-        archive_format_version_t format_version{};
-        try {
-            FileReader file_reader;
-            file_reader.open(metadata_file_path);
-            ArchiveMetadata const metadata{file_reader};
-            format_version = metadata.get_archive_format_version();
-            file_reader.close();
-        } catch (TraceableException& traceable_exception) {
-            auto error_code = traceable_exception.get_error_code();
-            if (ErrorCode_errno == error_code) {
-                SPDLOG_CRITICAL(
-                        "streaming_archive::reader::Archive: Failed to read archive metadata file "
-                        "{} at {}:{} - errno={}",
-                        metadata_file_path.c_str(),
-                        traceable_exception.get_filename(),
-                        traceable_exception.get_line_number(),
-                        errno
-                );
-            } else {
-                SPDLOG_CRITICAL(
-                        "streaming_archive::reader::Archive: Failed to read archive metadata file "
-                        "{} at {}:{} - error={}",
-                        metadata_file_path.c_str(),
-                        traceable_exception.get_filename(),
-                        traceable_exception.get_line_number(),
-                        error_code
-                );
+    // Read the metadata file
+    string metadata_file_path = path + '/' + cMetadataFileName;
+    archive_format_version_t format_version{};
+    try {
+        FileReader file_reader;
+        file_reader.open(metadata_file_path);
+        ArchiveMetadata const metadata{file_reader};
+        format_version = metadata.get_archive_format_version();
+        file_reader.close();
+    } catch (TraceableException& traceable_exception) {
+        auto error_code = traceable_exception.get_error_code();
+        if (ErrorCode_errno == error_code) {
+            SPDLOG_CRITICAL(
+                    "streaming_archive::reader::Archive: Failed to read archive metadata file "
+                    "{} at {}:{} - errno={}",
+                    metadata_file_path.c_str(),
+                    traceable_exception.get_filename(),
+                    traceable_exception.get_line_number(),
+                    errno
+            );
+        } else {
+            SPDLOG_CRITICAL(
+                    "streaming_archive::reader::Archive: Failed to read archive metadata file "
+                    "{} at {}:{} - error={}",
+                    metadata_file_path.c_str(),
+                    traceable_exception.get_filename(),
+                    traceable_exception.get_line_number(),
+                    error_code
+            );
+        }
+        throw;
+    }
+
+    // Check archive matches format version
+    if (cArchiveFormatVersion != format_version) {
+        SPDLOG_ERROR("streaming_archive::reader::Archive: Archive uses an unsupported format.");
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
+    }
+
+    auto metadata_db_path = boost::filesystem::path(path) / cMetadataDBFileName;
+    if (false == boost::filesystem::exists(metadata_db_path)) {
+        SPDLOG_ERROR(
+                "streaming_archive::reader::Archive: Metadata DB not found: {}",
+                metadata_db_path.string()
+        );
+        throw OperationFailed(ErrorCode_FileNotFound, __FILENAME__, __LINE__);
+    }
+    m_metadata_db.open(metadata_db_path.string());
+
+    // Open log-type dictionary
+    string logtype_dict_path = m_path;
+    logtype_dict_path += '/';
+    logtype_dict_path += cLogTypeDictFilename;
+    string logtype_segment_index_path = m_path;
+    logtype_segment_index_path += '/';
+    logtype_segment_index_path += cLogTypeSegmentIndexFilename;
+    m_logtype_dictionary.open(logtype_dict_path, logtype_segment_index_path);
+
+    // Open variables dictionary
+    string var_dict_path = m_path;
+    var_dict_path += '/';
+    var_dict_path += cVarDictFilename;
+    string var_segment_index_path = m_path;
+    var_segment_index_path += '/';
+    var_segment_index_path += cVarSegmentIndexFilename;
+    m_var_dictionary.open(var_dict_path, var_segment_index_path);
+
+    // Open segment manager
+    m_segments_dir_path = m_path;
+    m_segments_dir_path += '/';
+    m_segments_dir_path += cSegmentsDirname;
+    m_segments_dir_path += '/';
+    m_segment_manager.open(m_segments_dir_path);
+
+    // Open segment list
+    string segment_list_path = m_segments_dir_path;
+    segment_list_path += cSegmentListFilename;
+}
+
+void Archive::close() {
+    m_logtype_dictionary.close();
+    m_var_dictionary.close();
+    m_segment_manager.close();
+    m_segments_dir_path.clear();
+    m_metadata_db.close();
+    m_path.clear();
+}
+
+void Archive::refresh_dictionaries() {
+    m_logtype_dictionary.read_new_entries();
+    m_var_dictionary.read_new_entries();
+}
+
+ErrorCode Archive::open_file(File& file, MetadataDB::FileIterator const& file_metadata_ix) {
+    return file.open_me(m_logtype_dictionary, file_metadata_ix, m_segment_manager);
+}
+
+void Archive::close_file(File& file) {
+    file.close_me();
+}
+
+void Archive::reset_file_indices(streaming_archive::reader::File& file) {
+    file.reset_indices();
+}
+
+LogTypeDictionaryReader const& Archive::get_logtype_dictionary() const {
+    return m_logtype_dictionary;
+}
+
+VariableDictionaryReader const& Archive::get_var_dictionary() const {
+    return m_var_dictionary;
+}
+
+bool Archive::find_message_in_time_range(
+        File& file,
+        epochtime_t search_begin_timestamp,
+        epochtime_t search_end_timestamp,
+        Message& msg
+) {
+    return file.find_message_in_time_range(search_begin_timestamp, search_end_timestamp, msg);
+}
+
+SubQuery const* Archive::find_message_matching_query(File& file, Query const& query, Message& msg) {
+    return file.find_message_matching_query(query, msg);
+}
+
+bool Archive::get_next_message(File& file, Message& msg) {
+    return file.get_next_message(msg);
+}
+
+bool Archive::decompress_message(
+        File& file,
+        Message const& compressed_msg,
+        string& decompressed_msg
+) {
+    decompressed_msg.clear();
+
+    // Build original message content
+    logtype_dictionary_id_t const logtype_id = compressed_msg.get_logtype_id();
+    auto const& logtype_entry = m_logtype_dictionary.get_entry(logtype_id);
+    if (!EncodedVariableInterpreter::decode_variables_into_message(
+                logtype_entry,
+                m_var_dictionary,
+                compressed_msg.get_vars(),
+                decompressed_msg
+        ))
+    {
+        SPDLOG_ERROR(
+                "streaming_archive::reader::Archive: Failed to decompress variables from "
+                "logtype id {}",
+                compressed_msg.get_logtype_id()
+        );
+        return false;
+    }
+
+    // Determine which timestamp pattern to use
+    auto const& timestamp_patterns = file.get_timestamp_patterns();
+    if (!timestamp_patterns.empty()
+        && compressed_msg.get_message_number()
+                   >= timestamp_patterns[file.get_current_ts_pattern_ix()].first)
+    {
+        while (true) {
+            if (file.get_current_ts_pattern_ix() >= timestamp_patterns.size() - 1) {
+                // Already at last timestamp pattern
+                break;
             }
-            throw;
+            auto next_patt_start_message_num
+                    = timestamp_patterns[file.get_current_ts_pattern_ix() + 1].first;
+            if (compressed_msg.get_message_number() < next_patt_start_message_num) {
+                // Not yet time for next timestamp pattern
+                break;
+            }
+            file.increment_current_ts_pattern_ix();
         }
+        timestamp_patterns[file.get_current_ts_pattern_ix()].second.insert_formatted_timestamp(
+                compressed_msg.get_ts_in_milli(),
+                decompressed_msg
+        );
+    }
 
-        // Check archive matches format version
-        if (cArchiveFormatVersion != format_version) {
-            SPDLOG_ERROR("streaming_archive::reader::Archive: Archive uses an unsupported format.");
-            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-        }
+    return true;
+}
 
-        auto metadata_db_path = boost::filesystem::path(path) / cMetadataDBFileName;
-        if (false == boost::filesystem::exists(metadata_db_path)) {
+void Archive::decompress_empty_directories(string const& output_dir) {
+    boost::filesystem::path output_dir_path = boost::filesystem::path(output_dir);
+
+    string path;
+    auto ix_ptr = m_metadata_db.get_empty_directory_iterator();
+    for (auto& ix = *ix_ptr; ix.has_next(); ix.next()) {
+        ix.get_path(path);
+        auto empty_directory_path = output_dir_path / path;
+        auto error_code = create_directory_structure(empty_directory_path.string(), 0700);
+        if (ErrorCode_Success != error_code) {
             SPDLOG_ERROR(
-                    "streaming_archive::reader::Archive: Metadata DB not found: {}",
-                    metadata_db_path.string()
+                    "Failed to create directory structure {}, errno={}",
+                    empty_directory_path.string().c_str(),
+                    errno
             );
-            throw OperationFailed(ErrorCode_FileNotFound, __FILENAME__, __LINE__);
-        }
-        m_metadata_db.open(metadata_db_path.string());
-
-        // Open log-type dictionary
-        string logtype_dict_path = m_path;
-        logtype_dict_path += '/';
-        logtype_dict_path += cLogTypeDictFilename;
-        string logtype_segment_index_path = m_path;
-        logtype_segment_index_path += '/';
-        logtype_segment_index_path += cLogTypeSegmentIndexFilename;
-        m_logtype_dictionary.open(logtype_dict_path, logtype_segment_index_path);
-
-        // Open variables dictionary
-        string var_dict_path = m_path;
-        var_dict_path += '/';
-        var_dict_path += cVarDictFilename;
-        string var_segment_index_path = m_path;
-        var_segment_index_path += '/';
-        var_segment_index_path += cVarSegmentIndexFilename;
-        m_var_dictionary.open(var_dict_path, var_segment_index_path);
-
-        // Open segment manager
-        m_segments_dir_path = m_path;
-        m_segments_dir_path += '/';
-        m_segments_dir_path += cSegmentsDirname;
-        m_segments_dir_path += '/';
-        m_segment_manager.open(m_segments_dir_path);
-
-        // Open segment list
-        string segment_list_path = m_segments_dir_path;
-        segment_list_path += cSegmentListFilename;
-    }
-
-    void Archive::close() {
-        m_logtype_dictionary.close();
-        m_var_dictionary.close();
-        m_segment_manager.close();
-        m_segments_dir_path.clear();
-        m_metadata_db.close();
-        m_path.clear();
-    }
-
-    void Archive::refresh_dictionaries() {
-        m_logtype_dictionary.read_new_entries();
-        m_var_dictionary.read_new_entries();
-    }
-
-    ErrorCode Archive::open_file(File& file, MetadataDB::FileIterator const& file_metadata_ix) {
-        return file.open_me(m_logtype_dictionary, file_metadata_ix, m_segment_manager);
-    }
-
-    void Archive::close_file(File& file) {
-        file.close_me();
-    }
-
-    void Archive::reset_file_indices(streaming_archive::reader::File& file) {
-        file.reset_indices();
-    }
-
-    LogTypeDictionaryReader const& Archive::get_logtype_dictionary() const {
-        return m_logtype_dictionary;
-    }
-
-    VariableDictionaryReader const& Archive::get_var_dictionary() const {
-        return m_var_dictionary;
-    }
-
-    bool Archive::find_message_in_time_range(
-            File& file,
-            epochtime_t search_begin_timestamp,
-            epochtime_t search_end_timestamp,
-            Message& msg
-    ) {
-        return file.find_message_in_time_range(search_begin_timestamp, search_end_timestamp, msg);
-    }
-
-    SubQuery const*
-    Archive::find_message_matching_query(File& file, Query const& query, Message& msg) {
-        return file.find_message_matching_query(query, msg);
-    }
-
-    bool Archive::get_next_message(File& file, Message& msg) {
-        return file.get_next_message(msg);
-    }
-
-    bool Archive::decompress_message(
-            File& file,
-            Message const& compressed_msg,
-            string& decompressed_msg
-    ) {
-        decompressed_msg.clear();
-
-        // Build original message content
-        logtype_dictionary_id_t const logtype_id = compressed_msg.get_logtype_id();
-        auto const& logtype_entry = m_logtype_dictionary.get_entry(logtype_id);
-        if (!EncodedVariableInterpreter::decode_variables_into_message(
-                    logtype_entry,
-                    m_var_dictionary,
-                    compressed_msg.get_vars(),
-                    decompressed_msg
-            ))
-        {
-            SPDLOG_ERROR(
-                    "streaming_archive::reader::Archive: Failed to decompress variables from "
-                    "logtype id {}",
-                    compressed_msg.get_logtype_id()
-            );
-            return false;
-        }
-
-        // Determine which timestamp pattern to use
-        auto const& timestamp_patterns = file.get_timestamp_patterns();
-        if (!timestamp_patterns.empty()
-            && compressed_msg.get_message_number()
-                       >= timestamp_patterns[file.get_current_ts_pattern_ix()].first)
-        {
-            while (true) {
-                if (file.get_current_ts_pattern_ix() >= timestamp_patterns.size() - 1) {
-                    // Already at last timestamp pattern
-                    break;
-                }
-                auto next_patt_start_message_num
-                        = timestamp_patterns[file.get_current_ts_pattern_ix() + 1].first;
-                if (compressed_msg.get_message_number() < next_patt_start_message_num) {
-                    // Not yet time for next timestamp pattern
-                    break;
-                }
-                file.increment_current_ts_pattern_ix();
-            }
-            timestamp_patterns[file.get_current_ts_pattern_ix()].second.insert_formatted_timestamp(
-                    compressed_msg.get_ts_in_milli(),
-                    decompressed_msg
-            );
-        }
-
-        return true;
-    }
-
-    void Archive::decompress_empty_directories(string const& output_dir) {
-        boost::filesystem::path output_dir_path = boost::filesystem::path(output_dir);
-
-        string path;
-        auto ix_ptr = m_metadata_db.get_empty_directory_iterator();
-        for (auto& ix = *ix_ptr; ix.has_next(); ix.next()) {
-            ix.get_path(path);
-            auto empty_directory_path = output_dir_path / path;
-            auto error_code = create_directory_structure(empty_directory_path.string(), 0700);
-            if (ErrorCode_Success != error_code) {
-                SPDLOG_ERROR(
-                        "Failed to create directory structure {}, errno={}",
-                        empty_directory_path.string().c_str(),
-                        errno
-                );
-                throw OperationFailed(error_code, __FILENAME__, __LINE__);
-            }
+            throw OperationFailed(error_code, __FILENAME__, __LINE__);
         }
     }
-}}  // namespace streaming_archive::reader
+}
+}  // namespace streaming_archive::reader

--- a/components/core/src/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/streaming_archive/reader/Archive.hpp
@@ -17,135 +17,132 @@
 #include "File.hpp"
 #include "Message.hpp"
 
-namespace streaming_archive { namespace reader {
-    class Archive {
+namespace streaming_archive::reader {
+class Archive {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_archive::reader::Archive operation failed";
-            }
-        };
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /**
-         * Opens archive for reading
-         * @param path
-         * @throw streaming_archive::reader::Archive::OperationFailed if could not stat file or it
-         * isn't a directory or metadata is corrupted
-         * @throw FileReader::OperationFailed if failed to open any dictionary
-         */
-        void open(std::string const& path);
-        void close();
-
-        /**
-         * Reads any new entries added to the dictionaries
-         * @throw Same as LogTypeDictionary::read_from_file and VariableDictionary::read_from_file
-         */
-        void refresh_dictionaries();
-        LogTypeDictionaryReader const& get_logtype_dictionary() const;
-        VariableDictionaryReader const& get_var_dictionary() const;
-
-        /**
-         * Opens file with given path
-         * @param file
-         * @param file_metadata_ix
-         * @return Same as streaming_archive::reader::File::open_me
-         */
-        ErrorCode open_file(File& file, MetadataDB::FileIterator const& file_metadata_ix);
-        /**
-         * Wrapper for streaming_archive::reader::File::close_me
-         * @param file
-         */
-        void close_file(File& file);
-        /**
-         * Wrapper for streaming_archive::reader::File::reset_indices
-         * @param file
-         */
-        void reset_file_indices(File& file);
-
-        /**
-         * Wrapper for streaming_archive::reader::File::find_message_in_time_range
-         */
-        bool find_message_in_time_range(
-                File& file,
-                epochtime_t search_begin_timestamp,
-                epochtime_t search_end_timestamp,
-                Message& msg
-        );
-        /**
-         * Wrapper for streaming_archive::reader::File::find_message_matching_query
-         */
-        SubQuery const* find_message_matching_query(File& file, Query const& query, Message& msg);
-        /**
-         * Wrapper for streaming_archive::reader::File::get_next_message
-         */
-        bool get_next_message(File& file, Message& msg);
-
-        /**
-         * Decompresses a given message from a given file
-         * @param file
-         * @param compressed_msg
-         * @param decompressed_msg
-         * @return true if message was successfully decompressed, false otherwise
-         * @throw TimestampPattern::OperationFailed if failed to insert timestamp
-         */
-        bool decompress_message(
-                File& file,
-                Message const& compressed_msg,
-                std::string& decompressed_msg
-        );
-
-        void decompress_empty_directories(std::string const& output_dir);
-
-        std::unique_ptr<MetadataDB::FileIterator> get_file_iterator() {
-            return m_metadata_db
-                    .get_file_iterator(cEpochTimeMin, cEpochTimeMax, "", false, cInvalidSegmentId);
+        char const* what() const noexcept override {
+            return "streaming_archive::reader::Archive operation failed";
         }
-
-        std::unique_ptr<MetadataDB::FileIterator> get_file_iterator(std::string const& file_path) {
-            return m_metadata_db.get_file_iterator(
-                    cEpochTimeMin,
-                    cEpochTimeMax,
-                    file_path,
-                    false,
-                    cInvalidSegmentId
-            );
-        }
-
-        std::unique_ptr<MetadataDB::FileIterator>
-        get_file_iterator(epochtime_t begin_ts, epochtime_t end_ts, std::string const& file_path) {
-            return m_metadata_db
-                    .get_file_iterator(begin_ts, end_ts, file_path, false, cInvalidSegmentId);
-        }
-
-        std::unique_ptr<MetadataDB::FileIterator> get_file_iterator(
-                epochtime_t begin_ts,
-                epochtime_t end_ts,
-                std::string const& file_path,
-                segment_id_t segment_id
-        ) {
-            return m_metadata_db.get_file_iterator(begin_ts, end_ts, file_path, true, segment_id);
-        }
-
-    private:
-        // Variables
-        std::string m_id;
-        std::string m_path;
-        std::string m_segments_dir_path;
-        LogTypeDictionaryReader m_logtype_dictionary;
-        VariableDictionaryReader m_var_dictionary;
-
-        SegmentManager m_segment_manager;
-
-        MetadataDB m_metadata_db;
     };
-}}  // namespace streaming_archive::reader
+
+    // Methods
+    /**
+     * Opens archive for reading
+     * @param path
+     * @throw streaming_archive::reader::Archive::OperationFailed if could not stat file or it
+     * isn't a directory or metadata is corrupted
+     * @throw FileReader::OperationFailed if failed to open any dictionary
+     */
+    void open(std::string const& path);
+    void close();
+
+    /**
+     * Reads any new entries added to the dictionaries
+     * @throw Same as LogTypeDictionary::read_from_file and VariableDictionary::read_from_file
+     */
+    void refresh_dictionaries();
+    LogTypeDictionaryReader const& get_logtype_dictionary() const;
+    VariableDictionaryReader const& get_var_dictionary() const;
+
+    /**
+     * Opens file with given path
+     * @param file
+     * @param file_metadata_ix
+     * @return Same as streaming_archive::reader::File::open_me
+     */
+    ErrorCode open_file(File& file, MetadataDB::FileIterator const& file_metadata_ix);
+    /**
+     * Wrapper for streaming_archive::reader::File::close_me
+     * @param file
+     */
+    void close_file(File& file);
+    /**
+     * Wrapper for streaming_archive::reader::File::reset_indices
+     * @param file
+     */
+    void reset_file_indices(File& file);
+
+    /**
+     * Wrapper for streaming_archive::reader::File::find_message_in_time_range
+     */
+    bool find_message_in_time_range(
+            File& file,
+            epochtime_t search_begin_timestamp,
+            epochtime_t search_end_timestamp,
+            Message& msg
+    );
+    /**
+     * Wrapper for streaming_archive::reader::File::find_message_matching_query
+     */
+    SubQuery const* find_message_matching_query(File& file, Query const& query, Message& msg);
+    /**
+     * Wrapper for streaming_archive::reader::File::get_next_message
+     */
+    bool get_next_message(File& file, Message& msg);
+
+    /**
+     * Decompresses a given message from a given file
+     * @param file
+     * @param compressed_msg
+     * @param decompressed_msg
+     * @return true if message was successfully decompressed, false otherwise
+     * @throw TimestampPattern::OperationFailed if failed to insert timestamp
+     */
+    bool
+    decompress_message(File& file, Message const& compressed_msg, std::string& decompressed_msg);
+
+    void decompress_empty_directories(std::string const& output_dir);
+
+    std::unique_ptr<MetadataDB::FileIterator> get_file_iterator() {
+        return m_metadata_db
+                .get_file_iterator(cEpochTimeMin, cEpochTimeMax, "", false, cInvalidSegmentId);
+    }
+
+    std::unique_ptr<MetadataDB::FileIterator> get_file_iterator(std::string const& file_path) {
+        return m_metadata_db.get_file_iterator(
+                cEpochTimeMin,
+                cEpochTimeMax,
+                file_path,
+                false,
+                cInvalidSegmentId
+        );
+    }
+
+    std::unique_ptr<MetadataDB::FileIterator>
+    get_file_iterator(epochtime_t begin_ts, epochtime_t end_ts, std::string const& file_path) {
+        return m_metadata_db
+                .get_file_iterator(begin_ts, end_ts, file_path, false, cInvalidSegmentId);
+    }
+
+    std::unique_ptr<MetadataDB::FileIterator> get_file_iterator(
+            epochtime_t begin_ts,
+            epochtime_t end_ts,
+            std::string const& file_path,
+            segment_id_t segment_id
+    ) {
+        return m_metadata_db.get_file_iterator(begin_ts, end_ts, file_path, true, segment_id);
+    }
+
+private:
+    // Variables
+    std::string m_id;
+    std::string m_path;
+    std::string m_segments_dir_path;
+    LogTypeDictionaryReader m_logtype_dictionary;
+    VariableDictionaryReader m_var_dictionary;
+
+    SegmentManager m_segment_manager;
+
+    MetadataDB m_metadata_db;
+};
+}  // namespace streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_ARCHIVE_HPP

--- a/components/core/src/streaming_archive/reader/Message.cpp
+++ b/components/core/src/streaming_archive/reader/Message.cpp
@@ -1,39 +1,39 @@
 #include "Message.hpp"
 
-namespace streaming_archive { namespace reader {
-    size_t Message::get_message_number() const {
-        return m_message_number;
-    }
+namespace streaming_archive::reader {
+size_t Message::get_message_number() const {
+    return m_message_number;
+}
 
-    logtype_dictionary_id_t Message::get_logtype_id() const {
-        return m_logtype_id;
-    }
+logtype_dictionary_id_t Message::get_logtype_id() const {
+    return m_logtype_id;
+}
 
-    std::vector<encoded_variable_t> const& Message::get_vars() const {
-        return m_vars;
-    }
+std::vector<encoded_variable_t> const& Message::get_vars() const {
+    return m_vars;
+}
 
-    epochtime_t Message::get_ts_in_milli() const {
-        return m_timestamp;
-    }
+epochtime_t Message::get_ts_in_milli() const {
+    return m_timestamp;
+}
 
-    void Message::set_message_number(uint64_t message_number) {
-        m_message_number = message_number;
-    }
+void Message::set_message_number(uint64_t message_number) {
+    m_message_number = message_number;
+}
 
-    void Message::set_logtype_id(logtype_dictionary_id_t logtype_id) {
-        m_logtype_id = logtype_id;
-    }
+void Message::set_logtype_id(logtype_dictionary_id_t logtype_id) {
+    m_logtype_id = logtype_id;
+}
 
-    void Message::add_var(encoded_variable_t var) {
-        m_vars.push_back(var);
-    }
+void Message::add_var(encoded_variable_t var) {
+    m_vars.push_back(var);
+}
 
-    void Message::set_timestamp(epochtime_t timestamp) {
-        m_timestamp = timestamp;
-    }
+void Message::set_timestamp(epochtime_t timestamp) {
+    m_timestamp = timestamp;
+}
 
-    void Message::clear_vars() {
-        m_vars.clear();
-    }
-}}  // namespace streaming_archive::reader
+void Message::clear_vars() {
+    m_vars.clear();
+}
+}  // namespace streaming_archive::reader

--- a/components/core/src/streaming_archive/reader/Message.hpp
+++ b/components/core/src/streaming_archive/reader/Message.hpp
@@ -6,31 +6,31 @@
 
 #include "../../Defs.h"
 
-namespace streaming_archive { namespace reader {
-    class Message {
-    public:
-        // Methods
-        size_t get_message_number() const;
-        logtype_dictionary_id_t get_logtype_id() const;
-        std::vector<encoded_variable_t> const& get_vars() const;
-        epochtime_t get_ts_in_milli() const;
+namespace streaming_archive::reader {
+class Message {
+public:
+    // Methods
+    size_t get_message_number() const;
+    logtype_dictionary_id_t get_logtype_id() const;
+    std::vector<encoded_variable_t> const& get_vars() const;
+    epochtime_t get_ts_in_milli() const;
 
-        void set_message_number(uint64_t message_number);
-        void set_logtype_id(logtype_dictionary_id_t logtype_id);
-        void add_var(encoded_variable_t var);
-        void set_timestamp(epochtime_t timestamp);
+    void set_message_number(uint64_t message_number);
+    void set_logtype_id(logtype_dictionary_id_t logtype_id);
+    void add_var(encoded_variable_t var);
+    void set_timestamp(epochtime_t timestamp);
 
-        void clear_vars();
+    void clear_vars();
 
-    private:
-        friend class Archive;
+private:
+    friend class Archive;
 
-        // Variables
-        size_t m_message_number;
-        logtype_dictionary_id_t m_logtype_id;
-        std::vector<encoded_variable_t> m_vars;
-        epochtime_t m_timestamp;
-    };
-}}  // namespace streaming_archive::reader
+    // Variables
+    size_t m_message_number;
+    logtype_dictionary_id_t m_logtype_id;
+    std::vector<encoded_variable_t> m_vars;
+    epochtime_t m_timestamp;
+};
+}  // namespace streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_MESSAGE_HPP

--- a/components/core/src/streaming_archive/reader/Segment.cpp
+++ b/components/core/src/streaming_archive/reader/Segment.cpp
@@ -15,97 +15,91 @@ using std::string;
 using std::to_string;
 using std::unique_ptr;
 
-namespace streaming_archive { namespace reader {
-    Segment::~Segment() {
-        // If user forgot to explicitly close the file for some reason, close it again (doesn't
-        // hurt)
-        close();
-    }
+namespace streaming_archive::reader {
+Segment::~Segment() {
+    // If user forgot to explicitly close the file for some reason, close it again (doesn't
+    // hurt)
+    close();
+}
 
-    ErrorCode Segment::try_open(string const& segment_dir_path, segment_id_t segment_id) {
-        // Construct segment path
-        string segment_path = segment_dir_path;
-        segment_path += std::to_string(segment_id);
+ErrorCode Segment::try_open(string const& segment_dir_path, segment_id_t segment_id) {
+    // Construct segment path
+    string segment_path = segment_dir_path;
+    segment_path += std::to_string(segment_id);
 
-        if (segment_path == m_segment_path) {
-            // Do nothing if segment file path is the same because it is already memory mapped
-            // If we want to re-open the same file, we need to close it first
-            return ErrorCode_Success;
-        }
-
-        // Get the size of the compressed segment file
-        boost::system::error_code boost_error_code;
-        size_t segment_file_size = boost::filesystem::file_size(segment_path, boost_error_code);
-        if (boost_error_code) {
-            SPDLOG_ERROR(
-                    "streaming_archive::reader::Segment: Unable to obtain file size for segment: "
-                    "{}",
-                    segment_path.c_str()
-            );
-            SPDLOG_ERROR(
-                    "streaming_archive::reader::Segment: {}",
-                    boost_error_code.message().c_str()
-            );
-            return ErrorCode_Failure;
-        }
-
-        // Sanity check: previously used memory mapped file should be closed before opening a new
-        // one
-        if (m_memory_mapped_segment_file.is_open()) {
-            SPDLOG_WARN(
-                    "streaming_archive::reader::Segment: Previous segment should be closed before "
-                    "opening new one: {}",
-                    segment_path.c_str()
-            );
-            m_memory_mapped_segment_file.close();
-        }
-        // Create read only memory mapped file
-        boost::iostreams::mapped_file_params memory_map_params;
-        memory_map_params.path = segment_path;
-        memory_map_params.flags = boost::iostreams::mapped_file::readonly;
-        memory_map_params.length = segment_file_size;
-        // Try to map it to the same memory location as the previous memory mapped file
-        memory_map_params.hint = m_memory_mapped_segment_file.data();
-        m_memory_mapped_segment_file.open(memory_map_params);
-        if (!m_memory_mapped_segment_file.is_open()) {
-            SPDLOG_ERROR(
-                    "streaming_archive::reader:Segment: Unable to memory map the compressed "
-                    "segment with path: {}",
-                    segment_path.c_str()
-            );
-            return ErrorCode_Failure;
-        }
-
-        m_decompressor.open(m_memory_mapped_segment_file.data(), segment_file_size);
-
-        m_segment_path = segment_path;
+    if (segment_path == m_segment_path) {
+        // Do nothing if segment file path is the same because it is already memory mapped
+        // If we want to re-open the same file, we need to close it first
         return ErrorCode_Success;
     }
 
-    void Segment::close() {
-        if (!m_segment_path.empty()) {
-            m_decompressor.close();
-            m_memory_mapped_segment_file.close();
-            m_segment_path.clear();
-        }
+    // Get the size of the compressed segment file
+    boost::system::error_code boost_error_code;
+    size_t segment_file_size = boost::filesystem::file_size(segment_path, boost_error_code);
+    if (boost_error_code) {
+        SPDLOG_ERROR(
+                "streaming_archive::reader::Segment: Unable to obtain file size for segment: "
+                "{}",
+                segment_path.c_str()
+        );
+        SPDLOG_ERROR("streaming_archive::reader::Segment: {}", boost_error_code.message().c_str());
+        return ErrorCode_Failure;
     }
 
-    ErrorCode Segment::try_read(
-            uint64_t decompressed_stream_pos,
-            char* extraction_buf,
-            uint64_t extraction_len
-    ) {
-        // We always assume the passed in buffer is already pre-allocated, but we check anyway as a
-        // precaution
-        if (nullptr == extraction_buf) {
-            SPDLOG_ERROR("streaming_archive::reader::Segment: Extraction buffer not allocated "
-                         "during decompression");
-            return ErrorCode_BadParam;
-        }
-        return m_decompressor.get_decompressed_stream_region(
-                decompressed_stream_pos,
-                extraction_buf,
-                extraction_len
+    // Sanity check: previously used memory mapped file should be closed before opening a new
+    // one
+    if (m_memory_mapped_segment_file.is_open()) {
+        SPDLOG_WARN(
+                "streaming_archive::reader::Segment: Previous segment should be closed before "
+                "opening new one: {}",
+                segment_path.c_str()
         );
+        m_memory_mapped_segment_file.close();
     }
-}}  // namespace streaming_archive::reader
+    // Create read only memory mapped file
+    boost::iostreams::mapped_file_params memory_map_params;
+    memory_map_params.path = segment_path;
+    memory_map_params.flags = boost::iostreams::mapped_file::readonly;
+    memory_map_params.length = segment_file_size;
+    // Try to map it to the same memory location as the previous memory mapped file
+    memory_map_params.hint = m_memory_mapped_segment_file.data();
+    m_memory_mapped_segment_file.open(memory_map_params);
+    if (!m_memory_mapped_segment_file.is_open()) {
+        SPDLOG_ERROR(
+                "streaming_archive::reader:Segment: Unable to memory map the compressed "
+                "segment with path: {}",
+                segment_path.c_str()
+        );
+        return ErrorCode_Failure;
+    }
+
+    m_decompressor.open(m_memory_mapped_segment_file.data(), segment_file_size);
+
+    m_segment_path = segment_path;
+    return ErrorCode_Success;
+}
+
+void Segment::close() {
+    if (!m_segment_path.empty()) {
+        m_decompressor.close();
+        m_memory_mapped_segment_file.close();
+        m_segment_path.clear();
+    }
+}
+
+ErrorCode
+Segment::try_read(uint64_t decompressed_stream_pos, char* extraction_buf, uint64_t extraction_len) {
+    // We always assume the passed in buffer is already pre-allocated, but we check anyway as a
+    // precaution
+    if (nullptr == extraction_buf) {
+        SPDLOG_ERROR("streaming_archive::reader::Segment: Extraction buffer not allocated "
+                     "during decompression");
+        return ErrorCode_BadParam;
+    }
+    return m_decompressor.get_decompressed_stream_region(
+            decompressed_stream_pos,
+            extraction_buf,
+            extraction_len
+    );
+}
+}  // namespace streaming_archive::reader

--- a/components/core/src/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/streaming_archive/reader/Segment.hpp
@@ -12,57 +12,57 @@
 #include "../../streaming_compression/zstd/Decompressor.hpp"
 #include "../Constants.hpp"
 
-namespace streaming_archive { namespace reader {
+namespace streaming_archive::reader {
+/**
+ * Class for reading segments. A segment is a container for multiple compressed buffers that
+ * itself may be further compressed and stored on disk.
+ */
+class Segment {
+public:
+    // Constructor
+    Segment() : m_segment_path({}){};
+
+    // Destructor
+    ~Segment();
+
     /**
-     * Class for reading segments. A segment is a container for multiple compressed buffers that
-     * itself may be further compressed and stored on disk.
+     * Opens a segment with the given ID from the given directory
+     * @param segment_dir_path
+     * @param segment_id
+     * @return ErrorCode_Failure if unable to memory map the segment file
+     * @return ErrorCode_Success on success
      */
-    class Segment {
-    public:
-        // Constructor
-        Segment() : m_segment_path({}){};
+    ErrorCode try_open(std::string const& segment_dir_path, segment_id_t segment_id);
 
-        // Destructor
-        ~Segment();
+    /**
+     * Closes the segment
+     */
+    void close();
 
-        /**
-         * Opens a segment with the given ID from the given directory
-         * @param segment_dir_path
-         * @param segment_id
-         * @return ErrorCode_Failure if unable to memory map the segment file
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_open(std::string const& segment_dir_path, segment_id_t segment_id);
+    /**
+     * Reads content with the given offset and length into a buffer
+     * @param decompressed_stream_pos Offset of the content in the segment
+     * @param extraction_buf Buffer to store the content
+     * @param extraction_len Length of the buffer
+     * @return ErrorCode_Truncated if decompressed_stream_pos is outside of the segment
+     * @return ErrorCode_Failure if decompression failed
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode
+    try_read(uint64_t decompressed_stream_pos, char* extraction_buf, uint64_t extraction_len);
 
-        /**
-         * Closes the segment
-         */
-        void close();
-
-        /**
-         * Reads content with the given offset and length into a buffer
-         * @param decompressed_stream_pos Offset of the content in the segment
-         * @param extraction_buf Buffer to store the content
-         * @param extraction_len Length of the buffer
-         * @return ErrorCode_Truncated if decompressed_stream_pos is outside of the segment
-         * @return ErrorCode_Failure if decompression failed
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode
-        try_read(uint64_t decompressed_stream_pos, char* extraction_buf, uint64_t extraction_len);
-
-    private:
-        std::string m_segment_path;
-        boost::iostreams::mapped_file_source m_memory_mapped_segment_file;
+private:
+    std::string m_segment_path;
+    boost::iostreams::mapped_file_source m_memory_mapped_segment_file;
 
 #if USE_PASSTHROUGH_COMPRESSION
-        streaming_compression::passthrough::Decompressor m_decompressor;
+    streaming_compression::passthrough::Decompressor m_decompressor;
 #elif USE_ZSTD_COMPRESSION
-        streaming_compression::zstd::Decompressor m_decompressor;
+    streaming_compression::zstd::Decompressor m_decompressor;
 #else
-        static_assert(false, "Unsupported compression mode.");
+    static_assert(false, "Unsupported compression mode.");
 #endif
-    };
-}}  // namespace streaming_archive::reader
+};
+}  // namespace streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_SEGMENT_HPP

--- a/components/core/src/streaming_archive/reader/SegmentManager.cpp
+++ b/components/core/src/streaming_archive/reader/SegmentManager.cpp
@@ -2,51 +2,51 @@
 
 using std::string;
 
-namespace streaming_archive { namespace reader {
-    void SegmentManager::open(string const& segment_dir_path) {
-        // Cleanup in case caller forgot to call close before calling this function
-        close();
-        m_segment_dir_path = segment_dir_path;
-    }
+namespace streaming_archive::reader {
+void SegmentManager::open(string const& segment_dir_path) {
+    // Cleanup in case caller forgot to call close before calling this function
+    close();
+    m_segment_dir_path = segment_dir_path;
+}
 
-    void SegmentManager::close() {
-        for (auto& id_segment_pair : m_id_to_open_segment) {
-            id_segment_pair.second.close();
+void SegmentManager::close() {
+    for (auto& id_segment_pair : m_id_to_open_segment) {
+        id_segment_pair.second.close();
+    }
+    m_id_to_open_segment.clear();
+    m_lru_ids_of_open_segments.clear();
+}
+
+ErrorCode SegmentManager::try_read(
+        segment_id_t segment_id,
+        uint64_t const decompressed_stream_pos,
+        char* extraction_buf,
+        uint64_t const extraction_len
+) {
+    static size_t const cMaxLRUSegments = 2;
+
+    // Check that segment exists or insert it if not
+    if (m_id_to_open_segment.count(segment_id) == 0) {
+        // Insert and open segment
+        ErrorCode error_code
+                = m_id_to_open_segment[segment_id].try_open(m_segment_dir_path, segment_id);
+        if (ErrorCode_Success != error_code) {
+            m_id_to_open_segment.erase(segment_id);
+            return error_code;
         }
-        m_id_to_open_segment.clear();
-        m_lru_ids_of_open_segments.clear();
-    }
+        m_lru_ids_of_open_segments.push_back(segment_id);
 
-    ErrorCode SegmentManager::try_read(
-            segment_id_t segment_id,
-            uint64_t const decompressed_stream_pos,
-            char* extraction_buf,
-            uint64_t const extraction_len
-    ) {
-        static size_t const cMaxLRUSegments = 2;
-
-        // Check that segment exists or insert it if not
-        if (m_id_to_open_segment.count(segment_id) == 0) {
-            // Insert and open segment
-            ErrorCode error_code
-                    = m_id_to_open_segment[segment_id].try_open(m_segment_dir_path, segment_id);
-            if (ErrorCode_Success != error_code) {
-                m_id_to_open_segment.erase(segment_id);
-                return error_code;
-            }
-            m_lru_ids_of_open_segments.push_back(segment_id);
-
-            // Evict a segment if necessary
-            if (m_lru_ids_of_open_segments.size() >= cMaxLRUSegments) {
-                auto id_of_segment_to_evict = m_lru_ids_of_open_segments.front();
-                m_lru_ids_of_open_segments.pop_front();
-                m_id_to_open_segment.at(id_of_segment_to_evict).close();
-                m_id_to_open_segment.erase(id_of_segment_to_evict);
-            }
+        // Evict a segment if necessary
+        if (m_lru_ids_of_open_segments.size() >= cMaxLRUSegments) {
+            auto id_of_segment_to_evict = m_lru_ids_of_open_segments.front();
+            m_lru_ids_of_open_segments.pop_front();
+            m_id_to_open_segment.at(id_of_segment_to_evict).close();
+            m_id_to_open_segment.erase(id_of_segment_to_evict);
         }
-
-        // Extract data from compressed segment
-        auto& segment = m_id_to_open_segment.at(segment_id);
-        return segment.try_read(decompressed_stream_pos, extraction_buf, extraction_len);
     }
-}}  // namespace streaming_archive::reader
+
+    // Extract data from compressed segment
+    auto& segment = m_id_to_open_segment.at(segment_id);
+    return segment.try_read(decompressed_stream_pos, extraction_buf, extraction_len);
+}
+}  // namespace streaming_archive::reader

--- a/components/core/src/streaming_archive/reader/SegmentManager.hpp
+++ b/components/core/src/streaming_archive/reader/SegmentManager.hpp
@@ -9,50 +9,50 @@
 #include "../../Defs.h"
 #include "Segment.hpp"
 
-namespace streaming_archive { namespace reader {
+namespace streaming_archive::reader {
+/**
+ * This class handles segments in a given directory. This primarily consists of reading from
+ * segments in a given directory.
+ */
+class SegmentManager {
+public:
+    // Methods
     /**
-     * This class handles segments in a given directory. This primarily consists of reading from
-     * segments in a given directory.
+     * Opens the segment manager
+     * @param segment_dir_path
      */
-    class SegmentManager {
-    public:
-        // Methods
-        /**
-         * Opens the segment manager
-         * @param segment_dir_path
-         */
-        void open(std::string const& segment_dir_path);
+    void open(std::string const& segment_dir_path);
 
-        /**
-         * Closes the segment manager
-         */
-        void close();
+    /**
+     * Closes the segment manager
+     */
+    void close();
 
-        /**
-         * Tries to read content with the given offset and length from a segment with the given ID
-         * into a buffer
-         * @param segment_id
-         * @param decompressed_stream_pos
-         * @param extraction_buf
-         * @param extraction_len
-         * @return Same as streaming_archive::reader::Segment::try_open
-         * @return Same as streaming_archive::reader::Segment::try_read
-         * @throw std::out_of_range if a segment ID cannot be found unexpectedly
-         */
-        ErrorCode try_read(
-                segment_id_t segment_id,
-                uint64_t const decompressed_stream_pos,
-                char* extraction_buf,
-                uint64_t const extraction_len
-        );
+    /**
+     * Tries to read content with the given offset and length from a segment with the given ID
+     * into a buffer
+     * @param segment_id
+     * @param decompressed_stream_pos
+     * @param extraction_buf
+     * @param extraction_len
+     * @return Same as streaming_archive::reader::Segment::try_open
+     * @return Same as streaming_archive::reader::Segment::try_read
+     * @throw std::out_of_range if a segment ID cannot be found unexpectedly
+     */
+    ErrorCode try_read(
+            segment_id_t segment_id,
+            uint64_t const decompressed_stream_pos,
+            char* extraction_buf,
+            uint64_t const extraction_len
+    );
 
-    private:
-        std::string m_segment_dir_path;
+private:
+    std::string m_segment_dir_path;
 
-        std::unordered_map<segment_id_t, Segment> m_id_to_open_segment;
-        // List of open segment IDs in LRU order (LRU segment ID at front)
-        std::list<segment_id_t> m_lru_ids_of_open_segments;
-    };
-}}  // namespace streaming_archive::reader
+    std::unordered_map<segment_id_t, Segment> m_id_to_open_segment;
+    // List of open segment IDs in LRU order (LRU segment ID at front)
+    std::list<segment_id_t> m_lru_ids_of_open_segments;
+};
+}  // namespace streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_SEGMENTMANAGER_HPP

--- a/components/core/src/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/streaming_archive/writer/Archive.hpp
@@ -23,325 +23,324 @@
 #include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
 
-namespace streaming_archive { namespace writer {
-    class Archive {
+namespace streaming_archive::writer {
+class Archive {
+public:
+    // Types
+    /**
+     * Structure used to pass settings when opening a new archive
+     * @param id
+     * @param creator_id
+     * @param creation_num
+     * @param target_segment_uncompressed_size
+     * @param compression_level Compression level of the compressor being opened
+     * @param output_dir Output directory
+     * @param global_metadata_db
+     * @param print_archive_stats_progress Enable printing statistics about the archive as it's
+     * compressed
+     */
+    struct UserConfig {
+        boost::uuids::uuid id;
+        boost::uuids::uuid creator_id;
+        size_t creation_num;
+        size_t target_segment_uncompressed_size;
+        int compression_level;
+        std::string output_dir;
+        clp::GlobalMetadataDB* global_metadata_db;
+        bool print_archive_stats_progress;
+    };
+
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        /**
-         * Structure used to pass settings when opening a new archive
-         * @param id
-         * @param creator_id
-         * @param creation_num
-         * @param target_segment_uncompressed_size
-         * @param compression_level Compression level of the compressor being opened
-         * @param output_dir Output directory
-         * @param global_metadata_db
-         * @param print_archive_stats_progress Enable printing statistics about the archive as it's
-         * compressed
-         */
-        struct UserConfig {
-            boost::uuids::uuid id;
-            boost::uuids::uuid creator_id;
-            size_t creation_num;
-            size_t target_segment_uncompressed_size;
-            int compression_level;
-            std::string output_dir;
-            clp::GlobalMetadataDB* global_metadata_db;
-            bool print_archive_stats_progress;
-        };
-
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_archive::writer::Archive operation failed";
-            }
-        };
-
-        TimestampPattern* m_old_ts_pattern;
-        size_t m_target_data_size_of_dicts;
-        UserConfig m_archive_user_config;
-        std::string m_path_for_compression;
-        group_id_t m_group_id;
-        size_t m_target_encoded_file_size;
-        std::string m_schema_file_path;
-
         // Constructors
-        Archive()
-                : m_segments_dir_fd(-1),
-                  m_compression_level(0),
-                  m_global_metadata_db(nullptr),
-                  m_old_ts_pattern(nullptr),
-                  m_schema_file_path() {}
-
-        // Destructor
-        ~Archive();
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /**
-         * Creates the directory structure for the archive and opens writers for the dictionaries
-         * @param user_config Settings configurable by the user
-         * @throw FileWriter::OperationFailed if any dictionary writer could not be opened
-         * @throw streaming_archive::writer::Archive::OperationFailed if archive already exists, if
-         * it could not be stat-ed, if the directory structure could not be created, if the file is
-         * not reset or problems with metadata.
-         */
-        void open(UserConfig const& user_config);
-        /**
-         * Writes a final snapshot of the archive, closes all open files, and closes the
-         * dictionaries
-         * @throw FileWriter::OperationFailed if any writer could not be closed
-         * @throw streaming_archive::writer::Archive::OperationFailed if any empty directories could
-         * not be removed
-         * @throw streaming_archive::writer::Archive::OperationFailed if the file is not reset
-         * @throw Same as streaming_archive::writer::SegmentManager::close
-         * @throw Same as streaming_archive::writer::Archive::write_dir_snapshot
-         */
-        void close();
-
-        /**
-         * Creates and opens a file with the given path
-         * @param path
-         * @param group_id
-         * @param orig_file_id
-         * @param split_ix
-         * @return Pointer to the new file
-         */
-        void create_and_open_file(
-                std::string const& path,
-                group_id_t group_id,
-                boost::uuids::uuid const& orig_file_id,
-                size_t split_ix
-        );
-
-        void close_file();
-
-        File const& get_file() const;
-
-        /**
-         * Sets the split status of the current encoded file
-         * @param is_split
-         */
-        void set_file_is_split(bool is_split);
-
-        /**
-         * Wrapper for streaming_archive::writer::File::change_ts_pattern
-         * @param pattern
-         */
-        void change_ts_pattern(TimestampPattern const* pattern);
-        /**
-         * Encodes and writes a message to the current encoded file
-         * @param timestamp
-         * @param message
-         * @param num_uncompressed_bytes
-         * @throw FileWriter::OperationFailed if any write fails
-         */
-        void
-        write_msg(epochtime_t timestamp, std::string const& message, size_t num_uncompressed_bytes);
-
-        /**
-         * Encodes and writes a message to the given file using schema file
-         * @param log_event_view
-         * @throw FileWriter::OperationFailed if any write fails
-         */
-        void write_msg_using_schema(log_surgeon::LogEventView const& log_event_view);
-
-        /**
-         * Writes an IR log event to the current encoded file
-         * @tparam encoded_variable_t The type of the encoded variables in the log event
-         * @param log_event
-         */
-        template <typename encoded_variable_t>
-        void write_log_event_ir(ir::LogEvent<encoded_variable_t> const& log_event);
-
-        /**
-         * Writes snapshot of archive to disk including metadata of all files and new dictionary
-         * entries
-         * @throw FileWriter::OperationFailed if failed to write or flush dictionaries
-         * @throw std::out_of_range if dictionary ID unexpectedly didn't exist
-         * @throw Same as streaming_archive::writer::Archive::persist_file_metadata
-         */
-        void write_dir_snapshot();
-
-        /**
-         * Adds the encoded file to the segment
-         * @throw streaming_archive::writer::Archive::OperationFailed if failed the file is not
-         * tracked by the current archive
-         * @throw Same as streaming_archive::writer::Archive::persist_file_metadata
-         */
-        void append_file_to_segment();
-
-        /**
-         * Adds empty directories to the archive
-         * @param empty_directory_paths
-         * @throw streaming_archive::writer::Archive::OperationFailed if failed to insert paths to
-         * the database
-         */
-        void add_empty_directories(std::vector<std::string> const& empty_directory_paths);
-
-        boost::uuids::uuid const& get_id() const { return m_id; }
-
-        std::string const& get_id_as_string() const { return m_id_as_string; }
-
-        size_t get_data_size_of_dictionaries() const {
-            return m_logtype_dict.get_data_size() + m_var_dict.get_data_size();
+        char const* what() const noexcept override {
+            return "streaming_archive::writer::Archive operation failed";
         }
+    };
 
-    private:
-        // Types
-        /**
-         * Custom less-than comparator for sets to:
-         * - Primary sort order File pointers in increasing order of their group ID, then
-         * - Secondary sort order File pointers in increasing order of their end timestamp, then
-         * - Tertiary sort order File pointers in alphabetical order of their paths, then
-         * - Determine uniqueness by their ID
-         */
-        class FileGroupIdAndEndTimestampLTSetComparator {
-        public:
-            // Methods
-            bool operator()(File const* lhs, File const* rhs) const {
-                // Primary sort by file's group ID
-                if (lhs->get_group_id() != rhs->get_group_id()) {
-                    return lhs->get_group_id() < rhs->get_group_id();
+    TimestampPattern* m_old_ts_pattern;
+    size_t m_target_data_size_of_dicts;
+    UserConfig m_archive_user_config;
+    std::string m_path_for_compression;
+    group_id_t m_group_id;
+    size_t m_target_encoded_file_size;
+    std::string m_schema_file_path;
+
+    // Constructors
+    Archive()
+            : m_segments_dir_fd(-1),
+              m_compression_level(0),
+              m_global_metadata_db(nullptr),
+              m_old_ts_pattern(nullptr),
+              m_schema_file_path() {}
+
+    // Destructor
+    ~Archive();
+
+    // Methods
+    /**
+     * Creates the directory structure for the archive and opens writers for the dictionaries
+     * @param user_config Settings configurable by the user
+     * @throw FileWriter::OperationFailed if any dictionary writer could not be opened
+     * @throw streaming_archive::writer::Archive::OperationFailed if archive already exists, if
+     * it could not be stat-ed, if the directory structure could not be created, if the file is
+     * not reset or problems with metadata.
+     */
+    void open(UserConfig const& user_config);
+    /**
+     * Writes a final snapshot of the archive, closes all open files, and closes the
+     * dictionaries
+     * @throw FileWriter::OperationFailed if any writer could not be closed
+     * @throw streaming_archive::writer::Archive::OperationFailed if any empty directories could
+     * not be removed
+     * @throw streaming_archive::writer::Archive::OperationFailed if the file is not reset
+     * @throw Same as streaming_archive::writer::SegmentManager::close
+     * @throw Same as streaming_archive::writer::Archive::write_dir_snapshot
+     */
+    void close();
+
+    /**
+     * Creates and opens a file with the given path
+     * @param path
+     * @param group_id
+     * @param orig_file_id
+     * @param split_ix
+     * @return Pointer to the new file
+     */
+    void create_and_open_file(
+            std::string const& path,
+            group_id_t group_id,
+            boost::uuids::uuid const& orig_file_id,
+            size_t split_ix
+    );
+
+    void close_file();
+
+    File const& get_file() const;
+
+    /**
+     * Sets the split status of the current encoded file
+     * @param is_split
+     */
+    void set_file_is_split(bool is_split);
+
+    /**
+     * Wrapper for streaming_archive::writer::File::change_ts_pattern
+     * @param pattern
+     */
+    void change_ts_pattern(TimestampPattern const* pattern);
+    /**
+     * Encodes and writes a message to the current encoded file
+     * @param timestamp
+     * @param message
+     * @param num_uncompressed_bytes
+     * @throw FileWriter::OperationFailed if any write fails
+     */
+    void
+    write_msg(epochtime_t timestamp, std::string const& message, size_t num_uncompressed_bytes);
+
+    /**
+     * Encodes and writes a message to the given file using schema file
+     * @param log_event_view
+     * @throw FileWriter::OperationFailed if any write fails
+     */
+    void write_msg_using_schema(log_surgeon::LogEventView const& log_event_view);
+
+    /**
+     * Writes an IR log event to the current encoded file
+     * @tparam encoded_variable_t The type of the encoded variables in the log event
+     * @param log_event
+     */
+    template <typename encoded_variable_t>
+    void write_log_event_ir(ir::LogEvent<encoded_variable_t> const& log_event);
+
+    /**
+     * Writes snapshot of archive to disk including metadata of all files and new dictionary
+     * entries
+     * @throw FileWriter::OperationFailed if failed to write or flush dictionaries
+     * @throw std::out_of_range if dictionary ID unexpectedly didn't exist
+     * @throw Same as streaming_archive::writer::Archive::persist_file_metadata
+     */
+    void write_dir_snapshot();
+
+    /**
+     * Adds the encoded file to the segment
+     * @throw streaming_archive::writer::Archive::OperationFailed if failed the file is not
+     * tracked by the current archive
+     * @throw Same as streaming_archive::writer::Archive::persist_file_metadata
+     */
+    void append_file_to_segment();
+
+    /**
+     * Adds empty directories to the archive
+     * @param empty_directory_paths
+     * @throw streaming_archive::writer::Archive::OperationFailed if failed to insert paths to
+     * the database
+     */
+    void add_empty_directories(std::vector<std::string> const& empty_directory_paths);
+
+    boost::uuids::uuid const& get_id() const { return m_id; }
+
+    std::string const& get_id_as_string() const { return m_id_as_string; }
+
+    size_t get_data_size_of_dictionaries() const {
+        return m_logtype_dict.get_data_size() + m_var_dict.get_data_size();
+    }
+
+private:
+    // Types
+    /**
+     * Custom less-than comparator for sets to:
+     * - Primary sort order File pointers in increasing order of their group ID, then
+     * - Secondary sort order File pointers in increasing order of their end timestamp, then
+     * - Tertiary sort order File pointers in alphabetical order of their paths, then
+     * - Determine uniqueness by their ID
+     */
+    class FileGroupIdAndEndTimestampLTSetComparator {
+    public:
+        // Methods
+        bool operator()(File const* lhs, File const* rhs) const {
+            // Primary sort by file's group ID
+            if (lhs->get_group_id() != rhs->get_group_id()) {
+                return lhs->get_group_id() < rhs->get_group_id();
+            } else {
+                // Secondary sort by file's end timestamp, from earliest to latest
+                if (lhs->get_end_ts() != rhs->get_end_ts()) {
+                    return lhs->get_end_ts() < rhs->get_end_ts();
                 } else {
-                    // Secondary sort by file's end timestamp, from earliest to latest
-                    if (lhs->get_end_ts() != rhs->get_end_ts()) {
-                        return lhs->get_end_ts() < rhs->get_end_ts();
+                    // Tertiary sort by file path, alphabetically
+                    if (lhs->get_orig_path() != rhs->get_orig_path()) {
+                        return lhs->get_orig_path() < rhs->get_orig_path();
                     } else {
-                        // Tertiary sort by file path, alphabetically
-                        if (lhs->get_orig_path() != rhs->get_orig_path()) {
-                            return lhs->get_orig_path() < rhs->get_orig_path();
-                        } else {
-                            return lhs->get_id() < rhs->get_id();
-                        }
+                        return lhs->get_id() < rhs->get_id();
                     }
                 }
             }
-        };
-
-        // Methods
-        void update_segment_indices(
-                logtype_dictionary_id_t logtype_id,
-                std::vector<variable_dictionary_id_t> const& var_ids
-        );
-
-        /**
-         * Appends the content of the current encoded file to the given segment
-         * @param segment
-         * @param logtype_ids_in_segment
-         * @param var_ids_in_segment
-         * @param files_in_segment
-         */
-        void append_file_contents_to_segment(
-                Segment& segment,
-                ArrayBackedPosIntSet<logtype_dictionary_id_t>& logtype_ids_in_segment,
-                ArrayBackedPosIntSet<variable_dictionary_id_t>& var_ids_in_segment,
-                std::vector<File*>& files_in_segment
-        );
-        /**
-         * Writes the given files' metadata to the database using bulk writes
-         * @param files
-         * @throw streaming_archive::writer::Archive::OperationFailed if failed to replace old
-         * metadata for any file
-         * @throw mongocxx::logic_error if invalid database operation is created
-         */
-        void persist_file_metadata(std::vector<File*> const& files);
-        /**
-         * Closes a given segment, persists the metadata of the files in the segment, and cleans up
-         * any data remaining outside the segment
-         * @param segment
-         * @param files
-         * @param segment_logtype_ids
-         * @param segment_var_ids
-         * @throw Same as streaming_archive::writer::Segment::close
-         * @throw Same as streaming_archive::writer::Archive::persist_file_metadata
-         */
-        void close_segment_and_persist_file_metadata(
-                Segment& segment,
-                std::vector<File*>& files,
-                ArrayBackedPosIntSet<logtype_dictionary_id_t>& segment_logtype_ids,
-                ArrayBackedPosIntSet<variable_dictionary_id_t>& segment_var_ids
-        );
-
-        /**
-         * @return The size (in bytes) of compressed data whose size may change before the archive
-         * is closed
-         */
-        uint64_t get_dynamic_compressed_size();
-        /**
-         * Updates the archive's metadata
-         */
-        void update_metadata();
-
-        // Variables
-        boost::uuids::uuid m_id;
-        std::string m_id_as_string;
-
-        // Used to order the archives created by a single thread
-        // NOTE: This is necessary because files may be split across archives and we want to
-        // decompress their parts in order.
-        boost::uuids::uuid m_creator_id;
-        std::string m_creator_id_as_string;
-        size_t m_creation_num;
-
-        std::string m_path;
-        std::string m_segments_dir_path;
-        int m_segments_dir_fd;
-
-        // Holds the file being compressed
-        File* m_file;
-
-        LogTypeDictionaryWriter m_logtype_dict;
-        // Holds preallocated logtype dictionary entry for performance
-        LogTypeDictionaryEntry m_logtype_dict_entry;
-        std::vector<encoded_variable_t> m_encoded_vars;
-        std::vector<variable_dictionary_id_t> m_var_ids;
-        VariableDictionaryWriter m_var_dict;
-
-        boost::uuids::random_generator m_uuid_generator;
-
-        file_id_t m_next_file_id;
-        // Since we batch metadata persistence operations, we need to keep track of files whose
-        // metadata should be persisted Accordingly:
-        // - m_files_with_timestamps_in_segment contains files that 1) have been moved to an open
-        //   segment and 2) contain timestamps
-        // - m_files_without_timestamps_in_segment contains files that 1) have been moved to an open
-        //   segment and 2) do not contain timestamps
-        segment_id_t m_next_segment_id;
-        std::vector<File*> m_files_with_timestamps_in_segment;
-        std::vector<File*> m_files_without_timestamps_in_segment;
-
-        size_t m_target_segment_uncompressed_size;
-        Segment m_segment_for_files_with_timestamps;
-        ArrayBackedPosIntSet<logtype_dictionary_id_t>
-                m_logtype_ids_in_segment_for_files_with_timestamps;
-        ArrayBackedPosIntSet<variable_dictionary_id_t>
-                m_var_ids_in_segment_for_files_with_timestamps;
-        // Logtype and variable IDs for a file that hasn't yet been assigned to the timestamp or
-        // timestamp-less segment
-        std::unordered_set<logtype_dictionary_id_t> m_logtype_ids_for_file_with_unassigned_segment;
-        std::unordered_set<variable_dictionary_id_t> m_var_ids_for_file_with_unassigned_segment;
-        Segment m_segment_for_files_without_timestamps;
-        ArrayBackedPosIntSet<logtype_dictionary_id_t>
-                m_logtype_ids_in_segment_for_files_without_timestamps;
-        ArrayBackedPosIntSet<variable_dictionary_id_t>
-                m_var_ids_in_segment_for_files_without_timestamps;
-
-        int m_compression_level;
-
-        MetadataDB m_metadata_db;
-
-        std::optional<ArchiveMetadata> m_local_metadata;
-        FileWriter m_metadata_file_writer;
-
-        clp::GlobalMetadataDB* m_global_metadata_db;
-
-        bool m_print_archive_stats_progress;
+        }
     };
-}}  // namespace streaming_archive::writer
+
+    // Methods
+    void update_segment_indices(
+            logtype_dictionary_id_t logtype_id,
+            std::vector<variable_dictionary_id_t> const& var_ids
+    );
+
+    /**
+     * Appends the content of the current encoded file to the given segment
+     * @param segment
+     * @param logtype_ids_in_segment
+     * @param var_ids_in_segment
+     * @param files_in_segment
+     */
+    void append_file_contents_to_segment(
+            Segment& segment,
+            ArrayBackedPosIntSet<logtype_dictionary_id_t>& logtype_ids_in_segment,
+            ArrayBackedPosIntSet<variable_dictionary_id_t>& var_ids_in_segment,
+            std::vector<File*>& files_in_segment
+    );
+    /**
+     * Writes the given files' metadata to the database using bulk writes
+     * @param files
+     * @throw streaming_archive::writer::Archive::OperationFailed if failed to replace old
+     * metadata for any file
+     * @throw mongocxx::logic_error if invalid database operation is created
+     */
+    void persist_file_metadata(std::vector<File*> const& files);
+    /**
+     * Closes a given segment, persists the metadata of the files in the segment, and cleans up
+     * any data remaining outside the segment
+     * @param segment
+     * @param files
+     * @param segment_logtype_ids
+     * @param segment_var_ids
+     * @throw Same as streaming_archive::writer::Segment::close
+     * @throw Same as streaming_archive::writer::Archive::persist_file_metadata
+     */
+    void close_segment_and_persist_file_metadata(
+            Segment& segment,
+            std::vector<File*>& files,
+            ArrayBackedPosIntSet<logtype_dictionary_id_t>& segment_logtype_ids,
+            ArrayBackedPosIntSet<variable_dictionary_id_t>& segment_var_ids
+    );
+
+    /**
+     * @return The size (in bytes) of compressed data whose size may change before the archive
+     * is closed
+     */
+    uint64_t get_dynamic_compressed_size();
+    /**
+     * Updates the archive's metadata
+     */
+    void update_metadata();
+
+    // Variables
+    boost::uuids::uuid m_id;
+    std::string m_id_as_string;
+
+    // Used to order the archives created by a single thread
+    // NOTE: This is necessary because files may be split across archives and we want to
+    // decompress their parts in order.
+    boost::uuids::uuid m_creator_id;
+    std::string m_creator_id_as_string;
+    size_t m_creation_num;
+
+    std::string m_path;
+    std::string m_segments_dir_path;
+    int m_segments_dir_fd;
+
+    // Holds the file being compressed
+    File* m_file;
+
+    LogTypeDictionaryWriter m_logtype_dict;
+    // Holds preallocated logtype dictionary entry for performance
+    LogTypeDictionaryEntry m_logtype_dict_entry;
+    std::vector<encoded_variable_t> m_encoded_vars;
+    std::vector<variable_dictionary_id_t> m_var_ids;
+    VariableDictionaryWriter m_var_dict;
+
+    boost::uuids::random_generator m_uuid_generator;
+
+    file_id_t m_next_file_id;
+    // Since we batch metadata persistence operations, we need to keep track of files whose
+    // metadata should be persisted Accordingly:
+    // - m_files_with_timestamps_in_segment contains files that 1) have been moved to an open
+    //   segment and 2) contain timestamps
+    // - m_files_without_timestamps_in_segment contains files that 1) have been moved to an open
+    //   segment and 2) do not contain timestamps
+    segment_id_t m_next_segment_id;
+    std::vector<File*> m_files_with_timestamps_in_segment;
+    std::vector<File*> m_files_without_timestamps_in_segment;
+
+    size_t m_target_segment_uncompressed_size;
+    Segment m_segment_for_files_with_timestamps;
+    ArrayBackedPosIntSet<logtype_dictionary_id_t>
+            m_logtype_ids_in_segment_for_files_with_timestamps;
+    ArrayBackedPosIntSet<variable_dictionary_id_t> m_var_ids_in_segment_for_files_with_timestamps;
+    // Logtype and variable IDs for a file that hasn't yet been assigned to the timestamp or
+    // timestamp-less segment
+    std::unordered_set<logtype_dictionary_id_t> m_logtype_ids_for_file_with_unassigned_segment;
+    std::unordered_set<variable_dictionary_id_t> m_var_ids_for_file_with_unassigned_segment;
+    Segment m_segment_for_files_without_timestamps;
+    ArrayBackedPosIntSet<logtype_dictionary_id_t>
+            m_logtype_ids_in_segment_for_files_without_timestamps;
+    ArrayBackedPosIntSet<variable_dictionary_id_t>
+            m_var_ids_in_segment_for_files_without_timestamps;
+
+    int m_compression_level;
+
+    MetadataDB m_metadata_db;
+
+    std::optional<ArchiveMetadata> m_local_metadata;
+    FileWriter m_metadata_file_writer;
+
+    clp::GlobalMetadataDB* m_global_metadata_db;
+
+    bool m_print_archive_stats_progress;
+};
+}  // namespace streaming_archive::writer
 
 #endif  // STREAMING_ARCHIVE_WRITER_ARCHIVE_HPP

--- a/components/core/src/streaming_archive/writer/File.cpp
+++ b/components/core/src/streaming_archive/writer/File.cpp
@@ -7,138 +7,137 @@ using std::to_string;
 using std::unordered_set;
 using std::vector;
 
-namespace streaming_archive { namespace writer {
-    void File::open() {
-        if (m_is_written_out) {
-            throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
-        }
-        m_timestamps = std::make_unique<PageAllocatedVector<epochtime_t>>();
-        m_logtypes = std::make_unique<PageAllocatedVector<logtype_dictionary_id_t>>();
-        m_variables = std::make_unique<PageAllocatedVector<encoded_variable_t>>();
-        m_is_open = true;
+namespace streaming_archive::writer {
+void File::open() {
+    if (m_is_written_out) {
+        throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+    }
+    m_timestamps = std::make_unique<PageAllocatedVector<epochtime_t>>();
+    m_logtypes = std::make_unique<PageAllocatedVector<logtype_dictionary_id_t>>();
+    m_variables = std::make_unique<PageAllocatedVector<encoded_variable_t>>();
+    m_is_open = true;
+}
+
+void File::append_to_segment(LogTypeDictionaryWriter const& logtype_dict, Segment& segment) {
+    if (m_is_open) {
+        throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
     }
 
-    void File::append_to_segment(LogTypeDictionaryWriter const& logtype_dict, Segment& segment) {
-        if (m_is_open) {
-            throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
-        }
+    // Append files to segment
+    uint64_t segment_timestamps_uncompressed_pos;
+    segment.append(
+            reinterpret_cast<char const*>(m_timestamps->data()),
+            m_timestamps->size_in_bytes(),
+            segment_timestamps_uncompressed_pos
+    );
+    uint64_t segment_logtypes_uncompressed_pos;
+    segment.append(
+            reinterpret_cast<char const*>(m_logtypes->data()),
+            m_logtypes->size_in_bytes(),
+            segment_logtypes_uncompressed_pos
+    );
+    uint64_t segment_variables_uncompressed_pos;
+    segment.append(
+            reinterpret_cast<char const*>(m_variables->data()),
+            m_variables->size_in_bytes(),
+            segment_variables_uncompressed_pos
+    );
+    set_segment_metadata(
+            segment.get_id(),
+            segment_timestamps_uncompressed_pos,
+            segment_logtypes_uncompressed_pos,
+            segment_variables_uncompressed_pos
+    );
+    m_segmentation_state = SegmentationState_MovingToSegment;
 
-        // Append files to segment
-        uint64_t segment_timestamps_uncompressed_pos;
-        segment.append(
-                reinterpret_cast<char const*>(m_timestamps->data()),
-                m_timestamps->size_in_bytes(),
-                segment_timestamps_uncompressed_pos
-        );
-        uint64_t segment_logtypes_uncompressed_pos;
-        segment.append(
-                reinterpret_cast<char const*>(m_logtypes->data()),
-                m_logtypes->size_in_bytes(),
-                segment_logtypes_uncompressed_pos
-        );
-        uint64_t segment_variables_uncompressed_pos;
-        segment.append(
-                reinterpret_cast<char const*>(m_variables->data()),
-                m_variables->size_in_bytes(),
-                segment_variables_uncompressed_pos
-        );
-        set_segment_metadata(
-                segment.get_id(),
-                segment_timestamps_uncompressed_pos,
-                segment_logtypes_uncompressed_pos,
-                segment_variables_uncompressed_pos
-        );
-        m_segmentation_state = SegmentationState_MovingToSegment;
+    // Mark file as written out and clear in-memory columns and clear the in-memory data (except
+    // metadata)
+    m_is_written_out = true;
+    m_timestamps.reset(nullptr);
+    m_logtypes.reset(nullptr);
+    m_variables.reset(nullptr);
+}
 
-        // Mark file as written out and clear in-memory columns and clear the in-memory data (except
-        // metadata)
-        m_is_written_out = true;
-        m_timestamps.reset(nullptr);
-        m_logtypes.reset(nullptr);
-        m_variables.reset(nullptr);
+void File::write_encoded_msg(
+        epochtime_t timestamp,
+        logtype_dictionary_id_t logtype_id,
+        vector<encoded_variable_t> const& encoded_vars,
+        vector<variable_dictionary_id_t> const& var_ids,
+        size_t num_uncompressed_bytes
+) {
+    m_timestamps->push_back(timestamp);
+    m_logtypes->push_back(logtype_id);
+    m_variables->push_back_all(encoded_vars);
+
+    // Update metadata
+    ++m_num_messages;
+    m_num_variables += encoded_vars.size();
+
+    if (timestamp < m_begin_ts) {
+        m_begin_ts = timestamp;
+    }
+    if (timestamp > m_end_ts) {
+        m_end_ts = timestamp;
     }
 
-    void File::write_encoded_msg(
-            epochtime_t timestamp,
-            logtype_dictionary_id_t logtype_id,
-            vector<encoded_variable_t> const& encoded_vars,
-            vector<variable_dictionary_id_t> const& var_ids,
-            size_t num_uncompressed_bytes
-    ) {
-        m_timestamps->push_back(timestamp);
-        m_logtypes->push_back(logtype_id);
-        m_variables->push_back_all(encoded_vars);
+    m_num_uncompressed_bytes += num_uncompressed_bytes;
+    m_is_metadata_clean = false;
+}
 
-        // Update metadata
-        ++m_num_messages;
-        m_num_variables += encoded_vars.size();
+void File::change_ts_pattern(TimestampPattern const* pattern) {
+    if (nullptr == pattern) {
+        m_timestamp_patterns.emplace_back(m_num_messages, TimestampPattern());
+    } else {
+        m_timestamp_patterns.emplace_back(m_num_messages, *pattern);
+    }
+    m_is_metadata_clean = false;
+}
 
-        if (timestamp < m_begin_ts) {
-            m_begin_ts = timestamp;
-        }
-        if (timestamp > m_end_ts) {
-            m_end_ts = timestamp;
-        }
+bool File::is_in_uncommitted_segment() const {
+    return (SegmentationState_MovingToSegment == m_segmentation_state);
+}
 
-        m_num_uncompressed_bytes += num_uncompressed_bytes;
-        m_is_metadata_clean = false;
+void File::mark_as_in_committed_segment() {
+    m_segmentation_state = SegmentationState_InSegment;
+}
+
+bool File::is_metadata_dirty() const {
+    return !m_is_metadata_clean;
+}
+
+void File::mark_metadata_as_clean() {
+    m_is_metadata_clean = true;
+}
+
+string File::get_encoded_timestamp_patterns() const {
+    string encoded_timestamp_patterns;
+    string encoded_timestamp_pattern;
+
+    // TODO We could build this procedurally
+    for (auto const& timestamp_pattern : m_timestamp_patterns) {
+        encoded_timestamp_pattern.assign(to_string(timestamp_pattern.first));
+        encoded_timestamp_pattern += ':';
+        encoded_timestamp_pattern += to_string(timestamp_pattern.second.get_num_spaces_before_ts());
+        encoded_timestamp_pattern += ':';
+        encoded_timestamp_pattern += timestamp_pattern.second.get_format();
+        encoded_timestamp_pattern += '\n';
+
+        encoded_timestamp_patterns += encoded_timestamp_pattern;
     }
 
-    void File::change_ts_pattern(TimestampPattern const* pattern) {
-        if (nullptr == pattern) {
-            m_timestamp_patterns.emplace_back(m_num_messages, TimestampPattern());
-        } else {
-            m_timestamp_patterns.emplace_back(m_num_messages, *pattern);
-        }
-        m_is_metadata_clean = false;
-    }
+    return encoded_timestamp_patterns;
+}
 
-    bool File::is_in_uncommitted_segment() const {
-        return (SegmentationState_MovingToSegment == m_segmentation_state);
-    }
-
-    void File::mark_as_in_committed_segment() {
-        m_segmentation_state = SegmentationState_InSegment;
-    }
-
-    bool File::is_metadata_dirty() const {
-        return !m_is_metadata_clean;
-    }
-
-    void File::mark_metadata_as_clean() {
-        m_is_metadata_clean = true;
-    }
-
-    string File::get_encoded_timestamp_patterns() const {
-        string encoded_timestamp_patterns;
-        string encoded_timestamp_pattern;
-
-        // TODO We could build this procedurally
-        for (auto const& timestamp_pattern : m_timestamp_patterns) {
-            encoded_timestamp_pattern.assign(to_string(timestamp_pattern.first));
-            encoded_timestamp_pattern += ':';
-            encoded_timestamp_pattern
-                    += to_string(timestamp_pattern.second.get_num_spaces_before_ts());
-            encoded_timestamp_pattern += ':';
-            encoded_timestamp_pattern += timestamp_pattern.second.get_format();
-            encoded_timestamp_pattern += '\n';
-
-            encoded_timestamp_patterns += encoded_timestamp_pattern;
-        }
-
-        return encoded_timestamp_patterns;
-    }
-
-    void File::set_segment_metadata(
-            segment_id_t segment_id,
-            uint64_t segment_timestamps_uncompressed_pos,
-            uint64_t segment_logtypes_uncompressed_pos,
-            uint64_t segment_variables_uncompressed_pos
-    ) {
-        m_segment_id = segment_id;
-        m_segment_timestamps_pos = segment_timestamps_uncompressed_pos;
-        m_segment_logtypes_pos = segment_logtypes_uncompressed_pos;
-        m_segment_variables_pos = segment_variables_uncompressed_pos;
-        m_is_metadata_clean = false;
-    }
-}}  // namespace streaming_archive::writer
+void File::set_segment_metadata(
+        segment_id_t segment_id,
+        uint64_t segment_timestamps_uncompressed_pos,
+        uint64_t segment_logtypes_uncompressed_pos,
+        uint64_t segment_variables_uncompressed_pos
+) {
+    m_segment_id = segment_id;
+    m_segment_timestamps_pos = segment_timestamps_uncompressed_pos;
+    m_segment_logtypes_pos = segment_logtypes_uncompressed_pos;
+    m_segment_variables_pos = segment_variables_uncompressed_pos;
+    m_is_metadata_clean = false;
+}
+}  // namespace streaming_archive::writer

--- a/components/core/src/streaming_archive/writer/File.hpp
+++ b/components/core/src/streaming_archive/writer/File.hpp
@@ -14,243 +14,243 @@
 #include "../../TimestampPattern.hpp"
 #include "Segment.hpp"
 
-namespace streaming_archive { namespace writer {
-    /**
-     * Class representing a log file encoded in three columns - timestamps, logtype IDs, and
-     * variables.
-     */
-    class File {
+namespace streaming_archive::writer {
+/**
+ * Class representing a log file encoded in three columns - timestamps, logtype IDs, and
+ * variables.
+ */
+class File {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_archive::writer::File operation failed";
-            }
-        };
-
         // Constructors
-        File(boost::uuids::uuid const& id,
-             boost::uuids::uuid const& orig_file_id,
-             std::string const& orig_log_path,
-             group_id_t group_id,
-             size_t split_ix)
-                : m_id(id),
-                  m_orig_file_id(orig_file_id),
-                  m_orig_log_path(orig_log_path),
-                  m_begin_ts(cEpochTimeMax),
-                  m_end_ts(cEpochTimeMin),
-                  m_group_id(group_id),
-                  m_num_uncompressed_bytes(0),
-                  m_num_messages(0),
-                  m_num_variables(0),
-                  m_segment_id(cInvalidSegmentId),
-                  m_segment_timestamps_pos(0),
-                  m_segment_logtypes_pos(0),
-                  m_segment_variables_pos(0),
-                  m_is_split(split_ix > 0),
-                  m_split_ix(split_ix),
-                  m_segmentation_state(SegmentationState_NotInSegment),
-                  m_is_metadata_clean(false),
-                  m_is_written_out(false),
-                  m_is_open(false) {}
-
-        // Destructor
-        virtual ~File() = default;
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        bool is_open() const { return m_is_open; }
-
-        void open();
-
-        void close() { m_is_open = false; }
-
-        /**
-         * Appends the file's columns to the given segment
-         * @param logtype_dict
-         * @param segment
-         */
-        void append_to_segment(LogTypeDictionaryWriter const& logtype_dict, Segment& segment);
-        /**
-         * Writes an encoded message to the respective columns and updates the metadata of the file
-         * @param timestamp
-         * @param logtype_id
-         * @param encoded_vars
-         * @param var_ids
-         * @param num_uncompressed_bytes
-         */
-        void write_encoded_msg(
-                epochtime_t timestamp,
-                logtype_dictionary_id_t logtype_id,
-                std::vector<encoded_variable_t> const& encoded_vars,
-                std::vector<variable_dictionary_id_t> const& var_ids,
-                size_t num_uncompressed_bytes
-        );
-
-        /**
-         * Changes timestamp pattern in use at current message in file
-         * @param pattern
-         */
-        void change_ts_pattern(TimestampPattern const* pattern);
-
-        /**
-         * Returns whether the file contains any timestamp pattern
-         * @return true if the file contains a timestamp pattern, false otherwise
-         */
-        bool has_ts_pattern() const { return m_timestamp_patterns.empty() == false; }
-
-        /**
-         * Gets the file's uncompressed size
-         * @return File's uncompressed size in bytes
-         */
-        uint64_t get_num_uncompressed_bytes() const { return m_num_uncompressed_bytes; }
-
-        /**
-         * Gets the file's encoded size in bytes
-         * @return Encoded size in bytes
-         */
-        size_t get_encoded_size_in_bytes() const {
-            return m_num_messages * sizeof(epochtime_t)
-                   + m_num_messages * sizeof(logtype_dictionary_id_t)
-                   + m_num_variables * sizeof(encoded_variable_t);
+        char const* what() const noexcept override {
+            return "streaming_archive::writer::File operation failed";
         }
-
-        /**
-         * Gets the file's compression group ID
-         * @return The compression group ID
-         */
-        group_id_t get_group_id() const { return m_group_id; }
-
-        /**
-         * Tests if the file has been moved to segment that has not yet been committed
-         * @return true if in uncommitted segment, false otherwise
-         */
-        bool is_in_uncommitted_segment() const;
-        /**
-         * Marks this file as being within a committed segment
-         */
-        void mark_as_in_committed_segment();
-        /**
-         * Tests if file's current metadata is dirty
-         * @return
-         */
-        bool is_metadata_dirty() const;
-        /**
-         * Marks the file's metadata as clean
-         */
-        void mark_metadata_as_clean();
-
-        void set_is_split(bool is_split) { m_is_split = is_split; }
-
-        /**
-         * Gets file's original file path
-         * @return file path
-         */
-        std::string const& get_orig_path() const { return m_orig_log_path; }
-
-        boost::uuids::uuid const& get_orig_file_id() const { return m_orig_file_id; }
-
-        std::string get_orig_file_id_as_string() const {
-            return boost::uuids::to_string(m_orig_file_id);
-        }
-
-        boost::uuids::uuid const& get_id() const { return m_id; }
-
-        std::string get_id_as_string() const { return boost::uuids::to_string(m_id); }
-
-        epochtime_t get_begin_ts() const { return m_begin_ts; }
-
-        epochtime_t get_end_ts() const { return m_end_ts; }
-
-        std::vector<std::pair<int64_t, TimestampPattern>> const& get_timestamp_patterns() const {
-            return m_timestamp_patterns;
-        }
-
-        std::string get_encoded_timestamp_patterns() const;
-
-        uint64_t get_num_messages() const { return m_num_messages; }
-
-        uint64_t get_num_variables() const { return m_num_variables; }
-
-        bool is_in_segment() const { return SegmentationState_InSegment == m_segmentation_state; }
-
-        segment_id_t get_segment_id() const { return m_segment_id; }
-
-        uint64_t get_segment_timestamps_pos() const { return m_segment_timestamps_pos; }
-
-        uint64_t get_segment_logtypes_pos() const { return m_segment_logtypes_pos; }
-
-        uint64_t get_segment_variables_pos() const { return m_segment_variables_pos; }
-
-        bool is_split() const { return m_is_split; }
-
-        size_t get_split_ix() const { return m_split_ix; }
-
-    private:
-        // Types
-        typedef enum {
-            SegmentationState_NotInSegment = 0,
-            SegmentationState_MovingToSegment,
-            SegmentationState_InSegment
-        } SegmentationState;
-
-        // Methods
-        /**
-         * Sets segment-related metadata to the given values
-         * @param segment_id
-         * @param segment_timestamps_uncompressed_pos
-         * @param segment_logtypes_uncompressed_pos
-         * @param segment_variables_uncompressed_pos
-         */
-        void set_segment_metadata(
-                segment_id_t segment_id,
-                uint64_t segment_timestamps_uncompressed_pos,
-                uint64_t segment_logtypes_uncompressed_pos,
-                uint64_t segment_variables_uncompressed_pos
-        );
-
-        // Variables
-        // Metadata
-        boost::uuids::uuid m_id;
-        boost::uuids::uuid m_orig_file_id;
-
-        std::string m_orig_log_path;
-
-        epochtime_t m_begin_ts;
-        epochtime_t m_end_ts;
-        std::vector<std::pair<int64_t, TimestampPattern>> m_timestamp_patterns;
-
-        group_id_t m_group_id;
-
-        uint64_t m_num_uncompressed_bytes;
-
-        uint64_t m_num_messages;
-        uint64_t m_num_variables;
-
-        segment_id_t m_segment_id;
-        uint64_t m_segment_timestamps_pos;
-        uint64_t m_segment_logtypes_pos;
-        uint64_t m_segment_variables_pos;
-
-        bool m_is_split;
-        size_t m_split_ix;
-
-        // Data variables
-        std::unique_ptr<PageAllocatedVector<epochtime_t>> m_timestamps;
-        std::unique_ptr<PageAllocatedVector<logtype_dictionary_id_t>> m_logtypes;
-        std::unique_ptr<PageAllocatedVector<encoded_variable_t>> m_variables;
-
-        // State variables
-        SegmentationState m_segmentation_state;
-        bool m_is_metadata_clean;
-        bool m_is_written_out;
-        bool m_is_open;
     };
-}}  // namespace streaming_archive::writer
+
+    // Constructors
+    File(boost::uuids::uuid const& id,
+         boost::uuids::uuid const& orig_file_id,
+         std::string const& orig_log_path,
+         group_id_t group_id,
+         size_t split_ix)
+            : m_id(id),
+              m_orig_file_id(orig_file_id),
+              m_orig_log_path(orig_log_path),
+              m_begin_ts(cEpochTimeMax),
+              m_end_ts(cEpochTimeMin),
+              m_group_id(group_id),
+              m_num_uncompressed_bytes(0),
+              m_num_messages(0),
+              m_num_variables(0),
+              m_segment_id(cInvalidSegmentId),
+              m_segment_timestamps_pos(0),
+              m_segment_logtypes_pos(0),
+              m_segment_variables_pos(0),
+              m_is_split(split_ix > 0),
+              m_split_ix(split_ix),
+              m_segmentation_state(SegmentationState_NotInSegment),
+              m_is_metadata_clean(false),
+              m_is_written_out(false),
+              m_is_open(false) {}
+
+    // Destructor
+    virtual ~File() = default;
+
+    // Methods
+    bool is_open() const { return m_is_open; }
+
+    void open();
+
+    void close() { m_is_open = false; }
+
+    /**
+     * Appends the file's columns to the given segment
+     * @param logtype_dict
+     * @param segment
+     */
+    void append_to_segment(LogTypeDictionaryWriter const& logtype_dict, Segment& segment);
+    /**
+     * Writes an encoded message to the respective columns and updates the metadata of the file
+     * @param timestamp
+     * @param logtype_id
+     * @param encoded_vars
+     * @param var_ids
+     * @param num_uncompressed_bytes
+     */
+    void write_encoded_msg(
+            epochtime_t timestamp,
+            logtype_dictionary_id_t logtype_id,
+            std::vector<encoded_variable_t> const& encoded_vars,
+            std::vector<variable_dictionary_id_t> const& var_ids,
+            size_t num_uncompressed_bytes
+    );
+
+    /**
+     * Changes timestamp pattern in use at current message in file
+     * @param pattern
+     */
+    void change_ts_pattern(TimestampPattern const* pattern);
+
+    /**
+     * Returns whether the file contains any timestamp pattern
+     * @return true if the file contains a timestamp pattern, false otherwise
+     */
+    bool has_ts_pattern() const { return m_timestamp_patterns.empty() == false; }
+
+    /**
+     * Gets the file's uncompressed size
+     * @return File's uncompressed size in bytes
+     */
+    uint64_t get_num_uncompressed_bytes() const { return m_num_uncompressed_bytes; }
+
+    /**
+     * Gets the file's encoded size in bytes
+     * @return Encoded size in bytes
+     */
+    size_t get_encoded_size_in_bytes() const {
+        return m_num_messages * sizeof(epochtime_t)
+               + m_num_messages * sizeof(logtype_dictionary_id_t)
+               + m_num_variables * sizeof(encoded_variable_t);
+    }
+
+    /**
+     * Gets the file's compression group ID
+     * @return The compression group ID
+     */
+    group_id_t get_group_id() const { return m_group_id; }
+
+    /**
+     * Tests if the file has been moved to segment that has not yet been committed
+     * @return true if in uncommitted segment, false otherwise
+     */
+    bool is_in_uncommitted_segment() const;
+    /**
+     * Marks this file as being within a committed segment
+     */
+    void mark_as_in_committed_segment();
+    /**
+     * Tests if file's current metadata is dirty
+     * @return
+     */
+    bool is_metadata_dirty() const;
+    /**
+     * Marks the file's metadata as clean
+     */
+    void mark_metadata_as_clean();
+
+    void set_is_split(bool is_split) { m_is_split = is_split; }
+
+    /**
+     * Gets file's original file path
+     * @return file path
+     */
+    std::string const& get_orig_path() const { return m_orig_log_path; }
+
+    boost::uuids::uuid const& get_orig_file_id() const { return m_orig_file_id; }
+
+    std::string get_orig_file_id_as_string() const {
+        return boost::uuids::to_string(m_orig_file_id);
+    }
+
+    boost::uuids::uuid const& get_id() const { return m_id; }
+
+    std::string get_id_as_string() const { return boost::uuids::to_string(m_id); }
+
+    epochtime_t get_begin_ts() const { return m_begin_ts; }
+
+    epochtime_t get_end_ts() const { return m_end_ts; }
+
+    std::vector<std::pair<int64_t, TimestampPattern>> const& get_timestamp_patterns() const {
+        return m_timestamp_patterns;
+    }
+
+    std::string get_encoded_timestamp_patterns() const;
+
+    uint64_t get_num_messages() const { return m_num_messages; }
+
+    uint64_t get_num_variables() const { return m_num_variables; }
+
+    bool is_in_segment() const { return SegmentationState_InSegment == m_segmentation_state; }
+
+    segment_id_t get_segment_id() const { return m_segment_id; }
+
+    uint64_t get_segment_timestamps_pos() const { return m_segment_timestamps_pos; }
+
+    uint64_t get_segment_logtypes_pos() const { return m_segment_logtypes_pos; }
+
+    uint64_t get_segment_variables_pos() const { return m_segment_variables_pos; }
+
+    bool is_split() const { return m_is_split; }
+
+    size_t get_split_ix() const { return m_split_ix; }
+
+private:
+    // Types
+    typedef enum {
+        SegmentationState_NotInSegment = 0,
+        SegmentationState_MovingToSegment,
+        SegmentationState_InSegment
+    } SegmentationState;
+
+    // Methods
+    /**
+     * Sets segment-related metadata to the given values
+     * @param segment_id
+     * @param segment_timestamps_uncompressed_pos
+     * @param segment_logtypes_uncompressed_pos
+     * @param segment_variables_uncompressed_pos
+     */
+    void set_segment_metadata(
+            segment_id_t segment_id,
+            uint64_t segment_timestamps_uncompressed_pos,
+            uint64_t segment_logtypes_uncompressed_pos,
+            uint64_t segment_variables_uncompressed_pos
+    );
+
+    // Variables
+    // Metadata
+    boost::uuids::uuid m_id;
+    boost::uuids::uuid m_orig_file_id;
+
+    std::string m_orig_log_path;
+
+    epochtime_t m_begin_ts;
+    epochtime_t m_end_ts;
+    std::vector<std::pair<int64_t, TimestampPattern>> m_timestamp_patterns;
+
+    group_id_t m_group_id;
+
+    uint64_t m_num_uncompressed_bytes;
+
+    uint64_t m_num_messages;
+    uint64_t m_num_variables;
+
+    segment_id_t m_segment_id;
+    uint64_t m_segment_timestamps_pos;
+    uint64_t m_segment_logtypes_pos;
+    uint64_t m_segment_variables_pos;
+
+    bool m_is_split;
+    size_t m_split_ix;
+
+    // Data variables
+    std::unique_ptr<PageAllocatedVector<epochtime_t>> m_timestamps;
+    std::unique_ptr<PageAllocatedVector<logtype_dictionary_id_t>> m_logtypes;
+    std::unique_ptr<PageAllocatedVector<encoded_variable_t>> m_variables;
+
+    // State variables
+    SegmentationState m_segmentation_state;
+    bool m_is_metadata_clean;
+    bool m_is_written_out;
+    bool m_is_open;
+};
+}  // namespace streaming_archive::writer
 
 #endif  // STREAMING_ARCHIVE_WRITER_FILE_HPP

--- a/components/core/src/streaming_archive/writer/Segment.cpp
+++ b/components/core/src/streaming_archive/writer/Segment.cpp
@@ -15,75 +15,75 @@ using std::string;
 using std::to_string;
 using std::unique_ptr;
 
-namespace streaming_archive { namespace writer {
-    Segment::~Segment() {
-        if (!m_segment_path.empty()) {
-            SPDLOG_ERROR(
-                    "streaming_archive::writer::Segment: Segment {} not closed before being "
-                    "destroyed causing possible data loss",
-                    m_segment_path.c_str()
-            );
-        }
+namespace streaming_archive::writer {
+Segment::~Segment() {
+    if (!m_segment_path.empty()) {
+        SPDLOG_ERROR(
+                "streaming_archive::writer::Segment: Segment {} not closed before being "
+                "destroyed causing possible data loss",
+                m_segment_path.c_str()
+        );
+    }
+}
+
+void Segment::open(string const& segments_dir_path, segment_id_t id, int compression_level) {
+    if (!m_segment_path.empty()) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    void Segment::open(string const& segments_dir_path, segment_id_t id, int compression_level) {
-        if (!m_segment_path.empty()) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
+    m_id = id;
 
-        m_id = id;
+    // Construct segment path
+    m_segment_path = segments_dir_path;
+    m_segment_path += std::to_string(m_id);
 
-        // Construct segment path
-        m_segment_path = segments_dir_path;
-        m_segment_path += std::to_string(m_id);
+    m_offset = 0;
+    m_compressed_size = 0;
 
-        m_offset = 0;
-        m_compressed_size = 0;
-
-        m_file_writer.open(m_segment_path, FileWriter::OpenMode::CREATE_FOR_WRITING);
+    m_file_writer.open(m_segment_path, FileWriter::OpenMode::CREATE_FOR_WRITING);
 #if USE_PASSTHROUGH_COMPRESSION
-        m_compressor.open(m_file_writer);
+    m_compressor.open(m_file_writer);
 #elif USE_ZSTD_COMPRESSION
-        m_compressor.open(m_file_writer, compression_level);
+    m_compressor.open(m_file_writer, compression_level);
 #else
-        static_assert(false, "Unsupported compression mode.");
+    static_assert(false, "Unsupported compression mode.");
 #endif
-    }
+}
 
-    void Segment::close() {
-        m_compressor.close();
+void Segment::close() {
+    m_compressor.close();
+    m_compressed_size = m_file_writer.get_pos();
+
+    m_file_writer.flush();
+    m_file_writer.close();
+
+    // Clear Segment
+    m_segment_path.clear();
+}
+
+void Segment::append(char const* buf, uint64_t const buf_len, uint64_t& offset) {
+    // Compress
+    m_compressor.write(buf, buf_len);
+
+    // Return offset and update it
+    offset = m_offset;
+    m_offset += buf_len;
+}
+
+uint64_t Segment::get_uncompressed_size() {
+    return m_offset;
+}
+
+size_t Segment::get_compressed_size() {
+    if (is_open()) {
+        // NOTE: We update the compressed size only on request to avoid any potential overhead
+        // from getting the file writer's position
         m_compressed_size = m_file_writer.get_pos();
-
-        m_file_writer.flush();
-        m_file_writer.close();
-
-        // Clear Segment
-        m_segment_path.clear();
     }
+    return m_compressed_size;
+}
 
-    void Segment::append(char const* buf, uint64_t const buf_len, uint64_t& offset) {
-        // Compress
-        m_compressor.write(buf, buf_len);
-
-        // Return offset and update it
-        offset = m_offset;
-        m_offset += buf_len;
-    }
-
-    uint64_t Segment::get_uncompressed_size() {
-        return m_offset;
-    }
-
-    size_t Segment::get_compressed_size() {
-        if (is_open()) {
-            // NOTE: We update the compressed size only on request to avoid any potential overhead
-            // from getting the file writer's position
-            m_compressed_size = m_file_writer.get_pos();
-        }
-        return m_compressed_size;
-    }
-
-    bool Segment::is_open() const {
-        return !m_segment_path.empty();
-    }
-}}  // namespace streaming_archive::writer
+bool Segment::is_open() const {
+    return !m_segment_path.empty();
+}
+}  // namespace streaming_archive::writer

--- a/components/core/src/streaming_archive/writer/Segment.hpp
+++ b/components/core/src/streaming_archive/writer/Segment.hpp
@@ -11,89 +11,89 @@
 #include "../../TraceableException.hpp"
 #include "../Constants.hpp"
 
-namespace streaming_archive { namespace writer {
-    /**
-     * Class for writing segments. A segment is a container for multiple compressed buffers that
-     * itself may be further compressed and then stored on disk.
-     */
-    class Segment {
+namespace streaming_archive::writer {
+/**
+ * Class for writing segments. A segment is a container for multiple compressed buffers that
+ * itself may be further compressed and then stored on disk.
+ */
+class Segment {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_archive::writer::Segment operation failed";
-            }
-        };
-
         // Constructors
-        Segment() : m_id(cInvalidSegmentId), m_offset(0) {}
-
-        // Destructor
-        ~Segment();
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /**
-         * Creates a segment in the given directory
-         * @param segments_dir_path
-         * @param id
-         * @param compression_level
-         * @throw streaming_archive::writer::Segment::OperationFailed if segment wasn't closed
-         * before this call
-         */
-        void open(std::string const& segments_dir_path, segment_id_t id, int compression_level);
-        /**
-         * Closes the segment
-         * @throw streaming_archive::writer::Segment::OperationFailed if compression fails
-         * @throw FileWriter::OperationFailed on open, write, or close failure
-         */
-        void close();
-
-        /**
-         * Appends the given buffer to the segment
-         * @param buf Buffer to append
-         * @param buf_len
-         * @param offset Offset of the buffer in the segment
-         * @throw streaming_archive::writer::Segment::OperationFailed if compression fails
-         */
-        void append(char const* buf, uint64_t buf_len, uint64_t& offset);
-
-        segment_id_t get_id() const { return m_id; }
-
-        bool is_open() const;
-        /**
-         * @return The amount of data (in bytes) appended (input) to the segment. Calling this after
-         * the segment has been closed will return the final uncompressed size of the segment.
-         */
-        uint64_t get_uncompressed_size();
-        /**
-         * @return The on-disk size (in bytes) of the segment. Calling this after the segment has
-         * been closed will return the final compressed size of the segment.
-         */
-        size_t get_compressed_size();
-
-    private:
-        // Variables
-        std::string m_segment_path;
-        segment_id_t m_id;
-
-        uint64_t m_offset;  // total input bytes processed
-        uint64_t m_compressed_size;
-
-        FileWriter m_file_writer;
-#if USE_PASSTHROUGH_COMPRESSION
-        streaming_compression::passthrough::Compressor m_compressor;
-#elif USE_ZSTD_COMPRESSION
-        streaming_compression::zstd::Compressor m_compressor;
-#else
-        static_assert(false, "Unsupported compression mode.");
-#endif
+        char const* what() const noexcept override {
+            return "streaming_archive::writer::Segment operation failed";
+        }
     };
-}}  // namespace streaming_archive::writer
+
+    // Constructors
+    Segment() : m_id(cInvalidSegmentId), m_offset(0) {}
+
+    // Destructor
+    ~Segment();
+
+    // Methods
+    /**
+     * Creates a segment in the given directory
+     * @param segments_dir_path
+     * @param id
+     * @param compression_level
+     * @throw streaming_archive::writer::Segment::OperationFailed if segment wasn't closed
+     * before this call
+     */
+    void open(std::string const& segments_dir_path, segment_id_t id, int compression_level);
+    /**
+     * Closes the segment
+     * @throw streaming_archive::writer::Segment::OperationFailed if compression fails
+     * @throw FileWriter::OperationFailed on open, write, or close failure
+     */
+    void close();
+
+    /**
+     * Appends the given buffer to the segment
+     * @param buf Buffer to append
+     * @param buf_len
+     * @param offset Offset of the buffer in the segment
+     * @throw streaming_archive::writer::Segment::OperationFailed if compression fails
+     */
+    void append(char const* buf, uint64_t buf_len, uint64_t& offset);
+
+    segment_id_t get_id() const { return m_id; }
+
+    bool is_open() const;
+    /**
+     * @return The amount of data (in bytes) appended (input) to the segment. Calling this after
+     * the segment has been closed will return the final uncompressed size of the segment.
+     */
+    uint64_t get_uncompressed_size();
+    /**
+     * @return The on-disk size (in bytes) of the segment. Calling this after the segment has
+     * been closed will return the final compressed size of the segment.
+     */
+    size_t get_compressed_size();
+
+private:
+    // Variables
+    std::string m_segment_path;
+    segment_id_t m_id;
+
+    uint64_t m_offset;  // total input bytes processed
+    uint64_t m_compressed_size;
+
+    FileWriter m_file_writer;
+#if USE_PASSTHROUGH_COMPRESSION
+    streaming_compression::passthrough::Compressor m_compressor;
+#elif USE_ZSTD_COMPRESSION
+    streaming_compression::zstd::Compressor m_compressor;
+#else
+    static_assert(false, "Unsupported compression mode.");
+#endif
+};
+}  // namespace streaming_archive::writer
 
 #endif  // STREAMING_ARCHIVE_WRITER_SEGMENT_HPP

--- a/components/core/src/streaming_compression/passthrough/Compressor.cpp
+++ b/components/core/src/streaming_compression/passthrough/Compressor.cpp
@@ -2,44 +2,44 @@
 
 #include "../../Defs.h"
 
-namespace streaming_compression { namespace passthrough {
-    void Compressor::write(char const* data, size_t const data_length) {
-        if (nullptr == m_compressed_stream_file_writer) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-
-        if (0 == data_length) {
-            // Nothing needs to be done because we do not need to compress anything
-            return;
-        }
-        if (nullptr == data) {
-            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-        }
-
-        m_compressed_stream_file_writer->write(data, data_length);
+namespace streaming_compression::passthrough {
+void Compressor::write(char const* data, size_t const data_length) {
+    if (nullptr == m_compressed_stream_file_writer) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    void Compressor::flush() {
-        if (nullptr == m_compressed_stream_file_writer) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-
-        m_compressed_stream_file_writer->flush();
+    if (0 == data_length) {
+        // Nothing needs to be done because we do not need to compress anything
+        return;
+    }
+    if (nullptr == data) {
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
     }
 
-    ErrorCode Compressor::try_get_pos(size_t& pos) const {
-        if (nullptr == m_compressed_stream_file_writer) {
-            return ErrorCode_NotInit;
-        }
+    m_compressed_stream_file_writer->write(data, data_length);
+}
 
-        return m_compressed_stream_file_writer->try_get_pos(pos);
+void Compressor::flush() {
+    if (nullptr == m_compressed_stream_file_writer) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    void Compressor::close() {
-        m_compressed_stream_file_writer = nullptr;
+    m_compressed_stream_file_writer->flush();
+}
+
+ErrorCode Compressor::try_get_pos(size_t& pos) const {
+    if (nullptr == m_compressed_stream_file_writer) {
+        return ErrorCode_NotInit;
     }
 
-    void Compressor::open(FileWriter& file_writer) {
-        m_compressed_stream_file_writer = &file_writer;
-    }
-}}  // namespace streaming_compression::passthrough
+    return m_compressed_stream_file_writer->try_get_pos(pos);
+}
+
+void Compressor::close() {
+    m_compressed_stream_file_writer = nullptr;
+}
+
+void Compressor::open(FileWriter& file_writer) {
+    m_compressed_stream_file_writer = &file_writer;
+}
+}  // namespace streaming_compression::passthrough

--- a/components/core/src/streaming_compression/passthrough/Compressor.hpp
+++ b/components/core/src/streaming_compression/passthrough/Compressor.hpp
@@ -5,70 +5,70 @@
 #include "../../TraceableException.hpp"
 #include "../Compressor.hpp"
 
-namespace streaming_compression { namespace passthrough {
-    /**
-     * Compressor that passes all data through without any compression.
-     */
-    class Compressor : public ::streaming_compression::Compressor {
+namespace streaming_compression::passthrough {
+/**
+ * Compressor that passes all data through without any compression.
+ */
+class Compressor : public ::streaming_compression::Compressor {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_compression::passthrough::Compressor operation failed";
-            }
-        };
-
         // Constructors
-        Compressor()
-                : ::streaming_compression::Compressor(CompressorType::Passthrough),
-                  m_compressed_stream_file_writer(nullptr) {}
-
-        // Explicitly disable copy and move constructor/assignment
-        Compressor(Compressor const&) = delete;
-        Compressor& operator=(Compressor const&) = delete;
-
-        // Methods implementing the WriterInterface
-        /**
-         * Writes the given data to the compressor
-         * @param data
-         * @param data_length
-         */
-        void write(char const* data, size_t data_length) override;
-        /**
-         * Flushes any buffered data
-         */
-        void flush() override;
-        /**
-         * Tries to get the current position of the write head
-         * @param pos Position of the write head
-         * @return ErrorCode_NotInit if the compressor is not open
-         * @return Same as FileWriter::try_get_pos
-         */
-        ErrorCode try_get_pos(size_t& pos) const override;
-
-        // Methods implementing the Compressor interface
-        /**
-         * Closes the compressor
-         */
-        void close() override;
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /**
-         * Initializes the compressor
-         * @param file_writer
-         */
-        void open(FileWriter& file_writer);
-
-    private:
-        // Variables
-        FileWriter* m_compressed_stream_file_writer;
+        char const* what() const noexcept override {
+            return "streaming_compression::passthrough::Compressor operation failed";
+        }
     };
-}}  // namespace streaming_compression::passthrough
+
+    // Constructors
+    Compressor()
+            : ::streaming_compression::Compressor(CompressorType::Passthrough),
+              m_compressed_stream_file_writer(nullptr) {}
+
+    // Explicitly disable copy and move constructor/assignment
+    Compressor(Compressor const&) = delete;
+    Compressor& operator=(Compressor const&) = delete;
+
+    // Methods implementing the WriterInterface
+    /**
+     * Writes the given data to the compressor
+     * @param data
+     * @param data_length
+     */
+    void write(char const* data, size_t data_length) override;
+    /**
+     * Flushes any buffered data
+     */
+    void flush() override;
+    /**
+     * Tries to get the current position of the write head
+     * @param pos Position of the write head
+     * @return ErrorCode_NotInit if the compressor is not open
+     * @return Same as FileWriter::try_get_pos
+     */
+    ErrorCode try_get_pos(size_t& pos) const override;
+
+    // Methods implementing the Compressor interface
+    /**
+     * Closes the compressor
+     */
+    void close() override;
+
+    // Methods
+    /**
+     * Initializes the compressor
+     * @param file_writer
+     */
+    void open(FileWriter& file_writer);
+
+private:
+    // Variables
+    FileWriter* m_compressed_stream_file_writer;
+};
+}  // namespace streaming_compression::passthrough
 
 #endif  // STREAMING_COMPRESSION_PASSTHROUGH_COMPRESSOR_HPP

--- a/components/core/src/streaming_compression/passthrough/Decompressor.cpp
+++ b/components/core/src/streaming_compression/passthrough/Decompressor.cpp
@@ -2,128 +2,128 @@
 
 #include <cstring>
 
-namespace streaming_compression { namespace passthrough {
-    ErrorCode Decompressor::try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) {
-        if (InputType::NotInitialized == m_input_type) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-        if (nullptr == buf) {
-            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-        }
+namespace streaming_compression::passthrough {
+ErrorCode Decompressor::try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) {
+    if (InputType::NotInitialized == m_input_type) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
+    }
+    if (nullptr == buf) {
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
+    }
 
-        switch (m_input_type) {
-            case InputType::CompressedDataBuf:
-                if (m_compressed_data_buf_len == m_decompressed_stream_pos) {
-                    return ErrorCode_EndOfFile;
-                }
-
-                num_bytes_read = std::min(
-                        num_bytes_to_read,
-                        m_compressed_data_buf_len - m_decompressed_stream_pos
-                );
-                memcpy(buf, &m_compressed_data_buf[m_decompressed_stream_pos], num_bytes_read);
-                break;
-            case InputType::File: {
-                auto error_code = m_file_reader->try_read(buf, num_bytes_to_read, num_bytes_read);
-                if (ErrorCode_Success != error_code) {
-                    return error_code;
-                }
-                break;
+    switch (m_input_type) {
+        case InputType::CompressedDataBuf:
+            if (m_compressed_data_buf_len == m_decompressed_stream_pos) {
+                return ErrorCode_EndOfFile;
             }
-            default:
-                throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
-        }
-        m_decompressed_stream_pos += num_bytes_read;
 
-        return ErrorCode_Success;
-    }
-
-    ErrorCode Decompressor::try_seek_from_begin(size_t pos) {
-        if (InputType::NotInitialized == m_input_type) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-
-        switch (m_input_type) {
-            case InputType::CompressedDataBuf:
-                if (pos > m_compressed_data_buf_len) {
-                    return ErrorCode_Truncated;
-                }
-                break;
-            case InputType::File: {
-                auto error_code = m_file_reader->try_seek_from_begin(pos);
-                if (ErrorCode_Success != error_code) {
-                    return error_code;
-                }
-                break;
+            num_bytes_read = std::min(
+                    num_bytes_to_read,
+                    m_compressed_data_buf_len - m_decompressed_stream_pos
+            );
+            memcpy(buf, &m_compressed_data_buf[m_decompressed_stream_pos], num_bytes_read);
+            break;
+        case InputType::File: {
+            auto error_code = m_file_reader->try_read(buf, num_bytes_to_read, num_bytes_read);
+            if (ErrorCode_Success != error_code) {
+                return error_code;
             }
-            default:
-                throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+            break;
         }
-        m_decompressed_stream_pos = pos;
+        default:
+            throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+    }
+    m_decompressed_stream_pos += num_bytes_read;
 
-        return ErrorCode_Success;
+    return ErrorCode_Success;
+}
+
+ErrorCode Decompressor::try_seek_from_begin(size_t pos) {
+    if (InputType::NotInitialized == m_input_type) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    ErrorCode Decompressor::try_get_pos(size_t& pos) {
-        if (InputType::NotInitialized == m_input_type) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
+    switch (m_input_type) {
+        case InputType::CompressedDataBuf:
+            if (pos > m_compressed_data_buf_len) {
+                return ErrorCode_Truncated;
+            }
+            break;
+        case InputType::File: {
+            auto error_code = m_file_reader->try_seek_from_begin(pos);
+            if (ErrorCode_Success != error_code) {
+                return error_code;
+            }
+            break;
         }
+        default:
+            throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+    }
+    m_decompressed_stream_pos = pos;
 
-        pos = m_decompressed_stream_pos;
+    return ErrorCode_Success;
+}
 
-        return ErrorCode_Success;
+ErrorCode Decompressor::try_get_pos(size_t& pos) {
+    if (InputType::NotInitialized == m_input_type) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    void Decompressor::open(char const* compressed_data_buf, size_t compressed_data_buf_size) {
-        if (InputType::NotInitialized != m_input_type) {
-            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-        }
+    pos = m_decompressed_stream_pos;
 
-        m_compressed_data_buf = compressed_data_buf;
-        m_compressed_data_buf_len = compressed_data_buf_size;
-        m_decompressed_stream_pos = 0;
-        m_input_type = InputType::CompressedDataBuf;
+    return ErrorCode_Success;
+}
+
+void Decompressor::open(char const* compressed_data_buf, size_t compressed_data_buf_size) {
+    if (InputType::NotInitialized != m_input_type) {
+        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
     }
 
-    void Decompressor::open(FileReader& file_reader, size_t file_read_buffer_capacity) {
-        if (InputType::NotInitialized != m_input_type) {
-            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-        }
+    m_compressed_data_buf = compressed_data_buf;
+    m_compressed_data_buf_len = compressed_data_buf_size;
+    m_decompressed_stream_pos = 0;
+    m_input_type = InputType::CompressedDataBuf;
+}
 
-        m_file_reader = &file_reader;
-        m_decompressed_stream_pos = 0;
-        m_input_type = InputType::File;
+void Decompressor::open(FileReader& file_reader, size_t file_read_buffer_capacity) {
+    if (InputType::NotInitialized != m_input_type) {
+        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
     }
 
-    void Decompressor::close() {
-        switch (m_input_type) {
-            case InputType::CompressedDataBuf:
-                m_compressed_data_buf = nullptr;
-                m_compressed_data_buf_len = 0;
-                break;
-            case InputType::File:
-                m_file_reader = nullptr;
-                break;
-            case InputType::NotInitialized:
-                // Do nothing
-                break;
-            default:
-                throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
-        }
-        m_input_type = InputType::NotInitialized;
+    m_file_reader = &file_reader;
+    m_decompressed_stream_pos = 0;
+    m_input_type = InputType::File;
+}
+
+void Decompressor::close() {
+    switch (m_input_type) {
+        case InputType::CompressedDataBuf:
+            m_compressed_data_buf = nullptr;
+            m_compressed_data_buf_len = 0;
+            break;
+        case InputType::File:
+            m_file_reader = nullptr;
+            break;
+        case InputType::NotInitialized:
+            // Do nothing
+            break;
+        default:
+            throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
     }
+    m_input_type = InputType::NotInitialized;
+}
 
-    ErrorCode Decompressor::get_decompressed_stream_region(
-            size_t decompressed_stream_pos,
-            char* extraction_buf,
-            size_t extraction_len
-    ) {
-        auto error_code = try_seek_from_begin(decompressed_stream_pos);
-        if (ErrorCode_Success != error_code) {
-            return error_code;
-        }
-
-        error_code = try_read_exact_length(extraction_buf, extraction_len);
+ErrorCode Decompressor::get_decompressed_stream_region(
+        size_t decompressed_stream_pos,
+        char* extraction_buf,
+        size_t extraction_len
+) {
+    auto error_code = try_seek_from_begin(decompressed_stream_pos);
+    if (ErrorCode_Success != error_code) {
         return error_code;
     }
-}}  // namespace streaming_compression::passthrough
+
+    error_code = try_read_exact_length(extraction_buf, extraction_len);
+    return error_code;
+}
+}  // namespace streaming_compression::passthrough

--- a/components/core/src/streaming_compression/passthrough/Decompressor.hpp
+++ b/components/core/src/streaming_compression/passthrough/Decompressor.hpp
@@ -5,103 +5,103 @@
 #include "../../TraceableException.hpp"
 #include "../Decompressor.hpp"
 
-namespace streaming_compression { namespace passthrough {
-    /**
-     * Decompressor that passes all data through without any decompression.
-     */
-    class Decompressor : public ::streaming_compression::Decompressor {
+namespace streaming_compression::passthrough {
+/**
+ * Decompressor that passes all data through without any decompression.
+ */
+class Decompressor : public ::streaming_compression::Decompressor {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_compression::passthrough::Decompressor operation failed";
-            }
-        };
-
         // Constructors
-        Decompressor()
-                : ::streaming_compression::Decompressor(CompressorType::Passthrough),
-                  m_input_type(InputType::NotInitialized),
-                  m_compressed_data_buf(nullptr),
-                  m_compressed_data_buf_len(0),
-                  m_decompressed_stream_pos(0) {}
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
-        // Destructor
-        ~Decompressor() = default;
-
-        // Explicitly disable copy and move constructor/assignment
-        Decompressor(Decompressor const&) = delete;
-        Decompressor& operator=(Decompressor const&) = delete;
-
-        // Methods implementing the ReaderInterface
-        /**
-         * Tries to read up to a given number of bytes from the decompressor
-         * @param buf
-         * @param num_bytes_to_read The number of bytes to try and read
-         * @param num_bytes_read The actual number of bytes read
-         * @return ErrorCode_NotInit if the decompressor is not open
-         * @return ErrorCode_BadParam if buf is invalid
-         * @return ErrorCode_EndOfFile on EOF
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) override;
-        /**
-         * Tries to seek from the beginning to the given position
-         * @param pos
-         * @return ErrorCode_NotInit if the decompressor is not open
-         * @return ErrorCode_Truncated if the position is past the last byte in the file
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_seek_from_begin(size_t pos) override;
-        /**
-         * Tries to get the current position of the read head
-         * @param pos Position of the read head in the file
-         * @return ErrorCode_NotInit if the decompressor is not open
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_get_pos(size_t& pos) override;
-
-        // Methods implementing the Decompressor interface
-        void open(char const* compressed_data_buf, size_t compressed_data_buf_size) override;
-        void open(FileReader& file_reader, size_t file_read_buffer_capacity) override;
-        void close() override;
-        /**
-         * Decompresses and copies the range of uncompressed data described by
-         * decompressed_stream_pos and extraction_len into extraction_buf
-         * @param decompressed_stream_pos
-         * @param extraction_buf
-         * @param extraction_len
-         * @return Same as streaming_compression::passthrough::Decompressor::try_seek_from_begin
-         * @return Same as ReaderInterface::try_read_exact_length
-         */
-        ErrorCode get_decompressed_stream_region(
-                size_t decompressed_stream_pos,
-                char* extraction_buf,
-                size_t extraction_len
-        ) override;
-
-    private:
-        enum class InputType {
-            NotInitialized,
-            CompressedDataBuf,
-            File
-        };
-
-        // Variables
-        InputType m_input_type;
-
-        FileReader* m_file_reader;
-        char const* m_compressed_data_buf;
-        size_t m_compressed_data_buf_len;
-
-        size_t m_decompressed_stream_pos;
+        // Methods
+        char const* what() const noexcept override {
+            return "streaming_compression::passthrough::Decompressor operation failed";
+        }
     };
-}}  // namespace streaming_compression::passthrough
+
+    // Constructors
+    Decompressor()
+            : ::streaming_compression::Decompressor(CompressorType::Passthrough),
+              m_input_type(InputType::NotInitialized),
+              m_compressed_data_buf(nullptr),
+              m_compressed_data_buf_len(0),
+              m_decompressed_stream_pos(0) {}
+
+    // Destructor
+    ~Decompressor() = default;
+
+    // Explicitly disable copy and move constructor/assignment
+    Decompressor(Decompressor const&) = delete;
+    Decompressor& operator=(Decompressor const&) = delete;
+
+    // Methods implementing the ReaderInterface
+    /**
+     * Tries to read up to a given number of bytes from the decompressor
+     * @param buf
+     * @param num_bytes_to_read The number of bytes to try and read
+     * @param num_bytes_read The actual number of bytes read
+     * @return ErrorCode_NotInit if the decompressor is not open
+     * @return ErrorCode_BadParam if buf is invalid
+     * @return ErrorCode_EndOfFile on EOF
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) override;
+    /**
+     * Tries to seek from the beginning to the given position
+     * @param pos
+     * @return ErrorCode_NotInit if the decompressor is not open
+     * @return ErrorCode_Truncated if the position is past the last byte in the file
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode try_seek_from_begin(size_t pos) override;
+    /**
+     * Tries to get the current position of the read head
+     * @param pos Position of the read head in the file
+     * @return ErrorCode_NotInit if the decompressor is not open
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode try_get_pos(size_t& pos) override;
+
+    // Methods implementing the Decompressor interface
+    void open(char const* compressed_data_buf, size_t compressed_data_buf_size) override;
+    void open(FileReader& file_reader, size_t file_read_buffer_capacity) override;
+    void close() override;
+    /**
+     * Decompresses and copies the range of uncompressed data described by
+     * decompressed_stream_pos and extraction_len into extraction_buf
+     * @param decompressed_stream_pos
+     * @param extraction_buf
+     * @param extraction_len
+     * @return Same as streaming_compression::passthrough::Decompressor::try_seek_from_begin
+     * @return Same as ReaderInterface::try_read_exact_length
+     */
+    ErrorCode get_decompressed_stream_region(
+            size_t decompressed_stream_pos,
+            char* extraction_buf,
+            size_t extraction_len
+    ) override;
+
+private:
+    enum class InputType {
+        NotInitialized,
+        CompressedDataBuf,
+        File
+    };
+
+    // Variables
+    InputType m_input_type;
+
+    FileReader* m_file_reader;
+    char const* m_compressed_data_buf;
+    size_t m_compressed_data_buf_len;
+
+    size_t m_decompressed_stream_pos;
+};
+}  // namespace streaming_compression::passthrough
 
 #endif  // STREAMING_COMPRESSION_PASSTHROUGH_DECOMPRESSOR_HPP

--- a/components/core/src/streaming_compression/zstd/Compressor.cpp
+++ b/components/core/src/streaming_compression/zstd/Compressor.cpp
@@ -3,156 +3,156 @@
 #include "../../Defs.h"
 #include "../../spdlog_with_specializations.hpp"
 
-namespace streaming_compression { namespace zstd {
-    Compressor::Compressor()
-            : ::streaming_compression::Compressor(CompressorType::ZSTD),
-              m_compression_stream_contains_data(false),
-              m_compressed_stream_file_writer(nullptr) {
-        m_compression_stream = ZSTD_createCStream();
-        if (nullptr == m_compression_stream) {
-            SPDLOG_ERROR("streaming_compression::zstd::Compressor: ZSTD_createCStream() error");
-            throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
-        }
+namespace streaming_compression::zstd {
+Compressor::Compressor()
+        : ::streaming_compression::Compressor(CompressorType::ZSTD),
+          m_compression_stream_contains_data(false),
+          m_compressed_stream_file_writer(nullptr) {
+    m_compression_stream = ZSTD_createCStream();
+    if (nullptr == m_compression_stream) {
+        SPDLOG_ERROR("streaming_compression::zstd::Compressor: ZSTD_createCStream() error");
+        throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
+    }
+}
+
+Compressor::~Compressor() {
+    ZSTD_freeCStream(m_compression_stream);
+}
+
+void Compressor::open(FileWriter& file_writer, int const compression_level) {
+    if (nullptr != m_compressed_stream_file_writer) {
+        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
     }
 
-    Compressor::~Compressor() {
-        ZSTD_freeCStream(m_compression_stream);
-    }
+    // Setup compressed stream parameters
+    size_t compressed_stream_block_size = ZSTD_CStreamOutSize();
+    m_compressed_stream_block_buffer = std::make_unique<char[]>(compressed_stream_block_size);
+    m_compressed_stream_block.dst = m_compressed_stream_block_buffer.get();
+    m_compressed_stream_block.size = compressed_stream_block_size;
 
-    void Compressor::open(FileWriter& file_writer, int const compression_level) {
-        if (nullptr != m_compressed_stream_file_writer) {
-            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-        }
-
-        // Setup compressed stream parameters
-        size_t compressed_stream_block_size = ZSTD_CStreamOutSize();
-        m_compressed_stream_block_buffer = std::make_unique<char[]>(compressed_stream_block_size);
-        m_compressed_stream_block.dst = m_compressed_stream_block_buffer.get();
-        m_compressed_stream_block.size = compressed_stream_block_size;
-
-        // Setup compression stream
-        auto init_result = ZSTD_initCStream(m_compression_stream, compression_level);
-        if (ZSTD_isError(init_result)) {
-            SPDLOG_ERROR(
-                    "streaming_compression::zstd::Compressor: ZSTD_initCStream() error: {}",
-                    ZSTD_getErrorName(init_result)
-            );
-            throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
-        }
-
-        m_compressed_stream_file_writer = &file_writer;
-
-        m_uncompressed_stream_pos = 0;
-    }
-
-    void Compressor::close() {
-        if (nullptr == m_compressed_stream_file_writer) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-
-        flush();
-        m_compressed_stream_file_writer = nullptr;
-    }
-
-    void Compressor::write(char const* data, size_t data_length) {
-        if (nullptr == m_compressed_stream_file_writer) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-
-        if (0 == data_length) {
-            // Nothing needs to be done because we do not need to compress anything
-            return;
-        }
-        if (nullptr == data) {
-            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-        }
-
-        ZSTD_inBuffer uncompressed_stream_block = {data, data_length, 0};
-        while (uncompressed_stream_block.pos < uncompressed_stream_block.size) {
-            m_compressed_stream_block.pos = 0;
-            auto error = ZSTD_compressStream(
-                    m_compression_stream,
-                    &m_compressed_stream_block,
-                    &uncompressed_stream_block
-            );
-            if (ZSTD_isError(error)) {
-                SPDLOG_ERROR(
-                        "streaming_compression::zstd::Compressor: ZSTD_compressStream() error: {}",
-                        ZSTD_getErrorName(error)
-                );
-                throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
-            }
-            if (m_compressed_stream_block.pos) {
-                // Write to disk only if there is data in the compressed stream
-                // block buffer
-                m_compressed_stream_file_writer->write(
-                        reinterpret_cast<char const*>(m_compressed_stream_block.dst),
-                        m_compressed_stream_block.pos
-                );
-            }
-        }
-
-        m_compression_stream_contains_data = true;
-        m_uncompressed_stream_pos += data_length;
-    }
-
-    void Compressor::flush() {
-        if (false == m_compression_stream_contains_data) {
-            return;
-        }
-
-        m_compressed_stream_block.pos = 0;
-        auto end_stream_result = ZSTD_endStream(m_compression_stream, &m_compressed_stream_block);
-        if (end_stream_result) {
-            // Note: Output buffer is large enough that it is guaranteed to have enough room to be
-            // able to flush the entire buffer, so this can only be an error
-            SPDLOG_ERROR(
-                    "streaming_compression::zstd::Compressor: ZSTD_endStream() error: {}",
-                    ZSTD_getErrorName(end_stream_result)
-            );
-            throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
-        }
-        m_compressed_stream_file_writer->write(
-                reinterpret_cast<char const*>(m_compressed_stream_block.dst),
-                m_compressed_stream_block.pos
+    // Setup compression stream
+    auto init_result = ZSTD_initCStream(m_compression_stream, compression_level);
+    if (ZSTD_isError(init_result)) {
+        SPDLOG_ERROR(
+                "streaming_compression::zstd::Compressor: ZSTD_initCStream() error: {}",
+                ZSTD_getErrorName(init_result)
         );
-
-        m_compression_stream_contains_data = false;
+        throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
     }
 
-    ErrorCode Compressor::try_get_pos(size_t& pos) const {
-        if (nullptr == m_compressed_stream_file_writer) {
-            return ErrorCode_NotInit;
-        }
+    m_compressed_stream_file_writer = &file_writer;
 
-        pos = m_uncompressed_stream_pos;
-        return ErrorCode_Success;
+    m_uncompressed_stream_pos = 0;
+}
+
+void Compressor::close() {
+    if (nullptr == m_compressed_stream_file_writer) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    void Compressor::flush_without_ending_frame() {
-        if (false == m_compression_stream_contains_data) {
-            return;
-        }
+    flush();
+    m_compressed_stream_file_writer = nullptr;
+}
 
-        while (true) {
-            m_compressed_stream_block.pos = 0;
-            auto result = ZSTD_flushStream(m_compression_stream, &m_compressed_stream_block);
-            if (ZSTD_isError(result)) {
-                SPDLOG_ERROR(
-                        "streaming_compression::zstd::Compressor: ZSTD_compressStream2() error: {}",
-                        ZSTD_getErrorName(result)
-                );
-                throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
-            }
-            if (m_compressed_stream_block.pos) {
-                m_compressed_stream_file_writer->write(
-                        reinterpret_cast<char const*>(m_compressed_stream_block.dst),
-                        m_compressed_stream_block.pos
-                );
-            }
-            if (0 == result) {
-                break;
-            }
+void Compressor::write(char const* data, size_t data_length) {
+    if (nullptr == m_compressed_stream_file_writer) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
+    }
+
+    if (0 == data_length) {
+        // Nothing needs to be done because we do not need to compress anything
+        return;
+    }
+    if (nullptr == data) {
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
+    }
+
+    ZSTD_inBuffer uncompressed_stream_block = {data, data_length, 0};
+    while (uncompressed_stream_block.pos < uncompressed_stream_block.size) {
+        m_compressed_stream_block.pos = 0;
+        auto error = ZSTD_compressStream(
+                m_compression_stream,
+                &m_compressed_stream_block,
+                &uncompressed_stream_block
+        );
+        if (ZSTD_isError(error)) {
+            SPDLOG_ERROR(
+                    "streaming_compression::zstd::Compressor: ZSTD_compressStream() error: {}",
+                    ZSTD_getErrorName(error)
+            );
+            throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
+        }
+        if (m_compressed_stream_block.pos) {
+            // Write to disk only if there is data in the compressed stream
+            // block buffer
+            m_compressed_stream_file_writer->write(
+                    reinterpret_cast<char const*>(m_compressed_stream_block.dst),
+                    m_compressed_stream_block.pos
+            );
         }
     }
-}}  // namespace streaming_compression::zstd
+
+    m_compression_stream_contains_data = true;
+    m_uncompressed_stream_pos += data_length;
+}
+
+void Compressor::flush() {
+    if (false == m_compression_stream_contains_data) {
+        return;
+    }
+
+    m_compressed_stream_block.pos = 0;
+    auto end_stream_result = ZSTD_endStream(m_compression_stream, &m_compressed_stream_block);
+    if (end_stream_result) {
+        // Note: Output buffer is large enough that it is guaranteed to have enough room to be
+        // able to flush the entire buffer, so this can only be an error
+        SPDLOG_ERROR(
+                "streaming_compression::zstd::Compressor: ZSTD_endStream() error: {}",
+                ZSTD_getErrorName(end_stream_result)
+        );
+        throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
+    }
+    m_compressed_stream_file_writer->write(
+            reinterpret_cast<char const*>(m_compressed_stream_block.dst),
+            m_compressed_stream_block.pos
+    );
+
+    m_compression_stream_contains_data = false;
+}
+
+ErrorCode Compressor::try_get_pos(size_t& pos) const {
+    if (nullptr == m_compressed_stream_file_writer) {
+        return ErrorCode_NotInit;
+    }
+
+    pos = m_uncompressed_stream_pos;
+    return ErrorCode_Success;
+}
+
+void Compressor::flush_without_ending_frame() {
+    if (false == m_compression_stream_contains_data) {
+        return;
+    }
+
+    while (true) {
+        m_compressed_stream_block.pos = 0;
+        auto result = ZSTD_flushStream(m_compression_stream, &m_compressed_stream_block);
+        if (ZSTD_isError(result)) {
+            SPDLOG_ERROR(
+                    "streaming_compression::zstd::Compressor: ZSTD_compressStream2() error: {}",
+                    ZSTD_getErrorName(result)
+            );
+            throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
+        }
+        if (m_compressed_stream_block.pos) {
+            m_compressed_stream_file_writer->write(
+                    reinterpret_cast<char const*>(m_compressed_stream_block.dst),
+                    m_compressed_stream_block.pos
+            );
+        }
+        if (0 == result) {
+            break;
+        }
+    }
+}
+}  // namespace streaming_compression::zstd

--- a/components/core/src/streaming_compression/zstd/Compressor.hpp
+++ b/components/core/src/streaming_compression/zstd/Compressor.hpp
@@ -12,84 +12,84 @@
 #include "../Compressor.hpp"
 #include "Constants.hpp"
 
-namespace streaming_compression { namespace zstd {
-    class Compressor : public ::streaming_compression::Compressor {
+namespace streaming_compression::zstd {
+class Compressor : public ::streaming_compression::Compressor {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_compression::zstd::Compressor operation failed";
-            }
-        };
-
-        // Constructor
-        Compressor();
-
-        // Destructor
-        ~Compressor();
-
-        // Explicitly disable copy and move constructor/assignment
-        Compressor(Compressor const&) = delete;
-        Compressor& operator=(Compressor const&) = delete;
-
-        // Methods implementing the WriterInterface
-        /**
-         * Writes the given data to the compressor
-         * @param data
-         * @param data_length
-         */
-        void write(char const* data, size_t data_length) override;
-        /**
-         * Writes any internally buffered data to file and ends the current frame
-         */
-        void flush() override;
-
-        /**
-         * Tries to get the current position of the write head
-         * @param pos Position of the write head
-         * @return ErrorCode_NotInit if the compressor is not open
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_get_pos(size_t& pos) const override;
-
-        // Methods implementing the Compressor interface
-        /**
-         * Closes the compressor
-         */
-        void close() override;
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /**
-         * Initialize streaming compressor
-         * @param file_writer
-         * @param compression_level
-         */
-        void open(FileWriter& file_writer, int compression_level = cDefaultCompressionLevel);
-
-        /**
-         * Flushes the stream without ending the current frame
-         */
-        void flush_without_ending_frame();
-
-    private:
-        // Variables
-        FileWriter* m_compressed_stream_file_writer;
-
-        // Compressed stream variables
-        ZSTD_CStream* m_compression_stream;
-        bool m_compression_stream_contains_data;
-
-        ZSTD_outBuffer m_compressed_stream_block;
-        std::unique_ptr<char[]> m_compressed_stream_block_buffer;
-
-        size_t m_uncompressed_stream_pos;
+        char const* what() const noexcept override {
+            return "streaming_compression::zstd::Compressor operation failed";
+        }
     };
-}}  // namespace streaming_compression::zstd
+
+    // Constructor
+    Compressor();
+
+    // Destructor
+    ~Compressor();
+
+    // Explicitly disable copy and move constructor/assignment
+    Compressor(Compressor const&) = delete;
+    Compressor& operator=(Compressor const&) = delete;
+
+    // Methods implementing the WriterInterface
+    /**
+     * Writes the given data to the compressor
+     * @param data
+     * @param data_length
+     */
+    void write(char const* data, size_t data_length) override;
+    /**
+     * Writes any internally buffered data to file and ends the current frame
+     */
+    void flush() override;
+
+    /**
+     * Tries to get the current position of the write head
+     * @param pos Position of the write head
+     * @return ErrorCode_NotInit if the compressor is not open
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode try_get_pos(size_t& pos) const override;
+
+    // Methods implementing the Compressor interface
+    /**
+     * Closes the compressor
+     */
+    void close() override;
+
+    // Methods
+    /**
+     * Initialize streaming compressor
+     * @param file_writer
+     * @param compression_level
+     */
+    void open(FileWriter& file_writer, int compression_level = cDefaultCompressionLevel);
+
+    /**
+     * Flushes the stream without ending the current frame
+     */
+    void flush_without_ending_frame();
+
+private:
+    // Variables
+    FileWriter* m_compressed_stream_file_writer;
+
+    // Compressed stream variables
+    ZSTD_CStream* m_compression_stream;
+    bool m_compression_stream_contains_data;
+
+    ZSTD_outBuffer m_compressed_stream_block;
+    std::unique_ptr<char[]> m_compressed_stream_block_buffer;
+
+    size_t m_uncompressed_stream_pos;
+};
+}  // namespace streaming_compression::zstd
 
 #endif  // STREAMING_COMPRESSION_ZSTD_COMPRESSOR_HPP

--- a/components/core/src/streaming_compression/zstd/Constants.hpp
+++ b/components/core/src/streaming_compression/zstd/Constants.hpp
@@ -4,8 +4,8 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace streaming_compression { namespace zstd {
-    constexpr int cDefaultCompressionLevel = 3;
-}}  // namespace streaming_compression::zstd
+namespace streaming_compression::zstd {
+constexpr int cDefaultCompressionLevel = 3;
+}  // namespace streaming_compression::zstd
 
 #endif  // STREAMING_COMPRESSION_ZSTD_CONSTANTS_HPP

--- a/components/core/src/streaming_compression/zstd/Decompressor.cpp
+++ b/components/core/src/streaming_compression/zstd/Decompressor.cpp
@@ -7,273 +7,272 @@
 #include "../../Defs.h"
 #include "../../spdlog_with_specializations.hpp"
 
-namespace streaming_compression { namespace zstd {
-    Decompressor::Decompressor()
-            : ::streaming_compression::Decompressor(CompressorType::ZSTD),
-              m_input_type(InputType::NotInitialized),
-              m_decompression_stream(nullptr),
-              m_file_reader(nullptr),
-              m_file_reader_initial_pos(0),
-              m_file_read_buffer_length(0),
-              m_file_read_buffer_capacity(0),
-              m_decompressed_stream_pos(0),
-              m_unused_decompressed_stream_block_size(0) {
-        m_decompression_stream = ZSTD_createDStream();
-        if (nullptr == m_decompression_stream) {
-            SPDLOG_ERROR("streaming_compression::zstd::Decompressor: ZSTD_createDStream() error");
-            throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
-        }
-
-        // Create block to hold unused decompressed data
-        m_unused_decompressed_stream_block_size = ZSTD_DStreamOutSize();
-        m_unused_decompressed_stream_block_buffer
-                = std::make_unique<char[]>(m_unused_decompressed_stream_block_size);
+namespace streaming_compression::zstd {
+Decompressor::Decompressor()
+        : ::streaming_compression::Decompressor(CompressorType::ZSTD),
+          m_input_type(InputType::NotInitialized),
+          m_decompression_stream(nullptr),
+          m_file_reader(nullptr),
+          m_file_reader_initial_pos(0),
+          m_file_read_buffer_length(0),
+          m_file_read_buffer_capacity(0),
+          m_decompressed_stream_pos(0),
+          m_unused_decompressed_stream_block_size(0) {
+    m_decompression_stream = ZSTD_createDStream();
+    if (nullptr == m_decompression_stream) {
+        SPDLOG_ERROR("streaming_compression::zstd::Decompressor: ZSTD_createDStream() error");
+        throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
     }
 
-    Decompressor::~Decompressor() {
-        ZSTD_freeDStream(m_decompression_stream);
+    // Create block to hold unused decompressed data
+    m_unused_decompressed_stream_block_size = ZSTD_DStreamOutSize();
+    m_unused_decompressed_stream_block_buffer
+            = std::make_unique<char[]>(m_unused_decompressed_stream_block_size);
+}
+
+Decompressor::~Decompressor() {
+    ZSTD_freeDStream(m_decompression_stream);
+}
+
+ErrorCode Decompressor::try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) {
+    if (InputType::NotInitialized == m_input_type) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
+    }
+    if (nullptr == buf) {
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
     }
 
-    ErrorCode Decompressor::try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) {
-        if (InputType::NotInitialized == m_input_type) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-        if (nullptr == buf) {
-            throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-        }
+    num_bytes_read = 0;
 
-        num_bytes_read = 0;
-
-        ZSTD_outBuffer decompressed_stream_block = {buf, num_bytes_to_read, 0};
-        while (decompressed_stream_block.pos < num_bytes_to_read) {
-            // Check if there's data that can be decompressed
-            if (m_compressed_stream_block.pos == m_compressed_stream_block.size) {
-                switch (m_input_type) {
-                    case InputType::CompressedDataBuf:
-                        // Fall through
-                    case InputType::MemoryMappedCompressedFile:
-                        num_bytes_read = decompressed_stream_block.pos;
-                        if (0 == decompressed_stream_block.pos) {
-                            return ErrorCode_EndOfFile;
-                        } else {
-                            return ErrorCode_Success;
-                        }
-                        break;
-                    case InputType::File: {
-                        auto error_code = m_file_reader->try_read(
-                                reinterpret_cast<char*>(m_file_read_buffer.get()),
-                                m_file_read_buffer_capacity,
-                                m_file_read_buffer_length
-                        );
-                        if (ErrorCode_Success != error_code) {
-                            if (ErrorCode_EndOfFile == error_code) {
-                                num_bytes_read = decompressed_stream_block.pos;
-                                if (0 == decompressed_stream_block.pos) {
-                                    return ErrorCode_EndOfFile;
-                                } else {
-                                    return ErrorCode_Success;
-                                }
-                            } else {
-                                return error_code;
-                            }
-                        }
-
-                        m_compressed_stream_block.pos = 0;
-                        m_compressed_stream_block.size = m_file_read_buffer_length;
-                        break;
+    ZSTD_outBuffer decompressed_stream_block = {buf, num_bytes_to_read, 0};
+    while (decompressed_stream_block.pos < num_bytes_to_read) {
+        // Check if there's data that can be decompressed
+        if (m_compressed_stream_block.pos == m_compressed_stream_block.size) {
+            switch (m_input_type) {
+                case InputType::CompressedDataBuf:
+                    // Fall through
+                case InputType::MemoryMappedCompressedFile:
+                    num_bytes_read = decompressed_stream_block.pos;
+                    if (0 == decompressed_stream_block.pos) {
+                        return ErrorCode_EndOfFile;
+                    } else {
+                        return ErrorCode_Success;
                     }
-                    default:
-                        throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+                    break;
+                case InputType::File: {
+                    auto error_code = m_file_reader->try_read(
+                            reinterpret_cast<char*>(m_file_read_buffer.get()),
+                            m_file_read_buffer_capacity,
+                            m_file_read_buffer_length
+                    );
+                    if (ErrorCode_Success != error_code) {
+                        if (ErrorCode_EndOfFile == error_code) {
+                            num_bytes_read = decompressed_stream_block.pos;
+                            if (0 == decompressed_stream_block.pos) {
+                                return ErrorCode_EndOfFile;
+                            } else {
+                                return ErrorCode_Success;
+                            }
+                        } else {
+                            return error_code;
+                        }
+                    }
+
+                    m_compressed_stream_block.pos = 0;
+                    m_compressed_stream_block.size = m_file_read_buffer_length;
+                    break;
                 }
-            }
-
-            // Decompress
-            size_t error = ZSTD_decompressStream(
-                    m_decompression_stream,
-                    &decompressed_stream_block,
-                    &m_compressed_stream_block
-            );
-            if (ZSTD_isError(error)) {
-                SPDLOG_ERROR(
-                        "streaming_compression::zstd::Decompressor: ZSTD_decompressStream() error: "
-                        "{}",
-                        ZSTD_getErrorName(error)
-                );
-                return ErrorCode_Failure;
+                default:
+                    throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
             }
         }
 
-        // Update decompression stream position
-        m_decompressed_stream_pos += decompressed_stream_block.pos;
-
-        num_bytes_read = decompressed_stream_block.pos;
-        return ErrorCode_Success;
-    }
-
-    ErrorCode Decompressor::try_seek_from_begin(size_t pos) {
-        if (InputType::NotInitialized == m_input_type) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-
-        // Check if we've already decompressed passed the desired position
-        if (m_decompressed_stream_pos > pos) {
-            // ZStd has no way for us to seek back to the desired position, so just reset the stream
-            // to the beginning
-            reset_stream();
-        }
-
-        // We need to fast forward the decompression stream to decompressed_stream_pos
-        ErrorCode error;
-        while (m_decompressed_stream_pos < pos) {
-            size_t num_bytes_to_decompress = std::min(
-                    m_unused_decompressed_stream_block_size,
-                    pos - m_decompressed_stream_pos
-            );
-            error = try_read_exact_length(
-                    m_unused_decompressed_stream_block_buffer.get(),
-                    num_bytes_to_decompress
-            );
-            if (ErrorCode_Success != error) {
-                return error;
-            }
-        }
-
-        return ErrorCode_Success;
-    }
-
-    ErrorCode Decompressor::try_get_pos(size_t& pos) {
-        if (InputType::NotInitialized == m_input_type) {
-            throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
-        }
-
-        pos = m_decompressed_stream_pos;
-        return ErrorCode_Success;
-    }
-
-    void Decompressor::open(char const* compressed_data_buf, size_t compressed_data_buf_size) {
-        if (InputType::NotInitialized != m_input_type) {
-            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-        }
-        m_input_type = InputType::CompressedDataBuf;
-
-        m_compressed_stream_block = {compressed_data_buf, compressed_data_buf_size, 0};
-
-        reset_stream();
-    }
-
-    void Decompressor::open(FileReader& file_reader, size_t file_read_buffer_capacity) {
-        if (InputType::NotInitialized != m_input_type) {
-            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-        }
-        m_input_type = InputType::File;
-
-        m_file_reader = &file_reader;
-        m_file_reader_initial_pos = m_file_reader->get_pos();
-
-        m_file_read_buffer_capacity = file_read_buffer_capacity;
-        m_file_read_buffer = std::make_unique<char[]>(m_file_read_buffer_capacity);
-        m_file_read_buffer_length = 0;
-
-        m_compressed_stream_block = {m_file_read_buffer.get(), m_file_read_buffer_length, 0};
-
-        reset_stream();
-    }
-
-    void Decompressor::close() {
-        switch (m_input_type) {
-            case InputType::MemoryMappedCompressedFile:
-                if (m_memory_mapped_compressed_file.is_open()) {
-                    // An existing file is memory mapped by the decompressor
-                    m_memory_mapped_compressed_file.close();
-                }
-                break;
-            case InputType::File:
-                m_file_read_buffer.reset();
-                m_file_read_buffer_capacity = 0;
-                m_file_read_buffer_length = 0;
-                m_file_reader = nullptr;
-                break;
-            case InputType::CompressedDataBuf:
-            case InputType::NotInitialized:
-                // Do nothing
-                break;
-            default:
-                throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
-        }
-        m_input_type = InputType::NotInitialized;
-    }
-
-    ErrorCode Decompressor::open(std::string const& compressed_file_path) {
-        if (InputType::NotInitialized != m_input_type) {
-            throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-        }
-        m_input_type = InputType::MemoryMappedCompressedFile;
-
-        // Create memory mapping for compressed_file_path, use boost read only
-        // memory mapped file
-        boost::system::error_code boost_error_code;
-        size_t compressed_file_size
-                = boost::filesystem::file_size(compressed_file_path, boost_error_code);
-        if (boost_error_code) {
+        // Decompress
+        size_t error = ZSTD_decompressStream(
+                m_decompression_stream,
+                &decompressed_stream_block,
+                &m_compressed_stream_block
+        );
+        if (ZSTD_isError(error)) {
             SPDLOG_ERROR(
-                    "streaming_compression::zstd::Decompressor: Unable to obtain file size for "
-                    "'{}' - {}.",
-                    compressed_file_path.c_str(),
-                    boost_error_code.message().c_str()
+                    "streaming_compression::zstd::Decompressor: ZSTD_decompressStream() error: "
+                    "{}",
+                    ZSTD_getErrorName(error)
             );
             return ErrorCode_Failure;
         }
-
-        boost::iostreams::mapped_file_params memory_map_params;
-        memory_map_params.path = compressed_file_path;
-        memory_map_params.flags = boost::iostreams::mapped_file::readonly;
-        memory_map_params.length = compressed_file_size;
-        // Try to map it to the same memory location as previous memory mapped
-        // file
-        memory_map_params.hint = m_memory_mapped_compressed_file.data();
-        m_memory_mapped_compressed_file.open(memory_map_params);
-        if (!m_memory_mapped_compressed_file.is_open()) {
-            SPDLOG_ERROR(
-                    "streaming_compression::zstd::Decompressor: Unable to memory map the "
-                    "compressed file with path: {}",
-                    compressed_file_path.c_str()
-            );
-            return ErrorCode_Failure;
-        }
-
-        // Configure input stream
-        m_compressed_stream_block
-                = {m_memory_mapped_compressed_file.data(), compressed_file_size, 0};
-
-        reset_stream();
-
-        return ErrorCode_Success;
     }
 
-    ErrorCode Decompressor::get_decompressed_stream_region(
-            size_t decompressed_stream_pos,
-            char* extraction_buf,
-            size_t extraction_len
-    ) {
-        auto error_code = try_seek_from_begin(decompressed_stream_pos);
-        if (ErrorCode_Success != error_code) {
-            return error_code;
-        }
+    // Update decompression stream position
+    m_decompressed_stream_pos += decompressed_stream_block.pos;
 
-        error_code = try_read_exact_length(extraction_buf, extraction_len);
+    num_bytes_read = decompressed_stream_block.pos;
+    return ErrorCode_Success;
+}
+
+ErrorCode Decompressor::try_seek_from_begin(size_t pos) {
+    if (InputType::NotInitialized == m_input_type) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
+    }
+
+    // Check if we've already decompressed passed the desired position
+    if (m_decompressed_stream_pos > pos) {
+        // ZStd has no way for us to seek back to the desired position, so just reset the stream
+        // to the beginning
+        reset_stream();
+    }
+
+    // We need to fast forward the decompression stream to decompressed_stream_pos
+    ErrorCode error;
+    while (m_decompressed_stream_pos < pos) {
+        size_t num_bytes_to_decompress = std::min(
+                m_unused_decompressed_stream_block_size,
+                pos - m_decompressed_stream_pos
+        );
+        error = try_read_exact_length(
+                m_unused_decompressed_stream_block_buffer.get(),
+                num_bytes_to_decompress
+        );
+        if (ErrorCode_Success != error) {
+            return error;
+        }
+    }
+
+    return ErrorCode_Success;
+}
+
+ErrorCode Decompressor::try_get_pos(size_t& pos) {
+    if (InputType::NotInitialized == m_input_type) {
+        throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
+    }
+
+    pos = m_decompressed_stream_pos;
+    return ErrorCode_Success;
+}
+
+void Decompressor::open(char const* compressed_data_buf, size_t compressed_data_buf_size) {
+    if (InputType::NotInitialized != m_input_type) {
+        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
+    }
+    m_input_type = InputType::CompressedDataBuf;
+
+    m_compressed_stream_block = {compressed_data_buf, compressed_data_buf_size, 0};
+
+    reset_stream();
+}
+
+void Decompressor::open(FileReader& file_reader, size_t file_read_buffer_capacity) {
+    if (InputType::NotInitialized != m_input_type) {
+        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
+    }
+    m_input_type = InputType::File;
+
+    m_file_reader = &file_reader;
+    m_file_reader_initial_pos = m_file_reader->get_pos();
+
+    m_file_read_buffer_capacity = file_read_buffer_capacity;
+    m_file_read_buffer = std::make_unique<char[]>(m_file_read_buffer_capacity);
+    m_file_read_buffer_length = 0;
+
+    m_compressed_stream_block = {m_file_read_buffer.get(), m_file_read_buffer_length, 0};
+
+    reset_stream();
+}
+
+void Decompressor::close() {
+    switch (m_input_type) {
+        case InputType::MemoryMappedCompressedFile:
+            if (m_memory_mapped_compressed_file.is_open()) {
+                // An existing file is memory mapped by the decompressor
+                m_memory_mapped_compressed_file.close();
+            }
+            break;
+        case InputType::File:
+            m_file_read_buffer.reset();
+            m_file_read_buffer_capacity = 0;
+            m_file_read_buffer_length = 0;
+            m_file_reader = nullptr;
+            break;
+        case InputType::CompressedDataBuf:
+        case InputType::NotInitialized:
+            // Do nothing
+            break;
+        default:
+            throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+    }
+    m_input_type = InputType::NotInitialized;
+}
+
+ErrorCode Decompressor::open(std::string const& compressed_file_path) {
+    if (InputType::NotInitialized != m_input_type) {
+        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
+    }
+    m_input_type = InputType::MemoryMappedCompressedFile;
+
+    // Create memory mapping for compressed_file_path, use boost read only
+    // memory mapped file
+    boost::system::error_code boost_error_code;
+    size_t compressed_file_size
+            = boost::filesystem::file_size(compressed_file_path, boost_error_code);
+    if (boost_error_code) {
+        SPDLOG_ERROR(
+                "streaming_compression::zstd::Decompressor: Unable to obtain file size for "
+                "'{}' - {}.",
+                compressed_file_path.c_str(),
+                boost_error_code.message().c_str()
+        );
+        return ErrorCode_Failure;
+    }
+
+    boost::iostreams::mapped_file_params memory_map_params;
+    memory_map_params.path = compressed_file_path;
+    memory_map_params.flags = boost::iostreams::mapped_file::readonly;
+    memory_map_params.length = compressed_file_size;
+    // Try to map it to the same memory location as previous memory mapped
+    // file
+    memory_map_params.hint = m_memory_mapped_compressed_file.data();
+    m_memory_mapped_compressed_file.open(memory_map_params);
+    if (!m_memory_mapped_compressed_file.is_open()) {
+        SPDLOG_ERROR(
+                "streaming_compression::zstd::Decompressor: Unable to memory map the "
+                "compressed file with path: {}",
+                compressed_file_path.c_str()
+        );
+        return ErrorCode_Failure;
+    }
+
+    // Configure input stream
+    m_compressed_stream_block = {m_memory_mapped_compressed_file.data(), compressed_file_size, 0};
+
+    reset_stream();
+
+    return ErrorCode_Success;
+}
+
+ErrorCode Decompressor::get_decompressed_stream_region(
+        size_t decompressed_stream_pos,
+        char* extraction_buf,
+        size_t extraction_len
+) {
+    auto error_code = try_seek_from_begin(decompressed_stream_pos);
+    if (ErrorCode_Success != error_code) {
         return error_code;
     }
 
-    void Decompressor::reset_stream() {
-        if (InputType::File == m_input_type) {
-            m_file_reader->seek_from_begin(m_file_reader_initial_pos);
-            m_file_read_buffer_length = 0;
-            m_compressed_stream_block.size = m_file_read_buffer_length;
-        }
+    error_code = try_read_exact_length(extraction_buf, extraction_len);
+    return error_code;
+}
 
-        ZSTD_initDStream(m_decompression_stream);
-        m_decompressed_stream_pos = 0;
-
-        m_compressed_stream_block.pos = 0;
+void Decompressor::reset_stream() {
+    if (InputType::File == m_input_type) {
+        m_file_reader->seek_from_begin(m_file_reader_initial_pos);
+        m_file_read_buffer_length = 0;
+        m_compressed_stream_block.size = m_file_read_buffer_length;
     }
-}}  // namespace streaming_compression::zstd
+
+    ZSTD_initDStream(m_decompression_stream);
+    m_decompressed_stream_pos = 0;
+
+    m_compressed_stream_block.pos = 0;
+}
+}  // namespace streaming_compression::zstd

--- a/components/core/src/streaming_compression/zstd/Decompressor.hpp
+++ b/components/core/src/streaming_compression/zstd/Decompressor.hpp
@@ -11,132 +11,132 @@
 #include "../../TraceableException.hpp"
 #include "../Decompressor.hpp"
 
-namespace streaming_compression { namespace zstd {
-    class Decompressor : public ::streaming_compression::Decompressor {
+namespace streaming_compression::zstd {
+class Decompressor : public ::streaming_compression::Decompressor {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
     public:
-        // Types
-        class OperationFailed : public TraceableException {
-        public:
-            // Constructors
-            OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                    : TraceableException(error_code, filename, line_number) {}
-
-            // Methods
-            char const* what() const noexcept override {
-                return "streaming_compression::zstd::Decompressor operation failed";
-            }
-        };
-
-        // Constructor
-        /**
-         * @throw Decompressor::OperationFailed if zstd decompressor stream
-         * cannot be initialized
-         */
-        Decompressor();
-
-        // Destructor
-        ~Decompressor();
-
-        // Explicitly disable copy and move constructor/assignment
-        Decompressor(Decompressor const&) = delete;
-        Decompressor& operator=(Decompressor const&) = delete;
-
-        // Methods implementing the ReaderInterface
-        /**
-         * Tries to read up to a given number of bytes from the decompressor
-         * @param buf
-         * @param num_bytes_to_read The number of bytes to try and read
-         * @param num_bytes_read The actual number of bytes read
-         * @return Same as FileReader::try_read if the decompressor is attached to a file
-         * @return ErrorCode_NotInit if the decompressor is not open
-         * @return ErrorCode_BadParam if buf is invalid
-         * @return ErrorCode_EndOfFile on EOF
-         * @return ErrorCode_Failure on decompression failure
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) override;
-        /**
-         * Tries to seek from the beginning to the given position
-         * @param pos
-         * @return ErrorCode_NotInit if the decompressor is not open
-         * @return Same as ReaderInterface::try_read_exact_length
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_seek_from_begin(size_t pos) override;
-        /**
-         * Tries to get the current position of the read head
-         * @param pos Position of the read head in the file
-         * @return ErrorCode_NotInit if the decompressor is not open
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode try_get_pos(size_t& pos) override;
-
-        // Methods implementing the Decompressor interface
-        void open(char const* compressed_data_buf, size_t compressed_data_buf_size) override;
-        void open(FileReader& file_reader, size_t file_read_buffer_capacity) override;
-        void close() override;
-        /**
-         * Decompresses and copies the range of uncompressed data described by
-         * decompressed_stream_pos and extraction_len into extraction_buf
-         * @param decompressed_stream_pos
-         * @param extraction_buf
-         * @param extraction_len
-         * @return Same as streaming_compression::zstd::Decompressor::try_seek_from_begin
-         * @return Same as ReaderInterface::try_read_exact_length
-         */
-        ErrorCode get_decompressed_stream_region(
-                size_t decompressed_stream_pos,
-                char* extraction_buf,
-                size_t extraction_len
-        ) override;
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
 
         // Methods
-        /***
-         * Initialize streaming decompressor to decompress from a compressed file specified by the
-         * given path
-         * @param compressed_file_path
-         * @param decompressed_stream_block_size
-         * @return ErrorCode_Failure if the provided path cannot be memory mapped
-         * @return ErrorCode_Success on success
-         */
-        ErrorCode open(std::string const& compressed_file_path);
-
-    private:
-        // Enum class
-        enum class InputType {
-            // Note: do nothing but generate an error to prevent this required
-            // parameter is not initialized properly
-            NotInitialized,
-            CompressedDataBuf,
-            MemoryMappedCompressedFile,
-            File
-        };
-
-        // Methods
-        /**
-         * Reset streaming decompression state so it will start decompressing from the beginning of
-         * the stream afterwards
-         */
-        void reset_stream();
-
-        // Variables
-        InputType m_input_type;
-
-        // Compressed stream variables
-        ZSTD_DStream* m_decompression_stream;
-
-        boost::iostreams::mapped_file_source m_memory_mapped_compressed_file;
-        FileReader* m_file_reader;
-        size_t m_file_reader_initial_pos;
-        std::unique_ptr<char[]> m_file_read_buffer;
-        size_t m_file_read_buffer_length;
-        size_t m_file_read_buffer_capacity;
-
-        ZSTD_inBuffer m_compressed_stream_block;
-
-        size_t m_decompressed_stream_pos;
-        size_t m_unused_decompressed_stream_block_size;
-        std::unique_ptr<char[]> m_unused_decompressed_stream_block_buffer;
+        char const* what() const noexcept override {
+            return "streaming_compression::zstd::Decompressor operation failed";
+        }
     };
-}}  // namespace streaming_compression::zstd
+
+    // Constructor
+    /**
+     * @throw Decompressor::OperationFailed if zstd decompressor stream
+     * cannot be initialized
+     */
+    Decompressor();
+
+    // Destructor
+    ~Decompressor();
+
+    // Explicitly disable copy and move constructor/assignment
+    Decompressor(Decompressor const&) = delete;
+    Decompressor& operator=(Decompressor const&) = delete;
+
+    // Methods implementing the ReaderInterface
+    /**
+     * Tries to read up to a given number of bytes from the decompressor
+     * @param buf
+     * @param num_bytes_to_read The number of bytes to try and read
+     * @param num_bytes_read The actual number of bytes read
+     * @return Same as FileReader::try_read if the decompressor is attached to a file
+     * @return ErrorCode_NotInit if the decompressor is not open
+     * @return ErrorCode_BadParam if buf is invalid
+     * @return ErrorCode_EndOfFile on EOF
+     * @return ErrorCode_Failure on decompression failure
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) override;
+    /**
+     * Tries to seek from the beginning to the given position
+     * @param pos
+     * @return ErrorCode_NotInit if the decompressor is not open
+     * @return Same as ReaderInterface::try_read_exact_length
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode try_seek_from_begin(size_t pos) override;
+    /**
+     * Tries to get the current position of the read head
+     * @param pos Position of the read head in the file
+     * @return ErrorCode_NotInit if the decompressor is not open
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode try_get_pos(size_t& pos) override;
+
+    // Methods implementing the Decompressor interface
+    void open(char const* compressed_data_buf, size_t compressed_data_buf_size) override;
+    void open(FileReader& file_reader, size_t file_read_buffer_capacity) override;
+    void close() override;
+    /**
+     * Decompresses and copies the range of uncompressed data described by
+     * decompressed_stream_pos and extraction_len into extraction_buf
+     * @param decompressed_stream_pos
+     * @param extraction_buf
+     * @param extraction_len
+     * @return Same as streaming_compression::zstd::Decompressor::try_seek_from_begin
+     * @return Same as ReaderInterface::try_read_exact_length
+     */
+    ErrorCode get_decompressed_stream_region(
+            size_t decompressed_stream_pos,
+            char* extraction_buf,
+            size_t extraction_len
+    ) override;
+
+    // Methods
+    /***
+     * Initialize streaming decompressor to decompress from a compressed file specified by the
+     * given path
+     * @param compressed_file_path
+     * @param decompressed_stream_block_size
+     * @return ErrorCode_Failure if the provided path cannot be memory mapped
+     * @return ErrorCode_Success on success
+     */
+    ErrorCode open(std::string const& compressed_file_path);
+
+private:
+    // Enum class
+    enum class InputType {
+        // Note: do nothing but generate an error to prevent this required
+        // parameter is not initialized properly
+        NotInitialized,
+        CompressedDataBuf,
+        MemoryMappedCompressedFile,
+        File
+    };
+
+    // Methods
+    /**
+     * Reset streaming decompression state so it will start decompressing from the beginning of
+     * the stream afterwards
+     */
+    void reset_stream();
+
+    // Variables
+    InputType m_input_type;
+
+    // Compressed stream variables
+    ZSTD_DStream* m_decompression_stream;
+
+    boost::iostreams::mapped_file_source m_memory_mapped_compressed_file;
+    FileReader* m_file_reader;
+    size_t m_file_reader_initial_pos;
+    std::unique_ptr<char[]> m_file_read_buffer;
+    size_t m_file_read_buffer_length;
+    size_t m_file_read_buffer_capacity;
+
+    ZSTD_inBuffer m_compressed_stream_block;
+
+    size_t m_decompressed_stream_pos;
+    size_t m_unused_decompressed_stream_block_size;
+    std::unique_ptr<char[]> m_unused_decompressed_stream_block_buffer;
+};
+}  // namespace streaming_compression::zstd
 #endif  // STREAMING_COMPRESSION_ZSTD_DECOMPRESSOR_HPP


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The current clang-format config formats a nested namespace with a joined name (`namespace a::b`) with no indentation but a nested namespace with separated names (`namespace a { namespace b {`) is formatted with indentation. This leads to tedious indentation changes (for the reviewer) when moving code into/out of a namespace.

This PR:
* Joins nested namespaces of the form `namespace a { namespace b { ... }}` into `namespace a::b { ... }`.
* Changes the clang-format config to not indent inner namespaces.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Built successfully.
* Unit tests pass.
