### PR TITLE
Move streaming_archive sources into the clp namespace.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -193,6 +193,29 @@ set(SOURCE_FILES_unitTest
         src/clp/GlobalMySQLMetadataDB.hpp
         src/clp/GlobalSQLiteMetadataDB.cpp
         src/clp/GlobalSQLiteMetadataDB.hpp
+        src/clp/streaming_archive/ArchiveMetadata.cpp
+        src/clp/streaming_archive/ArchiveMetadata.hpp
+        src/clp/streaming_archive/Constants.hpp
+        src/clp/streaming_archive/MetadataDB.cpp
+        src/clp/streaming_archive/MetadataDB.hpp
+        src/clp/streaming_archive/reader/Archive.cpp
+        src/clp/streaming_archive/reader/Archive.hpp
+        src/clp/streaming_archive/reader/File.cpp
+        src/clp/streaming_archive/reader/File.hpp
+        src/clp/streaming_archive/reader/Message.cpp
+        src/clp/streaming_archive/reader/Message.hpp
+        src/clp/streaming_archive/reader/Segment.cpp
+        src/clp/streaming_archive/reader/Segment.hpp
+        src/clp/streaming_archive/reader/SegmentManager.cpp
+        src/clp/streaming_archive/reader/SegmentManager.hpp
+        src/clp/streaming_archive/writer/Archive.cpp
+        src/clp/streaming_archive/writer/Archive.hpp
+        src/clp/streaming_archive/writer/File.cpp
+        src/clp/streaming_archive/writer/File.hpp
+        src/clp/streaming_archive/writer/Segment.cpp
+        src/clp/streaming_archive/writer/Segment.hpp
+        src/clp/streaming_archive/writer/utils.cpp
+        src/clp/streaming_archive/writer/utils.hpp
         src/database_utils.cpp
         src/database_utils.hpp
         src/Defs.h
@@ -280,29 +303,6 @@ set(SOURCE_FILES_unitTest
         src/SQLitePreparedStatement.hpp
         src/Stopwatch.cpp
         src/Stopwatch.hpp
-        src/streaming_archive/ArchiveMetadata.cpp
-        src/streaming_archive/ArchiveMetadata.hpp
-        src/streaming_archive/Constants.hpp
-        src/streaming_archive/MetadataDB.cpp
-        src/streaming_archive/MetadataDB.hpp
-        src/streaming_archive/reader/Archive.cpp
-        src/streaming_archive/reader/Archive.hpp
-        src/streaming_archive/reader/File.cpp
-        src/streaming_archive/reader/File.hpp
-        src/streaming_archive/reader/Message.cpp
-        src/streaming_archive/reader/Message.hpp
-        src/streaming_archive/reader/Segment.cpp
-        src/streaming_archive/reader/Segment.hpp
-        src/streaming_archive/reader/SegmentManager.cpp
-        src/streaming_archive/reader/SegmentManager.hpp
-        src/streaming_archive/writer/Archive.cpp
-        src/streaming_archive/writer/Archive.hpp
-        src/streaming_archive/writer/File.cpp
-        src/streaming_archive/writer/File.hpp
-        src/streaming_archive/writer/Segment.cpp
-        src/streaming_archive/writer/Segment.hpp
-        src/streaming_archive/writer/utils.cpp
-        src/streaming_archive/writer/utils.hpp
         src/streaming_compression/Compressor.hpp
         src/streaming_compression/Constants.hpp
         src/streaming_compression/Decompressor.hpp

--- a/components/core/src/Grep.cpp
+++ b/components/core/src/Grep.cpp
@@ -12,12 +12,12 @@
 #include "StringReader.hpp"
 #include "Utils.hpp"
 
+using clp::streaming_archive::reader::Archive;
+using clp::streaming_archive::reader::File;
+using clp::streaming_archive::reader::Message;
 using ir::is_delim;
 using std::string;
 using std::vector;
-using streaming_archive::reader::Archive;
-using streaming_archive::reader::File;
-using streaming_archive::reader::Message;
 using string_utils::clean_up_wildcard_search_string;
 using string_utils::is_alphabet;
 using string_utils::is_wildcard;

--- a/components/core/src/Grep.hpp
+++ b/components/core/src/Grep.hpp
@@ -6,10 +6,10 @@
 
 #include <log_surgeon/Lexer.hpp>
 
+#include "clp/streaming_archive/reader/Archive.hpp"
+#include "clp/streaming_archive/reader/File.hpp"
 #include "Defs.h"
 #include "Query.hpp"
-#include "streaming_archive/reader/Archive.hpp"
-#include "streaming_archive/reader/File.hpp"
 
 class Grep {
 public:
@@ -23,7 +23,7 @@ public:
      */
     typedef void (*OutputFunc)(
             std::string const& orig_file_path,
-            streaming_archive::reader::Message const& compressed_msg,
+            clp::streaming_archive::reader::Message const& compressed_msg,
             std::string const& decompressed_msg,
             void* custom_arg
     );
@@ -42,7 +42,7 @@ public:
      * @return Query if it may match a message, std::nullopt otherwise
      */
     static std::optional<Query> process_raw_query(
-            streaming_archive::reader::Archive const& archive,
+            clp::streaming_archive::reader::Archive const& archive,
             std::string const& search_string,
             epochtime_t search_begin_ts,
             epochtime_t search_end_ts,
@@ -93,7 +93,7 @@ public:
      * @param queries
      */
     static void calculate_sub_queries_relevant_to_file(
-            streaming_archive::reader::File const& compressed_file,
+            clp::streaming_archive::reader::File const& compressed_file,
             std::vector<Query>& queries
     );
 
@@ -106,23 +106,23 @@ public:
      * @param output_func
      * @param output_func_arg
      * @return Number of matches found
-     * @throw streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
+     * @throw clp::streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
      * fails
      * @throw TimestampPattern::OperationFailed if failed to insert timestamp into message
      */
     static size_t search_and_output(
             Query const& query,
             size_t limit,
-            streaming_archive::reader::Archive& archive,
-            streaming_archive::reader::File& compressed_file,
+            clp::streaming_archive::reader::Archive& archive,
+            clp::streaming_archive::reader::File& compressed_file,
             OutputFunc output_func,
             void* output_func_arg
     );
     static bool search_and_decompress(
             Query const& query,
-            streaming_archive::reader::Archive& archive,
-            streaming_archive::reader::File& compressed_file,
-            streaming_archive::reader::Message& compressed_msg,
+            clp::streaming_archive::reader::Archive& archive,
+            clp::streaming_archive::reader::File& compressed_file,
+            clp::streaming_archive::reader::Message& compressed_msg,
             std::string& decompressed_msg
     );
     /**
@@ -132,15 +132,15 @@ public:
      * @param archive
      * @param compressed_file
      * @return Number of matches found
-     * @throw streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
+     * @throw clp::streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
      * fails
      * @throw TimestampPattern::OperationFailed if failed to insert timestamp into message
      */
     static size_t search(
             Query const& query,
             size_t limit,
-            streaming_archive::reader::Archive& archive,
-            streaming_archive::reader::File& compressed_file
+            clp::streaming_archive::reader::Archive& archive,
+            clp::streaming_archive::reader::File& compressed_file
     );
 };
 

--- a/components/core/src/clp/GlobalMetadataDB.hpp
+++ b/components/core/src/clp/GlobalMetadataDB.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "../streaming_archive/ArchiveMetadata.hpp"
-#include "../streaming_archive/writer/File.hpp"
+#include "streaming_archive/ArchiveMetadata.hpp"
+#include "streaming_archive/writer/File.hpp"
 
 namespace clp {
 /**

--- a/components/core/src/clp/GlobalMySQLMetadataDB.cpp
+++ b/components/core/src/clp/GlobalMySQLMetadataDB.cpp
@@ -3,8 +3,8 @@
 #include <fmt/core.h>
 
 #include "../database_utils.hpp"
-#include "../streaming_archive/Constants.hpp"
 #include "../type_utils.hpp"
+#include "streaming_archive/Constants.hpp"
 
 using std::pair;
 using std::string;

--- a/components/core/src/clp/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/clp/GlobalSQLiteMetadataDB.cpp
@@ -7,8 +7,8 @@
 
 #include "../database_utils.hpp"
 #include "../spdlog_with_specializations.hpp"
-#include "../streaming_archive/Constants.hpp"
 #include "../type_utils.hpp"
+#include "streaming_archive/Constants.hpp"
 
 // Types
 enum class ArchivesTableFieldIndexes : uint16_t {
@@ -46,8 +46,10 @@ using std::to_string;
 using std::unordered_set;
 using std::vector;
 
-static void create_tables(
-        vector<std::pair<string, string>> const& archive_field_names_and_types,
+namespace clp {
+namespace {
+void create_tables(
+        vector<pair<string, string>> const& archive_field_names_and_types,
         vector<pair<string, string>> const& file_field_names_and_types,
         SQLiteDB& db
 ) {
@@ -115,7 +117,7 @@ static void create_tables(
     create_files_archive_id_index.step();
 }
 
-static SQLitePreparedStatement get_archives_select_statement(SQLiteDB& db) {
+SQLitePreparedStatement get_archives_select_statement(SQLiteDB& db) {
     auto statement_string = fmt::format(
             "SELECT {} FROM {} ORDER BY {} ASC, {} ASC",
             streaming_archive::cMetadataDB::Archive::Id,
@@ -127,7 +129,7 @@ static SQLitePreparedStatement get_archives_select_statement(SQLiteDB& db) {
     return db.prepare_statement(statement_string.c_str(), statement_string.length());
 }
 
-static SQLitePreparedStatement get_archives_for_time_window_select_statement(
+SQLitePreparedStatement get_archives_for_time_window_select_statement(
         SQLiteDB& db,
         epochtime_t begin_ts,
         epochtime_t end_ts
@@ -149,7 +151,7 @@ static SQLitePreparedStatement get_archives_for_time_window_select_statement(
     return statement;
 }
 
-static SQLitePreparedStatement
+SQLitePreparedStatement
 get_archives_for_file_select_statement(SQLiteDB& db, string const& file_path) {
     auto statement_string = fmt::format(
             "SELECT DISTINCT {}.{} FROM {} JOIN {} ON {}.{} = {}.{} WHERE {}.{} = ? ORDER BY {} "
@@ -173,8 +175,8 @@ get_archives_for_file_select_statement(SQLiteDB& db, string const& file_path) {
 
     return statement;
 }
+}  // namespace
 
-namespace clp {
 GlobalSQLiteMetadataDB::ArchiveIterator::ArchiveIterator(SQLiteDB& db)
         : m_statement(get_archives_select_statement(db)) {
     m_statement.step();

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -7,6 +7,25 @@ set(
         ../GlobalMySQLMetadataDB.hpp
         ../GlobalSQLiteMetadataDB.cpp
         ../GlobalSQLiteMetadataDB.hpp
+        ../streaming_archive/ArchiveMetadata.cpp
+        ../streaming_archive/ArchiveMetadata.hpp
+        ../streaming_archive/Constants.hpp
+        ../streaming_archive/MetadataDB.cpp
+        ../streaming_archive/MetadataDB.hpp
+        ../streaming_archive/reader/Archive.cpp
+        ../streaming_archive/reader/Archive.hpp
+        ../streaming_archive/reader/File.cpp
+        ../streaming_archive/reader/File.hpp
+        ../streaming_archive/reader/Message.cpp
+        ../streaming_archive/reader/Message.hpp
+        ../streaming_archive/reader/Segment.cpp
+        ../streaming_archive/reader/Segment.hpp
+        ../streaming_archive/reader/SegmentManager.cpp
+        ../streaming_archive/reader/SegmentManager.hpp
+        ../streaming_archive/writer/File.cpp
+        ../streaming_archive/writer/File.hpp
+        ../streaming_archive/writer/Segment.cpp
+        ../streaming_archive/writer/Segment.hpp
         "${PROJECT_SOURCE_DIR}/src/BufferReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.cpp"
@@ -64,25 +83,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/SQLitePreparedStatement.hpp"
         "${PROJECT_SOURCE_DIR}/src/Stopwatch.cpp"
         "${PROJECT_SOURCE_DIR}/src/Stopwatch.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/ArchiveMetadata.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/ArchiveMetadata.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/Constants.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/MetadataDB.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/MetadataDB.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Archive.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Archive.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/File.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/File.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Message.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Message.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Segment.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Segment.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/SegmentManager.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/SegmentManager.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/File.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/File.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Segment.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Segment.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/Constants.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/Decompressor.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/passthrough/Compressor.cpp"

--- a/components/core/src/clp/clg/clg.cpp
+++ b/components/core/src/clp/clg/clg.cpp
@@ -10,25 +10,25 @@
 #include "../../Grep.hpp"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../streaming_archive/Constants.hpp"
 #include "../../Utils.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
+#include "../streaming_archive/Constants.hpp"
 #include "CommandLineArguments.hpp"
 
 using clp::clg::CommandLineArguments;
 using clp::GlobalMetadataDB;
 using clp::GlobalMetadataDBConfig;
+using clp::streaming_archive::MetadataDB;
+using clp::streaming_archive::reader::Archive;
+using clp::streaming_archive::reader::File;
+using clp::streaming_archive::reader::Message;
 using std::cerr;
 using std::cout;
 using std::endl;
 using std::string;
 using std::to_string;
 using std::vector;
-using streaming_archive::MetadataDB;
-using streaming_archive::reader::Archive;
-using streaming_archive::reader::File;
-using streaming_archive::reader::Message;
 
 /**
  * Opens the archive and reads the dictionaries
@@ -511,7 +511,8 @@ int main(int argc, char const* argv[]) {
     std::unique_ptr<GlobalMetadataDB> global_metadata_db;
     switch (global_metadata_db_config.get_metadata_db_type()) {
         case GlobalMetadataDBConfig::MetadataDBType::SQLite: {
-            auto global_metadata_db_path = archives_dir / streaming_archive::cMetadataDBFileName;
+            auto global_metadata_db_path
+                    = archives_dir / clp::streaming_archive::cMetadataDBFileName;
             global_metadata_db
                     = std::make_unique<clp::GlobalSQLiteMetadataDB>(global_metadata_db_path.string()
                     );
@@ -569,7 +570,7 @@ int main(int argc, char const* argv[]) {
         }
 
         // Generate lexer if schema file exists
-        auto schema_file_path = archive_path / streaming_archive::cSchemaFileName;
+        auto schema_file_path = archive_path / clp::streaming_archive::cSchemaFileName;
         bool use_heuristic = true;
         if (std::filesystem::exists(schema_file_path)) {
             use_heuristic = false;

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -3,6 +3,25 @@ set(
         ../networking/socket_utils.cpp
         ../networking/socket_utils.hpp
         ../networking/SocketOperationFailed.hpp
+        ../streaming_archive/ArchiveMetadata.cpp
+        ../streaming_archive/ArchiveMetadata.hpp
+        ../streaming_archive/Constants.hpp
+        ../streaming_archive/MetadataDB.cpp
+        ../streaming_archive/MetadataDB.hpp
+        ../streaming_archive/reader/Archive.cpp
+        ../streaming_archive/reader/Archive.hpp
+        ../streaming_archive/reader/File.cpp
+        ../streaming_archive/reader/File.hpp
+        ../streaming_archive/reader/Message.cpp
+        ../streaming_archive/reader/Message.hpp
+        ../streaming_archive/reader/Segment.cpp
+        ../streaming_archive/reader/Segment.hpp
+        ../streaming_archive/reader/SegmentManager.cpp
+        ../streaming_archive/reader/SegmentManager.hpp
+        ../streaming_archive/writer/File.cpp
+        ../streaming_archive/writer/File.hpp
+        ../streaming_archive/writer/Segment.cpp
+        ../streaming_archive/writer/Segment.hpp
         "${PROJECT_SOURCE_DIR}/src/BufferReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.cpp"
@@ -54,25 +73,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/SQLitePreparedStatement.hpp"
         "${PROJECT_SOURCE_DIR}/src/Stopwatch.cpp"
         "${PROJECT_SOURCE_DIR}/src/Stopwatch.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/ArchiveMetadata.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/ArchiveMetadata.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/Constants.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/MetadataDB.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/MetadataDB.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Archive.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Archive.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/File.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/File.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Message.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Message.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Segment.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Segment.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/SegmentManager.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/SegmentManager.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/File.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/File.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Segment.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Segment.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/Constants.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/Decompressor.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/passthrough/Compressor.cpp"

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -11,13 +11,17 @@
 #include "../../Grep.hpp"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../streaming_archive/Constants.hpp"
 #include "../../Utils.hpp"
 #include "../networking/socket_utils.hpp"
+#include "../streaming_archive/Constants.hpp"
 #include "CommandLineArguments.hpp"
 #include "ControllerMonitoringThread.hpp"
 
 using clp::clo::CommandLineArguments;
+using clp::streaming_archive::MetadataDB;
+using clp::streaming_archive::reader::Archive;
+using clp::streaming_archive::reader::File;
+using clp::streaming_archive::reader::Message;
 using std::cerr;
 using std::cout;
 using std::endl;
@@ -25,10 +29,6 @@ using std::string;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
-using streaming_archive::MetadataDB;
-using streaming_archive::reader::Archive;
-using streaming_archive::reader::File;
-using streaming_archive::reader::Message;
 
 // Local types
 enum class SearchFilesResult {
@@ -228,7 +228,7 @@ static bool search_archive(
         SPDLOG_ERROR("Archive '{}' does not exist.", archive_path.c_str());
         return false;
     }
-    auto archive_metadata_file = archive_path / streaming_archive::cMetadataFileName;
+    auto archive_metadata_file = archive_path / clp::streaming_archive::cMetadataFileName;
     if (false == boost::filesystem::exists(archive_metadata_file)) {
         SPDLOG_ERROR(
                 "Archive metadata file '{}' does not exist. '{}' may not be an archive.",
@@ -239,7 +239,7 @@ static bool search_archive(
     }
 
     // Load lexers from schema file if it exists
-    auto schema_file_path = archive_path / streaming_archive::cSchemaFileName;
+    auto schema_file_path = archive_path / clp::streaming_archive::cSchemaFileName;
     unique_ptr<log_surgeon::lexers::ByteLexer> forward_lexer, reverse_lexer;
     bool use_heuristic = true;
     if (boost::filesystem::exists(schema_file_path)) {

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -7,6 +7,29 @@ set(
         ../GlobalMySQLMetadataDB.hpp
         ../GlobalSQLiteMetadataDB.cpp
         ../GlobalSQLiteMetadataDB.hpp
+        ../streaming_archive/ArchiveMetadata.cpp
+        ../streaming_archive/ArchiveMetadata.hpp
+        ../streaming_archive/Constants.hpp
+        ../streaming_archive/MetadataDB.cpp
+        ../streaming_archive/MetadataDB.hpp
+        ../streaming_archive/reader/Archive.cpp
+        ../streaming_archive/reader/Archive.hpp
+        ../streaming_archive/reader/File.cpp
+        ../streaming_archive/reader/File.hpp
+        ../streaming_archive/reader/Message.cpp
+        ../streaming_archive/reader/Message.hpp
+        ../streaming_archive/reader/Segment.cpp
+        ../streaming_archive/reader/Segment.hpp
+        ../streaming_archive/reader/SegmentManager.cpp
+        ../streaming_archive/reader/SegmentManager.hpp
+        ../streaming_archive/writer/Archive.cpp
+        ../streaming_archive/writer/Archive.hpp
+        ../streaming_archive/writer/File.cpp
+        ../streaming_archive/writer/File.hpp
+        ../streaming_archive/writer/Segment.cpp
+        ../streaming_archive/writer/Segment.hpp
+        ../streaming_archive/writer/utils.cpp
+        ../streaming_archive/writer/utils.hpp
         "${PROJECT_SOURCE_DIR}/src/ArrayBackedPosIntSet.hpp"
         "${PROJECT_SOURCE_DIR}/src/BufferedFileReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferedFileReader.hpp"
@@ -82,29 +105,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/SQLitePreparedStatement.hpp"
         "${PROJECT_SOURCE_DIR}/src/Stopwatch.cpp"
         "${PROJECT_SOURCE_DIR}/src/Stopwatch.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/ArchiveMetadata.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/ArchiveMetadata.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/Constants.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/MetadataDB.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/MetadataDB.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Archive.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Archive.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/File.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/File.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Message.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Message.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Segment.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/Segment.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/SegmentManager.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/reader/SegmentManager.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Archive.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Archive.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/File.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/File.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Segment.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/Segment.hpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/streaming_archive/writer/utils.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/Compressor.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/Constants.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/Decompressor.hpp"

--- a/components/core/src/clp/clp/FileCompressor.cpp
+++ b/components/core/src/clp/clp/FileCompressor.cpp
@@ -15,9 +15,12 @@
 #include "../../ir/utils.hpp"
 #include "../../LogSurgeonReader.hpp"
 #include "../../Profiler.hpp"
-#include "../../streaming_archive/writer/utils.hpp"
+#include "../streaming_archive/writer/utils.hpp"
 #include "utils.hpp"
 
+using clp::streaming_archive::writer::split_archive;
+using clp::streaming_archive::writer::split_file;
+using clp::streaming_archive::writer::split_file_and_archive;
 using ir::eight_byte_encoded_variable_t;
 using ir::four_byte_encoded_variable_t;
 using ir::has_ir_stream_magic_number;
@@ -30,9 +33,6 @@ using std::endl;
 using std::set;
 using std::string;
 using std::vector;
-using streaming_archive::writer::split_archive;
-using streaming_archive::writer::split_file;
-using streaming_archive::writer::split_file_and_archive;
 
 // Local prototypes
 /**
@@ -46,7 +46,7 @@ static void compute_and_add_empty_directories(
         set<string> const& directories,
         set<string> const& parent_directories,
         boost::filesystem::path const& parent_path,
-        streaming_archive::writer::Archive& archive
+        clp::streaming_archive::writer::Archive& archive
 );
 
 /**
@@ -57,14 +57,14 @@ static void compute_and_add_empty_directories(
  */
 static void write_message_to_encoded_file(
         ParsedMessage const& msg,
-        streaming_archive::writer::Archive& archive
+        clp::streaming_archive::writer::Archive& archive
 );
 
 static void compute_and_add_empty_directories(
         set<string> const& directories,
         set<string> const& parent_directories,
         boost::filesystem::path const& parent_path,
-        streaming_archive::writer::Archive& archive
+        clp::streaming_archive::writer::Archive& archive
 ) {
     // Determine empty directories by subtracting parent directories
     vector<string> empty_directories;
@@ -96,7 +96,7 @@ static void compute_and_add_empty_directories(
 
 static void write_message_to_encoded_file(
         ParsedMessage const& msg,
-        streaming_archive::writer::Archive& archive
+        clp::streaming_archive::writer::Archive& archive
 ) {
     if (msg.has_ts_patt_changed()) {
         archive.change_ts_pattern(msg.get_ts_patt());

--- a/components/core/src/clp/clp/FileCompressor.hpp
+++ b/components/core/src/clp/clp/FileCompressor.hpp
@@ -13,7 +13,7 @@
 #include "../../LibarchiveReader.hpp"
 #include "../../MessageParser.hpp"
 #include "../../ParsedMessage.hpp"
-#include "../../streaming_archive/writer/Archive.hpp"
+#include "../streaming_archive/writer/Archive.hpp"
 #include "FileToCompress.hpp"
 
 namespace clp::clp {

--- a/components/core/src/clp/clp/FileDecompressor.hpp
+++ b/components/core/src/clp/clp/FileDecompressor.hpp
@@ -4,10 +4,10 @@
 #include <string>
 
 #include "../../FileWriter.hpp"
-#include "../../streaming_archive/MetadataDB.hpp"
-#include "../../streaming_archive/reader/Archive.hpp"
-#include "../../streaming_archive/reader/File.hpp"
-#include "../../streaming_archive/reader/Message.hpp"
+#include "../streaming_archive/MetadataDB.hpp"
+#include "../streaming_archive/reader/Archive.hpp"
+#include "../streaming_archive/reader/File.hpp"
+#include "../streaming_archive/reader/Message.hpp"
 
 namespace clp::clp {
 /**

--- a/components/core/src/clp/clp/compression.cpp
+++ b/components/core/src/clp/clp/compression.cpp
@@ -7,21 +7,21 @@
 #include <boost/uuid/random_generator.hpp>
 
 #include "../../spdlog_with_specializations.hpp"
-#include "../../streaming_archive/writer/Archive.hpp"
-#include "../../streaming_archive/writer/utils.hpp"
 #include "../../Utils.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
+#include "../streaming_archive/writer/Archive.hpp"
+#include "../streaming_archive/writer/utils.hpp"
 #include "FileCompressor.hpp"
 #include "utils.hpp"
 
+using clp::streaming_archive::writer::split_archive;
 using std::cerr;
 using std::cout;
 using std::endl;
 using std::out_of_range;
 using std::string;
 using std::vector;
-using streaming_archive::writer::split_archive;
 
 namespace clp::clp {
 // Local prototypes

--- a/components/core/src/clp/clp/decompression.cpp
+++ b/components/core/src/clp/clp/decompression.cpp
@@ -8,11 +8,11 @@
 #include "../../ErrorCode.hpp"
 #include "../../FileWriter.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../streaming_archive/reader/Archive.hpp"
 #include "../../TraceableException.hpp"
 #include "../../Utils.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
+#include "../streaming_archive/reader/Archive.hpp"
 #include "FileDecompressor.hpp"
 
 using std::cerr;

--- a/components/core/src/clp/make_dictionaries_readable/make-dictionaries-readable.cpp
+++ b/components/core/src/clp/make_dictionaries_readable/make-dictionaries-readable.cpp
@@ -9,9 +9,9 @@
 #include "../../ir/types.hpp"
 #include "../../LogTypeDictionaryReader.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../streaming_archive/Constants.hpp"
 #include "../../type_utils.hpp"
 #include "../../VariableDictionaryReader.hpp"
+#include "../streaming_archive/Constants.hpp"
 #include "CommandLineArguments.hpp"
 
 using ir::VariablePlaceholder;
@@ -47,19 +47,19 @@ int main(int argc, char const* argv[]) {
 
     // Open log-type dictionary
     auto logtype_dict_path = boost::filesystem::path(command_line_args.get_archive_path())
-                             / streaming_archive::cLogTypeDictFilename;
+                             / clp::streaming_archive::cLogTypeDictFilename;
     auto logtype_segment_index_path = boost::filesystem::path(command_line_args.get_archive_path())
-                                      / streaming_archive::cLogTypeSegmentIndexFilename;
+                                      / clp::streaming_archive::cLogTypeSegmentIndexFilename;
     LogTypeDictionaryReader logtype_dict;
     logtype_dict.open(logtype_dict_path.string(), logtype_segment_index_path.string());
     logtype_dict.read_new_entries();
 
     // Write readable dictionary
     auto readable_logtype_dict_path = boost::filesystem::path(command_line_args.get_output_dir())
-                                      / streaming_archive::cLogTypeDictFilename;
+                                      / clp::streaming_archive::cLogTypeDictFilename;
     auto readable_logtype_segment_index_path
             = boost::filesystem::path(command_line_args.get_output_dir())
-              / streaming_archive::cLogTypeSegmentIndexFilename;
+              / clp::streaming_archive::cLogTypeSegmentIndexFilename;
     readable_logtype_dict_path += ".hr";
     readable_logtype_segment_index_path += ".hr";
     file_writer.open(readable_logtype_dict_path.string(), FileWriter::OpenMode::CREATE_FOR_WRITING);
@@ -131,19 +131,19 @@ int main(int argc, char const* argv[]) {
 
     // Open variables dictionary
     auto var_dict_path = boost::filesystem::path(command_line_args.get_archive_path())
-                         / streaming_archive::cVarDictFilename;
+                         / clp::streaming_archive::cVarDictFilename;
     auto var_segment_index_path = boost::filesystem::path(command_line_args.get_archive_path())
-                                  / streaming_archive::cVarSegmentIndexFilename;
+                                  / clp::streaming_archive::cVarSegmentIndexFilename;
     VariableDictionaryReader var_dict;
     var_dict.open(var_dict_path.string(), var_segment_index_path.string());
     var_dict.read_new_entries();
 
     // Write readable dictionary
     auto readable_var_dict_path = boost::filesystem::path(command_line_args.get_output_dir())
-                                  / streaming_archive::cVarDictFilename;
+                                  / clp::streaming_archive::cVarDictFilename;
     auto readable_var_segment_index_path
             = boost::filesystem::path(command_line_args.get_output_dir())
-              / streaming_archive::cVarSegmentIndexFilename;
+              / clp::streaming_archive::cVarSegmentIndexFilename;
     readable_var_dict_path += ".hr";
     readable_var_segment_index_path += ".hr";
     file_writer.open(readable_var_dict_path.string(), FileWriter::OpenMode::CREATE_FOR_WRITING);

--- a/components/core/src/clp/streaming_archive/ArchiveMetadata.cpp
+++ b/components/core/src/clp/streaming_archive/ArchiveMetadata.cpp
@@ -1,6 +1,6 @@
 #include "ArchiveMetadata.hpp"
 
-namespace streaming_archive {
+namespace clp::streaming_archive {
 ArchiveMetadata::ArchiveMetadata(
         archive_format_version_t archive_format_version,
         std::string creator_id,
@@ -51,4 +51,4 @@ void ArchiveMetadata::write_to_file(FileWriter& file_writer) const {
     file_writer.write_numeric_value(m_begin_timestamp);
     file_writer.write_numeric_value(m_end_timestamp);
 }
-}  // namespace streaming_archive
+}  // namespace clp::streaming_archive

--- a/components/core/src/clp/streaming_archive/ArchiveMetadata.hpp
+++ b/components/core/src/clp/streaming_archive/ArchiveMetadata.hpp
@@ -3,12 +3,12 @@
 
 #include <cstdint>
 
-#include "../Defs.h"
-#include "../FileReader.hpp"
-#include "../FileWriter.hpp"
+#include "../../Defs.h"
+#include "../../FileReader.hpp"
+#include "../../FileWriter.hpp"
 #include "Constants.hpp"
 
-namespace streaming_archive {
+namespace clp::streaming_archive {
 /**
  * A class to encapsulate metadata directly relating to an archive.
  */
@@ -103,6 +103,6 @@ private:
     uint64_t m_compressed_size{0};
     uint64_t m_dynamic_compressed_size{0};
 };
-}  // namespace streaming_archive
+}  // namespace clp::streaming_archive
 
 #endif  // STREAMING_ARCHIVE_ARCHIVEMETADATA_HPP

--- a/components/core/src/clp/streaming_archive/Constants.hpp
+++ b/components/core/src/clp/streaming_archive/Constants.hpp
@@ -1,9 +1,9 @@
 #ifndef STREAMING_ARCHIVE_CONSTANTS_HPP
 #define STREAMING_ARCHIVE_CONSTANTS_HPP
 
-#include "../Defs.h"
+#include "../../Defs.h"
 
-namespace streaming_archive {
+namespace clp::streaming_archive {
 constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevVersionFlag | 8;
 constexpr char cSegmentsDirname[] = "s";
 constexpr char cSegmentListFilename[] = "segment_list.txt";
@@ -53,6 +53,6 @@ namespace EmptyDirectory {
 constexpr char Path[] = "path";
 }  // namespace EmptyDirectory
 }  // namespace cMetadataDB
-}  // namespace streaming_archive
+}  // namespace clp::streaming_archive
 
 #endif  // STREAMING_ARCHIVE_CONSTANTS_HPP

--- a/components/core/src/clp/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/clp/streaming_archive/MetadataDB.cpp
@@ -4,9 +4,9 @@
 
 #include <fmt/core.h>
 
-#include "../database_utils.hpp"
-#include "../Defs.h"
-#include "../type_utils.hpp"
+#include "../../database_utils.hpp"
+#include "../../Defs.h"
+#include "../../type_utils.hpp"
 #include "Constants.hpp"
 
 // Types
@@ -34,7 +34,7 @@ using std::string;
 using std::to_string;
 using std::vector;
 
-namespace streaming_archive {
+namespace clp::streaming_archive {
 static void
 create_tables(vector<std::pair<string, string>> const& file_field_names_and_types, SQLiteDB& db) {
     fmt::memory_buffer statement_buffer;
@@ -633,4 +633,4 @@ void MetadataDB::add_empty_directories(vector<string> const& empty_directory_pat
         m_insert_empty_directories_statement->reset();
     }
 }
-}  // namespace streaming_archive
+}  // namespace clp::streaming_archive

--- a/components/core/src/clp/streaming_archive/MetadataDB.hpp
+++ b/components/core/src/clp/streaming_archive/MetadataDB.hpp
@@ -5,10 +5,10 @@
 #include <string>
 #include <vector>
 
-#include "../SQLiteDB.hpp"
+#include "../../SQLiteDB.hpp"
 #include "writer/File.hpp"
 
-namespace streaming_archive {
+namespace clp::streaming_archive {
 class MetadataDB {
 public:
     // Types
@@ -162,6 +162,6 @@ private:
     std::unique_ptr<SQLitePreparedStatement> m_upsert_file_statement;
     std::unique_ptr<SQLitePreparedStatement> m_insert_empty_directories_statement;
 };
-}  // namespace streaming_archive
+}  // namespace clp::streaming_archive
 
 #endif  // STREAMING_ARCHIVE_METADATADB_HPP

--- a/components/core/src/clp/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.cpp
@@ -8,9 +8,9 @@
 
 #include <boost/filesystem.hpp>
 
-#include "../../EncodedVariableInterpreter.hpp"
-#include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
+#include "../../../EncodedVariableInterpreter.hpp"
+#include "../../../spdlog_with_specializations.hpp"
+#include "../../../Utils.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../Constants.hpp"
 
@@ -18,7 +18,7 @@ using std::string;
 using std::unordered_set;
 using std::vector;
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 void Archive::open(string const& path) {
     // Determine whether path is file or directory
     struct stat path_stat = {};
@@ -235,4 +235,4 @@ void Archive::decompress_empty_directories(string const& output_dir) {
         }
     }
 }
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader

--- a/components/core/src/clp/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.hpp
@@ -8,16 +8,16 @@
 #include <string>
 #include <utility>
 
-#include "../../ErrorCode.hpp"
-#include "../../LogTypeDictionaryReader.hpp"
-#include "../../Query.hpp"
-#include "../../SQLiteDB.hpp"
-#include "../../VariableDictionaryReader.hpp"
+#include "../../../ErrorCode.hpp"
+#include "../../../LogTypeDictionaryReader.hpp"
+#include "../../../Query.hpp"
+#include "../../../SQLiteDB.hpp"
+#include "../../../VariableDictionaryReader.hpp"
 #include "../MetadataDB.hpp"
 #include "File.hpp"
 #include "Message.hpp"
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 class Archive {
 public:
     // Types
@@ -143,6 +143,6 @@ private:
 
     MetadataDB m_metadata_db;
 };
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_ARCHIVE_HPP

--- a/components/core/src/clp/streaming_archive/reader/File.cpp
+++ b/components/core/src/clp/streaming_archive/reader/File.cpp
@@ -3,14 +3,14 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "../../EncodedVariableInterpreter.hpp"
-#include "../../spdlog_with_specializations.hpp"
+#include "../../../EncodedVariableInterpreter.hpp"
+#include "../../../spdlog_with_specializations.hpp"
 #include "../Constants.hpp"
 #include "SegmentManager.hpp"
 
 using std::string;
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 epochtime_t File::get_begin_ts() const {
     return m_begin_ts;
 }
@@ -330,4 +330,4 @@ bool File::get_next_message(Message& msg) {
 
     return true;
 }
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader

--- a/components/core/src/clp/streaming_archive/reader/File.hpp
+++ b/components/core/src/clp/streaming_archive/reader/File.hpp
@@ -5,16 +5,16 @@
 #include <set>
 #include <vector>
 
-#include "../../Defs.h"
-#include "../../ErrorCode.hpp"
-#include "../../LogTypeDictionaryReader.hpp"
-#include "../../Query.hpp"
-#include "../../TimestampPattern.hpp"
+#include "../../../Defs.h"
+#include "../../../ErrorCode.hpp"
+#include "../../../LogTypeDictionaryReader.hpp"
+#include "../../../Query.hpp"
+#include "../../../TimestampPattern.hpp"
 #include "../MetadataDB.hpp"
 #include "Message.hpp"
 #include "SegmentManager.hpp"
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 class File {
 public:
     // Types
@@ -159,6 +159,6 @@ private:
     size_t m_split_ix;
     bool m_is_split;
 };
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_FILE_HPP

--- a/components/core/src/clp/streaming_archive/reader/Message.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.cpp
@@ -1,6 +1,6 @@
 #include "Message.hpp"
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 size_t Message::get_message_number() const {
     return m_message_number;
 }
@@ -36,4 +36,4 @@ void Message::set_timestamp(epochtime_t timestamp) {
 void Message::clear_vars() {
     m_vars.clear();
 }
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader

--- a/components/core/src/clp/streaming_archive/reader/Message.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.hpp
@@ -4,9 +4,9 @@
 #include <cstddef>
 #include <vector>
 
-#include "../../Defs.h"
+#include "../../../Defs.h"
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 class Message {
 public:
     // Methods
@@ -31,6 +31,6 @@ private:
     std::vector<encoded_variable_t> m_vars;
     epochtime_t m_timestamp;
 };
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_MESSAGE_HPP

--- a/components/core/src/clp/streaming_archive/reader/Segment.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Segment.cpp
@@ -7,15 +7,15 @@
 
 #include <boost/filesystem.hpp>
 
-#include "../../FileReader.hpp"
-#include "../../spdlog_with_specializations.hpp"
+#include "../../../FileReader.hpp"
+#include "../../../spdlog_with_specializations.hpp"
 
 using std::make_unique;
 using std::string;
 using std::to_string;
 using std::unique_ptr;
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 Segment::~Segment() {
     // If user forgot to explicitly close the file for some reason, close it again (doesn't
     // hurt)
@@ -102,4 +102,4 @@ Segment::try_read(uint64_t decompressed_stream_pos, char* extraction_buf, uint64
             extraction_len
     );
 }
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader

--- a/components/core/src/clp/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Segment.hpp
@@ -6,13 +6,13 @@
 
 #include <boost/iostreams/device/mapped_file.hpp>
 
-#include "../../Defs.h"
-#include "../../ErrorCode.hpp"
-#include "../../streaming_compression/passthrough/Decompressor.hpp"
-#include "../../streaming_compression/zstd/Decompressor.hpp"
+#include "../../../Defs.h"
+#include "../../../ErrorCode.hpp"
+#include "../../../streaming_compression/passthrough/Decompressor.hpp"
+#include "../../../streaming_compression/zstd/Decompressor.hpp"
 #include "../Constants.hpp"
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 /**
  * Class for reading segments. A segment is a container for multiple compressed buffers that
  * itself may be further compressed and stored on disk.
@@ -63,6 +63,6 @@ private:
     static_assert(false, "Unsupported compression mode.");
 #endif
 };
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_SEGMENT_HPP

--- a/components/core/src/clp/streaming_archive/reader/SegmentManager.cpp
+++ b/components/core/src/clp/streaming_archive/reader/SegmentManager.cpp
@@ -2,7 +2,7 @@
 
 using std::string;
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 void SegmentManager::open(string const& segment_dir_path) {
     // Cleanup in case caller forgot to call close before calling this function
     close();
@@ -49,4 +49,4 @@ ErrorCode SegmentManager::try_read(
     auto& segment = m_id_to_open_segment.at(segment_id);
     return segment.try_read(decompressed_stream_pos, extraction_buf, extraction_len);
 }
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader

--- a/components/core/src/clp/streaming_archive/reader/SegmentManager.hpp
+++ b/components/core/src/clp/streaming_archive/reader/SegmentManager.hpp
@@ -6,10 +6,10 @@
 #include <string>
 #include <unordered_map>
 
-#include "../../Defs.h"
+#include "../../../Defs.h"
 #include "Segment.hpp"
 
-namespace streaming_archive::reader {
+namespace clp::streaming_archive::reader {
 /**
  * This class handles segments in a given directory. This primarily consists of reading from
  * segments in a given directory.
@@ -53,6 +53,6 @@ private:
     // List of open segment IDs in LRU order (LRU segment ID at front)
     std::list<segment_id_t> m_lru_ids_of_open_segments;
 };
-}  // namespace streaming_archive::reader
+}  // namespace clp::streaming_archive::reader
 
 #endif  // STREAMING_ARCHIVE_READER_SEGMENTMANAGER_HPP

--- a/components/core/src/clp/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.cpp
@@ -14,10 +14,10 @@
 #include <log_surgeon/LogEvent.hpp>
 #include <log_surgeon/LogParser.hpp>
 
-#include "../../EncodedVariableInterpreter.hpp"
-#include "../../ir/types.hpp"
-#include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
+#include "../../../EncodedVariableInterpreter.hpp"
+#include "../../../ir/types.hpp"
+#include "../../../spdlog_with_specializations.hpp"
+#include "../../../Utils.hpp"
 #include "../Constants.hpp"
 #include "utils.hpp"
 
@@ -30,7 +30,7 @@ using std::string;
 using std::unordered_set;
 using std::vector;
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 Archive::~Archive() {
     if (m_path.empty() == false || m_file != nullptr
         || m_files_with_timestamps_in_segment.empty() == false
@@ -659,4 +659,4 @@ template void Archive::write_log_event_ir<eight_byte_encoded_variable_t>(
 template void Archive::write_log_event_ir<four_byte_encoded_variable_t>(
         ir::LogEvent<four_byte_encoded_variable_t> const& log_event
 );
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer

--- a/components/core/src/clp/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.hpp
@@ -14,16 +14,16 @@
 #include <log_surgeon/LogEvent.hpp>
 #include <log_surgeon/ReaderParser.hpp>
 
-#include "../../ArrayBackedPosIntSet.hpp"
-#include "../../clp/GlobalMetadataDB.hpp"
-#include "../../ErrorCode.hpp"
-#include "../../ir/LogEvent.hpp"
-#include "../../LogTypeDictionaryWriter.hpp"
-#include "../../VariableDictionaryWriter.hpp"
+#include "../../../ArrayBackedPosIntSet.hpp"
+#include "../../../ErrorCode.hpp"
+#include "../../../ir/LogEvent.hpp"
+#include "../../../LogTypeDictionaryWriter.hpp"
+#include "../../../VariableDictionaryWriter.hpp"
+#include "../../GlobalMetadataDB.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 class Archive {
 public:
     // Types
@@ -46,7 +46,7 @@ public:
         size_t target_segment_uncompressed_size;
         int compression_level;
         std::string output_dir;
-        clp::GlobalMetadataDB* global_metadata_db;
+        GlobalMetadataDB* global_metadata_db;
         bool print_archive_stats_progress;
     };
 
@@ -337,10 +337,10 @@ private:
     std::optional<ArchiveMetadata> m_local_metadata;
     FileWriter m_metadata_file_writer;
 
-    clp::GlobalMetadataDB* m_global_metadata_db;
+    GlobalMetadataDB* m_global_metadata_db;
 
     bool m_print_archive_stats_progress;
 };
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer
 
 #endif  // STREAMING_ARCHIVE_WRITER_ARCHIVE_HPP

--- a/components/core/src/clp/streaming_archive/writer/File.cpp
+++ b/components/core/src/clp/streaming_archive/writer/File.cpp
@@ -1,13 +1,13 @@
 #include "File.hpp"
 
-#include "../../EncodedVariableInterpreter.hpp"
+#include "../../../EncodedVariableInterpreter.hpp"
 
 using std::string;
 using std::to_string;
 using std::unordered_set;
 using std::vector;
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 void File::open() {
     if (m_is_written_out) {
         throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
@@ -140,4 +140,4 @@ void File::set_segment_metadata(
     m_segment_variables_pos = segment_variables_uncompressed_pos;
     m_is_metadata_clean = false;
 }
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer

--- a/components/core/src/clp/streaming_archive/writer/File.hpp
+++ b/components/core/src/clp/streaming_archive/writer/File.hpp
@@ -7,14 +7,14 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-#include "../../Defs.h"
-#include "../../ErrorCode.hpp"
-#include "../../LogTypeDictionaryWriter.hpp"
-#include "../../PageAllocatedVector.hpp"
-#include "../../TimestampPattern.hpp"
+#include "../../../Defs.h"
+#include "../../../ErrorCode.hpp"
+#include "../../../LogTypeDictionaryWriter.hpp"
+#include "../../../PageAllocatedVector.hpp"
+#include "../../../TimestampPattern.hpp"
 #include "Segment.hpp"
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 /**
  * Class representing a log file encoded in three columns - timestamps, logtype IDs, and
  * variables.
@@ -251,6 +251,6 @@ private:
     bool m_is_written_out;
     bool m_is_open;
 };
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer
 
 #endif  // STREAMING_ARCHIVE_WRITER_FILE_HPP

--- a/components/core/src/clp/streaming_archive/writer/Segment.cpp
+++ b/components/core/src/clp/streaming_archive/writer/Segment.cpp
@@ -6,16 +6,16 @@
 #include <cmath>
 #include <cstring>
 
-#include "../../ErrorCode.hpp"
-#include "../../FileWriter.hpp"
-#include "../../spdlog_with_specializations.hpp"
+#include "../../../ErrorCode.hpp"
+#include "../../../FileWriter.hpp"
+#include "../../../spdlog_with_specializations.hpp"
 
 using std::make_unique;
 using std::string;
 using std::to_string;
 using std::unique_ptr;
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 Segment::~Segment() {
     if (!m_segment_path.empty()) {
         SPDLOG_ERROR(
@@ -86,4 +86,4 @@ size_t Segment::get_compressed_size() {
 bool Segment::is_open() const {
     return !m_segment_path.empty();
 }
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer

--- a/components/core/src/clp/streaming_archive/writer/Segment.hpp
+++ b/components/core/src/clp/streaming_archive/writer/Segment.hpp
@@ -4,14 +4,14 @@
 #include <memory>
 #include <string>
 
-#include "../../Defs.h"
-#include "../../ErrorCode.hpp"
-#include "../../streaming_compression/passthrough/Compressor.hpp"
-#include "../../streaming_compression/zstd/Compressor.hpp"
-#include "../../TraceableException.hpp"
+#include "../../../Defs.h"
+#include "../../../ErrorCode.hpp"
+#include "../../../streaming_compression/passthrough/Compressor.hpp"
+#include "../../../streaming_compression/zstd/Compressor.hpp"
+#include "../../../TraceableException.hpp"
 #include "../Constants.hpp"
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 /**
  * Class for writing segments. A segment is a container for multiple compressed buffers that
  * itself may be further compressed and then stored on disk.
@@ -94,6 +94,6 @@ private:
     static_assert(false, "Unsupported compression mode.");
 #endif
 };
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer
 
 #endif  // STREAMING_ARCHIVE_WRITER_SEGMENT_HPP

--- a/components/core/src/clp/streaming_archive/writer/utils.cpp
+++ b/components/core/src/clp/streaming_archive/writer/utils.cpp
@@ -4,13 +4,13 @@
 
 #include <boost/uuid/random_generator.hpp>
 
-#include "../../Defs.h"
-#include "../../TimestampPattern.hpp"
+#include "../../../Defs.h"
+#include "../../../TimestampPattern.hpp"
 #include "Archive.hpp"
 
 using std::string;
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 auto split_archive(Archive::UserConfig& archive_user_config, Archive& archive_writer) -> void {
     archive_writer.close();
     archive_user_config.id = boost::uuids::random_generator()();
@@ -59,4 +59,4 @@ auto close_file_and_append_to_segment(Archive& archive_writer) -> void {
     archive_writer.close_file();
     archive_writer.append_file_to_segment();
 }
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer

--- a/components/core/src/clp/streaming_archive/writer/utils.hpp
+++ b/components/core/src/clp/streaming_archive/writer/utils.hpp
@@ -3,11 +3,11 @@
 
 #include <string>
 
-#include "../../Defs.h"
-#include "../../TimestampPattern.hpp"
+#include "../../../Defs.h"
+#include "../../../TimestampPattern.hpp"
 #include "Archive.hpp"
 
-namespace streaming_archive::writer {
+namespace clp::streaming_archive::writer {
 /**
  * Closes the current archive and starts a new one
  * @param archive_user_config
@@ -50,6 +50,6 @@ auto split_file_and_archive(
  * @param archive
  */
 auto close_file_and_append_to_segment(Archive& archive) -> void;
-}  // namespace streaming_archive::writer
+}  // namespace clp::streaming_archive::writer
 
 #endif  // STREAMING_ARCHIVE_WRITER_UTILS_HPP

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -2,9 +2,9 @@
 
 #include <Catch2/single_include/catch2/catch.hpp>
 
+#include "../src/clp/streaming_archive/Constants.hpp"
 #include "../src/EncodedVariableInterpreter.hpp"
 #include "../src/ir/types.hpp"
-#include "../src/streaming_archive/Constants.hpp"
 
 using ir::VariablePlaceholder;
 using std::string;

--- a/components/core/tests/test-Segment.cpp
+++ b/components/core/tests/test-Segment.cpp
@@ -3,8 +3,8 @@
 #include <boost/filesystem.hpp>
 #include <Catch2/single_include/catch2/catch.hpp>
 
-#include "../src/streaming_archive/reader/Segment.hpp"
-#include "../src/streaming_archive/writer/Segment.hpp"
+#include "../src/clp/streaming_archive/reader/Segment.hpp"
+#include "../src/clp/streaming_archive/writer/Segment.hpp"
 #include "../src/Utils.hpp"
 
 using std::string;
@@ -28,7 +28,7 @@ TEST_CASE("Test writing and reading a segment", "[Segment]") {
     REQUIRE(ErrorCode_Success == error_code);
 
     // Test segment writing
-    streaming_archive::writer::Segment writer_segment;
+    clp::streaming_archive::writer::Segment writer_segment;
 
     writer_segment.open(segments_dir_path, 0, 0);
     auto segment_id = writer_segment.get_id();
@@ -39,7 +39,7 @@ TEST_CASE("Test writing and reading a segment", "[Segment]") {
     writer_segment.close();
 
     // Test reading
-    streaming_archive::reader::Segment reader_segment;
+    clp::streaming_archive::reader::Segment reader_segment;
 
     error_code = reader_segment.try_open(segments_dir_path, segment_id);
     REQUIRE(ErrorCode_Success == error_code);


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR moves the `streaming_archive` sources into the `clp` namespace.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated unit tests pass.
* Validated compression and decompression with the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset.
* Validated a search `"DESERIALIZE_ERRORS"` returns the same (after sorting) results as `grep`.
