### PR TITLE
Move EncodedVariableInterpreter, Grep, and LogSurgeonReader sources into the clp namespace.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -186,6 +186,8 @@ set(SOURCE_FILES_unitTest
         src/clp/clp/run.hpp
         src/clp/clp/utils.cpp
         src/clp/clp/utils.hpp
+        src/clp/EncodedVariableInterpreter.cpp
+        src/clp/EncodedVariableInterpreter.hpp
         src/clp/GlobalMetadataDB.hpp
         src/clp/GlobalMetadataDBConfig.cpp
         src/clp/GlobalMetadataDBConfig.hpp
@@ -193,6 +195,10 @@ set(SOURCE_FILES_unitTest
         src/clp/GlobalMySQLMetadataDB.hpp
         src/clp/GlobalSQLiteMetadataDB.cpp
         src/clp/GlobalSQLiteMetadataDB.hpp
+        src/clp/Grep.cpp
+        src/clp/Grep.hpp
+        src/clp/LogSurgeonReader.cpp
+        src/clp/LogSurgeonReader.hpp
         src/clp/streaming_archive/ArchiveMetadata.cpp
         src/clp/streaming_archive/ArchiveMetadata.hpp
         src/clp/streaming_archive/Constants.hpp
@@ -224,8 +230,6 @@ set(SOURCE_FILES_unitTest
         src/DictionaryEntry.hpp
         src/DictionaryReader.hpp
         src/DictionaryWriter.hpp
-        src/EncodedVariableInterpreter.cpp
-        src/EncodedVariableInterpreter.hpp
         src/ErrorCode.hpp
         src/ffi/encoding_methods.cpp
         src/ffi/encoding_methods.hpp
@@ -255,8 +259,6 @@ set(SOURCE_FILES_unitTest
         src/FileReader.hpp
         src/FileWriter.cpp
         src/FileWriter.hpp
-        src/Grep.cpp
-        src/Grep.hpp
         src/ir/LogEvent.hpp
         src/ir/LogEventDeserializer.cpp
         src/ir/LogEventDeserializer.hpp
@@ -270,8 +272,6 @@ set(SOURCE_FILES_unitTest
         src/LibarchiveFileReader.hpp
         src/LibarchiveReader.cpp
         src/LibarchiveReader.hpp
-        src/LogSurgeonReader.cpp
-        src/LogSurgeonReader.hpp
         src/LogTypeDictionaryEntry.cpp
         src/LogTypeDictionaryEntry.hpp
         src/LogTypeDictionaryReader.hpp

--- a/components/core/src/clp/EncodedVariableInterpreter.cpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.cpp
@@ -5,12 +5,12 @@
 
 #include <string_utils/string_utils.hpp>
 
-#include "Defs.h"
-#include "ffi/ir_stream/decoding_methods.hpp"
-#include "ir/LogEvent.hpp"
-#include "ir/types.hpp"
-#include "spdlog_with_specializations.hpp"
-#include "type_utils.hpp"
+#include "../Defs.h"
+#include "../ffi/ir_stream/decoding_methods.hpp"
+#include "../ir/LogEvent.hpp"
+#include "../ir/types.hpp"
+#include "../spdlog_with_specializations.hpp"
+#include "../type_utils.hpp"
 
 using ffi::cEightByteEncodedFloatDigitsBitMask;
 using ir::eight_byte_encoded_variable_t;
@@ -21,6 +21,7 @@ using std::string;
 using std::unordered_set;
 using std::vector;
 
+namespace clp {
 variable_dictionary_id_t EncodedVariableInterpreter::decode_var_dict_id(
         encoded_variable_t encoded_var
 ) {
@@ -481,3 +482,4 @@ EncodedVariableInterpreter::encode_and_add_to_dictionary<four_byte_encoded_varia
         std::vector<variable_dictionary_id_t>& var_ids,
         size_t& raw_num_bytes
 );
+}  // namespace clp

--- a/components/core/src/clp/EncodedVariableInterpreter.hpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.hpp
@@ -1,16 +1,17 @@
-#ifndef ENCODEDVARIABLEINTERPRETER_HPP
-#define ENCODEDVARIABLEINTERPRETER_HPP
+#ifndef CLP_ENCODEDVARIABLEINTERPRETER_HPP
+#define CLP_ENCODEDVARIABLEINTERPRETER_HPP
 
 #include <string>
 #include <vector>
 
-#include "ir/LogEvent.hpp"
-#include "ir/types.hpp"
-#include "Query.hpp"
-#include "TraceableException.hpp"
-#include "VariableDictionaryReader.hpp"
-#include "VariableDictionaryWriter.hpp"
+#include "../ir/LogEvent.hpp"
+#include "../ir/types.hpp"
+#include "../Query.hpp"
+#include "../TraceableException.hpp"
+#include "../VariableDictionaryReader.hpp"
+#include "../VariableDictionaryWriter.hpp"
 
+namespace clp {
 /**
  * Class to parse and encode strings into encoded variables and to interpret encoded variables back
  * into strings. An encoded variable is one of:
@@ -197,5 +198,6 @@ private:
             std::vector<variable_dictionary_id_t>& var_ids
     );
 };
+}  // namespace clp
 
-#endif  // ENCODEDVARIABLEINTERPRETER_HPP
+#endif  // CLP_ENCODEDVARIABLEINTERPRETER_HPP

--- a/components/core/src/clp/Grep.cpp
+++ b/components/core/src/clp/Grep.cpp
@@ -5,12 +5,12 @@
 #include <log_surgeon/Constants.hpp>
 #include <string_utils/string_utils.hpp>
 
+#include "../ir/parsing.hpp"
+#include "../ir/types.hpp"
+#include "../StringReader.hpp"
+#include "../Utils.hpp"
 #include "EncodedVariableInterpreter.hpp"
-#include "ir/parsing.hpp"
-#include "ir/types.hpp"
 #include "LogSurgeonReader.hpp"
-#include "StringReader.hpp"
-#include "Utils.hpp"
 
 using clp::streaming_archive::reader::Archive;
 using clp::streaming_archive::reader::File;
@@ -23,6 +23,8 @@ using string_utils::is_alphabet;
 using string_utils::is_wildcard;
 using string_utils::wildcard_match_unsafe;
 
+namespace clp {
+namespace {
 // Local types
 enum class SubQueryMatchabilityResult {
     MayMatch,  // The subquery might match a message
@@ -268,7 +270,7 @@ public:
  * @param logtype
  * @return true if this token might match a message, false otherwise
  */
-static bool process_var_token(
+bool process_var_token(
         QueryToken const& query_token,
         Archive const& archive,
         bool ignore_case,
@@ -284,7 +286,7 @@ static bool process_var_token(
  * @param compressed_msg
  * @return true on success, false otherwise
  */
-static bool find_matching_message(
+bool find_matching_message(
         Query const& query,
         Archive& archive,
         SubQuery const*& matching_sub_query,
@@ -302,7 +304,7 @@ static bool find_matching_message(
  * @return SubQueryMatchabilityResult::WontMatch
  * @return SubQueryMatchabilityResult::MayMatch
  */
-static SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
+SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
         Archive const& archive,
         string& processed_search_string,
         vector<QueryToken>& query_tokens,
@@ -310,7 +312,7 @@ static SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
         SubQuery& sub_query
 );
 
-static bool process_var_token(
+bool process_var_token(
         QueryToken const& query_token,
         Archive const& archive,
         bool ignore_case,
@@ -370,7 +372,7 @@ static bool process_var_token(
     return true;
 }
 
-static bool find_matching_message(
+bool find_matching_message(
         Query const& query,
         Archive& archive,
         SubQuery const*& matching_sub_query,
@@ -492,6 +494,7 @@ SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
 
     return SubQueryMatchabilityResult::MayMatch;
 }
+}  // namespace
 
 std::optional<Query> Grep::process_raw_query(
         Archive const& archive,
@@ -1060,3 +1063,4 @@ size_t Grep::search(Query const& query, size_t limit, Archive& archive, File& co
 
     return num_matches;
 }
+}  // namespace clp

--- a/components/core/src/clp/Grep.hpp
+++ b/components/core/src/clp/Grep.hpp
@@ -1,16 +1,17 @@
-#ifndef GREP_HPP
-#define GREP_HPP
+#ifndef CLP_GREP_HPP
+#define CLP_GREP_HPP
 
 #include <optional>
 #include <string>
 
 #include <log_surgeon/Lexer.hpp>
 
-#include "clp/streaming_archive/reader/Archive.hpp"
-#include "clp/streaming_archive/reader/File.hpp"
-#include "Defs.h"
-#include "Query.hpp"
+#include "../Defs.h"
+#include "../Query.hpp"
+#include "streaming_archive/reader/Archive.hpp"
+#include "streaming_archive/reader/File.hpp"
 
+namespace clp {
 class Grep {
 public:
     // Types
@@ -23,7 +24,7 @@ public:
      */
     typedef void (*OutputFunc)(
             std::string const& orig_file_path,
-            clp::streaming_archive::reader::Message const& compressed_msg,
+            streaming_archive::reader::Message const& compressed_msg,
             std::string const& decompressed_msg,
             void* custom_arg
     );
@@ -42,7 +43,7 @@ public:
      * @return Query if it may match a message, std::nullopt otherwise
      */
     static std::optional<Query> process_raw_query(
-            clp::streaming_archive::reader::Archive const& archive,
+            streaming_archive::reader::Archive const& archive,
             std::string const& search_string,
             epochtime_t search_begin_ts,
             epochtime_t search_end_ts,
@@ -93,7 +94,7 @@ public:
      * @param queries
      */
     static void calculate_sub_queries_relevant_to_file(
-            clp::streaming_archive::reader::File const& compressed_file,
+            streaming_archive::reader::File const& compressed_file,
             std::vector<Query>& queries
     );
 
@@ -106,23 +107,23 @@ public:
      * @param output_func
      * @param output_func_arg
      * @return Number of matches found
-     * @throw clp::streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
+     * @throw streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
      * fails
      * @throw TimestampPattern::OperationFailed if failed to insert timestamp into message
      */
     static size_t search_and_output(
             Query const& query,
             size_t limit,
-            clp::streaming_archive::reader::Archive& archive,
-            clp::streaming_archive::reader::File& compressed_file,
+            streaming_archive::reader::Archive& archive,
+            streaming_archive::reader::File& compressed_file,
             OutputFunc output_func,
             void* output_func_arg
     );
     static bool search_and_decompress(
             Query const& query,
-            clp::streaming_archive::reader::Archive& archive,
-            clp::streaming_archive::reader::File& compressed_file,
-            clp::streaming_archive::reader::Message& compressed_msg,
+            streaming_archive::reader::Archive& archive,
+            streaming_archive::reader::File& compressed_file,
+            streaming_archive::reader::Message& compressed_msg,
             std::string& decompressed_msg
     );
     /**
@@ -132,16 +133,17 @@ public:
      * @param archive
      * @param compressed_file
      * @return Number of matches found
-     * @throw clp::streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
+     * @throw streaming_archive::reader::Archive::OperationFailed if decompression unexpectedly
      * fails
      * @throw TimestampPattern::OperationFailed if failed to insert timestamp into message
      */
     static size_t search(
             Query const& query,
             size_t limit,
-            clp::streaming_archive::reader::Archive& archive,
-            clp::streaming_archive::reader::File& compressed_file
+            streaming_archive::reader::Archive& archive,
+            streaming_archive::reader::File& compressed_file
     );
 };
+}  // namespace clp
 
-#endif  // GREP_HPP
+#endif  // CLP_GREP_HPP

--- a/components/core/src/clp/LogSurgeonReader.cpp
+++ b/components/core/src/clp/LogSurgeonReader.cpp
@@ -1,5 +1,6 @@
 #include "LogSurgeonReader.hpp"
 
+namespace clp {
 LogSurgeonReader::LogSurgeonReader(ReaderInterface& reader_interface)
         : m_reader_interface(reader_interface) {
     read = [this](char* buf, size_t count, size_t& read_to) -> log_surgeon::ErrorCode {
@@ -10,3 +11,4 @@ LogSurgeonReader::LogSurgeonReader(ReaderInterface& reader_interface)
         return log_surgeon::ErrorCode::Success;
     };
 }
+}  // namespace clp

--- a/components/core/src/clp/LogSurgeonReader.hpp
+++ b/components/core/src/clp/LogSurgeonReader.hpp
@@ -1,10 +1,11 @@
-#ifndef LOG_SURGEON_READER_HPP
-#define LOG_SURGEON_READER_HPP
+#ifndef CLP_LOG_SURGEON_READER_HPP
+#define CLP_LOG_SURGEON_READER_HPP
 
 #include <log_surgeon/Reader.hpp>
 
-#include "ReaderInterface.hpp"
+#include "../ReaderInterface.hpp"
 
+namespace clp {
 /*
  * Wrapper providing a read function that works with the parsers in log_surgeon.
  */
@@ -15,5 +16,6 @@ public:
 private:
     ReaderInterface& m_reader_interface;
 };
+}  // namespace clp
 
-#endif  // LOG_SURGEON_READER_HPP
+#endif  // CLP_LOG_SURGEON_READER_HPP

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(
         CLG_SOURCES
+        ../EncodedVariableInterpreter.cpp
+        ../EncodedVariableInterpreter.hpp
         ../GlobalMetadataDB.hpp
         ../GlobalMetadataDBConfig.cpp
         ../GlobalMetadataDBConfig.hpp
@@ -7,6 +9,10 @@ set(
         ../GlobalMySQLMetadataDB.hpp
         ../GlobalSQLiteMetadataDB.cpp
         ../GlobalSQLiteMetadataDB.hpp
+        ../Grep.cpp
+        ../Grep.hpp
+        ../LogSurgeonReader.cpp
+        ../LogSurgeonReader.hpp
         ../streaming_archive/ArchiveMetadata.cpp
         ../streaming_archive/ArchiveMetadata.hpp
         ../streaming_archive/Constants.hpp
@@ -35,8 +41,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/dictionary_utils.hpp"
         "${PROJECT_SOURCE_DIR}/src/DictionaryEntry.hpp"
         "${PROJECT_SOURCE_DIR}/src/DictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/EncodedVariableInterpreter.cpp"
-        "${PROJECT_SOURCE_DIR}/src/EncodedVariableInterpreter.hpp"
         "${PROJECT_SOURCE_DIR}/src/ErrorCode.hpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.cpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.hpp"
@@ -48,15 +52,11 @@ set(
         "${PROJECT_SOURCE_DIR}/src/FileReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.cpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Grep.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Grep.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/LogEvent.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.cpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.inc"
         "${PROJECT_SOURCE_DIR}/src/ir/types.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogSurgeonReader.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogSurgeonReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"

--- a/components/core/src/clp/clg/clg.cpp
+++ b/components/core/src/clp/clg/clg.cpp
@@ -7,18 +7,19 @@
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "../../Defs.h"
-#include "../../Grep.hpp"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../Utils.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
+#include "../Grep.hpp"
 #include "../streaming_archive/Constants.hpp"
 #include "CommandLineArguments.hpp"
 
 using clp::clg::CommandLineArguments;
 using clp::GlobalMetadataDB;
 using clp::GlobalMetadataDBConfig;
+using clp::Grep;
 using clp::streaming_archive::MetadataDB;
 using clp::streaming_archive::reader::Archive;
 using clp::streaming_archive::reader::File;

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(
         CLO_SOURCES
+        ../EncodedVariableInterpreter.cpp
+        ../EncodedVariableInterpreter.hpp
+        ../Grep.cpp
+        ../Grep.hpp
+        ../LogSurgeonReader.cpp
+        ../LogSurgeonReader.hpp
         ../networking/socket_utils.cpp
         ../networking/socket_utils.hpp
         ../networking/SocketOperationFailed.hpp
@@ -31,8 +37,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/dictionary_utils.hpp"
         "${PROJECT_SOURCE_DIR}/src/DictionaryEntry.hpp"
         "${PROJECT_SOURCE_DIR}/src/DictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/EncodedVariableInterpreter.cpp"
-        "${PROJECT_SOURCE_DIR}/src/EncodedVariableInterpreter.hpp"
         "${PROJECT_SOURCE_DIR}/src/ErrorCode.hpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.cpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.hpp"
@@ -44,15 +48,11 @@ set(
         "${PROJECT_SOURCE_DIR}/src/FileReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.cpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Grep.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Grep.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/LogEvent.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.cpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.inc"
         "${PROJECT_SOURCE_DIR}/src/ir/types.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogSurgeonReader.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogSurgeonReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -8,16 +8,17 @@
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "../../Defs.h"
-#include "../../Grep.hpp"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../Utils.hpp"
+#include "../Grep.hpp"
 #include "../networking/socket_utils.hpp"
 #include "../streaming_archive/Constants.hpp"
 #include "CommandLineArguments.hpp"
 #include "ControllerMonitoringThread.hpp"
 
 using clp::clo::CommandLineArguments;
+using clp::Grep;
 using clp::streaming_archive::MetadataDB;
 using clp::streaming_archive::reader::Archive;
 using clp::streaming_archive::reader::File;

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(
         CLP_SOURCES
+        ../EncodedVariableInterpreter.cpp
+        ../EncodedVariableInterpreter.hpp
         ../GlobalMetadataDB.hpp
         ../GlobalMetadataDBConfig.cpp
         ../GlobalMetadataDBConfig.hpp
@@ -7,6 +9,8 @@ set(
         ../GlobalMySQLMetadataDB.hpp
         ../GlobalSQLiteMetadataDB.cpp
         ../GlobalSQLiteMetadataDB.hpp
+        ../LogSurgeonReader.cpp
+        ../LogSurgeonReader.hpp
         ../streaming_archive/ArchiveMetadata.cpp
         ../streaming_archive/ArchiveMetadata.hpp
         ../streaming_archive/Constants.hpp
@@ -43,8 +47,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/DictionaryEntry.hpp"
         "${PROJECT_SOURCE_DIR}/src/DictionaryReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/DictionaryWriter.hpp"
-        "${PROJECT_SOURCE_DIR}/src/EncodedVariableInterpreter.cpp"
-        "${PROJECT_SOURCE_DIR}/src/EncodedVariableInterpreter.hpp"
         "${PROJECT_SOURCE_DIR}/src/ErrorCode.hpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.cpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.hpp"
@@ -72,8 +74,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/LibarchiveFileReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/LibarchiveReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/LibarchiveReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogSurgeonReader.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogSurgeonReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
         "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"

--- a/components/core/src/clp/clp/FileCompressor.cpp
+++ b/components/core/src/clp/clp/FileCompressor.cpp
@@ -13,8 +13,8 @@
 #include "../../ffi/ir_stream/decoding_methods.hpp"
 #include "../../ir/types.hpp"
 #include "../../ir/utils.hpp"
-#include "../../LogSurgeonReader.hpp"
 #include "../../Profiler.hpp"
+#include "../LogSurgeonReader.hpp"
 #include "../streaming_archive/writer/utils.hpp"
 #include "utils.hpp"
 

--- a/components/core/src/clp/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.cpp
@@ -8,9 +8,9 @@
 
 #include <boost/filesystem.hpp>
 
-#include "../../../EncodedVariableInterpreter.hpp"
 #include "../../../spdlog_with_specializations.hpp"
 #include "../../../Utils.hpp"
+#include "../../EncodedVariableInterpreter.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../Constants.hpp"
 

--- a/components/core/src/clp/streaming_archive/reader/File.cpp
+++ b/components/core/src/clp/streaming_archive/reader/File.cpp
@@ -3,8 +3,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "../../../EncodedVariableInterpreter.hpp"
 #include "../../../spdlog_with_specializations.hpp"
+#include "../../EncodedVariableInterpreter.hpp"
 #include "../Constants.hpp"
 #include "SegmentManager.hpp"
 

--- a/components/core/src/clp/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.cpp
@@ -14,10 +14,10 @@
 #include <log_surgeon/LogEvent.hpp>
 #include <log_surgeon/LogParser.hpp>
 
-#include "../../../EncodedVariableInterpreter.hpp"
 #include "../../../ir/types.hpp"
 #include "../../../spdlog_with_specializations.hpp"
 #include "../../../Utils.hpp"
+#include "../../EncodedVariableInterpreter.hpp"
 #include "../Constants.hpp"
 #include "utils.hpp"
 

--- a/components/core/src/clp/streaming_archive/writer/File.cpp
+++ b/components/core/src/clp/streaming_archive/writer/File.cpp
@@ -1,6 +1,6 @@
 #include "File.hpp"
 
-#include "../../../EncodedVariableInterpreter.hpp"
+#include "../../EncodedVariableInterpreter.hpp"
 
 using std::string;
 using std::to_string;

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -2,10 +2,11 @@
 
 #include <Catch2/single_include/catch2/catch.hpp>
 
+#include "../src/clp/EncodedVariableInterpreter.hpp"
 #include "../src/clp/streaming_archive/Constants.hpp"
-#include "../src/EncodedVariableInterpreter.hpp"
 #include "../src/ir/types.hpp"
 
+using clp::EncodedVariableInterpreter;
 using ir::VariablePlaceholder;
 using std::string;
 using std::to_string;

--- a/components/core/tests/test-Grep.cpp
+++ b/components/core/tests/test-Grep.cpp
@@ -4,8 +4,9 @@
 #include <log_surgeon/Lexer.hpp>
 #include <log_surgeon/SchemaParser.hpp>
 
-#include "../src/Grep.hpp"
+#include "../src/clp/Grep.hpp"
 
+using clp::Grep;
 using log_surgeon::DelimiterStringAST;
 using log_surgeon::lexers::ByteLexer;
 using log_surgeon::ParserAST;

--- a/components/core/tests/test-ParserWithUserSchema.cpp
+++ b/components/core/tests/test-ParserWithUserSchema.cpp
@@ -12,9 +12,10 @@
 
 #include "../src/clp/clp/run.hpp"
 #include "../src/clp/GlobalMySQLMetadataDB.hpp"
-#include "../src/LogSurgeonReader.hpp"
+#include "../src/clp/LogSurgeonReader.hpp"
 #include "../src/Utils.hpp"
 
+using clp::LogSurgeonReader;
 using log_surgeon::DelimiterStringAST;
 using log_surgeon::LALR1Parser;
 using log_surgeon::lexers::ByteLexer;


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR moves the `EncodedVariableInterpreter`, `Grep`, and `LogSurgeonReader` sources into the `clp` namespace.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated unit tests pass.
* Validated compression and decompression with the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset.
* Validated a search `"DESERIALIZE_ERRORS"` returns the same (after sorting) results as `grep`.
