### PR TITLE
Move Query, Utils, and dictionary-related sources into the clp namespace.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -186,6 +186,11 @@ set(SOURCE_FILES_unitTest
         src/clp/clp/run.hpp
         src/clp/clp/utils.cpp
         src/clp/clp/utils.hpp
+        src/clp/dictionary_utils.cpp
+        src/clp/dictionary_utils.hpp
+        src/clp/DictionaryEntry.hpp
+        src/clp/DictionaryReader.hpp
+        src/clp/DictionaryWriter.hpp
         src/clp/EncodedVariableInterpreter.cpp
         src/clp/EncodedVariableInterpreter.hpp
         src/clp/GlobalMetadataDB.hpp
@@ -199,6 +204,13 @@ set(SOURCE_FILES_unitTest
         src/clp/Grep.hpp
         src/clp/LogSurgeonReader.cpp
         src/clp/LogSurgeonReader.hpp
+        src/clp/LogTypeDictionaryEntry.cpp
+        src/clp/LogTypeDictionaryEntry.hpp
+        src/clp/LogTypeDictionaryReader.hpp
+        src/clp/LogTypeDictionaryWriter.cpp
+        src/clp/LogTypeDictionaryWriter.hpp
+        src/clp/Query.cpp
+        src/clp/Query.hpp
         src/clp/streaming_archive/ArchiveMetadata.cpp
         src/clp/streaming_archive/ArchiveMetadata.hpp
         src/clp/streaming_archive/Constants.hpp
@@ -222,14 +234,16 @@ set(SOURCE_FILES_unitTest
         src/clp/streaming_archive/writer/Segment.hpp
         src/clp/streaming_archive/writer/utils.cpp
         src/clp/streaming_archive/writer/utils.hpp
+        src/clp/Utils.cpp
+        src/clp/Utils.hpp
+        src/clp/VariableDictionaryEntry.cpp
+        src/clp/VariableDictionaryEntry.hpp
+        src/clp/VariableDictionaryReader.hpp
+        src/clp/VariableDictionaryWriter.cpp
+        src/clp/VariableDictionaryWriter.hpp
         src/database_utils.cpp
         src/database_utils.hpp
         src/Defs.h
-        src/dictionary_utils.cpp
-        src/dictionary_utils.hpp
-        src/DictionaryEntry.hpp
-        src/DictionaryReader.hpp
-        src/DictionaryWriter.hpp
         src/ErrorCode.hpp
         src/ffi/encoding_methods.cpp
         src/ffi/encoding_methods.hpp
@@ -272,11 +286,6 @@ set(SOURCE_FILES_unitTest
         src/LibarchiveFileReader.hpp
         src/LibarchiveReader.cpp
         src/LibarchiveReader.hpp
-        src/LogTypeDictionaryEntry.cpp
-        src/LogTypeDictionaryEntry.hpp
-        src/LogTypeDictionaryReader.hpp
-        src/LogTypeDictionaryWriter.cpp
-        src/LogTypeDictionaryWriter.hpp
         src/math_utils.hpp
         src/MessageParser.cpp
         src/MessageParser.hpp
@@ -292,8 +301,6 @@ set(SOURCE_FILES_unitTest
         src/Platform.hpp
         src/Profiler.cpp
         src/Profiler.hpp
-        src/Query.cpp
-        src/Query.hpp
         src/ReaderInterface.cpp
         src/ReaderInterface.hpp
         src/spdlog_with_specializations.hpp
@@ -321,13 +328,6 @@ set(SOURCE_FILES_unitTest
         src/TimestampPattern.hpp
         src/TraceableException.hpp
         src/type_utils.hpp
-        src/Utils.cpp
-        src/Utils.hpp
-        src/VariableDictionaryEntry.cpp
-        src/VariableDictionaryEntry.hpp
-        src/VariableDictionaryReader.hpp
-        src/VariableDictionaryWriter.cpp
-        src/VariableDictionaryWriter.hpp
         src/version.hpp
         src/WriterInterface.cpp
         src/WriterInterface.hpp

--- a/components/core/src/clp/DictionaryEntry.hpp
+++ b/components/core/src/clp/DictionaryEntry.hpp
@@ -1,11 +1,12 @@
-#ifndef DICTIONARYENTRY_HPP
-#define DICTIONARYENTRY_HPP
+#ifndef CLP_DICTIONARYENTRY_HPP
+#define CLP_DICTIONARYENTRY_HPP
 
 #include <set>
 #include <string>
 
-#include "Defs.h"
+#include "../Defs.h"
 
+namespace clp {
 /**
  * Template class representing a dictionary entry
  * @tparam DictionaryIdType
@@ -38,5 +39,6 @@ protected:
 
     std::set<segment_id_t> m_ids_of_segments_containing_entry;
 };
+}  // namespace clp
 
-#endif  // DICTIONARYENTRY_HPP
+#endif  // CLP_DICTIONARYENTRY_HPP

--- a/components/core/src/clp/DictionaryReader.hpp
+++ b/components/core/src/clp/DictionaryReader.hpp
@@ -1,5 +1,5 @@
-#ifndef DICTIONARYREADER_HPP
-#define DICTIONARYREADER_HPP
+#ifndef CLP_DICTIONARYREADER_HPP
+#define CLP_DICTIONARYREADER_HPP
 
 #include <string>
 #include <vector>
@@ -7,13 +7,14 @@
 #include <boost/algorithm/string.hpp>
 #include <string_utils/string_utils.hpp>
 
+#include "../FileReader.hpp"
+#include "../streaming_compression/passthrough/Decompressor.hpp"
+#include "../streaming_compression/zstd/Decompressor.hpp"
 #include "dictionary_utils.hpp"
 #include "DictionaryEntry.hpp"
-#include "FileReader.hpp"
-#include "streaming_compression/passthrough/Decompressor.hpp"
-#include "streaming_compression/zstd/Decompressor.hpp"
 #include "Utils.hpp"
 
+namespace clp {
 /**
  * Template class for reading dictionaries from disk and performing operations on them
  * @tparam DictionaryIdType
@@ -284,5 +285,6 @@ void DictionaryReader<DictionaryIdType, EntryType>::read_segment_ids() {
         m_entries[id].add_segment_containing_entry(segment_id);
     }
 }
+}  // namespace clp
 
-#endif  // DICTIONARYREADER_HPP
+#endif  // CLP_DICTIONARYREADER_HPP

--- a/components/core/src/clp/DictionaryWriter.hpp
+++ b/components/core/src/clp/DictionaryWriter.hpp
@@ -1,22 +1,23 @@
-#ifndef DICTIONARYWRITER_HPP
-#define DICTIONARYWRITER_HPP
+#ifndef CLP_DICTIONARYWRITER_HPP
+#define CLP_DICTIONARYWRITER_HPP
 
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-#include "ArrayBackedPosIntSet.hpp"
-#include "Defs.h"
+#include "../ArrayBackedPosIntSet.hpp"
+#include "../Defs.h"
+#include "../FileWriter.hpp"
+#include "../spdlog_with_specializations.hpp"
+#include "../streaming_compression/passthrough/Compressor.hpp"
+#include "../streaming_compression/passthrough/Decompressor.hpp"
+#include "../streaming_compression/zstd/Compressor.hpp"
+#include "../streaming_compression/zstd/Decompressor.hpp"
+#include "../TraceableException.hpp"
 #include "dictionary_utils.hpp"
-#include "FileWriter.hpp"
-#include "spdlog_with_specializations.hpp"
-#include "streaming_compression/passthrough/Compressor.hpp"
-#include "streaming_compression/passthrough/Decompressor.hpp"
-#include "streaming_compression/zstd/Compressor.hpp"
-#include "streaming_compression/zstd/Decompressor.hpp"
-#include "TraceableException.hpp"
 
+namespace clp {
 /**
  * Template class for performing operations on dictionaries and writing them to disk
  * @tparam DictionaryIdType
@@ -293,5 +294,6 @@ void DictionaryWriter<DictionaryIdType, EntryType>::index_segment(
     m_segment_index_file_writer.write_numeric_value<uint64_t>(m_num_segments_in_index);
     m_segment_index_file_writer.seek_from_begin(segment_index_file_writer_pos);
 }
+}  // namespace clp
 
-#endif  // DICTIONARYWRITER_HPP
+#endif  // CLP_DICTIONARYWRITER_HPP

--- a/components/core/src/clp/EncodedVariableInterpreter.hpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.hpp
@@ -6,10 +6,10 @@
 
 #include "../ir/LogEvent.hpp"
 #include "../ir/types.hpp"
-#include "../Query.hpp"
 #include "../TraceableException.hpp"
-#include "../VariableDictionaryReader.hpp"
-#include "../VariableDictionaryWriter.hpp"
+#include "Query.hpp"
+#include "VariableDictionaryReader.hpp"
+#include "VariableDictionaryWriter.hpp"
 
 namespace clp {
 /**

--- a/components/core/src/clp/Grep.cpp
+++ b/components/core/src/clp/Grep.cpp
@@ -8,9 +8,9 @@
 #include "../ir/parsing.hpp"
 #include "../ir/types.hpp"
 #include "../StringReader.hpp"
-#include "../Utils.hpp"
 #include "EncodedVariableInterpreter.hpp"
 #include "LogSurgeonReader.hpp"
+#include "Utils.hpp"
 
 using clp::streaming_archive::reader::Archive;
 using clp::streaming_archive::reader::File;

--- a/components/core/src/clp/Grep.hpp
+++ b/components/core/src/clp/Grep.hpp
@@ -7,7 +7,7 @@
 #include <log_surgeon/Lexer.hpp>
 
 #include "../Defs.h"
-#include "../Query.hpp"
+#include "Query.hpp"
 #include "streaming_archive/reader/Archive.hpp"
 #include "streaming_archive/reader/File.hpp"
 

--- a/components/core/src/clp/LogTypeDictionaryEntry.cpp
+++ b/components/core/src/clp/LogTypeDictionaryEntry.cpp
@@ -1,14 +1,15 @@
 #include "LogTypeDictionaryEntry.hpp"
 
-#include "ir/parsing.hpp"
-#include "ir/types.hpp"
-#include "type_utils.hpp"
+#include "../ir/parsing.hpp"
+#include "../ir/types.hpp"
+#include "../type_utils.hpp"
 #include "Utils.hpp"
 
 using ir::VariablePlaceholder;
 using std::string;
 using std::string_view;
 
+namespace clp {
 size_t LogTypeDictionaryEntry::get_placeholder_info(
         size_t placeholder_ix,
         VariablePlaceholder& placeholder
@@ -182,3 +183,4 @@ void LogTypeDictionaryEntry::read_from_file(streaming_compression::Decompressor&
         throw OperationFailed(error_code, __FILENAME__, __LINE__);
     }
 }
+}  // namespace clp

--- a/components/core/src/clp/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/clp/LogTypeDictionaryEntry.hpp
@@ -1,18 +1,19 @@
-#ifndef LOGTYPEDICTIONARYENTRY_HPP
-#define LOGTYPEDICTIONARYENTRY_HPP
+#ifndef CLP_LOGTYPEDICTIONARYENTRY_HPP
+#define CLP_LOGTYPEDICTIONARYENTRY_HPP
 
 #include <vector>
 
-#include "Defs.h"
+#include "../Defs.h"
+#include "../ErrorCode.hpp"
+#include "../FileReader.hpp"
+#include "../ir/types.hpp"
+#include "../streaming_compression/zstd/Compressor.hpp"
+#include "../streaming_compression/zstd/Decompressor.hpp"
+#include "../TraceableException.hpp"
+#include "../type_utils.hpp"
 #include "DictionaryEntry.hpp"
-#include "ErrorCode.hpp"
-#include "FileReader.hpp"
-#include "ir/types.hpp"
-#include "streaming_compression/zstd/Compressor.hpp"
-#include "streaming_compression/zstd/Decompressor.hpp"
-#include "TraceableException.hpp"
-#include "type_utils.hpp"
 
+namespace clp {
 /**
  * Class representing a logtype dictionary entry
  */
@@ -175,5 +176,6 @@ private:
     std::vector<size_t> m_placeholder_positions;
     size_t m_num_escaped_placeholders{0};
 };
+}  // namespace clp
 
-#endif  // LOGTYPEDICTIONARYENTRY_HPP
+#endif  // CLP_LOGTYPEDICTIONARYENTRY_HPP

--- a/components/core/src/clp/LogTypeDictionaryReader.hpp
+++ b/components/core/src/clp/LogTypeDictionaryReader.hpp
@@ -1,14 +1,16 @@
-#ifndef LOGTYPEDICTIONARYREADER_HPP
-#define LOGTYPEDICTIONARYREADER_HPP
+#ifndef CLP_LOGTYPEDICTIONARYREADER_HPP
+#define CLP_LOGTYPEDICTIONARYREADER_HPP
 
-#include "Defs.h"
+#include "../Defs.h"
 #include "DictionaryReader.hpp"
 #include "LogTypeDictionaryEntry.hpp"
 
+namespace clp {
 /**
  * Class for reading logtype dictionaries from disk and performing operations on them
  */
 class LogTypeDictionaryReader
         : public DictionaryReader<logtype_dictionary_id_t, LogTypeDictionaryEntry> {};
+}  // namespace clp
 
-#endif  // LOGTYPEDICTIONARYREADER_HPP
+#endif  // CLP_LOGTYPEDICTIONARYREADER_HPP

--- a/components/core/src/clp/LogTypeDictionaryWriter.cpp
+++ b/components/core/src/clp/LogTypeDictionaryWriter.cpp
@@ -4,6 +4,7 @@
 
 using std::string;
 
+namespace clp {
 bool LogTypeDictionaryWriter::add_entry(
         LogTypeDictionaryEntry& logtype_entry,
         logtype_dictionary_id_t& logtype_id
@@ -35,3 +36,4 @@ bool LogTypeDictionaryWriter::add_entry(
     }
     return is_new_entry;
 }
+}  // namespace clp

--- a/components/core/src/clp/LogTypeDictionaryWriter.hpp
+++ b/components/core/src/clp/LogTypeDictionaryWriter.hpp
@@ -1,13 +1,14 @@
-#ifndef LOGTYPEDICTIONARYWRITER_HPP
-#define LOGTYPEDICTIONARYWRITER_HPP
+#ifndef CLP_LOGTYPEDICTIONARYWRITER_HPP
+#define CLP_LOGTYPEDICTIONARYWRITER_HPP
 
 #include <memory>
 
-#include "Defs.h"
+#include "../Defs.h"
+#include "../FileWriter.hpp"
 #include "DictionaryWriter.hpp"
-#include "FileWriter.hpp"
 #include "LogTypeDictionaryEntry.hpp"
 
+namespace clp {
 /**
  * Class for performing operations on logtype dictionaries and writing them to disk
  */
@@ -35,5 +36,6 @@ public:
      */
     bool add_entry(LogTypeDictionaryEntry& logtype_entry, logtype_dictionary_id_t& logtype_id);
 };
+}  // namespace clp
 
-#endif  // LOGTYPEDICTIONARYWRITER_HPP
+#endif  // CLP_LOGTYPEDICTIONARYWRITER_HPP

--- a/components/core/src/clp/Query.cpp
+++ b/components/core/src/clp/Query.cpp
@@ -25,6 +25,7 @@ static void inplace_set_intersection(SetType const& a, SetType& b) {
     }
 }
 
+namespace clp {
 QueryVar::QueryVar(encoded_variable_t precise_non_dict_var) {
     m_precise_var = precise_non_dict_var;
     m_is_precise_var = true;
@@ -201,3 +202,4 @@ void Query::make_sub_queries_relevant_to_segment(segment_id_t segment_id) {
     }
     m_prev_segment_id = segment_id;
 }
+}  // namespace clp

--- a/components/core/src/clp/Query.hpp
+++ b/components/core/src/clp/Query.hpp
@@ -1,15 +1,16 @@
-#ifndef QUERY_HPP
-#define QUERY_HPP
+#ifndef CLP_QUERY_HPP
+#define CLP_QUERY_HPP
 
 #include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
-#include "Defs.h"
+#include "../Defs.h"
 #include "LogTypeDictionaryEntry.hpp"
 #include "VariableDictionaryEntry.hpp"
 
+namespace clp {
 /**
  * Class representing a variable in a subquery. It can represent a precise encoded variable or an
  * imprecise dictionary variable (i.e., a set of possible encoded dictionary variable IDs)
@@ -216,5 +217,6 @@ private:
     std::vector<SubQuery const*> m_relevant_sub_queries;
     segment_id_t m_prev_segment_id{cInvalidSegmentId};
 };
+}  // namespace clp
 
-#endif  // QUERY_HPP
+#endif  // CLP_QUERY_HPP

--- a/components/core/src/clp/Utils.cpp
+++ b/components/core/src/clp/Utils.cpp
@@ -14,12 +14,13 @@
 #include <spdlog/spdlog.h>
 #include <string_utils/string_utils.hpp>
 
-#include "spdlog_with_specializations.hpp"
+#include "../spdlog_with_specializations.hpp"
 
 using std::list;
 using std::string;
 using std::vector;
 
+namespace clp {
 ErrorCode create_directory(string const& path, mode_t mode, bool exist_ok) {
     int retval = mkdir(path.c_str(), mode);
     if (0 != retval) {
@@ -302,3 +303,4 @@ void load_lexer_from_file(
         lexer.generate();
     }
 }
+}  // namespace clp

--- a/components/core/src/clp/Utils.hpp
+++ b/components/core/src/clp/Utils.hpp
@@ -1,5 +1,5 @@
-#ifndef UTILS_HPP
-#define UTILS_HPP
+#ifndef CLP_UTILS_HPP
+#define CLP_UTILS_HPP
 
 #include <list>
 #include <set>
@@ -9,11 +9,12 @@
 
 #include <log_surgeon/Lexer.hpp>
 
-#include "Defs.h"
-#include "ErrorCode.hpp"
-#include "FileReader.hpp"
-#include "ParsedMessage.hpp"
+#include "../Defs.h"
+#include "../ErrorCode.hpp"
+#include "../FileReader.hpp"
+#include "../ParsedMessage.hpp"
 
+namespace clp {
 /**
  * Creates a directory with the given path
  * @param path
@@ -76,4 +77,6 @@ void load_lexer_from_file(
         bool done,
         log_surgeon::lexers::ByteLexer& forward_lexer_ptr
 );
-#endif  // UTILS_HPP
+}  // namespace clp
+
+#endif  // CLP_UTILS_HPP

--- a/components/core/src/clp/VariableDictionaryEntry.cpp
+++ b/components/core/src/clp/VariableDictionaryEntry.cpp
@@ -1,5 +1,6 @@
 #include "VariableDictionaryEntry.hpp"
 
+namespace clp {
 size_t VariableDictionaryEntry::get_data_size() const {
     return sizeof(m_id) + m_value.length()
            + m_ids_of_segments_containing_entry.size() * sizeof(segment_id_t);
@@ -40,3 +41,4 @@ void VariableDictionaryEntry::read_from_file(streaming_compression::Decompressor
         throw OperationFailed(error_code, __FILENAME__, __LINE__);
     }
 }
+}  // namespace clp

--- a/components/core/src/clp/VariableDictionaryEntry.hpp
+++ b/components/core/src/clp/VariableDictionaryEntry.hpp
@@ -1,13 +1,14 @@
-#ifndef VARIABLEDICTIONARYENTRY_HPP
-#define VARIABLEDICTIONARYENTRY_HPP
+#ifndef CLP_VARIABLEDICTIONARYENTRY_HPP
+#define CLP_VARIABLEDICTIONARYENTRY_HPP
 
-#include "Defs.h"
+#include "../Defs.h"
+#include "../ErrorCode.hpp"
+#include "../FileReader.hpp"
+#include "../streaming_compression/zstd/Compressor.hpp"
+#include "../streaming_compression/zstd/Decompressor.hpp"
 #include "DictionaryEntry.hpp"
-#include "ErrorCode.hpp"
-#include "FileReader.hpp"
-#include "streaming_compression/zstd/Compressor.hpp"
-#include "streaming_compression/zstd/Decompressor.hpp"
 
+namespace clp {
 /**
  * Class representing a variable dictionary entry
  */
@@ -66,5 +67,6 @@ public:
      */
     void read_from_file(streaming_compression::Decompressor& decompressor);
 };
+}  // namespace clp
 
-#endif  // VARIABLEDICTIONARYENTRY_HPP
+#endif  // CLP_VARIABLEDICTIONARYENTRY_HPP

--- a/components/core/src/clp/VariableDictionaryReader.hpp
+++ b/components/core/src/clp/VariableDictionaryReader.hpp
@@ -1,14 +1,16 @@
-#ifndef VARIABLEDICTIONARYREADER_HPP
-#define VARIABLEDICTIONARYREADER_HPP
+#ifndef CLP_VARIABLEDICTIONARYREADER_HPP
+#define CLP_VARIABLEDICTIONARYREADER_HPP
 
-#include "Defs.h"
+#include "../Defs.h"
 #include "DictionaryReader.hpp"
 #include "VariableDictionaryEntry.hpp"
 
+namespace clp {
 /**
  * Class for reading variable dictionaries from disk and performing operations on them
  */
 class VariableDictionaryReader
         : public DictionaryReader<variable_dictionary_id_t, VariableDictionaryEntry> {};
+}  // namespace clp
 
-#endif  // VARIABLEDICTIONARYREADER_HPP
+#endif  // CLP_VARIABLEDICTIONARYREADER_HPP

--- a/components/core/src/clp/VariableDictionaryWriter.cpp
+++ b/components/core/src/clp/VariableDictionaryWriter.cpp
@@ -1,8 +1,9 @@
 #include "VariableDictionaryWriter.hpp"
 
+#include "../spdlog_with_specializations.hpp"
 #include "dictionary_utils.hpp"
-#include "spdlog_with_specializations.hpp"
 
+namespace clp {
 bool VariableDictionaryWriter::add_entry(std::string const& value, variable_dictionary_id_t& id) {
     bool new_entry = false;
 
@@ -34,3 +35,4 @@ bool VariableDictionaryWriter::add_entry(std::string const& value, variable_dict
     }
     return new_entry;
 }
+}  // namespace clp

--- a/components/core/src/clp/VariableDictionaryWriter.hpp
+++ b/components/core/src/clp/VariableDictionaryWriter.hpp
@@ -1,10 +1,11 @@
-#ifndef VARIABLEDICTIONARYWRITER_HPP
-#define VARIABLEDICTIONARYWRITER_HPP
+#ifndef CLP_VARIABLEDICTIONARYWRITER_HPP
+#define CLP_VARIABLEDICTIONARYWRITER_HPP
 
-#include "Defs.h"
+#include "../Defs.h"
 #include "DictionaryWriter.hpp"
 #include "VariableDictionaryEntry.hpp"
 
+namespace clp {
 /**
  * Class for performing operations on variable dictionaries and writing them to disk
  */
@@ -31,5 +32,6 @@ public:
      */
     bool add_entry(std::string const& value, variable_dictionary_id_t& id);
 };
+}  // namespace clp
 
-#endif  // VARIABLEDICTIONARYWRITER_HPP
+#endif  // CLP_VARIABLEDICTIONARYWRITER_HPP

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(
         CLG_SOURCES
+        ../dictionary_utils.cpp
+        ../dictionary_utils.hpp
+        ../DictionaryEntry.hpp
+        ../DictionaryReader.hpp
         ../EncodedVariableInterpreter.cpp
         ../EncodedVariableInterpreter.hpp
         ../GlobalMetadataDB.hpp
@@ -13,6 +17,11 @@ set(
         ../Grep.hpp
         ../LogSurgeonReader.cpp
         ../LogSurgeonReader.hpp
+        ../LogTypeDictionaryEntry.cpp
+        ../LogTypeDictionaryEntry.hpp
+        ../LogTypeDictionaryReader.hpp
+        ../Query.cpp
+        ../Query.hpp
         ../streaming_archive/ArchiveMetadata.cpp
         ../streaming_archive/ArchiveMetadata.hpp
         ../streaming_archive/Constants.hpp
@@ -32,15 +41,18 @@ set(
         ../streaming_archive/writer/File.hpp
         ../streaming_archive/writer/Segment.cpp
         ../streaming_archive/writer/Segment.hpp
+        ../Utils.cpp
+        ../Utils.hpp
+        ../VariableDictionaryEntry.cpp
+        ../VariableDictionaryEntry.hpp
+        ../VariableDictionaryReader.hpp
+        ../VariableDictionaryWriter.cpp
+        ../VariableDictionaryWriter.hpp
         "${PROJECT_SOURCE_DIR}/src/BufferReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.cpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.hpp"
         "${PROJECT_SOURCE_DIR}/src/Defs.h"
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/ErrorCode.hpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.cpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.hpp"
@@ -57,9 +69,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.inc"
         "${PROJECT_SOURCE_DIR}/src/ir/types.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/MySQLDB.cpp"
         "${PROJECT_SOURCE_DIR}/src/MySQLDB.hpp"
         "${PROJECT_SOURCE_DIR}/src/MySQLParamBindings.cpp"
@@ -72,8 +81,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/Platform.hpp"
         "${PROJECT_SOURCE_DIR}/src/Profiler.cpp"
         "${PROJECT_SOURCE_DIR}/src/Profiler.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Query.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Query.hpp"
         "${PROJECT_SOURCE_DIR}/src/ReaderInterface.cpp"
         "${PROJECT_SOURCE_DIR}/src/ReaderInterface.hpp"
         "${PROJECT_SOURCE_DIR}/src/spdlog_with_specializations.hpp"
@@ -100,13 +107,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/TimestampPattern.hpp"
         "${PROJECT_SOURCE_DIR}/src/TraceableException.hpp"
         "${PROJECT_SOURCE_DIR}/src/type_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryWriter.cpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryWriter.hpp"
         "${PROJECT_SOURCE_DIR}/src/version.hpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.cpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.hpp"

--- a/components/core/src/clp/clg/clg.cpp
+++ b/components/core/src/clp/clg/clg.cpp
@@ -9,17 +9,19 @@
 #include "../../Defs.h"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
 #include "../Grep.hpp"
 #include "../streaming_archive/Constants.hpp"
+#include "../Utils.hpp"
 #include "CommandLineArguments.hpp"
 
 using clp::clg::CommandLineArguments;
 using clp::GlobalMetadataDB;
 using clp::GlobalMetadataDBConfig;
 using clp::Grep;
+using clp::load_lexer_from_file;
+using clp::Query;
 using clp::streaming_archive::MetadataDB;
 using clp::streaming_archive::reader::Archive;
 using clp::streaming_archive::reader::File;

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -1,14 +1,23 @@
 set(
         CLO_SOURCES
+        ../dictionary_utils.cpp
+        ../dictionary_utils.hpp
+        ../DictionaryEntry.hpp
+        ../DictionaryReader.hpp
         ../EncodedVariableInterpreter.cpp
         ../EncodedVariableInterpreter.hpp
         ../Grep.cpp
         ../Grep.hpp
         ../LogSurgeonReader.cpp
         ../LogSurgeonReader.hpp
+        ../LogTypeDictionaryEntry.cpp
+        ../LogTypeDictionaryEntry.hpp
+        ../LogTypeDictionaryReader.hpp
         ../networking/socket_utils.cpp
         ../networking/socket_utils.hpp
         ../networking/SocketOperationFailed.hpp
+        ../Query.cpp
+        ../Query.hpp
         ../streaming_archive/ArchiveMetadata.cpp
         ../streaming_archive/ArchiveMetadata.hpp
         ../streaming_archive/Constants.hpp
@@ -28,15 +37,18 @@ set(
         ../streaming_archive/writer/File.hpp
         ../streaming_archive/writer/Segment.cpp
         ../streaming_archive/writer/Segment.hpp
+        ../Utils.cpp
+        ../Utils.hpp
+        ../VariableDictionaryEntry.cpp
+        ../VariableDictionaryEntry.hpp
+        ../VariableDictionaryReader.hpp
+        ../VariableDictionaryWriter.cpp
+        ../VariableDictionaryWriter.hpp
         "${PROJECT_SOURCE_DIR}/src/BufferReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.cpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.hpp"
         "${PROJECT_SOURCE_DIR}/src/Defs.h"
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/ErrorCode.hpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.cpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.hpp"
@@ -53,17 +65,12 @@ set(
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.inc"
         "${PROJECT_SOURCE_DIR}/src/ir/types.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/PageAllocatedVector.hpp"
         "${PROJECT_SOURCE_DIR}/src/ParsedMessage.cpp"
         "${PROJECT_SOURCE_DIR}/src/ParsedMessage.hpp"
         "${PROJECT_SOURCE_DIR}/src/Platform.hpp"
         "${PROJECT_SOURCE_DIR}/src/Profiler.cpp"
         "${PROJECT_SOURCE_DIR}/src/Profiler.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Query.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Query.hpp"
         "${PROJECT_SOURCE_DIR}/src/ReaderInterface.cpp"
         "${PROJECT_SOURCE_DIR}/src/ReaderInterface.hpp"
         "${PROJECT_SOURCE_DIR}/src/spdlog_with_specializations.hpp"
@@ -92,13 +99,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/TimestampPattern.hpp"
         "${PROJECT_SOURCE_DIR}/src/TraceableException.hpp"
         "${PROJECT_SOURCE_DIR}/src/type_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryWriter.cpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryWriter.hpp"
         "${PROJECT_SOURCE_DIR}/src/version.hpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.cpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.hpp"

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -10,15 +10,17 @@
 #include "../../Defs.h"
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
 #include "../Grep.hpp"
 #include "../networking/socket_utils.hpp"
 #include "../streaming_archive/Constants.hpp"
+#include "../Utils.hpp"
 #include "CommandLineArguments.hpp"
 #include "ControllerMonitoringThread.hpp"
 
 using clp::clo::CommandLineArguments;
 using clp::Grep;
+using clp::load_lexer_from_file;
+using clp::Query;
 using clp::streaming_archive::MetadataDB;
 using clp::streaming_archive::reader::Archive;
 using clp::streaming_archive::reader::File;

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(
         CLP_SOURCES
+        ../dictionary_utils.cpp
+        ../dictionary_utils.hpp
+        ../DictionaryEntry.hpp
+        ../DictionaryReader.hpp
+        ../DictionaryWriter.hpp
         ../EncodedVariableInterpreter.cpp
         ../EncodedVariableInterpreter.hpp
         ../GlobalMetadataDB.hpp
@@ -11,6 +16,13 @@ set(
         ../GlobalSQLiteMetadataDB.hpp
         ../LogSurgeonReader.cpp
         ../LogSurgeonReader.hpp
+        ../LogTypeDictionaryEntry.cpp
+        ../LogTypeDictionaryEntry.hpp
+        ../LogTypeDictionaryReader.hpp
+        ../LogTypeDictionaryWriter.cpp
+        ../LogTypeDictionaryWriter.hpp
+        ../Query.cpp
+        ../Query.hpp
         ../streaming_archive/ArchiveMetadata.cpp
         ../streaming_archive/ArchiveMetadata.hpp
         ../streaming_archive/Constants.hpp
@@ -34,6 +46,13 @@ set(
         ../streaming_archive/writer/Segment.hpp
         ../streaming_archive/writer/utils.cpp
         ../streaming_archive/writer/utils.hpp
+        ../Utils.cpp
+        ../Utils.hpp
+        ../VariableDictionaryEntry.cpp
+        ../VariableDictionaryEntry.hpp
+        ../VariableDictionaryReader.hpp
+        ../VariableDictionaryWriter.cpp
+        ../VariableDictionaryWriter.hpp
         "${PROJECT_SOURCE_DIR}/src/ArrayBackedPosIntSet.hpp"
         "${PROJECT_SOURCE_DIR}/src/BufferedFileReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/BufferedFileReader.hpp"
@@ -42,11 +61,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/database_utils.cpp"
         "${PROJECT_SOURCE_DIR}/src/database_utils.hpp"
         "${PROJECT_SOURCE_DIR}/src/Defs.h"
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryWriter.hpp"
         "${PROJECT_SOURCE_DIR}/src/ErrorCode.hpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.cpp"
         "${PROJECT_SOURCE_DIR}/src/ffi/encoding_methods.hpp"
@@ -74,11 +88,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/LibarchiveFileReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/LibarchiveReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/LibarchiveReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryWriter.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryWriter.hpp"
         "${PROJECT_SOURCE_DIR}/src/math_utils.hpp"
         "${PROJECT_SOURCE_DIR}/src/MessageParser.cpp"
         "${PROJECT_SOURCE_DIR}/src/MessageParser.hpp"
@@ -94,8 +103,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/Platform.hpp"
         "${PROJECT_SOURCE_DIR}/src/Profiler.cpp"
         "${PROJECT_SOURCE_DIR}/src/Profiler.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Query.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Query.hpp"
         "${PROJECT_SOURCE_DIR}/src/ReaderInterface.cpp"
         "${PROJECT_SOURCE_DIR}/src/ReaderInterface.hpp"
         "${PROJECT_SOURCE_DIR}/src/spdlog_with_specializations.hpp"
@@ -123,13 +130,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/TimestampPattern.hpp"
         "${PROJECT_SOURCE_DIR}/src/TraceableException.hpp"
         "${PROJECT_SOURCE_DIR}/src/type_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryReader.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryWriter.cpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryWriter.hpp"
         "${PROJECT_SOURCE_DIR}/src/version.hpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.cpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.hpp"

--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -8,8 +8,8 @@
 
 #include "../../Defs.h"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
 #include "../../version.hpp"
+#include "../Utils.hpp"
 
 namespace po = boost::program_options;
 using std::cerr;

--- a/components/core/src/clp/clp/compression.cpp
+++ b/components/core/src/clp/clp/compression.cpp
@@ -7,11 +7,11 @@
 #include <boost/uuid/random_generator.hpp>
 
 #include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
 #include "../streaming_archive/writer/Archive.hpp"
 #include "../streaming_archive/writer/utils.hpp"
+#include "../Utils.hpp"
 #include "FileCompressor.hpp"
 #include "utils.hpp"
 

--- a/components/core/src/clp/clp/decompression.cpp
+++ b/components/core/src/clp/clp/decompression.cpp
@@ -9,10 +9,10 @@
 #include "../../FileWriter.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../TraceableException.hpp"
-#include "../../Utils.hpp"
 #include "../GlobalMySQLMetadataDB.hpp"
 #include "../GlobalSQLiteMetadataDB.hpp"
 #include "../streaming_archive/reader/Archive.hpp"
+#include "../Utils.hpp"
 #include "FileDecompressor.hpp"
 
 using std::cerr;

--- a/components/core/src/clp/clp/run.cpp
+++ b/components/core/src/clp/clp/run.cpp
@@ -7,7 +7,7 @@
 
 #include "../../Profiler.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
+#include "../Utils.hpp"
 #include "CommandLineArguments.hpp"
 #include "compression.hpp"
 #include "decompression.hpp"

--- a/components/core/src/clp/clp/utils.cpp
+++ b/components/core/src/clp/clp/utils.cpp
@@ -6,7 +6,7 @@
 
 #include "../../ErrorCode.hpp"
 #include "../../spdlog_with_specializations.hpp"
-#include "../../Utils.hpp"
+#include "../Utils.hpp"
 
 using std::string;
 using std::vector;

--- a/components/core/src/clp/dictionary_utils.cpp
+++ b/components/core/src/clp/dictionary_utils.cpp
@@ -1,5 +1,6 @@
 #include "dictionary_utils.hpp"
 
+namespace clp {
 void open_dictionary_for_reading(
         std::string const& dictionary_path,
         std::string const& segment_index_path,
@@ -43,3 +44,4 @@ uint64_t read_segment_index_header(FileReader& file_reader) {
     file_reader.seek_from_begin(segment_index_file_reader_pos);
     return num_segments;
 }
+}  // namespace clp

--- a/components/core/src/clp/dictionary_utils.hpp
+++ b/components/core/src/clp/dictionary_utils.hpp
@@ -1,11 +1,12 @@
-#ifndef DICTIONARY_UTILS_HPP
-#define DICTIONARY_UTILS_HPP
+#ifndef CLP_DICTIONARY_UTILS_HPP
+#define CLP_DICTIONARY_UTILS_HPP
 
 #include <string>
 
-#include "FileReader.hpp"
-#include "streaming_compression/Decompressor.hpp"
+#include "../FileReader.hpp"
+#include "../streaming_compression/Decompressor.hpp"
 
+namespace clp {
 void open_dictionary_for_reading(
         std::string const& dictionary_path,
         std::string const& segment_index_path,
@@ -19,5 +20,6 @@ void open_dictionary_for_reading(
 uint64_t read_dictionary_header(FileReader& file_reader);
 
 uint64_t read_segment_index_header(FileReader& file_reader);
+}  // namespace clp
 
-#endif  // DICTIONARY_UTILS_HPP
+#endif  // CLP_DICTIONARY_UTILS_HPP

--- a/components/core/src/clp/make_dictionaries_readable/CMakeLists.txt
+++ b/components/core/src/clp/make_dictionaries_readable/CMakeLists.txt
@@ -1,18 +1,23 @@
 set(
         MAKE_DICTIONARIES_READABLE_SOURCES
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/dictionary_utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/DictionaryReader.hpp"
+        ../dictionary_utils.cpp
+        ../dictionary_utils.hpp
+        ../DictionaryEntry.hpp
+        ../DictionaryReader.hpp
+        ../LogTypeDictionaryEntry.cpp
+        ../LogTypeDictionaryEntry.hpp
+        ../LogTypeDictionaryReader.hpp
+        ../Utils.cpp
+        ../Utils.hpp
+        ../VariableDictionaryEntry.cpp
+        ../VariableDictionaryEntry.hpp
+        ../VariableDictionaryReader.hpp
         "${PROJECT_SOURCE_DIR}/src/FileReader.cpp"
         "${PROJECT_SOURCE_DIR}/src/FileReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.cpp"
         "${PROJECT_SOURCE_DIR}/src/FileWriter.hpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.cpp"
         "${PROJECT_SOURCE_DIR}/src/ir/parsing.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/LogTypeDictionaryReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/ParsedMessage.cpp"
         "${PROJECT_SOURCE_DIR}/src/ParsedMessage.hpp"
         "${PROJECT_SOURCE_DIR}/src/ReaderInterface.cpp"
@@ -23,11 +28,6 @@ set(
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/passthrough/Decompressor.hpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/zstd/Decompressor.cpp"
         "${PROJECT_SOURCE_DIR}/src/streaming_compression/zstd/Decompressor.hpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.cpp"
-        "${PROJECT_SOURCE_DIR}/src/Utils.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.cpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryEntry.hpp"
-        "${PROJECT_SOURCE_DIR}/src/VariableDictionaryReader.hpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.cpp"
         "${PROJECT_SOURCE_DIR}/src/WriterInterface.hpp"
         "${PROJECT_SOURCE_DIR}/submodules/date/include/date/date.h"

--- a/components/core/src/clp/make_dictionaries_readable/make-dictionaries-readable.cpp
+++ b/components/core/src/clp/make_dictionaries_readable/make-dictionaries-readable.cpp
@@ -7,11 +7,11 @@
 
 #include "../../FileWriter.hpp"
 #include "../../ir/types.hpp"
-#include "../../LogTypeDictionaryReader.hpp"
 #include "../../spdlog_with_specializations.hpp"
 #include "../../type_utils.hpp"
-#include "../../VariableDictionaryReader.hpp"
+#include "../LogTypeDictionaryReader.hpp"
 #include "../streaming_archive/Constants.hpp"
+#include "../VariableDictionaryReader.hpp"
 #include "CommandLineArguments.hpp"
 
 using ir::VariablePlaceholder;
@@ -50,7 +50,7 @@ int main(int argc, char const* argv[]) {
                              / clp::streaming_archive::cLogTypeDictFilename;
     auto logtype_segment_index_path = boost::filesystem::path(command_line_args.get_archive_path())
                                       / clp::streaming_archive::cLogTypeSegmentIndexFilename;
-    LogTypeDictionaryReader logtype_dict;
+    clp::LogTypeDictionaryReader logtype_dict;
     logtype_dict.open(logtype_dict_path.string(), logtype_segment_index_path.string());
     logtype_dict.read_new_entries();
 
@@ -134,7 +134,7 @@ int main(int argc, char const* argv[]) {
                          / clp::streaming_archive::cVarDictFilename;
     auto var_segment_index_path = boost::filesystem::path(command_line_args.get_archive_path())
                                   / clp::streaming_archive::cVarSegmentIndexFilename;
-    VariableDictionaryReader var_dict;
+    clp::VariableDictionaryReader var_dict;
     var_dict.open(var_dict_path.string(), var_segment_index_path.string());
     var_dict.read_new_entries();
 

--- a/components/core/src/clp/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.cpp
@@ -9,8 +9,8 @@
 #include <boost/filesystem.hpp>
 
 #include "../../../spdlog_with_specializations.hpp"
-#include "../../../Utils.hpp"
 #include "../../EncodedVariableInterpreter.hpp"
+#include "../../Utils.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../Constants.hpp"
 

--- a/components/core/src/clp/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.hpp
@@ -9,10 +9,10 @@
 #include <utility>
 
 #include "../../../ErrorCode.hpp"
-#include "../../../LogTypeDictionaryReader.hpp"
-#include "../../../Query.hpp"
 #include "../../../SQLiteDB.hpp"
-#include "../../../VariableDictionaryReader.hpp"
+#include "../../LogTypeDictionaryReader.hpp"
+#include "../../Query.hpp"
+#include "../../VariableDictionaryReader.hpp"
 #include "../MetadataDB.hpp"
 #include "File.hpp"
 #include "Message.hpp"

--- a/components/core/src/clp/streaming_archive/reader/File.hpp
+++ b/components/core/src/clp/streaming_archive/reader/File.hpp
@@ -7,9 +7,9 @@
 
 #include "../../../Defs.h"
 #include "../../../ErrorCode.hpp"
-#include "../../../LogTypeDictionaryReader.hpp"
-#include "../../../Query.hpp"
 #include "../../../TimestampPattern.hpp"
+#include "../../LogTypeDictionaryReader.hpp"
+#include "../../Query.hpp"
 #include "../MetadataDB.hpp"
 #include "Message.hpp"
 #include "SegmentManager.hpp"

--- a/components/core/src/clp/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.cpp
@@ -16,8 +16,8 @@
 
 #include "../../../ir/types.hpp"
 #include "../../../spdlog_with_specializations.hpp"
-#include "../../../Utils.hpp"
 #include "../../EncodedVariableInterpreter.hpp"
+#include "../../Utils.hpp"
 #include "../Constants.hpp"
 #include "utils.hpp"
 

--- a/components/core/src/clp/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.hpp
@@ -17,9 +17,9 @@
 #include "../../../ArrayBackedPosIntSet.hpp"
 #include "../../../ErrorCode.hpp"
 #include "../../../ir/LogEvent.hpp"
-#include "../../../LogTypeDictionaryWriter.hpp"
-#include "../../../VariableDictionaryWriter.hpp"
 #include "../../GlobalMetadataDB.hpp"
+#include "../../LogTypeDictionaryWriter.hpp"
+#include "../../VariableDictionaryWriter.hpp"
 #include "../ArchiveMetadata.hpp"
 #include "../MetadataDB.hpp"
 

--- a/components/core/src/clp/streaming_archive/writer/File.hpp
+++ b/components/core/src/clp/streaming_archive/writer/File.hpp
@@ -9,9 +9,9 @@
 
 #include "../../../Defs.h"
 #include "../../../ErrorCode.hpp"
-#include "../../../LogTypeDictionaryWriter.hpp"
 #include "../../../PageAllocatedVector.hpp"
 #include "../../../TimestampPattern.hpp"
+#include "../../LogTypeDictionaryWriter.hpp"
 #include "Segment.hpp"
 
 namespace clp::streaming_archive::writer {

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -380,7 +380,7 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
         char const cVarSegmentIndexPath[] = "var.segindex";
 
         // Open writer
-        VariableDictionaryWriter var_dict_writer;
+        clp::VariableDictionaryWriter var_dict_writer;
         var_dict_writer.open(cVarDictPath, cVarSegmentIndexPath, cVariableDictionaryIdMax);
 
         // Test encoding
@@ -406,7 +406,7 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
               + enum_to_underlying_type(VariablePlaceholder::Dictionary);
         // clang-format on
 
-        LogTypeDictionaryEntry logtype_dict_entry;
+        clp::LogTypeDictionaryEntry logtype_dict_entry;
         EncodedVariableInterpreter::encode_and_add_to_dictionary(
                 msg,
                 logtype_dict_entry,
@@ -434,13 +434,13 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
         REQUIRE(var_ids.size() == encoded_var_id_ix);
 
         // Open reader
-        VariableDictionaryReader var_dict_reader;
+        clp::VariableDictionaryReader var_dict_reader;
         var_dict_reader.open(cVarDictPath, cVarSegmentIndexPath);
         var_dict_reader.read_new_entries();
 
         // Test searching
         string search_logtype = "here is a string with a small int ";
-        SubQuery sub_query;
+        clp::SubQuery sub_query;
         REQUIRE(EncodedVariableInterpreter::encode_and_search_dictionary(
                 var_strs[0],
                 var_dict_reader,

--- a/components/core/tests/test-Grep.cpp
+++ b/components/core/tests/test-Grep.cpp
@@ -7,6 +7,7 @@
 #include "../src/clp/Grep.hpp"
 
 using clp::Grep;
+using clp::load_lexer_from_file;
 using log_surgeon::DelimiterStringAST;
 using log_surgeon::lexers::ByteLexer;
 using log_surgeon::ParserAST;

--- a/components/core/tests/test-ParserWithUserSchema.cpp
+++ b/components/core/tests/test-ParserWithUserSchema.cpp
@@ -13,8 +13,9 @@
 #include "../src/clp/clp/run.hpp"
 #include "../src/clp/GlobalMySQLMetadataDB.hpp"
 #include "../src/clp/LogSurgeonReader.hpp"
-#include "../src/Utils.hpp"
+#include "../src/clp/Utils.hpp"
 
+using clp::load_lexer_from_file;
 using clp::LogSurgeonReader;
 using log_surgeon::DelimiterStringAST;
 using log_surgeon::LALR1Parser;

--- a/components/core/tests/test-Segment.cpp
+++ b/components/core/tests/test-Segment.cpp
@@ -5,7 +5,7 @@
 
 #include "../src/clp/streaming_archive/reader/Segment.hpp"
 #include "../src/clp/streaming_archive/writer/Segment.hpp"
-#include "../src/Utils.hpp"
+#include "../src/clp/Utils.hpp"
 
 using std::string;
 
@@ -24,7 +24,7 @@ TEST_CASE("Test writing and reading a segment", "[Segment]") {
 
     // Create directory for segments
     string segments_dir_path = "unit-test-segment/";
-    error_code = create_directory_structure(segments_dir_path, 0700);
+    error_code = clp::create_directory_structure(segments_dir_path, 0700);
     REQUIRE(ErrorCode_Success == error_code);
 
     // Test segment writing

--- a/components/core/tests/test-Utils.cpp
+++ b/components/core/tests/test-Utils.cpp
@@ -10,8 +10,11 @@
 #include <boost/range/combine.hpp>
 #include <Catch2/single_include/catch2/catch.hpp>
 
-#include "../src/Utils.hpp"
+#include "../src/clp/Utils.hpp"
 
+using clp::create_directory_structure;
+using clp::get_parent_directory_path;
+using clp::get_unambiguous_path;
 using std::string;
 
 TEST_CASE("create_directory_structure", "[create_directory_structure]") {


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR moves the `Query.*`, `Utils.*`, and dictionary-related sources into the `clp` namespace.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated unit tests pass.
* Validated compression and decompression with the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset.
* Validated a search `"DESERIALIZE_ERRORS"` returns the same (after sorting) results as `grep`.
