### PR TITLE
Fix incomplete renaming of package scripts.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -431,7 +431,7 @@ def main(argv):
             start_worker(instance_id, clp_config, container_clp_config, num_cpus, mounts)
     except Exception as ex:
         # Stop CLP
-        subprocess.run(['python3', str(clp_home / 'sbin' / 'stop-clp')], check=True)
+        subprocess.run(['python3', str(clp_home / 'sbin' / 'stop-clp.sh')], check=True)
 
         if type(ex) == ValueError:
             logger.error(f"Failed to start CLP: {ex}")

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -431,7 +431,7 @@ def main(argv):
             start_worker(instance_id, clp_config, container_clp_config, num_cpus, mounts)
     except Exception as ex:
         # Stop CLP
-        subprocess.run(['python3', str(clp_home / 'sbin' / 'stop-clp.sh')], check=True)
+        subprocess.run([str(clp_home / 'sbin' / 'stop-clp.sh')], check=True)
 
         if type(ex) == ValueError:
             logger.error(f"Failed to start CLP: {ex}")

--- a/components/package-template/src/README.md
+++ b/components/package-template/src/README.md
@@ -8,13 +8,13 @@ without decompression. CLP's compression ratio is significantly higher than gzip
 ### Starting CLP
 
 ```shell
-sbin/start-clp
+sbin/start-clp.sh
 ```
 
 ### Compressing logs
 
 ```shell
-sbin/compress <uncompressed log files/directories>
+sbin/compress.sh <uncompressed log files/directories>
 ```
 
 For more options, run the script with the `--help` option.
@@ -22,7 +22,7 @@ For more options, run the script with the `--help` option.
 ### Decompressing logs
 
 ```shell
-sbin/decompress -d <output directory> 
+sbin/decompress.sh -d <output directory> 
 ```
 
 For more options, run the script with the `--help` option.
@@ -30,7 +30,7 @@ For more options, run the script with the `--help` option.
 ### Searching logs
 
 ```bash
-sbin/search <your * wildcard * query>
+sbin/search.sh <your * wildcard * query>
 ```
 
 CLP supports two wildcard characters:
@@ -113,9 +113,9 @@ On the control node, run the following commands (these must be started in the
 order below):
 
 ```bash
-sbin/start-clp db
-sbin/start-clp queue
-sbin/start-clp scheduler
+sbin/start-clp.sh db
+sbin/start-clp.sh queue
+sbin/start-clp.sh scheduler
 ```
 
 ### Starting the worker-node components
@@ -123,7 +123,7 @@ sbin/start-clp scheduler
 On every node you want to run workers, run this command:
 
 ```bash
-sbin/start-clp worker
+sbin/start-clp.sh worker
 ```
 
 ### Stopping components
@@ -131,13 +131,13 @@ sbin/start-clp worker
 To stop an individual component on a node, you can use:
 
 ```bash
-sbin/stop-clp <component name>
+sbin/stop-clp.sh <component name>
 ```
 
 To stop all components on a node, you can use:
 
 ```bash
-sbin/stop-clp
+sbin/stop-clp.sh
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

#179 moved the package scripts into a Python package but we missed updating some references to the scripts in the code (when the package tries to stop itself on error when starting up) and the readme.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated that the package could be started and stopped successfully.
* Validated that the package can successfully stop itself when it encounters an error during start up.