### PR TITLE
Add clp-s to the container image containing core's binaries; Add docs for using the container image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ searching the compressed logs without decompression. To learn more about it, you
 
 # Getting Started
 
-You can download a release from the [releases](https://github.com/y-scope/clp/releases) page, or
-you can build the [latest](docs/Building.md).
+You can download a [release package](https://github.com/y-scope/clp/releases) which includes support
+for distributed compression and search. Or, to quickly try CLP's *core* compression and search, you
+can use a [prebuilt container](docs/core/clp-core-container.md).
+
+We also have guides for building the [package](docs/Building.md) and
+[CLP core](components/core/README.md) from source.
 
 For some logs you can use to test CLP, check out our open-source 
 [datasets](docs/Datasets.md).

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ directory:
 The artifacts published to [GitHub packages][1] in this repo are a set of Docker container images
 useful for building and running CLP:
 
-| Image name                                                        | Image contents                                                                              | Link   |
-|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------|--------|
-| `ghcr.io/y-scope/clp/clp-core-dependencies-x86-centos7.4:main`    | The dependencies necessary to build CLP core in a Centos 7.4 x86 environment.               | [↗][2] |
-| `ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-focal:main` | The dependencies necessary to build CLP core in an Ubuntu Focal x86 environment.            | [↗][3] |
-| `ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-jammy:main` | The dependencies necessary to build CLP core in an Ubuntu Jammy x86 environment.            | [↗][4] |
-| `ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main`              | The CLP core binaries (`clp`, `clg`, `clo`, etc.) built in an Ubuntu Focal x86 environment. | [↗][5] |
-| `ghcr.io/y-scope/clp/clp-execution-x86-ubuntu-focal:main`         | The dependencies necessary to run the CLP package in an x86 environment.                    | [↗][6] |
+| Image name                                                        | Image contents                                                                                | Link   |
+|-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
+| `ghcr.io/y-scope/clp/clp-core-dependencies-x86-centos7.4:main`    | The dependencies necessary to build CLP core in a Centos 7.4 x86 environment.                 | [↗][2] |
+| `ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-focal:main` | The dependencies necessary to build CLP core in an Ubuntu Focal x86 environment.              | [↗][3] |
+| `ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-jammy:main` | The dependencies necessary to build CLP core in an Ubuntu Jammy x86 environment.              | [↗][4] |
+| `ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main`              | The CLP core binaries (`clg`, `clp`, `clp-s`, etc.) built in an Ubuntu Focal x86 environment. | [↗][5] |
+| `ghcr.io/y-scope/clp/clp-execution-x86-ubuntu-focal:main`         | The dependencies necessary to run the CLP package in an x86 environment.                      | [↗][6] |
 
 # Next Steps
 

--- a/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
@@ -2,9 +2,9 @@ FROM ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-focal:main
 
 WORKDIR /clp
 
-ADD ./clp ./
-ADD ./clo ./
 ADD ./clg ./
+ADD ./clp ./
+ADD ./clp-s ./
 ADD ./make-dictionaries-readable ./
 
 CMD bash

--- a/docs/core/clp-core-container.md
+++ b/docs/core/clp-core-container.md
@@ -1,0 +1,35 @@
+# Using CLP's core through a container
+
+To quickly try CLP's core compression, decompression, and search (outside of the package), you can
+use the [clp-core-x86-ubuntu-focal][1] container as follows.
+
+1. Pull the container image:
+
+    ```shell
+    docker pull ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main
+    ```
+
+2. Start the container with mounts for your logs and output directories:
+
+    > [!NOTE]
+    > Be sure to change the paths in the command below before running it.
+
+    ```shell
+    docker run \
+      --rm \
+      -it \
+      -u $(id -u):$(id -g) \
+      --volume /my/logs/dir:/mnt/logs \
+      --volume /my/data/dir:/mnt/data \
+      ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main /bin/bash
+    ```
+
+   * Change `/my/logs/dir` to the directory on your machine that contains the logs you wish to
+     compress. It will be mounted at `/mnt/logs` in the container.
+   * Change `/my/data/dir` to the directory on your machine where you want to store the generated
+     archives. It will be mounted at `/mnt/data` in the container.
+
+3. Follow the usage instructions in [Using CLP for unstructured logs](clp-unstructured.md) or
+   [Using CLP for semi-structured logs](clp-structured.md), depending on your use case.
+
+[1]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-x86-ubuntu-focal

--- a/docs/core/clp-core-container.md
+++ b/docs/core/clp-core-container.md
@@ -3,32 +3,33 @@
 To quickly try CLP's core compression, decompression, and search (outside of the package), you can
 use the [clp-core-x86-ubuntu-focal][1] container as follows.
 
-1. Pull the container image:
+Pull the container image:
 
-    ```shell
-    docker pull ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main
-    ```
+```shell
+docker pull ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main
+```
 
-2. Start the container with mounts for your logs and output directories:
-   > [!NOTE]
-   > Be sure to change the paths in the command below before running it.
+Start the container with mounts for your logs and output directories:
 
-    ```shell
-    docker run \
-      --rm \
-      -it \
-      -u $(id -u):$(id -g) \
-      --volume /my/logs/dir:/mnt/logs \
-      --volume /my/data/dir:/mnt/data \
-      ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main /bin/bash
-    ```
+> [!NOTE]
+> Be sure to change the paths in the command below before running it.
 
-   * Change `/my/logs/dir` to the directory on your machine that contains the logs you wish to
-     compress. It will be mounted at `/mnt/logs` in the container.
-   * Change `/my/data/dir` to the directory on your machine where you want to store the generated
-     archives. It will be mounted at `/mnt/data` in the container.
+```shell
+docker run \
+  --rm \
+  -it \
+  -u $(id -u):$(id -g) \
+  --volume /my/logs/dir:/mnt/logs \
+  --volume /my/data/dir:/mnt/data \
+  ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main /bin/bash
+```
 
-3. Follow the usage instructions in [Using CLP for unstructured logs](clp-unstructured.md) or
-   [Using CLP for semi-structured logs](clp-structured.md), depending on your use case.
+* Change `/my/logs/dir` to the directory on your machine that contains the logs you wish to
+  compress. It will be mounted at `/mnt/logs` in the container.
+* Change `/my/data/dir` to the directory on your machine where you want to store the generated
+  archives. It will be mounted at `/mnt/data` in the container.
+
+Follow the usage instructions in [Using CLP for unstructured logs](clp-unstructured.md) or
+[Using CLP for semi-structured logs](clp-structured.md), depending on your use case.
 
 [1]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-x86-ubuntu-focal

--- a/docs/core/clp-core-container.md
+++ b/docs/core/clp-core-container.md
@@ -10,9 +10,8 @@ use the [clp-core-x86-ubuntu-focal][1] container as follows.
     ```
 
 2. Start the container with mounts for your logs and output directories:
-
-    > [!NOTE]
-    > Be sure to change the paths in the command below before running it.
+   > [!NOTE]
+   > Be sure to change the paths in the command below before running it.
 
     ```shell
     docker run \


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR adds `clp-s` to ` clp-core-x86-ubuntu-focal` and adds a README for how to use it. This PR also removes `clo` from the container since it is not used outside the package.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Built ` clp-core-x86-ubuntu-focal ` locally and validated that it contained `clp-s`.
* Validated that, following the README, it was possible to use `clg`, `clp` and `clp-s` to compression, decompress, and search logs.
