### PR TITLE
Add missing file to changes relevant for rebuilding container image.

### DIFF
--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -106,6 +106,7 @@ jobs:
               - ".github/actions/**"
               - ".github/workflows/clp-core-build.yaml"
               - ${{env.PATHS_FILTER_LIB_INSTALL_GLOB}}
+              - "components/core/tools/docker-images/clp-core-ubuntu-${{env.OS_NAME}}/**"
               - "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}/**"
               - "components/core/tools/scripts/lib_install/${{env.OS_NAME}}/**"
             ${{inputs.PATHS_FILTER_CLP_FILTER}}

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -106,7 +106,7 @@ jobs:
               - ".github/actions/**"
               - ".github/workflows/clp-core-build.yaml"
               - ${{env.PATHS_FILTER_LIB_INSTALL_GLOB}}
-              - "components/core/tools/docker-images/clp-core-ubuntu-${{env.OS_NAME}}/**"
+              - "components/core/tools/docker-images/clp-core-${{env.OS_NAME}}/**"
               - "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}/**"
               - "components/core/tools/scripts/lib_install/${{env.OS_NAME}}/**"
             ${{inputs.PATHS_FILTER_CLP_FILTER}}


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The filter in `.github/workflows/clp-core-build.yaml` for deciding when to build and push the container images did not include the `Dockerfile` for `clp-core-x86-ubuntu-focal`, so #225 did not end up building and pushing the new container image to ghcr.io. This PR adds it to the filter.

Strictly speaking, when `components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile` changes, we don't need to build and push `clp-core-dependencies-x86-ubuntu-focal`, but separating the filters for the two images is more work than it's worth.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Merged this PR to `main` in my fork.
* Pushed a change to `components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile` in my fork and validated that the image filter was true.
