### PR TITLE
Package build fixes:

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ vars:
   CORE_COMPONENT_BUILD_DIR: "{{.TASKFILE_DIR}}/build/core"
   LINT_VENV_DIR: "{{.TASKFILE_DIR}}/.lint-venv"
   PACKAGE_BUILD_DIR: "{{.TASKFILE_DIR}}/build/clp-package"
+  PACKAGE_VENV_DIR: "{{.TASKFILE_DIR}}/build/package-venv"
   PACKAGE_VERSION: "0.0.3-dev"
   PYTHON_VERSION:
     sh: "python3 -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\""
@@ -54,24 +55,28 @@ tasks:
       - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y {{.VERSIONED_PACKAGE_NAME}}.tar.gz)"
 
   package:
+    vars:
+      PACKAGE_VERSION_FILE: "{{.PACKAGE_BUILD_DIR}}/VERSION"
     deps:
       - "core"
       - "clp-package-utils"
       - "clp-py-utils"
       - "compression-job-handler"
       - "job-orchestration"
+      - "package-venv"
     cmds:
       - task: "clean-package"
       - "mkdir -p '{{.PACKAGE_BUILD_DIR}}'"
       - "rsync -a components/package-template/src/ '{{.PACKAGE_BUILD_DIR}}'"
       - "mkdir -p '{{.PACKAGE_BUILD_DIR}}/lib/python3/site-packages'"
-      - >-
-        pip3 install --upgrade
-        components/clp-package-utils/dist/*.whl
-        components/clp-py-utils/dist/*.whl
-        components/compression-job-handler/dist/*.whl
-        components/job-orchestration/dist/*.whl
-        -t "{{.PACKAGE_BUILD_DIR}}/lib/python3/site-packages"
+      - |-
+        . "{{.PACKAGE_VENV_DIR}}/bin/activate"
+        pip3 install --upgrade \
+          components/clp-package-utils/dist/*.whl \
+          components/clp-py-utils/dist/*.whl \
+          components/compression-job-handler/dist/*.whl \
+          components/job-orchestration/dist/*.whl \
+          -t "{{.PACKAGE_BUILD_DIR}}/lib/python3/site-packages"
       - "mkdir -p '{{.PACKAGE_BUILD_DIR}}/bin'"
       - >-
         rsync -a
@@ -79,6 +84,9 @@ tasks:
         "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
         "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
         "{{.PACKAGE_BUILD_DIR}}/bin/"
+      # This step must be last since we use this file to detect whether the package was built
+      # successfully
+      - "echo {{.PACKAGE_VERSION}} > '{{.PACKAGE_VERSION_FILE}}'"
     method: "timestamp"
     sources:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
@@ -91,8 +99,8 @@ tasks:
       - "components/job-orchestration/dist/*.whl"
       - "components/package-template/src/**"
     status:
-      - "test -d {{.PACKAGE_BUILD_DIR}}"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.PACKAGE_BUILD_DIR}}')"
+      - "test -e '{{.PACKAGE_VERSION_FILE}}'"
+      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.PACKAGE_VERSION_FILE}}')"
 
   core:
     deps: ["core-submodules"]
@@ -206,6 +214,27 @@ tasks:
     cmds:
       - "{{.SRC_DIR}}/tools/scripts/deps-download/download-all.sh"
 
+  package-venv:
+    internal: true
+    vars:
+      CREATION_TIMESTAMP_FILE: "{{.PACKAGE_VENV_DIR}}/creation_time.txt"
+    cmds:
+      - "rm -rf '{{.PACKAGE_VENV_DIR}}'"
+      - "python3 -m venv '{{.PACKAGE_VENV_DIR}}'"
+      - |-
+        . "{{.PACKAGE_VENV_DIR}}/bin/activate"
+        pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
+      # This step must be last since we use this file to detect whether the venv was created
+      # successfully
+      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
+    method: "timestamp"
+    sources:
+      - "{{.TASKFILE_DIR}}/requirements.txt"
+      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+    status:
+      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
+      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"
+
   python-component:
     internal: true
     requires:
@@ -244,6 +273,7 @@ tasks:
     label: "{{.COMPONENT}}_venv"
     dir: "components/{{.COMPONENT}}"
     vars:
+      CREATION_TIMESTAMP_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}/venv/creation_time.txt"
       VENV_DIR: "{{.BUILD_DIR}}/{{.COMPONENT}}/venv"
     cmds:
       - "rm -rf '{{.VENV_DIR}}'"
@@ -252,14 +282,17 @@ tasks:
         . "{{.VENV_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
         poetry update
+      # This step must be last since we use this file to detect whether the venv was created
+      # successfully
+      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
     method: "timestamp"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "pyproject.toml"
     status:
-      - "test -d '{{.VENV_DIR}}'"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.VENV_DIR}}')"
+      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
+      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"
 
   clean-python-component:
     internal: true
@@ -273,6 +306,8 @@ tasks:
 
   lint-venv:
     internal: true
+    vars:
+      CREATION_TIMESTAMP_FILE: "{{.LINT_VENV_DIR}}/creation_time.txt"
     dir: "{{.TASKFILE_DIR}}"
     cmds:
       - "rm -rf '{{.LINT_VENV_DIR}}'"
@@ -285,10 +320,13 @@ tasks:
         . "{{.LINT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade pip
         pip3 install --upgrade -r lint-requirements.txt
+      # This step must be last since we use this file to detect whether the venv was created
+      # successfully
+      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
     method: "timestamp"
     sources:
       - "lint-requirements.txt"
       - "Taskfile.yml"
     status:
-      - "test -d {{.LINT_VENV_DIR}}"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y {{.LINT_VENV_DIR}})"
+      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
+      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -244,6 +244,7 @@ tasks:
       - task: "component-venv"
         vars:
           COMPONENT: "{{.COMPONENT}}"
+          COMPONENT_VENV_DIR: "{{.VENV_DIR}}"
     vars:
       PACKAGE:
         sh: "echo {{.COMPONENT}} | tr - _"
@@ -269,17 +270,16 @@ tasks:
   component-venv:
     internal: true
     requires:
-      vars: ["COMPONENT"]
+      vars: ["COMPONENT", "COMPONENT_VENV_DIR"]
     label: "{{.COMPONENT}}_venv"
     dir: "components/{{.COMPONENT}}"
     vars:
-      CREATION_TIMESTAMP_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}/venv/creation_time.txt"
-      VENV_DIR: "{{.BUILD_DIR}}/{{.COMPONENT}}/venv"
+      CREATION_TIMESTAMP_FILE: "{{.COMPONENT_VENV_DIR}}/creation_time.txt"
     cmds:
-      - "rm -rf '{{.VENV_DIR}}'"
-      - "python3 -m venv '{{.VENV_DIR}}'"
+      - "rm -rf '{{.COMPONENT_VENV_DIR}}'"
+      - "python3 -m venv '{{.COMPONENT_VENV_DIR}}'"
       - |-
-        . "{{.VENV_DIR}}/bin/activate"
+        . "{{.COMPONENT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
         poetry update
       # This step must be last since we use this file to detect whether the venv was created

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -11,6 +11,7 @@ prebuilt version instead, check out the [releases](https://github.com/y-scope/cl
   * It should be possible to build a package for a different environment, it just requires a some
     extra configuration.
 * Python 3.8 or newer
+* python3-venv
 * [Task](https://taskfile.dev/)
 
 # Setup


### PR DESCRIPTION
- Use a file to detect successful venv/package.
- Use a venv when installing components into the package.

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR fixes three issues:

1. When the package fails to build (e.g., because python3-venv was not installed), the Taskfile doesn't detect that the venv/package creation was unsuccessful; this is because we use the presence of the venv/package directory to determine whether the task was already completed.
    * This PR changes the Taskfile to create a file at the end of each venv and package task, and then we use this file to determine whether the task was completed successfully.
2. Attempting to build the package in an environment with an older version of `poetry` (compared to the one used to build the components) already installed caused the build to fail when installing the components into the package.
    * This PR creates a venv to be used when installing the components into package.
3. The build docs don't mention that `python3-venv` is a requirement.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated that when the build fails (e.g., due to missing python3-venv), attempting to rebuild doesn't erroneously detect that the venvs from the previous run were created successfully.
* Built the package successfully in an environment with an older version of `poetry` installed.
