### PR TITLE
Container image build fixes:

### DIFF
--- a/components/core/tools/scripts/lib_install/centos7.4/install-all.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-all.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 "$script_dir"/install-prebuilt-packages.sh

--- a/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 # Enable gcc 10
 source /opt/rh/devtoolset-10/enable
 

--- a/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
@@ -3,14 +3,16 @@
 # Exit on any error
 set -e
 
-# Error on undefined variable
-set -u
-
 # Enable gcc 10
 source /opt/rh/devtoolset-10/enable
 
 # Enable git
 source /opt/rh/rh-git227/enable
+
+# Error on undefined variable
+# NOTE: We enable this *after* sourcing the scripts above since we can't guarantee they won't have
+# unbound variables in them.
+set -u
 
 # NOTE: cmake and boost must be installed first since the remaining packages depend on them
 ./tools/scripts/lib_install/install-cmake.sh 3.21.2

--- a/components/core/tools/scripts/lib_install/centos7.4/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-prebuilt-packages.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 yum install -y \
   bzip2 \
   centos-release-scl \

--- a/components/core/tools/scripts/lib_install/macos-12/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos-12/install-all.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 brew update
 brew install \
   boost \

--- a/components/core/tools/scripts/lib_install/mongoc.sh
+++ b/components/core/tools/scripts/lib_install/mongoc.sh
@@ -43,10 +43,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-install_command_prefix_args=()
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  install_command_prefix_args+=("sudo")
+  install_cmd_args+=("sudo")
 fi
 
 # Download
@@ -84,7 +84,7 @@ set -e
 
 # Install
 if [ $checkinstall_installed -eq 0 ] ; then
-  install_command_prefix_args+=(
+  install_cmd_args+=(
     checkinstall
     --pkgname "${package_name}"
     --pkgversion "${version}"
@@ -94,7 +94,13 @@ if [ $checkinstall_installed -eq 0 ] ; then
     --pakdir "${deb_output_dir}"
   )
 fi
-"${install_command_prefix_args[@]}" cmake --build . --target install --parallel
+install_cmd_args+=(
+  cmake
+  --build .
+  --target install
+  --parallel
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf "$temp_dir"

--- a/components/core/tools/scripts/lib_install/mongocxx.sh
+++ b/components/core/tools/scripts/lib_install/mongocxx.sh
@@ -43,10 +43,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-install_command_prefix_args=()
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  install_command_prefix_args+=("sudo")
+  install_cmd_args+=("sudo")
 fi
 
 # Download
@@ -86,7 +86,7 @@ set -e
 
 # Install
 if [ $checkinstall_installed -eq 0 ] ; then
-  install_command_prefix_args+=(
+  install_cmd_args+=(
     checkinstall
     --pkgname "${package_name}"
     --pkgversion "${version}"
@@ -96,7 +96,13 @@ if [ $checkinstall_installed -eq 0 ] ; then
     --pakdir "${deb_output_dir}"
   )
 fi
-"${install_command_prefix_args[@]}" cmake --build . --target install --parallel
+install_cmd_args+=(
+  cmake
+  --build .
+  --target install
+  --parallel
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf "$temp_dir"

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 "$script_dir"/install-prebuilt-packages.sh

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 ./tools/scripts/lib_install/fmtlib.sh 8.0.1
 ./tools/scripts/lib_install/libarchive.sh 3.5.1
 ./tools/scripts/lib_install/lz4.sh 1.8.2

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ca-certificates \

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-all.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-all.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 "$script_dir"/install-prebuilt-packages.sh

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 ./tools/scripts/lib_install/fmtlib.sh 8.0.1
 ./tools/scripts/lib_install/libarchive.sh 3.5.1
 ./tools/scripts/lib_install/lz4.sh 1.8.2

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ca-certificates \

--- a/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
   checkinstall \


### PR DESCRIPTION
- Error on failure to install any package into the container image.
- Don't use an empty array as a command (for older Bash versions).

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Recent failures to install packages in the CentOS container were not being caught until we tried to build CLP in the container since the script which calls the package install script didn't exit on error. In addition, mongoc and mongocxx were failing to install in the CentOS container since it uses an older version of bash which doesn't support expanding an empty array (it treats it as an unbound variable).

This PR adds error checks in the scripts which call the package install scripts and fixes the mongoc/cxx install scripts to support the older version of bash.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated that the mongo/cxx install failures were caught when the install scripts were configured to exit on error.
* Validated workflows succeeded.
