### PR TITLE
Add MongoDB output support for clp-s search

### DIFF
--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -107,6 +107,7 @@ set(
         search/OrOfAndForm.hpp
         search/Output.cpp
         search/Output.hpp
+        search/OutputHandler.cpp
         search/OutputHandler.hpp
         search/SchemaMatch.cpp
         search/SchemaMatch.hpp

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -107,6 +107,7 @@ set(
         search/OrOfAndForm.hpp
         search/Output.cpp
         search/Output.hpp
+        search/OutputHandler.hpp
         search/SchemaMatch.cpp
         search/SchemaMatch.hpp
         search/SearchUtils.cpp
@@ -125,6 +126,7 @@ target_link_libraries(
         absl::flat_hash_map
         Boost::filesystem Boost::iostreams Boost::program_options
         kql
+        ${MONGOCXX_TARGET}
         simdjson
         spdlog::spdlog
         ZStd::ZStd

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -297,13 +297,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                             "MongoDB uri and collection must be specified together"
                     );
                 }
-
-                m_mongodb_enabled = true;
                 if (m_batch_size == 0) {
                     throw std::invalid_argument("Batch size must be greater than 0");
                 }
-            } else {
-                m_mongodb_enabled = false;
+
+                m_mongodb_enabled = true;
             }
 
             if (m_archives_dir.empty()) {

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -218,6 +218,12 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             po::options_description search_options;
             // clang-format off
             search_options.add_options()(
+                    "mongodb-config",
+                    po::value<std::vector<std::string>>()->value_name("MONGODB_CONFIG")->
+                        multitoken(),
+                    "The uri, database, and collection for the MongoDB instance that the "
+                    "search results should be sent to."
+            )(
                     "archives-dir",
                     po::value<std::string>(&m_archives_dir),
                     "The directory containing the archives"
@@ -258,6 +264,25 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << visible_options << '\n';
                 return ParsingResult::InfoCommand;
             }
+
+            if (parsed_command_line_options.count("mongodb-config")) {
+                auto const& mongodb_config
+                        = parsed_command_line_options["mongodb-config"].as<std::vector<std::string>>();
+                if (mongodb_config.size() != 5) {
+                    throw std::invalid_argument(
+                            "mongodb-config must be a list of 3 strings: uri, database, collection"
+                    );
+                }
+                m_mongodb_enabled = true;
+                m_mongodb_uri = mongodb_config[0];
+                m_mongodb_database = mongodb_config[1];
+                m_mongodb_collection = mongodb_config[2];
+                m_archives_dir = mongodb_config[3];
+                m_query = mongodb_config[4];
+            } else {
+                m_mongodb_enabled = false;
+            }
+
             if (m_archives_dir.empty()) {
                 throw std::invalid_argument("No archives directory specified");
             }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -247,7 +247,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "batch-size",
                     po::value<uint64_t>(&m_batch_size)->value_name("BATCH_SIZE")->
                         default_value(m_batch_size),
-                    "The number of documents to insert to MongoDB in a batch"
+                    "The number of documents to insert into MongoDB in a batch"
             );
             // clang-format on
             search_options.add(mongodb_options);
@@ -280,8 +280,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                              R"( "level: INFO" and output to MongoDB)"
                           << std::endl;
                 std::cerr << "  " << m_program_name
-                          << " s --mongodb-uri mongodb://127.0.0.1:27017/test --mongodb-collection "
-                             R"(test archives-dir "level: INFO")"
+                          << " s --mongodb-uri mongodb://127.0.0.1:27017/test --mongodb-collection"
+                             R"( test archives-dir "level: INFO")"
                           << std::endl;
 
                 po::options_description visible_options;
@@ -293,7 +293,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             if (false == m_mongodb_uri.empty() || false == m_mongodb_collection.empty()) {
                 if (m_mongodb_uri.empty() || m_mongodb_collection.empty()) {
-                    throw std::invalid_argument("MongoDB uri and collection must be both specified"
+                    throw std::invalid_argument(
+                            "MongoDB uri and collection must be specified together"
                     );
                 }
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -266,8 +266,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             }
 
             if (parsed_command_line_options.count("mongodb-config")) {
-                auto const& mongodb_config
-                        = parsed_command_line_options["mongodb-config"].as<std::vector<std::string>>();
+                auto const& mongodb_config = parsed_command_line_options["mongodb-config"]
+                                                     .as<std::vector<std::string>>();
                 if (mongodb_config.size() != 5) {
                     throw std::invalid_argument(
                             "mongodb-config must be a list of 3 strings: uri, database, collection"

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -21,7 +21,12 @@ public:
     };
 
     // Constructors
-    explicit CommandLineArguments(std::string const& program_name) : m_program_name(program_name) {}
+    explicit CommandLineArguments(std::string const& program_name)
+            : m_program_name(program_name),
+              m_compression_level(3),
+              m_target_encoded_size(8UL * 1024 * 1024 * 1024),  // 8 GB
+              m_mongodb_enabled(false),
+              m_batch_size(1000) {}
 
     // Methods
     ParsingResult parse_arguments(int argc, char const* argv[]);
@@ -46,9 +51,9 @@ public:
 
     std::string const& get_mongodb_uri() const { return m_mongodb_uri; }
 
-    std::string const& get_mongodb_database() const { return m_mongodb_database; }
-
     std::string const& get_mongodb_collection() const { return m_mongodb_collection; }
+
+    uint64_t get_batch_size() const { return m_batch_size; }
 
     std::string const& get_query() const { return m_query; }
 
@@ -77,8 +82,8 @@ private:
     // MongoDB configuration variables
     bool m_mongodb_enabled;
     std::string m_mongodb_uri;
-    std::string m_mongodb_database;
     std::string m_mongodb_collection;
+    uint64_t m_batch_size;
 
     // Search variables
     std::string m_query;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -21,12 +21,7 @@ public:
     };
 
     // Constructors
-    explicit CommandLineArguments(std::string const& program_name)
-            : m_program_name(program_name),
-              m_compression_level(3),
-              m_target_encoded_size(8UL * 1024 * 1024 * 1024),  // 8 GiB
-              m_mongodb_enabled(false),
-              m_batch_size(1000) {}
+    explicit CommandLineArguments(std::string const& program_name) : m_program_name(program_name) {}
 
     // Methods
     ParsingResult parse_arguments(int argc, char const* argv[]);
@@ -76,14 +71,14 @@ private:
     std::string m_archives_dir;
     std::string m_output_dir;
     std::string m_timestamp_key;
-    int m_compression_level;
-    size_t m_target_encoded_size;
+    int m_compression_level = 3;
+    size_t m_target_encoded_size = 8UL * 1024 * 1024 * 1024;  // 8 GiB
 
     // MongoDB configuration variables
-    bool m_mongodb_enabled;
+    bool m_mongodb_enabled = false;
     std::string m_mongodb_uri;
     std::string m_mongodb_collection;
-    uint64_t m_batch_size;
+    uint64_t m_batch_size = 1000;
 
     // Search variables
     std::string m_query;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -71,14 +71,14 @@ private:
     std::string m_archives_dir;
     std::string m_output_dir;
     std::string m_timestamp_key;
-    int m_compression_level = 3;
-    size_t m_target_encoded_size = 8UL * 1024 * 1024 * 1024;  // 8 GiB
+    int m_compression_level{3};
+    size_t m_target_encoded_size{8ULL * 1024 * 1024 * 1024};  // 8 GiB
 
     // MongoDB configuration variables
-    bool m_mongodb_enabled = false;
+    bool m_mongodb_enabled{false};
     std::string m_mongodb_uri;
     std::string m_mongodb_collection;
-    uint64_t m_batch_size = 1000;
+    uint64_t m_batch_size{1000};
 
     // Search variables
     std::string m_query;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -24,7 +24,7 @@ public:
     explicit CommandLineArguments(std::string const& program_name)
             : m_program_name(program_name),
               m_compression_level(3),
-              m_target_encoded_size(8UL * 1024 * 1024 * 1024),  // 8 GB
+              m_target_encoded_size(8UL * 1024 * 1024 * 1024),  // 8 GiB
               m_mongodb_enabled(false),
               m_batch_size(1000) {}
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -42,6 +42,14 @@ public:
 
     size_t get_target_encoded_size() const { return m_target_encoded_size; }
 
+    bool get_mongodb_enabled() const { return m_mongodb_enabled; }
+
+    std::string const& get_mongodb_uri() const { return m_mongodb_uri; }
+
+    std::string const& get_mongodb_database() const { return m_mongodb_database; }
+
+    std::string const& get_mongodb_collection() const { return m_mongodb_collection; }
+
     std::string const& get_query() const { return m_query; }
 
 private:
@@ -65,6 +73,12 @@ private:
     std::string m_timestamp_key;
     int m_compression_level;
     size_t m_target_encoded_size;
+
+    // MongoDB configuration variables
+    bool m_mongodb_enabled;
+    std::string m_mongodb_uri;
+    std::string m_mongodb_database;
+    std::string m_mongodb_collection;
 
     // Search variables
     std::string m_query;

--- a/components/core/src/clp_s/Defs.hpp
+++ b/components/core/src/clp_s/Defs.hpp
@@ -5,6 +5,7 @@
 
 // C++ libraries
 #include <atomic>
+#include <cinttypes>
 #include <cstdint>
 #include <limits>
 
@@ -17,6 +18,7 @@ static double const cDoubleEpochTimeMin = std::numeric_limits<double>::lowest();
 static double const cDoubleEpochTimeMax = std::numeric_limits<double>::max();
 #define SECONDS_TO_EPOCHTIME(x) x * 1000
 #define MICROSECONDS_TO_EPOCHTIME(x) 0
+#define EPOCHTIME_T_PRINTF_FMT PRId64
 
 typedef uint64_t variable_dictionary_id_t;
 static variable_dictionary_id_t const cVariableDictionaryIdMax = UINT64_MAX;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -11,6 +11,7 @@
 #include "search/NarrowTypes.hpp"
 #include "search/OrOfAndForm.hpp"
 #include "search/Output.hpp"
+#include "search/OutputHandler.hpp"
 #include "search/SchemaMatch.hpp"
 #include "TimestampPattern.hpp"
 #include "Utils.hpp"
@@ -116,8 +117,19 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
 
+        std::shared_ptr<OutputHandler> output_handler;
+        if (command_line_arguments.get_mongodb_enabled()) {
+            output_handler = std::make_shared<MongoOutputHandler>(
+                    command_line_arguments.get_mongodb_uri(),
+                    command_line_arguments.get_mongodb_database(),
+                    command_line_arguments.get_mongodb_collection()
+            );
+        } else {
+            output_handler = std::make_shared<StandardOutputHandler>();
+        }
+
         // output result
-        Output output(schema_tree, schemas, match_pass, expr, archives_dir, timestamp_dict);
+        Output output(schema_tree, schemas, match_pass, expr, archives_dir, timestamp_dict, output_handler);
         output.filter();
     }
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -118,13 +118,12 @@ int main(int argc, char const* argv[]) {
         }
 
         std::shared_ptr<OutputHandler> output_handler;
-        mongocxx::instance mongocxx_instance_{};
+        mongocxx::instance mongocxx_instance{};
         if (command_line_arguments.get_mongodb_enabled()) {
-            output_handler = std::make_shared<ResultsCacheOutputHandler>(
+            output_handler = std::make_unique<ResultsCacheOutputHandler>(
                     command_line_arguments.get_mongodb_uri(),
                     command_line_arguments.get_mongodb_collection(),
-                    command_line_arguments.get_batch_size(),
-                    false  // set it to false because we don't implement timestamp extraction
+                    command_line_arguments.get_batch_size()
             );
         } else {
             output_handler = std::make_shared<StandardOutputHandler>();

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -129,7 +129,15 @@ int main(int argc, char const* argv[]) {
         }
 
         // output result
-        Output output(schema_tree, schemas, match_pass, expr, archives_dir, timestamp_dict, output_handler);
+        Output output(
+                schema_tree,
+                schemas,
+                match_pass,
+                expr,
+                archives_dir,
+                timestamp_dict,
+                output_handler
+        );
         output.filter();
     }
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -118,6 +118,7 @@ int main(int argc, char const* argv[]) {
         }
 
         std::shared_ptr<OutputHandler> output_handler;
+        mongocxx::instance mongocxx_instance_{};
         if (command_line_arguments.get_mongodb_enabled()) {
             output_handler = std::make_shared<ResultsCacheOutputHandler>(
                     command_line_arguments.get_mongodb_uri(),

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -119,10 +119,11 @@ int main(int argc, char const* argv[]) {
 
         std::shared_ptr<OutputHandler> output_handler;
         if (command_line_arguments.get_mongodb_enabled()) {
-            output_handler = std::make_shared<MongoOutputHandler>(
+            output_handler = std::make_shared<ResultsCacheOutputHandler>(
                     command_line_arguments.get_mongodb_uri(),
-                    command_line_arguments.get_mongodb_database(),
-                    command_line_arguments.get_mongodb_collection()
+                    command_line_arguments.get_mongodb_collection(),
+                    command_line_arguments.get_batch_size(),
+                    false  // set it to false because we don't implement timestamp extraction
             );
         } else {
             output_handler = std::make_shared<StandardOutputHandler>();

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -117,7 +117,7 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
 
-        std::shared_ptr<OutputHandler> output_handler;
+        std::unique_ptr<OutputHandler> output_handler;
         mongocxx::instance mongocxx_instance{};
         if (command_line_arguments.get_mongodb_enabled()) {
             output_handler = std::make_unique<ResultsCacheOutputHandler>(
@@ -126,7 +126,7 @@ int main(int argc, char const* argv[]) {
                     command_line_arguments.get_batch_size()
             );
         } else {
-            output_handler = std::make_shared<StandardOutputHandler>();
+            output_handler = std::make_unique<StandardOutputHandler>();
         }
 
         // output result
@@ -137,7 +137,7 @@ int main(int argc, char const* argv[]) {
                 expr,
                 archives_dir,
                 timestamp_dict,
-                output_handler
+                std::move(output_handler)
         );
         output.filter();
     }

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -110,12 +110,12 @@ void Output::filter() {
 
             reader.initialize_filter(this);
             while (reader.get_next_message(message, this)) {
-                m_output_handler->Write(message);
+                m_output_handler->write(message);
             }
             reader.close();
         }
 
-        m_output_handler->Flush();
+        m_output_handler->flush();
 
         m_var_dict->close();
         m_log_dict->close();

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -110,10 +110,12 @@ void Output::filter() {
 
             reader.initialize_filter(this);
             while (reader.get_next_message(message, this)) {
-                write(STDOUT_FILENO, message.c_str(), message.length());
+                m_output_handler->Write(message);
             }
             reader.close();
         }
+
+        m_output_handler->Flush();
 
         m_var_dict->close();
         m_log_dict->close();

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -31,7 +31,7 @@ public:
            std::shared_ptr<Expression> expr,
            std::string archives_dir,
            std::shared_ptr<TimestampDictionaryReader> timestamp_dict,
-           std::shared_ptr<OutputHandler> output_handler)
+           std::unique_ptr<OutputHandler> output_handler)
             : m_schema_tree(std::move(tree)),
               m_schemas(std::move(schemas)),
               m_match(match),
@@ -49,7 +49,7 @@ private:
     SchemaMatch& m_match;
     std::shared_ptr<Expression> m_expr;
     std::string m_archives_dir;
-    std::shared_ptr<OutputHandler> m_output_handler;
+    std::unique_ptr<OutputHandler> m_output_handler;
 
     // variables for the current schema being filtered
     std::vector<BaseColumnReader*> m_searched_columns;

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -14,6 +14,7 @@
 #include "clp_search/Query.hpp"
 #include "Expression.hpp"
 #include "Integral.hpp"
+#include "OutputHandler.hpp"
 #include "SchemaMatch.hpp"
 #include "StringLiteral.hpp"
 
@@ -29,13 +30,15 @@ public:
            SchemaMatch& match,
            std::shared_ptr<Expression> expr,
            std::string archives_dir,
-           std::shared_ptr<TimestampDictionaryReader> timestamp_dict)
+           std::shared_ptr<TimestampDictionaryReader> timestamp_dict,
+           std::shared_ptr<OutputHandler> output_handler)
             : m_schema_tree(std::move(tree)),
               m_schemas(std::move(schemas)),
               m_match(match),
               m_expr(std::move(expr)),
               m_archives_dir(std::move(archives_dir)),
-              m_timestamp_dict(std::move(timestamp_dict)) {}
+              m_timestamp_dict(std::move(timestamp_dict)),
+              m_output_handler(std::move(output_handler)) {}
 
     /**
      * Filters messages from all archives
@@ -46,6 +49,7 @@ private:
     SchemaMatch& m_match;
     std::shared_ptr<Expression> m_expr;
     std::string m_archives_dir;
+    std::shared_ptr<OutputHandler> m_output_handler;
 
     // variables for the current schema being filtered
     std::vector<BaseColumnReader*> m_searched_columns;

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -45,5 +45,4 @@ void ResultsCacheOutputHandler::write(std::string const& message, epochtime_t ti
         throw OperationFailed(ErrorCode::ErrorCodeFailureDbBulkWrite, __FILENAME__, __LINE__);
     }
 }
-
 }  // namespace clp_s::search

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -1,0 +1,49 @@
+#include "OutputHandler.hpp"
+
+namespace clp_s::search {
+ResultsCacheOutputHandler::ResultsCacheOutputHandler(
+        std::string const& uri,
+        std::string const& collection,
+        uint64_t batch_size
+)
+        : m_batch_size(batch_size) {
+    try {
+        auto mongo_uri = mongocxx::uri(uri);
+        m_client = mongocxx::client(mongo_uri);
+        m_collection = m_client[mongo_uri.database()][collection];
+    } catch (mongocxx::exception const& e) {
+        throw OperationFailed(ErrorCode::ErrorCodeBadParamDbUri, __FILENAME__, __LINE__);
+    }
+}
+
+void ResultsCacheOutputHandler::flush() {
+    try {
+        if (false == m_results.empty()) {
+            m_collection.insert_many(m_results);
+            m_results.clear();
+        }
+    } catch (mongocxx::exception const& e) {
+        throw OperationFailed(ErrorCode::ErrorCodeFailureDbBulkWrite, __FILENAME__, __LINE__);
+    }
+}
+
+void ResultsCacheOutputHandler::write(std::string const& message, epochtime_t timestamp) {
+    try {
+        auto document = bsoncxx::builder::basic::make_document(
+                bsoncxx::builder::basic::kvp("original_path", ""),
+                bsoncxx::builder::basic::kvp("message", message),
+                bsoncxx::builder::basic::kvp("timestamp", timestamp)
+        );
+
+        m_results.push_back(std::move(document));
+
+        if (m_results.size() >= m_batch_size) {
+            m_collection.insert_many(m_results);
+            m_results.clear();
+        }
+    } catch (mongocxx::exception const& e) {
+        throw OperationFailed(ErrorCode::ErrorCodeFailureDbBulkWrite, __FILENAME__, __LINE__);
+    }
+}
+
+}  // namespace clp_s::search

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -1,0 +1,104 @@
+#ifndef CLP_S_SEARCH_OUTPUTHANDLER_HPP
+#define CLP_S_SEARCH_OUTPUTHANDLER_HPP
+
+#include <string>
+
+#include <mongocxx/client.hpp>
+#include <mongocxx/collection.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+#include "../Defs.hpp"
+
+namespace clp_s::search {
+class OutputHandler {
+public:
+    explicit OutputHandler(bool output_timestamp, bool decompress_full_log = true)
+            : output_timestamp_(output_timestamp),
+              decompress_full_log_(decompress_full_log) {}
+
+    virtual ~OutputHandler() = default;
+
+    virtual void Write(std::string const& message, epochtime_t timestamp) = 0;
+    virtual void Write(std::string const& message) = 0;
+    virtual void Flush() = 0;
+
+    bool OutputTimestamp() const { return output_timestamp_; }
+
+    bool DecompressFullLog() const { return decompress_full_log_; }
+
+    void SetDecompressFullLog(bool decompress_full_log) {
+        decompress_full_log_ = decompress_full_log;
+    }
+
+protected:
+    bool output_timestamp_;
+    bool decompress_full_log_;
+};
+
+class StandardOutputHandler : public OutputHandler {
+public:
+    explicit StandardOutputHandler(bool output_timestamp = false)
+            : OutputHandler(output_timestamp) {}
+
+    void Write(std::string const& message, epochtime_t timestamp) override {
+        printf("%lld %s", timestamp, message.c_str());
+    }
+
+    void Flush() override {}
+
+    void Write(std::string const& message) override {
+        printf("%s", message.c_str());
+    }
+};
+
+class MongoOutputHandler : public OutputHandler {
+public:
+    MongoOutputHandler(
+            std::string const& uri,
+            std::string const& db,
+            std::string const& collection,
+            bool output_timestamp = false,
+            uint64_t batch_size = 1000
+    )
+            : OutputHandler(output_timestamp),
+              batch_size_(batch_size) {
+        client_ = mongocxx::client((mongocxx::uri(uri)));
+        collection_ = client_[db][collection];
+    }
+
+    void Flush() override {
+        if (!results_.empty()) {
+            collection_.insert_many(results_);
+            results_.clear();
+        }
+    }
+
+    void Write(std::string const& message, epochtime_t timestamp) override {
+        auto document = bsoncxx::builder::basic::make_document(
+                bsoncxx::builder::basic::kvp("path", "logs.ndjson"),
+                bsoncxx::builder::basic::kvp("message", message),
+                bsoncxx::builder::basic::kvp("timestamp", timestamp)
+        );
+
+        results_.push_back(std::move(document));
+
+        if (results_.size() >= batch_size_) {
+            collection_.insert_many(results_);
+            results_.clear();
+        }
+    }
+
+    void Write(std::string const& message) override { Write(message, 0); }
+
+private:
+    mongocxx::instance instance_{};
+    mongocxx::client client_;
+    mongocxx::collection collection_;
+    std::vector<bsoncxx::document::value> results_;
+    uint64_t batch_size_;
+};
+}  // namespace clp_s::search
+
+#endif  // CLP_S_SEARCH_OUTPUTHANDLER_HPP

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -48,9 +48,7 @@ public:
 
     void Flush() override {}
 
-    void Write(std::string const& message) override {
-        printf("%s", message.c_str());
-    }
+    void Write(std::string const& message) override { printf("%s", message.c_str()); }
 };
 
 class MongoOutputHandler : public OutputHandler {

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -51,40 +51,59 @@ public:
     void Write(std::string const& message) override { printf("%s", message.c_str()); }
 };
 
-class MongoOutputHandler : public OutputHandler {
+class ResultsCacheOutputHandler : public OutputHandler {
 public:
-    MongoOutputHandler(
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
+    };
+
+    ResultsCacheOutputHandler(
             std::string const& uri,
-            std::string const& db,
             std::string const& collection,
-            bool output_timestamp = false,
-            uint64_t batch_size = 1000
+            uint64_t batch_size,
+            bool output_timestamp = true
     )
             : OutputHandler(output_timestamp),
               batch_size_(batch_size) {
-        client_ = mongocxx::client((mongocxx::uri(uri)));
-        collection_ = client_[db][collection];
+        try {
+            auto mongo_uri = mongocxx::uri(uri);
+            client_ = mongocxx::client(mongo_uri);
+            collection_ = client_[mongo_uri.database()][collection];
+        } catch (mongocxx::exception const& e) {
+            throw OperationFailed(ErrorCode::ErrorCodeBadParamDbUri, __FILENAME__, __LINE__);
+        }
     }
 
     void Flush() override {
-        if (!results_.empty()) {
-            collection_.insert_many(results_);
-            results_.clear();
+        try {
+            if (!results_.empty()) {
+                collection_.insert_many(results_);
+                results_.clear();
+            }
+        } catch (mongocxx::exception const& e) {
+            throw OperationFailed(ErrorCode::ErrorCodeFailureDbBulkWrite, __FILENAME__, __LINE__);
         }
     }
 
     void Write(std::string const& message, epochtime_t timestamp) override {
-        auto document = bsoncxx::builder::basic::make_document(
-                bsoncxx::builder::basic::kvp("path", "logs.ndjson"),
-                bsoncxx::builder::basic::kvp("message", message),
-                bsoncxx::builder::basic::kvp("timestamp", timestamp)
-        );
+        try {
+            auto document = bsoncxx::builder::basic::make_document(
+                    bsoncxx::builder::basic::kvp("path", "logs.ndjson"),
+                    bsoncxx::builder::basic::kvp("message", message),
+                    bsoncxx::builder::basic::kvp("timestamp", timestamp)
+            );
 
-        results_.push_back(std::move(document));
+            results_.push_back(std::move(document));
 
-        if (results_.size() >= batch_size_) {
-            collection_.insert_many(results_);
-            results_.clear();
+            if (results_.size() >= batch_size_) {
+                collection_.insert_many(results_);
+                results_.clear();
+            }
+        } catch (mongocxx::exception const& e) {
+            throw OperationFailed(ErrorCode::ErrorCodeFailureDbBulkWrite, __FILENAME__, __LINE__);
         }
     }
 

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -18,16 +18,17 @@ namespace clp_s::search {
  */
 class OutputHandler {
 public:
-    // Constructor
+    // Constructors
     explicit OutputHandler() = default;
 
     // Destructor
     virtual ~OutputHandler() = default;
 
+    // Methods
     /**
-     * Writes a message to the output handler.
-     * @param message The message to write.
-     * @param timestamp The timestamp of the message.
+     * Writes a log event to the output handler.
+     * @param message The message in the log event.
+     * @param timestamp The timestamp of the log event.
      */
     virtual void write(std::string const& message, epochtime_t timestamp) = 0;
 
@@ -48,7 +49,7 @@ public:
  */
 class StandardOutputHandler : public OutputHandler {
 public:
-    // Constructor
+    // Constructors
     explicit StandardOutputHandler() = default;
 
     // Methods inherited from OutputHandler
@@ -56,9 +57,9 @@ public:
         printf("%" EPOCHTIME_T_PRINTF_FMT " %s", timestamp, message.c_str());
     }
 
-    void flush() override {}
-
     void write(std::string const& message) override { printf("%s", message.c_str()); }
+
+    void flush() override {}
 };
 
 /**


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#223 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
#223 added supports for sending query results to results_cache (MongoDB) for clp package. This PR added MongoDB output support for clp-s binary. We will integrate clp-s with the package and allow user to choose between clp and clp-s in the upcoming PR.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Successfully compiled the source code
+ Tested search with output to both stdout and MongoDB
