### PR TITLE
Don't set timestamp format when splitting a timestamp-less file (fixes #167).

### DIFF
--- a/components/core/src/clp/streaming_archive/writer/File.cpp
+++ b/components/core/src/clp/streaming_archive/writer/File.cpp
@@ -85,12 +85,10 @@ void File::write_encoded_msg(
 }
 
 void File::change_ts_pattern(TimestampPattern const* pattern) {
-    if (nullptr == pattern) {
-        m_timestamp_patterns.emplace_back(m_num_messages, TimestampPattern());
-    } else {
+    if (nullptr != pattern) {
         m_timestamp_patterns.emplace_back(m_num_messages, *pattern);
+        m_is_metadata_clean = false;
     }
-    m_is_metadata_clean = false;
 }
 
 bool File::is_in_uncommitted_segment() const {

--- a/components/core/src/clp/streaming_archive/writer/File.cpp
+++ b/components/core/src/clp/streaming_archive/writer/File.cpp
@@ -85,10 +85,12 @@ void File::write_encoded_msg(
 }
 
 void File::change_ts_pattern(TimestampPattern const* pattern) {
-    if (nullptr != pattern) {
+    if (nullptr == pattern) {
+        m_timestamp_patterns.emplace_back(m_num_messages, TimestampPattern());
+    } else {
         m_timestamp_patterns.emplace_back(m_num_messages, *pattern);
-        m_is_metadata_clean = false;
     }
+    m_is_metadata_clean = false;
 }
 
 bool File::is_in_uncommitted_segment() const {

--- a/components/core/src/clp/streaming_archive/writer/utils.cpp
+++ b/components/core/src/clp/streaming_archive/writer/utils.cpp
@@ -32,7 +32,7 @@ auto split_file(
     close_file_and_append_to_segment(archive_writer);
 
     archive_writer.create_and_open_file(path_for_compression, group_id, orig_file_id, ++split_ix);
-    if (true == has_ts_pattern) {
+    if (has_ts_pattern) {
         // Initialize the file's timestamp pattern to the previous split's pattern
         archive_writer.change_ts_pattern(last_timestamp_pattern);
     }
@@ -55,7 +55,7 @@ auto split_file_and_archive(
     split_archive(archive_user_config, archive_writer);
 
     archive_writer.create_and_open_file(path_for_compression, group_id, orig_file_id, ++split_ix);
-    if (true == has_ts_pattern) {
+    if (has_ts_pattern) {
         // Initialize the file's timestamp pattern to the previous split's pattern
         archive_writer.change_ts_pattern(last_timestamp_pattern);
     }

--- a/components/core/src/clp/streaming_archive/writer/utils.cpp
+++ b/components/core/src/clp/streaming_archive/writer/utils.cpp
@@ -25,14 +25,17 @@ auto split_file(
         Archive& archive_writer
 ) -> void {
     auto const& encoded_file = archive_writer.get_file();
+    auto has_ts_pattern = encoded_file.has_ts_pattern();
     auto orig_file_id = encoded_file.get_orig_file_id();
     auto split_ix = encoded_file.get_split_ix();
     archive_writer.set_file_is_split(true);
     close_file_and_append_to_segment(archive_writer);
 
     archive_writer.create_and_open_file(path_for_compression, group_id, orig_file_id, ++split_ix);
-    // Initialize the file's timestamp pattern to the previous split's pattern
-    archive_writer.change_ts_pattern(last_timestamp_pattern);
+    if (true == has_ts_pattern) {
+        // Initialize the file's timestamp pattern to the previous split's pattern
+        archive_writer.change_ts_pattern(last_timestamp_pattern);
+    }
 }
 
 auto split_file_and_archive(
@@ -43,6 +46,7 @@ auto split_file_and_archive(
         Archive& archive_writer
 ) -> void {
     auto const& encoded_file = archive_writer.get_file();
+    auto has_ts_pattern = encoded_file.has_ts_pattern();
     auto orig_file_id = encoded_file.get_orig_file_id();
     auto split_ix = encoded_file.get_split_ix();
     archive_writer.set_file_is_split(true);
@@ -51,8 +55,10 @@ auto split_file_and_archive(
     split_archive(archive_user_config, archive_writer);
 
     archive_writer.create_and_open_file(path_for_compression, group_id, orig_file_id, ++split_ix);
-    // Initialize the file's timestamp pattern to the previous split's pattern
-    archive_writer.change_ts_pattern(last_timestamp_pattern);
+    if (true == has_ts_pattern) {
+        // Initialize the file's timestamp pattern to the previous split's pattern
+        archive_writer.change_ts_pattern(last_timestamp_pattern);
+    }
 }
 
 auto close_file_and_append_to_segment(Archive& archive_writer) -> void {


### PR DESCRIPTION
# References
fixes issue #167 

# Description

**Summary of issue:**

When compressing/decompressing Loghub dataset, one file without timestamps had logs out-of-order when compared to original dataset. Out-of-order logs were a result of compressing some logs to the incorrect segment. Specifically logs were being compressed into `m_segment_for_files_with_timestamp` instead of `m_segment_for_files_without_timestamp`.

For large files, the [split_file function][1] is called, which then calls [change_ts_pattern function][2], where there is a bug. The function is meant to pass timestamps from the first chunk of the file, to the second chunk, but if there is no timestamp, it passes an unintialized timestamp object. This is the bug, it should pass nothing for files without timestamps. Clp incorrectly believes the uninitialized timestamp object is a real timestamp, and the second chunk is compressed into `m_segment_for_files_with_timestamp` instead of `m_segment_for_files_without_timestamp`. The segment with timestamps is decompressed first leading to out-of-order logs. 

**Fix:**
Restructure [change_ts_pattern function][3] to do nothing if the file has no timestamps

**Discussion Topic:**
A similar issue may arise if a large log file has a large chunk of logs without timestamps followed by logs with timestamps. Not sure this is a realistic scenario, but noting here in case relevant. 

[1]: https://github.com/davemarco/clp/blob/9f7cc0363466e24f9da1db7e90dc8bad9651f991/components/core/src/clp/streaming_archive/writer/utils.cpp#L21C1-L36C2
[2]: https://github.com/davemarco/clp/blob/9f7cc0363466e24f9da1db7e90dc8bad9651f991/components/core/src/clp/streaming_archive/writer/File.cpp#L87
[3]: https://github.com/davemarco/clp/blob/8a49cb09c238169b85e4b27844f1fa4746a37dc0/components/core/src/clp/streaming_archive/writer/File.cpp#L87

# Validation performed
Compressed/decompressed entire dataset. Ran diff recursively on compressed/decompressed dataset with no differences vs. original.  

