### PR TITLE
Add support for printing compression stats for clp-s

### DIFF
--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -113,6 +113,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::value<std::string>(&m_timestamp_key)->value_name("TIMESTAMP_COLUMN_KEY")->
                         default_value(""),
                     "Path (e.g. x.y) for the field containing the log event's timestamp."
+            )(
+                    "print-stats",
+                    po::bool_switch(&m_print_stats),
+                    "Print compression statistics (ndjson)"
             );
             // clang-format on
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -36,11 +36,13 @@ public:
 
     std::string const& get_output_dir() const { return m_output_dir; }
 
-    std::string const& get_timestamp_key() const { return m_timestamp_key; }
-
     int get_compression_level() const { return m_compression_level; }
 
     size_t get_target_encoded_size() const { return m_target_encoded_size; }
+
+    std::string const& get_timestamp_key() const { return m_timestamp_key; }
+
+    bool print_stats() const { return m_print_stats; }
 
     std::string const& get_query() const { return m_query; }
 
@@ -62,9 +64,10 @@ private:
     std::vector<std::string> m_file_paths;
     std::string m_archives_dir;
     std::string m_output_dir;
-    std::string m_timestamp_key;
     int m_compression_level;
     size_t m_target_encoded_size;
+    std::string m_timestamp_key;
+    bool m_print_stats;
 
     // Search variables
     std::string m_query;

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -49,6 +49,11 @@ public:
         return 0;
     }
 
+    /**
+     * @return number of bytes read from the file
+     */
+    size_t get_bytes_read() { return m_bytes_read; }
+
 private:
     /**
      * Reads new JSON into the buffer and initializes iterators into the data.

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -27,10 +27,11 @@ using namespace simdjson;
 namespace clp_s {
 struct JsonParserOption {
     std::vector<std::string> file_paths;
-    std::vector<std::string> timestamp_column;
     std::string archives_dir;
     size_t target_encoded_size;
     int compression_level;
+    std::vector<std::string> timestamp_column;
+    bool print_stats;
 };
 
 class JsonParser {
@@ -78,23 +79,26 @@ private:
     void split_archive();
 
     int m_num_messages;
-    int m_compression_level;
+    int m_uncompressed_size;
+
     std::vector<std::string> m_file_paths;
     std::string m_archives_dir;
-    std::string m_schema_tree_path;
+    int m_compression_level;
+    size_t m_target_encoded_size;
+    bool m_print_stats;
 
     std::set<int32_t> m_current_schema;
     std::shared_ptr<SchemaMap> m_schema_map;
 
     std::shared_ptr<SchemaTree> m_schema_tree;
+    std::string m_schema_tree_path;
     ParsedMessage m_current_parsed_message;
-    std::shared_ptr<TimestampDictionaryWriter> m_timestamp_dictionary;
 
     std::vector<std::string> m_timestamp_column;
+    std::shared_ptr<TimestampDictionaryWriter> m_timestamp_dictionary;
 
     boost::uuids::random_generator m_generator;
     std::unique_ptr<ArchiveWriter> m_archive_writer;
-    size_t m_target_encoded_size;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -143,4 +143,13 @@ void TimestampDictionaryWriter::merge_local_range() {
         m_global_column_to_range[it.first].merge_range(it.second);
     }
 }
+
+bool TimestampDictionaryWriter::get_first_global_range(TimestampEntry& entry) {
+    if (m_global_column_to_range.empty()) {
+        return false;
+    }
+
+    entry = m_global_column_to_range.begin()->second;
+    return true;
+}
 }  // namespace clp_s

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -60,6 +60,8 @@ public:
 
     uint64_t get_pattern_id(TimestampPattern const* pattern);
 
+    bool get_first_global_range(TimestampEntry& entry);
+
     epochtime_t ingest_entry(std::string const& key, std::string const& timestamp, uint64_t& id);
 
     void ingest_entry(std::string const& key, double timestamp);

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -91,6 +91,16 @@ public:
     EvaluatedValue evaluate_filter(FilterOperation op, double timestamp);
     EvaluatedValue evaluate_filter(FilterOperation op, epochtime_t timestamp);
 
+    TimestampEncoding get_encoding() const { return m_encoding; }
+
+    double get_epoch_start_double() const { return m_epoch_start_double; }
+
+    double get_epoch_end_double() const { return m_epoch_end_double; }
+
+    epochtime_t get_epoch_start() const { return m_epoch_start; }
+
+    epochtime_t get_epoch_end() const { return m_epoch_end; }
+
 private:
     TimestampEncoding m_encoding;
     double m_epoch_start_double, m_epoch_end_double;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -46,12 +46,13 @@ int main(int argc, char const* argv[]) {
         clp_s::JsonParserOption option;
         option.file_paths = command_line_arguments.get_file_paths();
         option.archives_dir = command_line_arguments.get_archives_dir();
-        option.target_encoded_size = command_line_arguments.get_target_encoded_size();
         option.compression_level = command_line_arguments.get_compression_level();
+        option.target_encoded_size = command_line_arguments.get_target_encoded_size();
         auto const& timestamp_key = command_line_arguments.get_timestamp_key();
         if (false == timestamp_key.empty()) {
             clp_s::StringUtils::tokenize_column_descriptor(timestamp_key, option.timestamp_column);
         }
+        option.print_stats = command_line_arguments.print_stats();
 
         clp_s::JsonParser parser(option);
         parser.parse();


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR adds a command-line option, which prints statistics after compression. Similar to clp, it allows the package to read compression statistics from stdout and store them in the metadata database.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Built clp-s and compressed part of [mongodb](https://zenodo.org/records/10516285) dataset.
+ The statistics were shown after compression.
