### PR TITLE
Clean up Defs.h

### DIFF
--- a/components/core/src/clp/Defs.h
+++ b/components/core/src/clp/Defs.h
@@ -10,8 +10,6 @@ namespace clp {
 typedef int64_t epochtime_t;
 constexpr epochtime_t cEpochTimeMin = std::numeric_limits<epochtime_t>::min();
 constexpr epochtime_t cEpochTimeMax = std::numeric_limits<epochtime_t>::max();
-#define SECONDS_TO_EPOCHTIME(x) x * 1000
-#define MICROSECONDS_TO_EPOCHTIME(x) 0
 
 typedef uint64_t variable_dictionary_id_t;
 constexpr variable_dictionary_id_t cVariableDictionaryIdMax
@@ -30,7 +28,6 @@ typedef uint16_t archive_format_version_t;
 //   as possible) which should not have the flag
 constexpr archive_format_version_t cArchiveFormatDevVersionFlag = 0x8000;
 
-typedef uint64_t file_id_t;
 typedef uint64_t segment_id_t;
 constexpr segment_id_t cInvalidSegmentId = std::numeric_limits<segment_id_t>::max();
 
@@ -38,17 +35,8 @@ typedef int64_t encoded_variable_t;
 
 typedef uint64_t group_id_t;
 
-typedef uint64_t pipeline_id_t;
-constexpr pipeline_id_t cPipelineIdMax = std::numeric_limits<pipeline_id_t>::max();
-typedef std::atomic_uint64_t atomic_pipeline_id_t;
-
-// Macros
-// Rounds up VALUE to be a multiple of MULTIPLE
-#define ROUND_UP_TO_MULTIPLE(VALUE, MULTIPLE) ((VALUE + MULTIPLE - 1) / MULTIPLE) * MULTIPLE
-
 // Constants
 constexpr char cDefaultConfigFilename[] = ".clp.rc";
-constexpr int cMongoDbDuplicateKeyErrorCode = 11'000;
 }  // namespace clp
 
 #endif  // CLP_DEFS_H

--- a/components/core/src/clp/PageAllocatedVector.hpp
+++ b/components/core/src/clp/PageAllocatedVector.hpp
@@ -10,6 +10,7 @@
 
 #include "Defs.h"
 #include "ErrorCode.hpp"
+#include "math_utils.hpp"
 #include "Platform.hpp"
 #include "spdlog_with_specializations.hpp"
 #include "TraceableException.hpp"
@@ -250,9 +251,9 @@ void PageAllocatedVector<ValueType>::increase_capacity(size_t required_capacity)
     if (required_capacity <= m_capacity) {
         return;
     }
-    size_t new_size = ROUND_UP_TO_MULTIPLE(
+    size_t new_size = int_round_up_to_multiple(
             std::max(2 * m_capacity, required_capacity) * sizeof(ValueType),
-            m_page_size
+            static_cast<size_t>(m_page_size)
     );
 
     void* new_region;

--- a/components/core/src/clp/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.cpp
@@ -118,8 +118,6 @@ void Archive::open(UserConfig const& user_config) {
     auto metadata_db_path = archive_path / cMetadataDBFileName;
     m_metadata_db.open(metadata_db_path.string());
 
-    m_next_file_id = 0;
-
     m_target_segment_uncompressed_size = user_config.target_segment_uncompressed_size;
     m_next_segment_id = 0;
     m_compression_level = user_config.compression_level;

--- a/components/core/src/clp/streaming_archive/writer/Archive.hpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.hpp
@@ -304,7 +304,6 @@ private:
 
     boost::uuids::random_generator m_uuid_generator;
 
-    file_id_t m_next_file_id;
     // Since we batch metadata persistence operations, we need to keep track of files whose
     // metadata should be persisted Accordingly:
     // - m_files_with_timestamps_in_segment contains files that 1) have been moved to an open


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR cleans up unused and obsolete definitions from Defs.h.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated unit tests pass.
* Validated compression and decompression with the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset.
* Validated a search `"DESERIALIZE_ERRORS"` returns the same (after sorting) results as `grep`.