### PR TITLE
Start celery through Python to work around incorrect Python shebang.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -379,7 +379,7 @@ def start_worker(instance_id: str, clp_config: CLPConfig, container_clp_config: 
     container_start_cmd.append(clp_config.execution_container)
 
     worker_cmd = [
-        str(clp_site_packages_dir / 'bin' / 'celery'),
+        'python3', str(clp_site_packages_dir / 'bin' / 'celery'),
         '-A',
         'job_orchestration.executor',
         'worker',


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

A locally built package fails to start the worker because the shebang in the celery script points to Python in the venv used to build the package (which is not inside the execution container).

There doesn't seem to an option to make an installed Python package ignore or use a different Python path from the one it was installed with so, for now, this PR works around the issue by calling `bin/celery` through Python rather than executing the script directly.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated the workers start up successfully.
* Validated compression and decompression with the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset.
* Validated a search "DESERIALIZE_ERRORS" returns the same (after sorting) results as grep.