### PR TITLE
Use simdjson for precise array search in clp-s

### DIFF
--- a/components/core/src/clp_s/SchemaReader.hpp
+++ b/components/core/src/clp_s/SchemaReader.hpp
@@ -6,8 +6,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include <json/single_include/nlohmann/json.hpp>
-
 #include "ColumnReader.hpp"
 #include "FileReader.hpp"
 #include "JsonSerializer.hpp"

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -587,11 +587,13 @@ bool Output::evaluate_array_filter(
 
     // pre-evaluate whether we can match strings or numbers to eliminate
     // duplicate effort on every item
-    m_maybe_string = operand->as_var_string(m_array_search_string, op)
+    m_maybe_string = op == FilterOperation::EXISTS || op == FilterOperation::NEXISTS
+                     || operand->as_var_string(m_array_search_string, op)
                      || operand->as_clp_string(m_array_search_string, op);
     double tmp_double;
     int64_t tmp_int;
-    m_maybe_number = operand->as_float(tmp_double, op) || operand->as_int(tmp_int, op);
+    m_maybe_number = op == FilterOperation::EXISTS || op == FilterOperation::NEXISTS
+                     || operand->as_float(tmp_double, op) || operand->as_int(tmp_int, op);
 
     return evaluate_array_filter(array, op, unresolved_tokens, 0, operand);
 }

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -587,13 +587,13 @@ bool Output::evaluate_array_filter(
 
     // pre-evaluate whether we can match strings or numbers to eliminate
     // duplicate effort on every item
-    m_maybe_string = op == FilterOperation::EXISTS || op == FilterOperation::NEXISTS
-                     || operand->as_var_string(m_array_search_string, op)
-                     || operand->as_clp_string(m_array_search_string, op);
+    m_maybe_string = !(op == FilterOperation::EXISTS || op == FilterOperation::NEXISTS)
+                     && (operand->as_var_string(m_array_search_string, op)
+                         || operand->as_clp_string(m_array_search_string, op));
     double tmp_double;
     int64_t tmp_int;
-    m_maybe_number = op == FilterOperation::EXISTS || op == FilterOperation::NEXISTS
-                     || operand->as_float(tmp_double, op) || operand->as_int(tmp_int, op);
+    m_maybe_number = !(op == FilterOperation::EXISTS || op == FilterOperation::NEXISTS)
+                     && (operand->as_float(tmp_double, op) || operand->as_int(tmp_int, op));
 
     return evaluate_array_filter(array, op, unresolved_tokens, 0, operand);
 }
@@ -646,7 +646,9 @@ bool Output::evaluate_array_filter(
             }
         } break;
         case ondemand::json_type::boolean: {
-            if (unresolved_tokens.size() != cur_idx) {
+            if (unresolved_tokens.size() != cur_idx || op == FilterOperation::EXISTS
+                || op == FilterOperation::NEXISTS)
+            {
                 break;
             }
             bool tmp_bool;
@@ -655,7 +657,9 @@ bool Output::evaluate_array_filter(
             }
         } break;
         case ondemand::json_type::null: {
-            if (operand->as_null(op)) {
+            if (op != FilterOperation::EXISTS && op != FilterOperation::NEXISTS
+                && operand->as_null(op))
+            {
                 match = op == FilterOperation::EQ;
             }
         } break;

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -3,8 +3,6 @@
 #include <regex>
 #include <stack>
 
-#include <json/single_include/nlohmann/json.hpp>
-
 #include "../FileWriter.hpp"
 #include "../ReaderUtils.hpp"
 #include "../Utils.hpp"
@@ -15,8 +13,6 @@
 #include "FilterExpr.hpp"
 #include "OrExpr.hpp"
 #include "SearchUtils.hpp"
-
-using json = nlohmann::json;
 
 #define eval(op, a, b) (((op) == FilterOperation::EQ) ? ((a) == (b)) : ((a) != (b)))
 
@@ -580,83 +576,136 @@ bool Output::evaluate_var_string_filter(
 bool Output::evaluate_array_filter(
         FilterOperation op,
         DescriptorList const& unresolved_tokens,
-        std::string const& value,
+        std::string& value,
         std::shared_ptr<Literal> const& operand
-) const {
-    auto object = json::parse(value);
-    return evaluate_array_filter(object, op, unresolved_tokens, 0, operand, true);
+) {
+    if (value.capacity() < (value.size() + simdjson::SIMDJSON_PADDING)) {
+        value.reserve(value.size() + simdjson::SIMDJSON_PADDING);
+    }
+    auto obj = m_array_parser.iterate(value);
+    ondemand::array array = obj.get_array();
+
+    // pre-evaluate whether we can match strings or numbers to eliminate
+    // duplicate effort on every item
+    m_maybe_string = operand->as_var_string(m_array_search_string, op)
+                     || operand->as_clp_string(m_array_search_string, op);
+    double tmp_double;
+    int64_t tmp_int;
+    m_maybe_number = operand->as_float(tmp_double, op) || operand->as_int(tmp_int, op);
+
+    return evaluate_array_filter(array, op, unresolved_tokens, 0, operand);
 }
 
 bool Output::evaluate_array_filter(
-        json& object,
+        ondemand::value& item,
         FilterOperation op,
         DescriptorList const& unresolved_tokens,
         size_t cur_idx,
-        std::shared_ptr<Literal> const& operand,
-        bool array_or_object
+        std::shared_ptr<Literal> const& operand
 ) const {
     bool match = false;
-    if (cur_idx > unresolved_tokens.size()) {
-        return false;
-    }
-
-    for (auto i = object.begin(); i != object.end(); ++i) {
-        auto& value = i.value();
-        if (value.is_array()) {
-            match |= evaluate_array_filter(value, op, unresolved_tokens, cur_idx, operand, true);
-        } else if (value.is_object()) {
-            if (false == array_or_object && cur_idx < unresolved_tokens.size()
-                && i.key() == unresolved_tokens[cur_idx].get_token())
-            {
-                match |= evaluate_array_filter(
-                        value,
-                        op,
-                        unresolved_tokens,
-                        cur_idx + 1,
-                        operand,
-                        false
-                );
-            } else if (array_or_object) {
-                match |= evaluate_array_filter(
-                        value,
-                        op,
-                        unresolved_tokens,
-                        cur_idx,
-                        operand,
-                        false
-                );
-            }
-        } else if (((array_or_object && cur_idx == unresolved_tokens.size())
-                    || (!array_or_object && cur_idx == unresolved_tokens.size() - 1
-                        && i.key() == unresolved_tokens[cur_idx].get_token())))
-        {
-            std::string tmp_string;
-            int64_t tmp_int;
-            double tmp_float;
-            bool tmp_bool;
-            if (FilterOperation::EXISTS == op || FilterOperation::NEXISTS == op
-                || (value.is_number_integer() && operand->as_int(tmp_int, op)
-                    && eval(op, value.get<int64_t>(), tmp_int))
-                || (value.is_number_float() && operand->as_float(tmp_float, op)
-                    && eval(op, value.get<double>(), tmp_float))
-                || (value.is_boolean() && operand->as_bool(tmp_bool, op)
-                    && eval(op, value.get<bool>(), tmp_bool)))
-            {
+    switch (item.type()) {
+        case ondemand::json_type::object: {
+            ondemand::object nested_object = item.get_object();
+            if (evaluate_array_filter(nested_object, op, unresolved_tokens, cur_idx, operand)) {
                 match = true;
-            } else if (value.is_string() && (operand->as_var_string(tmp_string, op) || operand->as_clp_string(tmp_string, op)))
-            {
-                std::string s = value.get<std::string>();
-                match = wildcard_match(s, tmp_string) ? op == FilterOperation::EQ
-                                                      : op == FilterOperation::NEQ;
             }
-        }
+        } break;
+        case ondemand::json_type::array: {
+            ondemand::array nested_array = item.get_array();
+            if (evaluate_array_filter(nested_array, op, unresolved_tokens, cur_idx, operand)) {
+                match = true;
+            }
+        } break;
+        case ondemand::json_type::string: {
+            if (true == m_maybe_string && unresolved_tokens.size() == cur_idx
+                && wildcard_match(item.get_string().value(), m_array_search_string))
+            {
+                match = op == FilterOperation::EQ;
+            }
+        } break;
+        case ondemand::json_type::number: {
+            if (false == m_maybe_number || unresolved_tokens.size() != cur_idx) {
+                break;
+            }
+            ondemand::number number = item.get_number();
+            if (number.is_double()) {
+                double tmp_double;
+                operand->as_float(tmp_double, op);
+                match = eval(op, number.get_double(), tmp_double);
+            } else if (number.is_uint64()) {
+                int64_t tmp_int;
+                operand->as_int(tmp_int, op);
+                match = eval(op, number.get_uint64(), tmp_int);
+            } else {
+                int64_t tmp_int;
+                operand->as_int(tmp_int, op);
+                match = eval(op, number.get_int64(), tmp_int);
+            }
+        } break;
+        case ondemand::json_type::boolean: {
+            if (unresolved_tokens.size() != cur_idx) {
+                break;
+            }
+            bool tmp_bool;
+            if (operand->as_bool(tmp_bool, op) && eval(op, item.get_bool(), tmp_bool)) {
+                match = true;
+            }
+        } break;
+        case ondemand::json_type::null: {
+            if (operand->as_null(op)) {
+                match = op == FilterOperation::EQ;
+            }
+        } break;
+    }
+    return match;
+}
 
-        if (match) {
+bool Output::evaluate_array_filter(
+        ondemand::array& array,
+        FilterOperation op,
+        DescriptorList const& unresolved_tokens,
+        size_t cur_idx,
+        std::shared_ptr<Literal> const& operand
+) const {
+    bool match = false;
+    for (ondemand::value item : array) {
+        if (evaluate_array_filter(item, op, unresolved_tokens, cur_idx, operand)) {
             return true;
         }
     }
+    return false;
+}
 
-    return match;
+bool Output::evaluate_array_filter(
+        ondemand::object& object,
+        FilterOperation op,
+        DescriptorList const& unresolved_tokens,
+        size_t cur_idx,
+        std::shared_ptr<Literal> const& operand
+) const {
+    if (cur_idx >= unresolved_tokens.size()) {
+        return false;
+    }
+
+    for (auto field : object) {
+        // Note: field.key() yields the escaped JSON key, so the descriptor tokens passed to search
+        // must likewise be escaped.
+        if (field.key() != unresolved_tokens[cur_idx].get_token()) {
+            continue;
+        }
+
+        cur_idx += 1;
+        if (cur_idx == unresolved_tokens.size()
+            && (op == FilterOperation::EXISTS || op == FilterOperation::NEXISTS))
+        {
+            return op == FilterOperation::EXISTS;
+        }
+
+        ondemand::value item = field.value();
+        return evaluate_array_filter(item, op, unresolved_tokens, cur_idx, operand);
+    }
+    return false;
 }
 
 bool Output::evaluate_wildcard_array_filter(

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -236,7 +236,7 @@ private:
     );
 
     /**
-     * The implementation of evaluate_array_filter
+     * Evaluates a filter expression on a single value for precise array search.
      * @param item
      * @param op
      * @param unresolved_tokens
@@ -244,7 +244,7 @@ private:
      * @param operand
      * @return true if the expression evaluates to true, false otherwise
      */
-    inline bool evaluate_array_filter(
+    inline bool evaluate_array_filter_value(
             ondemand::value& item,
             FilterOperation op,
             DescriptorList const& unresolved_tokens,
@@ -253,7 +253,7 @@ private:
     ) const;
 
     /**
-     * The implementation of evaluate_array_filter
+     * Evaluates a filter expression on an array (top level or nested) for precise array search.
      * @param array
      * @param op
      * @param unresolved_tokens
@@ -261,7 +261,7 @@ private:
      * @param operand
      * @return true if the expression evaluates to true, false otherwise
      */
-    bool evaluate_array_filter(
+    bool evaluate_array_filter_array(
             ondemand::array& array,
             FilterOperation op,
             DescriptorList const& unresolved_tokens,
@@ -270,7 +270,7 @@ private:
     ) const;
 
     /**
-     * The implementation of evaluate_array_filter
+     * Evaluates a filter expression on an object inside of an array for precise array search.
      * @param object
      * @param op
      * @param unresolved_tokens
@@ -278,7 +278,7 @@ private:
      * @param operand
      * @return true if the expression evaluates to true, false otherwise
      */
-    bool evaluate_array_filter(
+    bool evaluate_array_filter_object(
             ondemand::object& object,
             FilterOperation op,
             DescriptorList const& unresolved_tokens,

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -241,7 +241,6 @@ private:
      * @param op
      * @param unresolved_tokens
      * @param cur_idx
-     * @param value
      * @param operand
      * @return true if the expression evaluates to true, false otherwise
      */

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -19,7 +19,6 @@
 #include "StringLiteral.hpp"
 
 using namespace simdjson;
-using nlohmann::json;
 using namespace clp_s::search::clp_search;
 
 namespace clp_s::search {
@@ -232,7 +231,42 @@ private:
     bool evaluate_array_filter(
             FilterOperation op,
             DescriptorList const& unresolved_tokens,
-            std::string const& value,
+            std::string& value,
+            std::shared_ptr<Literal> const& operand
+    );
+
+    /**
+     * The implementation of evaluate_array_filter
+     * @param item
+     * @param op
+     * @param unresolved_tokens
+     * @param cur_idx
+     * @param value
+     * @param operand
+     * @return true if the expression evaluates to true, false otherwise
+     */
+    inline bool evaluate_array_filter(
+            ondemand::value& item,
+            FilterOperation op,
+            DescriptorList const& unresolved_tokens,
+            size_t cur_idx,
+            std::shared_ptr<Literal> const& operand
+    ) const;
+
+    /**
+     * The implementation of evaluate_array_filter
+     * @param array
+     * @param op
+     * @param unresolved_tokens
+     * @param cur_idx
+     * @param operand
+     * @return true if the expression evaluates to true, false otherwise
+     */
+    bool evaluate_array_filter(
+            ondemand::array& array,
+            FilterOperation op,
+            DescriptorList const& unresolved_tokens,
+            size_t cur_idx,
             std::shared_ptr<Literal> const& operand
     ) const;
 
@@ -242,18 +276,15 @@ private:
      * @param op
      * @param unresolved_tokens
      * @param cur_idx
-     * @param value
      * @param operand
-     * @param array_or_object if true, we are traversing an array
      * @return true if the expression evaluates to true, false otherwise
      */
     bool evaluate_array_filter(
-            json& object,
+            ondemand::object& object,
             FilterOperation op,
             DescriptorList const& unresolved_tokens,
             size_t cur_idx,
-            std::shared_ptr<Literal> const& operand,
-            bool array_or_object
+            std::shared_ptr<Literal> const& operand
     ) const;
 
     /**

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -121,5 +121,10 @@ or
 * The order of log events is not preserved.
 * The input directory structure is not preserved and during decompression all files are written to
   the same file.
+* The KQL implementation doesn't fully respect the {} object within array syntax. A matching record
+  will satisfy all of the conditions in the filter, but not necessarily on the same object in the
+  array.
+* Searches on arrays must either be fully precise (no wildcard tokens in the key) or fully imprecise
+  (a single wildcard token).
 
 [1]: https://www.elastic.co/guide/en/kibana/current/kuery-query.html

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -121,7 +121,7 @@ or
 * The order of log events is not preserved.
 * The input directory structure is not preserved and during decompression all files are written to
   the same file.
-* The KQL implementation doesn't fully respect the {} object within array syntax. A matching record
+* The KQL implementation does not fully respect the {} object within array syntax. A matching record
   will satisfy all of the conditions in the filter, but not necessarily on the same object in the
   array.
 * Searches on arrays must either be fully precise (no wildcard tokens in the key) or fully imprecise

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -126,8 +126,7 @@ or
   array. This means that filters like `"a": {"b": 0, "c": 0}` will match documents like
   `{"a": [{"b": 0}, {"c": 0}]}` instead of matching only documents like `{"a": [{"b": 0, "c": 0}]}`
 * Searches on arrays must either be fully precise (no wildcard tokens in the key) or fully imprecise
-  (a single wildcard token). This means filters like `"*": "uuid"` and `"a.b.c": "uuid"` will be
-  allowed to search inside of array columns, but filters like `"a.*": "uuid"` or `a.*.c: "uuid"`
-  will not.
+  (a single wildcard token). This means filters like `"*": "uuid"` and `"a.b.c": "uuid"` will search
+  inside of array columns, but filters like `"a.*": "uuid"` or `a.*.c: "uuid"` will not.
 
 [1]: https://www.elastic.co/guide/en/kibana/current/kuery-query.html

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -123,8 +123,11 @@ or
   the same file.
 * The KQL implementation does not fully respect the {} object within array syntax. A matching record
   will satisfy all of the conditions in the filter, but not necessarily on the same object in the
-  array.
+  array. This means that filters like `"a": {"b": 0, "c": 0}` will match documents like
+  `{"a": [{"b": 0}, {"c": 0}]}` instead of matching only documents like `{"a": [{"b": 0, "c": 0}]}`
 * Searches on arrays must either be fully precise (no wildcard tokens in the key) or fully imprecise
-  (a single wildcard token).
+  (a single wildcard token). This means filters like `"*": "uuid"` and `"a.b.c": "uuid"` will be
+  allowed to search inside of array columns, but filters like `"a.*": "uuid"` or `a.*.c: "uuid"`
+  will not.
 
 [1]: https://www.elastic.co/guide/en/kibana/current/kuery-query.html


### PR DESCRIPTION
# Description
For precise search within an array nlohmann json is currently being used to parse and scan json arrays.

This PR replaces the nlohmann based implementation with a simdjson based implementation to improve array scan performance.

This PR also updates the clp-s README to better describe the current limitations on array searches.

# Validation performed
Compared execution speed with previous implementation and saw ~1.7x speedup on queries on real data.

