### PR TITLE
Use a vector instead of a set to represent clp-s schemas

### DIFF
--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -40,7 +40,7 @@ void ArchiveReader::open(ArchiveReaderOption& option) {
 
     // Open schema readers and load encoded messages
     for (int32_t schema_id : schema_ids) {
-        auto& schema = m_id_to_schema[schema_id];
+        auto& schema = m_schema_map[schema_id];
         auto schema_reader = new SchemaReader(m_schema_tree, schema_id);
         schema_reader->open(encoded_messages_dir + "/" + std::to_string(schema_id));
 

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -8,6 +8,7 @@
 #include <boost/filesystem.hpp>
 
 #include "DictionaryReader.hpp"
+#include "ReaderUtils.hpp"
 #include "SchemaReader.hpp"
 #include "TimestampDictionaryReader.hpp"
 
@@ -29,11 +30,11 @@ public:
     // Constructor
     ArchiveReader(
             std::shared_ptr<SchemaTree> schema_tree,
-            std::map<int32_t, std::vector<int32_t>> id_to_schema,
+            ReaderUtils::SchemaMap schema_map,
             std::shared_ptr<TimestampDictionaryReader> timestamp_dict
     )
             : m_schema_tree(std::move(schema_tree)),
-              m_id_to_schema(std::move(id_to_schema)),
+              m_schema_map(std::move(schema_map)),
               m_timestamp_dict(std::move(timestamp_dict)) {}
 
     /**
@@ -61,7 +62,7 @@ private:
     std::shared_ptr<LogTypeDictionaryReader> m_array_dict;
 
     std::shared_ptr<SchemaTree> m_schema_tree;
-    std::map<int32_t, std::vector<int32_t>> m_id_to_schema;
+    ReaderUtils::SchemaMap m_schema_map;
     std::map<int32_t, SchemaReader*> m_schema_id_to_reader;
 
     std::shared_ptr<TimestampDictionaryReader> m_timestamp_dict;

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -29,7 +29,7 @@ public:
     // Constructor
     ArchiveReader(
             std::shared_ptr<SchemaTree> schema_tree,
-            std::map<int32_t, std::set<int32_t>> id_to_schema,
+            std::map<int32_t, std::vector<int32_t>> id_to_schema,
             std::shared_ptr<TimestampDictionaryReader> timestamp_dict
     )
             : m_schema_tree(std::move(schema_tree)),
@@ -61,7 +61,7 @@ private:
     std::shared_ptr<LogTypeDictionaryReader> m_array_dict;
 
     std::shared_ptr<SchemaTree> m_schema_tree;
-    std::map<int32_t, std::set<int32_t>> m_id_to_schema;
+    std::map<int32_t, std::vector<int32_t>> m_id_to_schema;
     std::map<int32_t, SchemaReader*> m_schema_id_to_reader;
 
     std::shared_ptr<TimestampDictionaryReader> m_timestamp_dict;

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -58,11 +58,7 @@ void ArchiveWriter::close() {
     m_encoded_message_size = 0UL;
 }
 
-void ArchiveWriter::append_message(
-        int32_t schema_id,
-        std::set<int32_t>& schema,
-        ParsedMessage& message
-) {
+void ArchiveWriter::append_message(int32_t schema_id, Schema& schema, ParsedMessage& message) {
     SchemaWriter* schema_writer;
     auto it = m_schema_id_to_writer.find(schema_id);
     if (it != m_schema_id_to_writer.end()) {
@@ -85,7 +81,7 @@ size_t ArchiveWriter::get_data_size() {
            + m_encoded_message_size;
 }
 
-void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, std::set<int32_t>& schema) {
+void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema& schema) {
     for (int32_t id : schema) {
         auto node = m_schema_tree->get_node(id);
         std::string key_name = node->get_key_name();

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -58,7 +58,11 @@ void ArchiveWriter::close() {
     m_encoded_message_size = 0UL;
 }
 
-void ArchiveWriter::append_message(int32_t schema_id, Schema& schema, ParsedMessage& message) {
+void ArchiveWriter::append_message(
+        int32_t schema_id,
+        Schema const& schema,
+        ParsedMessage& message
+) {
     SchemaWriter* schema_writer;
     auto it = m_schema_id_to_writer.find(schema_id);
     if (it != m_schema_id_to_writer.end()) {
@@ -81,7 +85,7 @@ size_t ArchiveWriter::get_data_size() {
            + m_encoded_message_size;
 }
 
-void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema& schema) {
+void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const& schema) {
     for (int32_t id : schema) {
         auto node = m_schema_tree->get_node(id);
         std::string key_name = node->get_key_name();

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -1,7 +1,6 @@
 #ifndef CLP_S_ARCHIVEWRITER_HPP
 #define CLP_S_ARCHIVEWRITER_HPP
 
-#include <set>
 #include <utility>
 
 #include <boost/filesystem.hpp>
@@ -9,6 +8,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "DictionaryWriter.hpp"
+#include "Schema.hpp"
 #include "SchemaTree.hpp"
 #include "SchemaWriter.hpp"
 #include "TimestampDictionaryWriter.hpp"
@@ -58,7 +58,7 @@ public:
      * @param schema
      * @param message
      */
-    void append_message(int32_t schema_id, std::set<int32_t>& schema, ParsedMessage& message);
+    void append_message(int32_t schema_id, Schema& schema, ParsedMessage& message);
 
     /**
      * @return Size of the uncompressed data written to the archive
@@ -71,7 +71,7 @@ private:
      * @param writer
      * @param schema
      */
-    void initialize_schema_writer(SchemaWriter* writer, std::set<int32_t>& schema);
+    void initialize_schema_writer(SchemaWriter* writer, Schema& schema);
 
     size_t m_encoded_message_size;
 

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -58,7 +58,7 @@ public:
      * @param schema
      * @param message
      */
-    void append_message(int32_t schema_id, Schema& schema, ParsedMessage& message);
+    void append_message(int32_t schema_id, Schema const& schema, ParsedMessage& message);
 
     /**
      * @return Size of the uncompressed data written to the archive
@@ -71,7 +71,7 @@ private:
      * @param writer
      * @param schema
      */
-    void initialize_schema_writer(SchemaWriter* writer, Schema& schema);
+    void initialize_schema_writer(SchemaWriter* writer, Schema const& schema);
 
     size_t m_encoded_message_size;
 

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -36,6 +36,8 @@ set(
         ParsedMessage.hpp
         ReaderUtils.cpp
         ReaderUtils.hpp
+        Schema.cpp
+        Schema.hpp
         SchemaMap.cpp
         SchemaMap.hpp
         SchemaReader.cpp

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -58,9 +58,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  x - decompress" << std::endl;
                 std::cerr << "  s - search" << std::endl;
                 std::cerr << std::endl;
-                std::cerr << "Try "
-                          << " c --help OR"
-                          << " x --help OR"
+                std::cerr << "Try " << " c --help OR" << " x --help OR"
                           << " s --help for command-specific details." << std::endl;
 
                 po::options_description visible_options;

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -58,7 +58,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  x - decompress" << std::endl;
                 std::cerr << "  s - search" << std::endl;
                 std::cerr << std::endl;
-                std::cerr << "Try " << " c --help OR" << " x --help OR"
+                std::cerr << "Try "
+                          << " c --help OR"
+                          << " x --help OR"
                           << " s --help for command-specific details." << std::endl;
 
                 po::options_description visible_options;

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -87,7 +87,7 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                 auto objref = object_stack.top();
                 auto it = ondemand::object_iterator(objref.begin());
                 if (it == objref.end()) {
-                    m_current_schema.insert(node_id);
+                    m_current_schema.insert_ordered(node_id);
                     object_stack.pop();
                     break;
                 } else {
@@ -100,7 +100,7 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                 std::string value = std::string(std::string_view(simdjson::to_json_string(line)));
                 node_id = m_schema_tree->add_node(node_id_stack.top(), NodeType::ARRAY, cur_key);
                 m_current_parsed_message.add_value(node_id, value);
-                m_current_schema.insert(node_id);
+                m_current_schema.insert_ordered(node_id);
                 break;
             }
             case ondemand::json_type::number: {
@@ -136,7 +136,7 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                         matches_timestamp = may_match_timestamp = can_match_timestamp = false;
                     }
                 }
-                m_current_schema.insert(node_id);
+                m_current_schema.insert_ordered(node_id);
                 break;
             }
             case ondemand::json_type::string: {
@@ -172,7 +172,7 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                     m_current_parsed_message.add_value(node_id, value);
                 }
 
-                m_current_schema.insert(node_id);
+                m_current_schema.insert_ordered(node_id);
                 break;
             }
             case ondemand::json_type::boolean: {
@@ -180,13 +180,13 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                 node_id = m_schema_tree->add_node(node_id_stack.top(), NodeType::BOOLEAN, cur_key);
 
                 m_current_parsed_message.add_value(node_id, value);
-                m_current_schema.insert(node_id);
+                m_current_schema.insert_ordered(node_id);
                 break;
             }
             case ondemand::json_type::null: {
                 node_id = m_schema_tree
                                   ->add_node(node_id_stack.top(), NodeType::NULLVALUE, cur_key);
-                m_current_schema.insert(node_id);
+                m_current_schema.insert_ordered(node_id);
                 break;
             }
         }

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -2,7 +2,6 @@
 #define CLP_S_JSONPARSER_HPP
 
 #include <map>
-#include <set>
 #include <string>
 #include <variant>
 #include <vector>
@@ -15,6 +14,7 @@
 #include "FileReader.hpp"
 #include "FileWriter.hpp"
 #include "ParsedMessage.hpp"
+#include "Schema.hpp"
 #include "SchemaMap.hpp"
 #include "SchemaTree.hpp"
 #include "SchemaWriter.hpp"
@@ -83,7 +83,7 @@ private:
     std::string m_archives_dir;
     std::string m_schema_tree_path;
 
-    std::set<int32_t> m_current_schema;
+    Schema m_current_schema;
     std::shared_ptr<SchemaMap> m_schema_map;
 
     std::shared_ptr<SchemaTree> m_schema_tree;

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -103,7 +103,7 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
             throw OperationFailed(error_code, __FILENAME__, __LINE__);
         }
 
-        std::set<int32_t>& schema = schemas[schema_id];
+        std::vector<int32_t>& schema = schemas[schema_id];
         for (size_t j = 0; j < schema_node_size; j++) {
             int32_t node_id;
             error_code = schema_id_decompressor.try_read_numeric_value(node_id);
@@ -111,7 +111,7 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
                 throw OperationFailed(error_code, __FILENAME__, __LINE__);
             }
 
-            schema.insert(node_id);
+            schema.push_back(node_id);
         }
     }
 
@@ -182,7 +182,7 @@ std::vector<int32_t> ReaderUtils::get_schemas(std::string const& archive_path) {
 
 void ReaderUtils::append_reader_columns(
         SchemaReader* reader,
-        std::set<int32_t>& columns,
+        std::vector<int32_t>& columns,
         std::shared_ptr<SchemaTree> const& schema_tree,
         std::shared_ptr<VariableDictionaryReader> const& var_dict,
         std::shared_ptr<LogTypeDictionaryReader> const& log_dict,

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -103,7 +103,7 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
             throw OperationFailed(error_code, __FILENAME__, __LINE__);
         }
 
-        std::vector<int32_t>& schema = schemas[schema_id];
+        auto& schema = schemas[schema_id];
         for (size_t j = 0; j < schema_node_size; j++) {
             int32_t node_id;
             error_code = schema_id_decompressor.try_read_numeric_value(node_id);

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -90,6 +90,8 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
         throw OperationFailed(error_code, __FILENAME__, __LINE__);
     }
 
+    // TODO: consider decompressing all schemas into the same buffer and providing access to them
+    // via const spans.
     for (size_t i = 0; i < schema_size; i++) {
         int32_t schema_id;
         error_code = schema_id_decompressor.try_read_numeric_value(schema_id);
@@ -111,7 +113,8 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
                 throw OperationFailed(error_code, __FILENAME__, __LINE__);
             }
 
-            schema.push_back(node_id);
+            // Maintain schema ordering defined at compression time
+            schema.insert_unordered(node_id);
         }
     }
 
@@ -182,7 +185,7 @@ std::vector<int32_t> ReaderUtils::get_schemas(std::string const& archive_path) {
 
 void ReaderUtils::append_reader_columns(
         SchemaReader* reader,
-        std::vector<int32_t>& columns,
+        Schema const& columns,
         std::shared_ptr<SchemaTree> const& schema_tree,
         std::shared_ptr<VariableDictionaryReader> const& var_dict,
         std::shared_ptr<LogTypeDictionaryReader> const& log_dict,

--- a/components/core/src/clp_s/ReaderUtils.hpp
+++ b/components/core/src/clp_s/ReaderUtils.hpp
@@ -17,7 +17,7 @@ public:
                 : TraceableException(error_code, filename, line_number) {}
     };
 
-    typedef std::map<int32_t, std::set<int32_t>> SchemaMap;
+    typedef std::map<int32_t, std::vector<int32_t>> SchemaMap;
     static constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;  // 64 KB
 
     /**
@@ -105,7 +105,7 @@ public:
      */
     static void append_reader_columns(
             SchemaReader* reader,
-            std::set<int32_t>& columns,
+            std::vector<int32_t>& columns,
             std::shared_ptr<SchemaTree> const& schema_tree,
             std::shared_ptr<VariableDictionaryReader> const& var_dict,
             std::shared_ptr<LogTypeDictionaryReader> const& log_dict,

--- a/components/core/src/clp_s/ReaderUtils.hpp
+++ b/components/core/src/clp_s/ReaderUtils.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_READERUTILS_HPP
 
 #include "DictionaryReader.hpp"
+#include "Schema.hpp"
 #include "SchemaReader.hpp"
 #include "SchemaTree.hpp"
 #include "TimestampDictionaryReader.hpp"
@@ -17,7 +18,7 @@ public:
                 : TraceableException(error_code, filename, line_number) {}
     };
 
-    typedef std::map<int32_t, std::vector<int32_t>> SchemaMap;
+    typedef std::map<int32_t, Schema> SchemaMap;
     static constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;  // 64 KB
 
     /**
@@ -105,7 +106,7 @@ public:
      */
     static void append_reader_columns(
             SchemaReader* reader,
-            std::vector<int32_t>& columns,
+            Schema const& columns,
             std::shared_ptr<SchemaTree> const& schema_tree,
             std::shared_ptr<VariableDictionaryReader> const& var_dict,
             std::shared_ptr<LogTypeDictionaryReader> const& log_dict,

--- a/components/core/src/clp_s/Schema.cpp
+++ b/components/core/src/clp_s/Schema.cpp
@@ -1,0 +1,22 @@
+#include "Schema.hpp"
+
+#include <algorithm>
+
+namespace clp_s {
+void Schema::insert_ordered(int32_t mst_node_id) {
+    m_schema.insert(
+            std::upper_bound(m_schema.begin(), m_schema.end() - m_num_unordered, mst_node_id),
+            mst_node_id
+    );
+}
+
+void Schema::insert_unordered(int32_t mst_node_id) {
+    m_schema.push_back(mst_node_id);
+    m_num_unordered += 1;
+}
+
+void Schema::insert_unordered(std::vector<int32_t> const& mst_node_ids) {
+    m_schema.insert(m_schema.end(), mst_node_ids.begin(), mst_node_ids.end());
+    m_num_unordered += mst_node_ids.size();
+}
+}  // namespace clp_s

--- a/components/core/src/clp_s/Schema.cpp
+++ b/components/core/src/clp_s/Schema.cpp
@@ -12,10 +12,10 @@ void Schema::insert_ordered(int32_t mst_node_id) {
 
 void Schema::insert_unordered(int32_t mst_node_id) {
     m_schema.push_back(mst_node_id);
-    m_num_unordered += 1;
+    ++m_num_unordered;
 }
 
-void Schema::insert_unordered(std::vector<int32_t> const& mst_node_ids) {
+void Schema::insert_unordered(schema_t const& mst_node_ids) {
     m_schema.insert(m_schema.end(), mst_node_ids.begin(), mst_node_ids.end());
     m_num_unordered += mst_node_ids.size();
 }

--- a/components/core/src/clp_s/Schema.cpp
+++ b/components/core/src/clp_s/Schema.cpp
@@ -5,18 +5,22 @@
 namespace clp_s {
 void Schema::insert_ordered(int32_t mst_node_id) {
     m_schema.insert(
-            std::upper_bound(m_schema.begin(), m_schema.end() - m_num_unordered, mst_node_id),
+            std::upper_bound(
+                    m_schema.begin(),
+                    m_schema.begin()
+                            + static_cast<decltype(m_schema)::difference_type>(m_num_ordered),
+                    mst_node_id
+            ),
             mst_node_id
     );
+    ++m_num_ordered;
 }
 
 void Schema::insert_unordered(int32_t mst_node_id) {
     m_schema.push_back(mst_node_id);
-    ++m_num_unordered;
 }
 
-void Schema::insert_unordered(schema_t const& mst_node_ids) {
-    m_schema.insert(m_schema.end(), mst_node_ids.begin(), mst_node_ids.end());
-    m_num_unordered += mst_node_ids.size();
+void Schema::insert_unordered(Schema const& schema) {
+    m_schema.insert(m_schema.end(), schema.begin(), schema.end());
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -68,6 +68,16 @@ public:
     [[nodiscard]] auto end() const { return m_schema.cend(); }
 
     /**
+     * @return constant iterator to the start of the underlying schema
+     */
+    [[nodiscard]] auto cbegin() const { return m_schema.cbegin(); }
+
+    /**
+     * @return constant iterator to the end of the underlying schema
+     */
+    [[nodiscard]] auto cend() const { return m_schema.cend(); }
+
+    /**
      * Less than comparison operator so that Schema can act as a key for SchemaMap
      * @return true if this schema is less than the schema on the right hand side
      * @return false otherwise

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -9,11 +9,11 @@ namespace clp_s {
 /**
  * Class representing a schema made up of MST nodes.
  *
- * Internally the schema is represented by a vector where the first m_num_ordered entries are
- * ordered by MST node Id, and all of the following entries are allowed to have arbitrary order.
+ * Internally, the schema is represented by a vector where the first m_num_ordered entries are
+ * ordered by MST node ID, and the following entries are allowed to have arbitrary order.
  *
- * In the current implementation of clp-s MST node Ids in a schema must be unique, so the caller
- * is responsible for not inserting duplicate MST nodes into a schema. Future version of clp-s will
+ * In the current implementation of clp-s, MST node IDs in a schema must be unique, so the caller
+ * is responsible for not inserting duplicate MST nodes into a schema. Future versions of clp-s will
  * likely relax this requirement.
  */
 class Schema {
@@ -29,7 +29,7 @@ public:
     void insert_unordered(int32_t mst_node_id);
 
     /**
-     * Inserts another schema into the unordered region of the schema maintaining that Schema's
+     * Inserts another schema into the unordered region of the schema, maintaining that Schema's
      * order.
      */
     void insert_unordered(Schema const& schema);
@@ -53,7 +53,7 @@ public:
     [[nodiscard]] auto begin() { return m_schema.begin(); }
 
     /**
-     * @return iterator to the start of the underlying schema
+     * @return iterator to the end of the underlying schema
      */
     [[nodiscard]] auto end() { return m_schema.end(); }
 

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -11,7 +11,7 @@ namespace clp_s {
  */
 class Schema {
 public:
-    typedef std::vector<int32_t> schema_t;
+    using schema_t = std::vector<int32_t>;
 
     /**
      * Insert a single node into the ordered region of the schema.
@@ -26,7 +26,7 @@ public:
     /**
      * Insert an unordered list of nodes into the unordered region of the schema.
      */
-    void insert_unordered(std::vector<int32_t> const& mst_node_ids);
+    void insert_unordered(schema_t const& mst_node_ids);
 
     /**
      * Clear the Schema object so that it can be reused without reallocating the underlying vector.
@@ -63,8 +63,8 @@ public:
     bool operator==(Schema const& rhs) const { return m_schema == rhs.m_schema; }
 
 private:
-    std::vector<int32_t> m_schema{};
-    size_t m_num_unordered{};
+    std::vector<int32_t> m_schema;
+    size_t m_num_unordered{0};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -8,11 +8,16 @@
 namespace clp_s {
 /**
  * Class representing a schema made up of MST nodes.
+ *
+ * Internally the schema is represented by a vector where the first m_num_ordered entries are
+ * ordered by MST node Id, and all of the following entries are allowed to have arbitrary order.
+ *
+ * In the current implementation of clp-s MST node Ids in a schema must be unique, so the caller
+ * is responsible for not inserting duplicate MST nodes into a schema. Future version of clp-s will
+ * likely relax this requirement.
  */
 class Schema {
 public:
-    using schema_t = std::vector<int32_t>;
-
     /**
      * Inserts a node into the ordered region of the schema.
      */
@@ -24,16 +29,17 @@ public:
     void insert_unordered(int32_t mst_node_id);
 
     /**
-     * Inserts an unordered list of nodes into the unordered region of the schema.
+     * Inserts another schema into the unordered region of the schema maintaining that Schema's
+     * order.
      */
-    void insert_unordered(schema_t const& mst_node_ids);
+    void insert_unordered(Schema const& schema);
 
     /**
      * Clear the Schema object so that it can be reused without reallocating the underlying vector.
      */
     void clear() {
         m_schema.clear();
-        m_num_unordered = 0;
+        m_num_ordered = 0;
     }
 
     /**
@@ -44,16 +50,16 @@ public:
     /**
      * @return iterators to the underlying schema
      */
-    auto begin() { return m_schema.begin(); }
+    [[nodiscard]] auto begin() { return m_schema.begin(); }
 
-    auto end() { return m_schema.end(); }
+    [[nodiscard]] auto end() { return m_schema.end(); }
 
     /**
      * @return constant iterators to the underlying schema
      */
-    auto begin() const { return m_schema.cbegin(); }
+    [[nodiscard]] auto begin() const { return m_schema.cbegin(); }
 
-    auto end() const { return m_schema.cend(); }
+    [[nodiscard]] auto end() const { return m_schema.cend(); }
 
     /**
      * Comparison operators so that Schema can act as a key for SchemaMap
@@ -64,7 +70,7 @@ public:
 
 private:
     std::vector<int32_t> m_schema;
-    size_t m_num_unordered{0};
+    size_t m_num_ordered{0};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -48,24 +48,37 @@ public:
     [[nodiscard]] size_t size() const { return m_schema.size(); }
 
     /**
-     * @return iterators to the underlying schema
+     * @return iterator to the start of the underlying schema
      */
     [[nodiscard]] auto begin() { return m_schema.begin(); }
 
+    /**
+     * @return iterator to the start of the underlying schema
+     */
     [[nodiscard]] auto end() { return m_schema.end(); }
 
     /**
-     * @return constant iterators to the underlying schema
+     * @return constant iterator to the start of the underlying schema
      */
     [[nodiscard]] auto begin() const { return m_schema.cbegin(); }
 
+    /**
+     * @return constant iterator to the end of the underlying schema
+     */
     [[nodiscard]] auto end() const { return m_schema.cend(); }
 
     /**
-     * Comparison operators so that Schema can act as a key for SchemaMap
+     * Less than comparison operator so that Schema can act as a key for SchemaMap
+     * @return true if this schema is less than the schema on the right hand side
+     * @return false otherwise
      */
     bool operator<(Schema const& rhs) const { return m_schema < rhs.m_schema; }
 
+    /**
+     * Equal to comparison operator so that Schema can act as a key for SchemaMap
+     * @return true if this schema is equal to the schema on the right hand side
+     * @return false otherwise
+     */
     bool operator==(Schema const& rhs) const { return m_schema == rhs.m_schema; }
 
 private:

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -7,24 +7,24 @@
 
 namespace clp_s {
 /**
- * Class representing a a schema made up of MST
+ * Class representing a schema made up of MST nodes.
  */
 class Schema {
 public:
     using schema_t = std::vector<int32_t>;
 
     /**
-     * Insert a single node into the ordered region of the schema.
+     * Inserts a node into the ordered region of the schema.
      */
     void insert_ordered(int32_t mst_node_id);
 
     /**
-     * Insert a single node into the unordered region of the schema.
+     * Inserts a node into the unordered region of the schema.
      */
     void insert_unordered(int32_t mst_node_id);
 
     /**
-     * Insert an unordered list of nodes into the unordered region of the schema.
+     * Inserts an unordered list of nodes into the unordered region of the schema.
      */
     void insert_unordered(schema_t const& mst_node_ids);
 
@@ -39,7 +39,7 @@ public:
     /**
      * @return the number of elements in the underlying schema
      */
-    size_t size() const { return m_schema.size(); }
+    [[nodiscard]] size_t size() const { return m_schema.size(); }
 
     /**
      * @return iterators to the underlying schema

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -1,0 +1,70 @@
+#ifndef CLP_S_SCHEMA_HPP
+#define CLP_S_SCHEMA_HPP
+
+#include <cstdint>
+#include <vector>
+
+namespace clp_s {
+/**
+ * Class representing a a schema made up of MST
+ */
+class Schema {
+public:
+    typedef std::vector<int32_t> schema_t;
+
+    /**
+     * Insert a single node into the ordered region of the schema.
+     */
+    void insert_ordered(int32_t mst_node_id);
+
+    /**
+     * Insert a single node into the unordered region of the schema.
+     */
+    void insert_unordered(int32_t mst_node_id);
+
+    /**
+     * Insert an unordered list of nodes into the unordered region of the schema.
+     */
+    void insert_unordered(std::vector<int32_t> const& mst_node_ids);
+
+    /**
+     * Clear the Schema object so that it can be reused without reallocating the underlying vector.
+     */
+    void clear() {
+        m_schema.clear();
+        m_num_unordered = 0;
+    }
+
+    /**
+     * @return the number of elements in the underlying schema
+     */
+    size_t size() const { return m_schema.size(); }
+
+    /**
+     * @return iterators to the underlying schema
+     */
+    auto begin() { return m_schema.begin(); }
+
+    auto end() { return m_schema.end(); }
+
+    /**
+     * @return constant iterators to the underlying schema
+     */
+    auto begin() const { return m_schema.cbegin(); }
+
+    auto end() const { return m_schema.cend(); }
+
+    /**
+     * Comparison operators so that Schema can act as a key for SchemaMap
+     */
+    bool operator<(Schema const& rhs) const { return m_schema < rhs.m_schema; }
+
+    bool operator==(Schema const& rhs) const { return m_schema == rhs.m_schema; }
+
+private:
+    std::vector<int32_t> m_schema{};
+    size_t m_num_unordered{};
+};
+}  // namespace clp_s
+
+#endif  // CLP_S_SCHEMA_HPP

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_SCHEMA_HPP
 #define CLP_S_SCHEMA_HPP
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/components/core/src/clp_s/SchemaMap.cpp
+++ b/components/core/src/clp_s/SchemaMap.cpp
@@ -4,7 +4,7 @@
 #include "ZstdCompressor.hpp"
 
 namespace clp_s {
-int32_t SchemaMap::add_schema(std::set<int32_t>& schema) {
+int32_t SchemaMap::add_schema(Schema& schema) {
     auto schema_it = m_schema_map.find(schema);
     if (schema_it != m_schema_map.end()) {
         return schema_it->second;

--- a/components/core/src/clp_s/SchemaMap.cpp
+++ b/components/core/src/clp_s/SchemaMap.cpp
@@ -5,13 +5,12 @@
 
 namespace clp_s {
 int32_t SchemaMap::add_schema(Schema const& schema) {
-    auto schema_it = m_schema_map.find(schema);
-    if (schema_it != m_schema_map.end()) {
+    auto const schema_it = m_schema_map.find(schema);
+    if (m_schema_map.end() != schema_it) {
         return schema_it->second;
-    } else {
-        m_schema_map[schema] = m_current_schema_id;
-        return m_current_schema_id++;
     }
+    m_schema_map.emplace(schema, m_current_schema_id);
+    return m_current_schema_id++;
 }
 
 void SchemaMap::store() {

--- a/components/core/src/clp_s/SchemaMap.cpp
+++ b/components/core/src/clp_s/SchemaMap.cpp
@@ -4,7 +4,7 @@
 #include "ZstdCompressor.hpp"
 
 namespace clp_s {
-int32_t SchemaMap::add_schema(Schema& schema) {
+int32_t SchemaMap::add_schema(Schema const& schema) {
     auto schema_it = m_schema_map.find(schema);
     if (schema_it != m_schema_map.end()) {
         return schema_it->second;

--- a/components/core/src/clp_s/SchemaMap.hpp
+++ b/components/core/src/clp_s/SchemaMap.hpp
@@ -9,7 +9,7 @@
 namespace clp_s {
 class SchemaMap {
 public:
-    typedef std::map<Schema, int32_t> schema_map_t;
+    using schema_map_t = std::map<Schema, int32_t>;
 
     // Constructor
     explicit SchemaMap(std::string const& archives_dir, int compression_level)

--- a/components/core/src/clp_s/SchemaMap.hpp
+++ b/components/core/src/clp_s/SchemaMap.hpp
@@ -2,13 +2,14 @@
 #define CLP_S_SCHEMAMAP_HPP
 
 #include <map>
-#include <set>
 #include <string>
+
+#include "Schema.hpp"
 
 namespace clp_s {
 class SchemaMap {
 public:
-    typedef std::map<std::set<int32_t>, int32_t> schema_map_t;
+    typedef std::map<Schema, int32_t> schema_map_t;
 
     // Constructor
     explicit SchemaMap(std::string const& archives_dir, int compression_level)
@@ -22,7 +23,7 @@ public:
      * @param schema
      * @return the Id of the schema
      */
-    int32_t add_schema(std::set<int32_t>& schema);
+    int32_t add_schema(Schema& schema);
 
     /**
      * Write the contents of the SchemaMap to archives_dir/schema_ids

--- a/components/core/src/clp_s/SchemaMap.hpp
+++ b/components/core/src/clp_s/SchemaMap.hpp
@@ -23,7 +23,7 @@ public:
      * @param schema
      * @return the Id of the schema
      */
-    int32_t add_schema(Schema& schema);
+    int32_t add_schema(Schema const& schema);
 
     /**
      * Write the contents of the SchemaMap to archives_dir/schema_ids


### PR DESCRIPTION
# Description
This PR replaces the in-memory representation of clp-s schemas with a class that wraps std::vector.

This new Schema class allows for schemas to contain a region of nodes ordered by mst node id, followed by a region of unordered nodes. This will be useful if we start supporting more generic parsers for some types of data which need to define their own order, or potentially if we change how we treat arrays.

This implementation still requires all of the node ids within a schema to be unique, though this restriction could be lifted if we make some changes to ParsedRecord and make some changes in Schema Matching.

Besides that, this change improves compression speed by about 10% for some datasets.

# Validation performed
- validated that compressed archives are identical for some datasets before and after this change
- benchmarked that compression speed is ~10% faster for some datasets
- benchmarked that search performance has no significant change

