### PR TITLE
Add package mode as clp package configuration parameter

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -449,7 +449,7 @@ def generic_start_worker(component_name: str, instance_id: str, clp_config: CLPC
         '-e', f'CLP_ARCHIVE_OUTPUT_DIR={container_clp_config.archive_output.directory}',
         '-e', f'CLP_LOGS_DIR={container_logs_dir}',
         '-e', f'CLP_LOGGING_LEVEL={worker_config.logging_level}',
-        '-e', f'CLP_PACKAGE_MODE={clp_config.package.mode}',
+        '-e', f'CLP_STORAGE_ENGINE={clp_config.package.storage_engine}',
         '-u', f'{os.getuid()}:{os.getgid()}',
         '--mount', str(mounts.clp_home),
     ]

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -449,6 +449,7 @@ def generic_start_worker(component_name: str, instance_id: str, clp_config: CLPC
         '-e', f'CLP_ARCHIVE_OUTPUT_DIR={container_clp_config.archive_output.directory}',
         '-e', f'CLP_LOGS_DIR={container_logs_dir}',
         '-e', f'CLP_LOGGING_LEVEL={worker_config.logging_level}',
+        '-e', f'CLP_PACKAGE_MODE={clp_config.package.mode}',
         '-u', f'{os.getuid()}:{os.getgid()}',
         '--mount', str(mounts.clp_home),
     ]

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -22,7 +22,6 @@ CLP_DEFAULT_CREDENTIALS_FILE_PATH = pathlib.Path('etc') / 'credentials.yml'
 CLP_METADATA_TABLE_PREFIX = 'clp_'
 SEARCH_JOBS_TABLE_NAME = 'distributed_search_jobs'
 
-# Package modes
 class StorageEngine(KebabCaseStrEnum):
     CLP = auto()
 

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -1,7 +1,10 @@
 import pathlib
 import typing
+from typing import Any, List
 
 from pydantic import BaseModel, validator
+from enum import auto
+from strenum import KebabCaseStrEnum
 
 from .core import get_config_value, make_config_path_absolute, read_yaml_config_file, validate_path_could_be_dir
 from .clp_logging import is_valid_logging_level, get_valid_logging_level
@@ -19,6 +22,22 @@ WORKER_COMPONENT_NAME = 'worker'
 CLP_DEFAULT_CREDENTIALS_FILE_PATH = pathlib.Path('etc') / 'credentials.yml'
 CLP_METADATA_TABLE_PREFIX = 'clp_'
 SEARCH_JOBS_TABLE_NAME = 'distributed_search_jobs'
+
+# Package modes
+class PackageMode(KebabCaseStrEnum):
+    CLP = auto()
+
+VALID_PACKAGE_MODES = [mode.value for mode in PackageMode]
+
+
+class Package(BaseModel):
+    mode: str = 'clp'
+
+    @validator('mode')
+    def validate_mode(cls, field):
+        if field not in VALID_PACKAGE_MODES:
+            raise ValueError(f"package.mode must be one of the follwing {'|'.join(VALID_PACKAGE_MODES)}")
+        return field
 
 
 class Database(BaseModel):
@@ -200,6 +219,7 @@ class CLPConfig(BaseModel):
 
     input_logs_directory: pathlib.Path = pathlib.Path('/')
 
+    package: Package = Package()
     database: Database = Database()
     queue: Queue = Queue()
     results_cache: ResultsCache = ResultsCache()

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -1,6 +1,5 @@
 import pathlib
 import typing
-from typing import Any, List
 
 from pydantic import BaseModel, validator
 from enum import auto

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -23,19 +23,19 @@ CLP_METADATA_TABLE_PREFIX = 'clp_'
 SEARCH_JOBS_TABLE_NAME = 'distributed_search_jobs'
 
 # Package modes
-class PackageMode(KebabCaseStrEnum):
+class StorageEngine(KebabCaseStrEnum):
     CLP = auto()
 
-VALID_PACKAGE_MODES = [mode.value for mode in PackageMode]
+VALID_STORAGE_ENGINES = [storage_engine.value for storage_engine in StorageEngine]
 
 
 class Package(BaseModel):
-    mode: str = 'clp'
+    storage_engine: str = 'clp'
 
-    @validator('mode')
-    def validate_mode(cls, field):
-        if field not in VALID_PACKAGE_MODES:
-            raise ValueError(f"package.mode must be one of the follwing {'|'.join(VALID_PACKAGE_MODES)}")
+    @validator('storage_engine')
+    def validate_storage_engine(cls, field):
+        if field not in VALID_STORAGE_ENGINES:
+            raise ValueError(f"package.storage_engine must be one of the follwing {'|'.join(VALID_STORAGE_ENGINES)}")
         return field
 
 

--- a/components/clp-py-utils/pyproject.toml
+++ b/components/clp-py-utils/pyproject.toml
@@ -14,6 +14,7 @@ mysql-connector-python = "^8.2.0"
 pydantic = "^1.10.13"
 python-Levenshtein = "~0.22"
 PyYAML = "^6.0.1"
+StrEnum = "^0.4.15"
 
 [build-system]
 requires = ["poetry-core"]

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -10,7 +10,7 @@ from celery.app.task import Task
 from celery.utils.log import get_task_logger
 
 from clp_py_utils.clp_logging import set_logging_level
-from clp_py_utils.clp_config import PackageMode
+from clp_py_utils.clp_config import StorageEngine
 
 from job_orchestration.executor.search.celery import app
 from job_orchestration.job_config import SearchConfig, SearchTaskResult
@@ -52,7 +52,7 @@ def search(
     archive_directory = Path(os.getenv('CLP_ARCHIVE_OUTPUT_DIR'))
     clp_logs_dir = Path(os.getenv("CLP_LOGS_DIR"))
     clp_logging_level = str(os.getenv("CLP_LOGGING_LEVEL"))
-    clp_package_mode = str(os.getenv("CLP_PACKAGE_MODE"))
+    clp_storage_engine = str(os.getenv("CLP_STORAGE_ENGINE"))
 
     # Setup logging to file
     worker_logs_dir = clp_logs_dir / job_id
@@ -66,7 +66,7 @@ def search(
     search_config = SearchConfig.parse_obj(search_config_obj)
     archive_path = archive_directory / archive_id
 
-    if PackageMode.CLP == clp_package_mode:
+    if StorageEngine.CLP == clp_storage_engine:
         search_cmd = make_clo_command(
             clp_home=clp_home,
             archive_path=archive_path,
@@ -75,12 +75,11 @@ def search(
             results_collection=job_id
         )
     else:
-        logger.error(f"Unsupported package mode {clp_package_mode}")
+        logger.error(f"Unsupported storage engine {clp_storage_engine}")
         return SearchTaskResult(
             success=False,
             task_id=task_id,
         ).dict()
-
 
     logger.info(f'Running: {" ".join(search_cmd)}')
     search_successful = False

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -10,12 +10,34 @@ from celery.app.task import Task
 from celery.utils.log import get_task_logger
 
 from clp_py_utils.clp_logging import set_logging_level
+from clp_py_utils.clp_config import PackageMode
 
 from job_orchestration.executor.search.celery import app
 from job_orchestration.job_config import SearchConfig, SearchTaskResult
 
 # Setup logging
 logger = get_task_logger(__name__)
+
+def make_clo_command(clp_home: Path, archive_path: Path, search_config: SearchConfig,
+                     results_cache_uri: str, results_collection: str):
+    search_cmd = [
+        str(clp_home / "bin" / "clo"),
+        results_cache_uri,
+        results_collection,
+        str(archive_path),
+        search_config.query_string
+    ]
+
+    if search_config.begin_timestamp is not None:
+        search_cmd.append('--tge')
+        search_cmd.append(str(search_config.begin_timestamp))
+    if search_config.end_timestamp is not None:
+        search_cmd.append('--tle')
+        search_cmd.append(str(search_config.end_timestamp))
+    if search_config.path_filter is not None:
+        search_cmd.append(search_config.path_filter)
+    
+    return search_cmd
 
 @app.task(bind=True)
 def search(
@@ -30,6 +52,7 @@ def search(
     archive_directory = Path(os.getenv('CLP_ARCHIVE_OUTPUT_DIR'))
     clp_logs_dir = Path(os.getenv("CLP_LOGS_DIR"))
     clp_logging_level = str(os.getenv("CLP_LOGGING_LEVEL"))
+    clp_package_mode = str(os.getenv("CLP_PACKAGE_MODE"))
 
     # Setup logging to file
     worker_logs_dir = clp_logs_dir / job_id
@@ -41,22 +64,23 @@ def search(
     logger.info(f"Started task for job {job_id}")
 
     search_config = SearchConfig.parse_obj(search_config_obj)
-    search_cmd = [
-        str(clp_home / "bin" / "clo"),
-        results_cache_uri,
-        job_id,
-        str(archive_directory / archive_id),
-        search_config.query_string,
-    ]
+    archive_path = archive_directory / archive_id
 
-    if search_config.begin_timestamp is not None:
-        search_cmd.append('--tge')
-        search_cmd.append(str(search_config.begin_timestamp))
-    if search_config.end_timestamp is not None:
-        search_cmd.append('--tle')
-        search_cmd.append(str(search_config.end_timestamp))
-    if search_config.path_filter is not None:
-        search_cmd.append(search_config.path_filter)
+    if PackageMode.CLP == clp_package_mode:
+        search_cmd = make_clo_command(
+            clp_home=clp_home,
+            archive_path=archive_path,
+            search_config=search_config,
+            results_cache_uri=results_cache_uri,
+            results_collection=job_id
+        )
+    else:
+        logger.error(f"Unsupported package mode {clp_package_mode}")
+        return SearchTaskResult(
+            success=False,
+            task_id=task_id,
+        ).dict()
+
 
     logger.info(f'Running: {" ".join(search_cmd)}')
     search_successful = False

--- a/components/job-orchestration/pyproject.toml
+++ b/components/job-orchestration/pyproject.toml
@@ -16,7 +16,6 @@ mysql-connector-python = "^8.2.0"
 pika = "^1.3.2"
 pydantic = "^1.10.13"
 PyYAML = "^6.0.1"
-StrEnum = "^0.4.15"
 zstandard = "~0.22"
 
 [build-system]

--- a/components/job-orchestration/pyproject.toml
+++ b/components/job-orchestration/pyproject.toml
@@ -16,6 +16,7 @@ mysql-connector-python = "^8.2.0"
 pika = "^1.3.2"
 pydantic = "^1.10.13"
 PyYAML = "^6.0.1"
+StrEnum = "^0.4.15"
 zstandard = "~0.22"
 
 [build-system]

--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -7,6 +7,9 @@
 ## File containing credentials for services
 #credentials_file_path: "etc/credentials.yml"
 #
+#package:
+#  mode: "clp"
+#
 #database:
 #  type: "mariadb"  # "mariadb" or "mysql"
 #  host: "localhost"

--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -8,7 +8,7 @@
 #credentials_file_path: "etc/credentials.yml"
 #
 #package:
-#  mode: "clp"
+#  storage_engine: "clp"
 #
 #database:
 #  type: "mariadb"  # "mariadb" or "mysql"


### PR DESCRIPTION
# Description
Add package mode configuration option for the clp package. Currently the only valid mode is "clp", but "clp-s" will also become valid once we finishing adding support.

This change pulls in the StrEnum package to allow us to easily enumerate all of the valid modes. We can't use python's built in string enums because they're only available in python 3.11+.

# Validation performed
- Verified that compression and search flow work as expected
- Verified that invalid modes will cause validation errors

