### PR TITLE
Add options to clp-s to filter on the authoratative timestamp column specified at ingestion time

### DIFF
--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -67,6 +67,8 @@ set(
 
 set(
         CLP_S_SEARCH_SOURCES
+        search/AddTimestampConditions.cpp
+        search/AddTimestampConditions.hpp
         search/AndExpr.cpp
         search/AndExpr.hpp
         search/BooleanLiteral.cpp

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -238,7 +238,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                 "tle",
                 po::value<epochtime_t>()->value_name("TS"),
-                "Find messages with UNIX timestamp <= TS ms"
+                "Find records with UNIX timestamp <= TS ms"
             );
             // clang-format on
             search_options.add(match_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -234,11 +234,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             match_options.add_options()(
                 "tge",
                 po::value<epochtime_t>()->value_name("TS"),
-                "Find records with UNIX timestamp >= TS ms"
+                "Find records with UNIX epoch timestamp >= TS ms"
             )(
                 "tle",
                 po::value<epochtime_t>()->value_name("TS"),
-                "Find records with UNIX timestamp <= TS ms"
+                "Find records with UNIX epoch timestamp <= TS ms"
             );
             // clang-format on
             search_options.add(match_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -247,9 +247,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             positional_options.add("archives-dir", 1);
             positional_options.add("query", 1);
 
-            po::options_description mongodb_options;
+            po::options_description output_options("Output Options");
             // clang-format off
-            mongodb_options.add_options()(
+            output_options.add_options()(
                     "mongodb-uri",
                     po::value<std::string>(&m_mongodb_uri)->value_name("MONGODB_URI"),
                     "MongoDB URI to connect to"
@@ -264,7 +264,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "The number of documents to insert into MongoDB in a batch"
             );
             // clang-format on
-            search_options.add(mongodb_options);
+            search_options.add(output_options);
 
             std::vector<std::string> unrecognized_options
                     = po::collect_unrecognized(parsed.options, po::include_positional);
@@ -301,7 +301,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 po::options_description visible_options;
                 visible_options.add(general_options);
                 visible_options.add(match_options);
-                visible_options.add(mongodb_options);
+                visible_options.add(output_options);
                 std::cerr << visible_options << '\n';
                 return ParsingResult::InfoCommand;
             }

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -1,8 +1,11 @@
 #ifndef CLP_S_COMMANDLINEARGUMENTS_HPP
 #define CLP_S_COMMANDLINEARGUMENTS_HPP
 
+#include <optional>
 #include <string>
 #include <vector>
+
+#include "Defs.hpp"
 
 namespace clp_s {
 class CommandLineArguments {
@@ -52,6 +55,10 @@ public:
 
     std::string const& get_query() const { return m_query; }
 
+    std::optional<epochtime_t> get_search_begin_ts() const { return m_search_begin_ts; }
+
+    std::optional<epochtime_t> get_search_end_ts() const { return m_search_end_ts; }
+
 private:
     // Methods
     void print_basic_usage() const;
@@ -82,6 +89,8 @@ private:
 
     // Search variables
     std::string m_query;
+    std::optional<epochtime_t> m_search_begin_ts;
+    std::optional<epochtime_t> m_search_end_ts;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -82,15 +82,16 @@ void TimestampDictionaryReader::read_new_entries(bool local) {
     }
 }
 
-std::string TimestampDictionaryReader::get_string_encoding(epochtime_t epoch, uint64_t format_id) {
+std::string
+TimestampDictionaryReader::get_string_encoding(epochtime_t epoch, uint64_t format_id) const {
     std::string ret;
-    m_patterns[format_id].insert_formatted_timestamp(epoch, ret);
+    m_patterns.at(format_id).insert_formatted_timestamp(epoch, ret);
 
     return ret;
 }
 
 std::optional<std::vector<std::string>>
-TimestampDictionaryReader::get_authoritative_timestamp_column() {
+TimestampDictionaryReader::get_authoritative_timestamp_column() const {
     // TODO: Currently, we only allow a single authoritative timestamp column at ingestion time, but
     // the timestamp dictionary is designed to store the ranges of several timestamp columns. We
     // should enforce a convention that the first entry in the timestamp dictionary corresponds to

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -88,4 +88,18 @@ std::string TimestampDictionaryReader::get_string_encoding(epochtime_t epoch, ui
 
     return ret;
 }
+
+std::optional<std::vector<std::string>>
+TimestampDictionaryReader::get_authoritative_timestamp_column() {
+    // TODO: Currently, we only allow a single authoritative timestamp column at ingestion time, but
+    // the timestamp dictionary is designed to store the ranges of several timestamp columns. We
+    // should enforce a convention that the first entry in the timestamp dictionary corresponds to
+    // the "authoritative" timestamp column for the dataset.
+    std::optional<std::vector<std::string>> timestamp_column;
+    for (auto it = tokenized_column_to_range_begin(); it != tokenized_column_to_range_end(); ++it) {
+        timestamp_column = it->first;
+        break;
+    }
+    return timestamp_column;
+}
 }  // namespace clp_s

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -96,11 +96,9 @@ TimestampDictionaryReader::get_authoritative_timestamp_column() const {
     // the timestamp dictionary is designed to store the ranges of several timestamp columns. We
     // should enforce a convention that the first entry in the timestamp dictionary corresponds to
     // the "authoritative" timestamp column for the dataset.
-    std::optional<std::vector<std::string>> timestamp_column;
     for (auto it = tokenized_column_to_range_begin(); tokenized_column_to_range_end() != it; ++it) {
-        timestamp_column = it->first;
-        break;
+        return it->first;
     }
-    return timestamp_column;
+    return std::nullopt;
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -96,7 +96,7 @@ TimestampDictionaryReader::get_authoritative_timestamp_column() {
     // should enforce a convention that the first entry in the timestamp dictionary corresponds to
     // the "authoritative" timestamp column for the dataset.
     std::optional<std::vector<std::string>> timestamp_column;
-    for (auto it = tokenized_column_to_range_begin(); it != tokenized_column_to_range_end(); ++it) {
+    for (auto it = tokenized_column_to_range_begin(); tokenized_column_to_range_end() != it; ++it) {
         timestamp_column = it->first;
         break;
     }

--- a/components/core/src/clp_s/TimestampDictionaryReader.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_TIMESTAMPDICTIONARYREADER_HPP
 
 #include <map>
+#include <optional>
 
 #include "FileReader.hpp"
 #include "search/FilterOperation.hpp"
@@ -78,6 +79,12 @@ public:
     tokenized_column_to_range_it_t tokenized_column_to_range_end() {
         return m_tokenized_column_to_range.end();
     }
+
+    /**
+     * @return the tokens for the authoritative timestamp column if it exists, or an
+     * empty option if it does not
+     */
+    std::optional<std::vector<std::string>> get_authoritative_timestamp_column();
 
 private:
     typedef std::map<uint64_t, TimestampPattern> id_to_pattern_t;

--- a/components/core/src/clp_s/TimestampDictionaryReader.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.hpp
@@ -54,37 +54,29 @@ public:
      * @param epoch
      * @param format_id
      */
-    std::string get_string_encoding(epochtime_t epoch, uint64_t format_id);
-
-    typedef std::map<uint64_t, TimestampPattern>::iterator id_to_pattern_iterator_t;
-    typedef std::vector<std::pair<std::vector<std::string>, TimestampEntry*>>::iterator
-            tokenized_column_to_range_it_t;
+    std::string get_string_encoding(epochtime_t epoch, uint64_t format_id) const;
 
     /**
      * Gets iterators for the timestamp patterns
      * @return begin and end iterators for the timestamp patterns
      */
-    id_to_pattern_iterator_t pattern_begin() { return m_patterns.begin(); }
+    auto pattern_begin() const { return m_patterns.begin(); }
 
-    id_to_pattern_iterator_t pattern_end() { return m_patterns.end(); }
+    auto pattern_end() const { return m_patterns.end(); }
 
     /**
      * Gets iterators for the column to range mappings
      * @return begin and end iterators for the column to range mappings
      */
-    tokenized_column_to_range_it_t tokenized_column_to_range_begin() {
-        return m_tokenized_column_to_range.begin();
-    }
+    auto tokenized_column_to_range_begin() const { return m_tokenized_column_to_range.begin(); }
 
-    tokenized_column_to_range_it_t tokenized_column_to_range_end() {
-        return m_tokenized_column_to_range.end();
-    }
+    auto tokenized_column_to_range_end() const { return m_tokenized_column_to_range.end(); }
 
     /**
      * @return the tokens for the authoritative timestamp column if it exists, or an
      * empty option if it does not
      */
-    std::optional<std::vector<std::string>> get_authoritative_timestamp_column();
+    std::optional<std::vector<std::string>> get_authoritative_timestamp_column() const;
 
 private:
     typedef std::map<uint64_t, TimestampPattern> id_to_pattern_t;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -4,6 +4,7 @@
 #include "JsonConstructor.hpp"
 #include "JsonParser.hpp"
 #include "ReaderUtils.hpp"
+#include "search/AddTimestampConditions.hpp"
 #include "search/ConvertToExists.hpp"
 #include "search/EmptyExpr.hpp"
 #include "search/EvaluateTimestampIndex.hpp"
@@ -80,6 +81,17 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
 
+        auto timestamp_dict = clp_s::ReaderUtils::read_timestamp_dictionary(archives_dir);
+        AddTimestampConditions add_timestamp_conditions(
+                timestamp_dict,
+                command_line_arguments.get_search_begin_ts(),
+                command_line_arguments.get_search_end_ts()
+        );
+        if (expr = add_timestamp_conditions.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
+            SPDLOG_ERROR("Query '{}' is logically false", query);
+            return 1;
+        }
+
         OrOfAndForm standardize_pass;
         if (expr = standardize_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
             SPDLOG_ERROR("Query '{}' is logically false", query);
@@ -100,7 +112,6 @@ int main(int argc, char const* argv[]) {
 
         // skip decompressing the archive if we won't match based on
         // the timestamp index
-        auto timestamp_dict = clp_s::ReaderUtils::read_timestamp_dictionary(archives_dir);
         EvaluateTimestampIndex timestamp_index(timestamp_dict);
         if (clp_s::EvaluatedValue::False == timestamp_index.run(expr)) {
             SPDLOG_ERROR("No matching timestamp ranges for query '{}'", query);

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -20,6 +20,7 @@
 
 using namespace clp_s::search;
 using clp_s::cEpochTimeMax;
+using clp_s::cEpochTimeMin;
 using clp_s::CommandLineArguments;
 
 int main(int argc, char const* argv[]) {
@@ -94,7 +95,7 @@ int main(int argc, char const* argv[]) {
                     "Query '{}' specified timestamp filters tge {} tle {}, but no authoritative "
                     "timestamp column was found for this archive",
                     query,
-                    command_line_arguments.get_search_begin_ts().value_or(0),
+                    command_line_arguments.get_search_begin_ts().value_or(cEpochTimeMin),
                     command_line_arguments.get_search_end_ts().value_or(cEpochTimeMax)
             );
             return 1;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -1,6 +1,7 @@
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "CommandLineArguments.hpp"
+#include "Defs.hpp"
 #include "JsonConstructor.hpp"
 #include "JsonParser.hpp"
 #include "ReaderUtils.hpp"
@@ -18,6 +19,7 @@
 #include "Utils.hpp"
 
 using namespace clp_s::search;
+using clp_s::cEpochTimeMax;
 using clp_s::CommandLineArguments;
 
 int main(int argc, char const* argv[]) {
@@ -83,12 +85,18 @@ int main(int argc, char const* argv[]) {
 
         auto timestamp_dict = clp_s::ReaderUtils::read_timestamp_dictionary(archives_dir);
         AddTimestampConditions add_timestamp_conditions(
-                timestamp_dict,
+                timestamp_dict->get_authoritative_timestamp_column(),
                 command_line_arguments.get_search_begin_ts(),
                 command_line_arguments.get_search_end_ts()
         );
         if (expr = add_timestamp_conditions.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
-            SPDLOG_ERROR("Query '{}' is logically false", query);
+            SPDLOG_ERROR(
+                    "Query '{}' specified timestamp filters tge {} tle {}, but no authoritative "
+                    "timestamp column was found for this archive",
+                    query,
+                    command_line_arguments.get_search_begin_ts().value_or(0),
+                    command_line_arguments.get_search_end_ts().value_or(cEpochTimeMax)
+            );
             return 1;
         }
 

--- a/components/core/src/clp_s/search/AddTimestampConditions.cpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.cpp
@@ -1,0 +1,52 @@
+#include "AddTimestampConditions.hpp"
+
+#include "AndExpr.hpp"
+#include "ColumnDescriptor.hpp"
+#include "DateLiteral.hpp"
+#include "EmptyExpr.hpp"
+#include "FilterExpr.hpp"
+
+namespace clp_s::search {
+std::shared_ptr<Expression> AddTimestampConditions::run(std::shared_ptr<Expression>& expr) {
+    if (false == m_begin_ts.has_value() && false == m_end_ts.has_value()) {
+        return expr;
+    }
+
+    // Find the name of the timestamp column
+    // TODO: At the moment we only allow a single timestamp column at ingestion time, but the
+    // timestamp dictionary is designed to store the ranges of several timestamp columns. We should
+    // enforce a convention that the first entry in the timestamp dictionary corresponds to the
+    // "authoratative" timestamp column for the dataset.
+    std::shared_ptr<ColumnDescriptor> timestamp_column;
+    for (auto it = m_timestamp_dict->tokenized_column_to_range_begin();
+         it != m_timestamp_dict->tokenized_column_to_range_end();
+         ++it)
+    {
+        timestamp_column = ColumnDescriptor::create(it->first);
+        break;
+    }
+
+    // If there is no authoratative timestamp column then the timestamp filters specified by the
+    // user do not make sense, and the query shouldn't match any results.
+    if (nullptr == timestamp_column) {
+        return EmptyExpr::create();
+    }
+
+    auto and_expr = AndExpr::create();
+    if (m_begin_ts.has_value()) {
+        auto date_literal = DateLiteral::create_from_int(m_begin_ts.value());
+        and_expr->add_operand(
+                FilterExpr::create(timestamp_column, FilterOperation::GTE, date_literal)
+        );
+    }
+    if (m_end_ts.has_value()) {
+        auto date_literal = DateLiteral::create_from_int(m_end_ts.value());
+        and_expr->add_operand(
+                FilterExpr::create(timestamp_column, FilterOperation::LTE, date_literal)
+        );
+    }
+    and_expr->add_operand(expr);
+
+    return and_expr;
+}
+}  // namespace clp_s::search

--- a/components/core/src/clp_s/search/AddTimestampConditions.cpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.cpp
@@ -12,25 +12,13 @@ std::shared_ptr<Expression> AddTimestampConditions::run(std::shared_ptr<Expressi
         return expr;
     }
 
-    // Find the name of the timestamp column
-    // TODO: Currently, we only allow a single authoritative timestamp column at ingestion time, but
-    // the timestamp dictionary is designed to store the ranges of several timestamp columns. We
-    // should enforce a convention that the first entry in the timestamp dictionary corresponds to
-    // the "authoritative" timestamp column for the dataset.
-    std::shared_ptr<ColumnDescriptor> timestamp_column;
-    for (auto it = m_timestamp_dict->tokenized_column_to_range_begin();
-         it != m_timestamp_dict->tokenized_column_to_range_end();
-         ++it)
-    {
-        timestamp_column = ColumnDescriptor::create(it->first);
-        break;
-    }
-
-    // If there is no authoritative timestamp column then the timestamp filters specified by the
-    // user do not make sense, and the query shouldn't match any results.
-    if (nullptr == timestamp_column) {
+    // If no timestamp column was passed then the timestamp filters do not make sense, and the query
+    // shouldn't match any results.
+    if (false == m_timestamp_column.has_value()) {
         return EmptyExpr::create();
     }
+
+    auto timestamp_column = ColumnDescriptor::create(m_timestamp_column.value());
 
     auto and_expr = AndExpr::create();
     if (m_begin_ts.has_value()) {

--- a/components/core/src/clp_s/search/AddTimestampConditions.cpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.cpp
@@ -13,10 +13,10 @@ std::shared_ptr<Expression> AddTimestampConditions::run(std::shared_ptr<Expressi
     }
 
     // Find the name of the timestamp column
-    // TODO: At the moment we only allow a single timestamp column at ingestion time, but the
-    // timestamp dictionary is designed to store the ranges of several timestamp columns. We should
-    // enforce a convention that the first entry in the timestamp dictionary corresponds to the
-    // "authoratative" timestamp column for the dataset.
+    // TODO: Currently, we only allow a single authoritative timestamp column at ingestion time, but
+    // the timestamp dictionary is designed to store the ranges of several timestamp columns. We
+    // should enforce a convention that the first entry in the timestamp dictionary corresponds to
+    // the "authoritative" timestamp column for the dataset.
     std::shared_ptr<ColumnDescriptor> timestamp_column;
     for (auto it = m_timestamp_dict->tokenized_column_to_range_begin();
          it != m_timestamp_dict->tokenized_column_to_range_end();
@@ -26,7 +26,7 @@ std::shared_ptr<Expression> AddTimestampConditions::run(std::shared_ptr<Expressi
         break;
     }
 
-    // If there is no authoratative timestamp column then the timestamp filters specified by the
+    // If there is no authoritative timestamp column then the timestamp filters specified by the
     // user do not make sense, and the query shouldn't match any results.
     if (nullptr == timestamp_column) {
         return EmptyExpr::create();

--- a/components/core/src/clp_s/search/AddTimestampConditions.hpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.hpp
@@ -9,6 +9,15 @@
 #include "Transformation.hpp"
 
 namespace clp_s::search {
+/**
+ * Transformation pass which takes optional begin and end filters on a timestamp column and augments
+ * the AST with additional filters on the provided timestamp column.
+ *
+ * Providing an empty option for begin_ts and end_ts always results in no change to the AST.
+ *
+ * If either begin_ts or end_ts is specified and the timestamp_column option is empty then this
+ * transformation pass will yield EmptyExpr.
+ */
 class AddTimestampConditions : public Transformation {
 public:
     // Constructors
@@ -24,6 +33,8 @@ public:
     /**
      * Takes in an AST and adds filters on the authoritative timestamp column if the user specified
      * such filters on the command line.
+     * @param expr the AST to transform
+     * @return the transformed AST
      */
     std::shared_ptr<Expression> run(std::shared_ptr<Expression>& expr) override;
 

--- a/components/core/src/clp_s/search/AddTimestampConditions.hpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.hpp
@@ -2,9 +2,10 @@
 #define CLP_S_ADD_TIMESTAMP_CONDITIONS_HPP
 
 #include <optional>
+#include <string>
+#include <vector>
 
 #include "../Defs.hpp"
-#include "../TimestampDictionaryReader.hpp"
 #include "Transformation.hpp"
 
 namespace clp_s::search {
@@ -12,11 +13,11 @@ class AddTimestampConditions : public Transformation {
 public:
     // Constructors
     AddTimestampConditions(
-            std::shared_ptr<TimestampDictionaryReader> const& timestamp_dict,
+            std::optional<std::vector<std::string>> const& timestamp_column,
             std::optional<epochtime_t> begin_ts,
             std::optional<epochtime_t> end_ts
     )
-            : m_timestamp_dict(timestamp_dict),
+            : m_timestamp_column(timestamp_column),
               m_begin_ts(begin_ts),
               m_end_ts(end_ts) {}
 
@@ -27,7 +28,7 @@ public:
     std::shared_ptr<Expression> run(std::shared_ptr<Expression>& expr) override;
 
 private:
-    std::shared_ptr<TimestampDictionaryReader> m_timestamp_dict;
+    std::optional<std::vector<std::string>> m_timestamp_column;
     std::optional<epochtime_t> m_begin_ts;
     std::optional<epochtime_t> m_end_ts;
 };

--- a/components/core/src/clp_s/search/AddTimestampConditions.hpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.hpp
@@ -1,0 +1,36 @@
+#ifndef CLP_S_ADD_TIMESTAMP_CONDITIONS_HPP
+#define CLP_S_ADD_TIMESTAMP_CONDITIONS_HPP
+
+#include <optional>
+
+#include "../Defs.hpp"
+#include "../TimestampDictionaryReader.hpp"
+#include "Transformation.hpp"
+
+namespace clp_s::search {
+class AddTimestampConditions : public Transformation {
+public:
+    // Constructors
+    AddTimestampConditions(
+            std::shared_ptr<TimestampDictionaryReader> const& timestamp_dict,
+            std::optional<epochtime_t> begin_ts,
+            std::optional<epochtime_t> end_ts
+    )
+            : m_timestamp_dict(timestamp_dict),
+              m_begin_ts(begin_ts),
+              m_end_ts(end_ts) {}
+
+    /**
+     * Takes in an AST and adds filters on the authoratative timestamp column if the user specified
+     * such filters on the command line.
+     */
+    std::shared_ptr<Expression> run(std::shared_ptr<Expression>& expr) override;
+
+private:
+    std::shared_ptr<TimestampDictionaryReader> m_timestamp_dict;
+    std::optional<epochtime_t> m_begin_ts;
+    std::optional<epochtime_t> m_end_ts;
+};
+}  // namespace clp_s::search
+
+#endif  // CLP_S_ADD_TIMESTAMP_CONDITIONS_HPP

--- a/components/core/src/clp_s/search/AddTimestampConditions.hpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.hpp
@@ -31,8 +31,7 @@ public:
               m_end_ts(end_ts) {}
 
     /**
-     * Takes in an AST and adds filters on the authoritative timestamp column if the user specified
-     * such filters on the command line.
+     * Takes in an AST and adds filters on the provided timestamp column.
      * @param expr the AST to transform
      * @return the transformed AST
      */

--- a/components/core/src/clp_s/search/AddTimestampConditions.hpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.hpp
@@ -21,7 +21,7 @@ public:
               m_end_ts(end_ts) {}
 
     /**
-     * Takes in an AST and adds filters on the authoratative timestamp column if the user specified
+     * Takes in an AST and adds filters on the authoritative timestamp column if the user specified
      * such filters on the command line.
      */
     std::shared_ptr<Expression> run(std::shared_ptr<Expression>& expr) override;

--- a/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
+++ b/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
@@ -53,7 +53,7 @@ EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& ex
              range_it != m_timestamp_dict->tokenized_column_to_range_end();
              range_it++)
         {
-            std::vector<std::string>& tokens = range_it->first;
+            std::vector<std::string> const& tokens = range_it->first;
             auto const& descriptors = column->get_descriptor_list();
             // TODO: handle wildcard matching; the initial check on timestamp index happens
             // before schema matching, so


### PR DESCRIPTION
# Description
This PR adds the optional --tle TS and --tge TS options to clp-s which specify filtering for records with a timestamp greater than or equal to or less than or equal to a given value respectively.

This filtering is performed by finding the authoritative timestamp column in the timestamp dictionary, and adding filters on that column directly to the search AST as required.

# Validation performed
- Validated that specifying an invalid time range (begin > end) prints an error message
- Validated that using tle or tge on an archive with no timestamp key returns no results
- Validated that specifying a timestamp filter with tle/tge will return identical results to specifying the same time filters in the search query

