### PR TITLE
Fix a bug of nested timestamp fields and store column IDs in the timestamp dictionary

### DIFF
--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -97,7 +97,9 @@ void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const&
                 writer->append_column(new FloatColumnWriter(key_name, id));
                 break;
             case NodeType::CLPSTRING:
-                writer->append_column(new ClpStringColumnWriter(key_name, id, m_var_dict, m_log_dict));
+                writer->append_column(
+                        new ClpStringColumnWriter(key_name, id, m_var_dict, m_log_dict)
+                );
                 break;
             case NodeType::VARSTRING:
                 writer->append_column(new VariableStringColumnWriter(key_name, id, m_var_dict));
@@ -106,14 +108,17 @@ void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const&
                 writer->append_column(new BooleanColumnWriter(key_name, id));
                 break;
             case NodeType::ARRAY:
-                writer->append_column(new ClpStringColumnWriter(key_name, id, m_var_dict, m_array_dict)
+                writer->append_column(
+                        new ClpStringColumnWriter(key_name, id, m_var_dict, m_array_dict)
                 );
                 break;
             case NodeType::DATESTRING:
                 writer->append_column(new DateStringColumnWriter(key_name, id, m_timestamp_dict));
                 break;
             case NodeType::FLOATDATESTRING:
-                writer->append_column(new FloatDateStringColumnWriter(key_name, id, m_timestamp_dict));
+                writer->append_column(
+                        new FloatDateStringColumnWriter(key_name, id, m_timestamp_dict)
+                );
                 break;
             case NodeType::OBJECT:
             case NodeType::NULLVALUE:

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -91,29 +91,29 @@ void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const&
         std::string key_name = node->get_key_name();
         switch (node->get_type()) {
             case NodeType::INTEGER:
-                writer->append_column(new Int64ColumnWriter(key_name));
+                writer->append_column(new Int64ColumnWriter(key_name, id));
                 break;
             case NodeType::FLOAT:
-                writer->append_column(new FloatColumnWriter(key_name));
+                writer->append_column(new FloatColumnWriter(key_name, id));
                 break;
             case NodeType::CLPSTRING:
-                writer->append_column(new ClpStringColumnWriter(key_name, m_var_dict, m_log_dict));
+                writer->append_column(new ClpStringColumnWriter(key_name, id, m_var_dict, m_log_dict));
                 break;
             case NodeType::VARSTRING:
-                writer->append_column(new VariableStringColumnWriter(key_name, m_var_dict));
+                writer->append_column(new VariableStringColumnWriter(key_name, id, m_var_dict));
                 break;
             case NodeType::BOOLEAN:
-                writer->append_column(new BooleanColumnWriter(key_name));
+                writer->append_column(new BooleanColumnWriter(key_name, id));
                 break;
             case NodeType::ARRAY:
-                writer->append_column(new ClpStringColumnWriter(key_name, m_var_dict, m_array_dict)
+                writer->append_column(new ClpStringColumnWriter(key_name, id, m_var_dict, m_array_dict)
                 );
                 break;
             case NodeType::DATESTRING:
-                writer->append_column(new DateStringColumnWriter(key_name, m_timestamp_dict));
+                writer->append_column(new DateStringColumnWriter(key_name, id, m_timestamp_dict));
                 break;
             case NodeType::FLOATDATESTRING:
-                writer->append_column(new FloatDateStringColumnWriter(key_name, m_timestamp_dict));
+                writer->append_column(new FloatDateStringColumnWriter(key_name, id, m_timestamp_dict));
                 break;
             case NodeType::OBJECT:
             case NodeType::NULLVALUE:

--- a/components/core/src/clp_s/ColumnWriter.cpp
+++ b/components/core/src/clp_s/ColumnWriter.cpp
@@ -104,7 +104,8 @@ void DateStringColumnWriter::add_value(
     std::string string_timestamp = std::get<std::string>(value);
 
     uint64_t encoding_id;
-    epochtime_t timestamp = m_timestamp_dict->ingest_entry(m_name, m_id, string_timestamp, encoding_id);
+    epochtime_t timestamp
+            = m_timestamp_dict->ingest_entry(m_name, m_id, string_timestamp, encoding_id);
 
     m_timestamps.push_back(timestamp);
     m_timestamp_encodings.push_back(encoding_id);

--- a/components/core/src/clp_s/ColumnWriter.cpp
+++ b/components/core/src/clp_s/ColumnWriter.cpp
@@ -104,7 +104,7 @@ void DateStringColumnWriter::add_value(
     std::string string_timestamp = std::get<std::string>(value);
 
     uint64_t encoding_id;
-    epochtime_t timestamp = m_timestamp_dict->ingest_entry(m_name, string_timestamp, encoding_id);
+    epochtime_t timestamp = m_timestamp_dict->ingest_entry(m_name, m_id, string_timestamp, encoding_id);
 
     m_timestamps.push_back(timestamp);
     m_timestamp_encodings.push_back(encoding_id);
@@ -128,7 +128,7 @@ void FloatDateStringColumnWriter::add_value(
     size = sizeof(double);
     double timestamp = std::get<double>(value);
 
-    m_timestamp_dict->ingest_entry(m_name, timestamp);
+    m_timestamp_dict->ingest_entry(m_name, m_id, timestamp);
 
     m_timestamps.push_back(timestamp);
 }

--- a/components/core/src/clp_s/ColumnWriter.hpp
+++ b/components/core/src/clp_s/ColumnWriter.hpp
@@ -18,7 +18,7 @@ namespace clp_s {
 class BaseColumnWriter {
 public:
     // Constructor
-    explicit BaseColumnWriter(std::string name) : m_name(std::move(name)) {}
+    explicit BaseColumnWriter(std::string name, int32_t id) : m_name(std::move(name)), m_id(id) {}
 
     // Destructor
     virtual ~BaseColumnWriter() = default;
@@ -44,12 +44,14 @@ public:
 
 protected:
     std::string m_name;
+    int32_t m_id;
 };
 
 class Int64ColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    explicit Int64ColumnWriter(std::string name) : BaseColumnWriter(std::move(name)) {}
+    explicit Int64ColumnWriter(std::string name, int32_t id)
+            : BaseColumnWriter(std::move(name), id) {}
 
     // Destructor
     ~Int64ColumnWriter() override = default;
@@ -66,7 +68,8 @@ private:
 class FloatColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    explicit FloatColumnWriter(std::string name) : BaseColumnWriter(std::move(name)) {}
+    explicit FloatColumnWriter(std::string name, int32_t id)
+            : BaseColumnWriter(std::move(name), id) {}
 
     // Destructor
     ~FloatColumnWriter() override = default;
@@ -83,7 +86,7 @@ private:
 class BooleanColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    explicit BooleanColumnWriter(std::string name) : BaseColumnWriter(std::move(name)) {}
+    explicit BooleanColumnWriter(std::string name, int32_t id) : BaseColumnWriter(std::move(name), id) {}
 
     // Destructor
     ~BooleanColumnWriter() override = default;
@@ -102,10 +105,11 @@ public:
     // Constructor
     ClpStringColumnWriter(
             std::string const& name,
+            int32_t id,
             std::shared_ptr<VariableDictionaryWriter> var_dict,
             std::shared_ptr<LogTypeDictionaryWriter> log_dict
     )
-            : BaseColumnWriter(name),
+            : BaseColumnWriter(name, id),
               m_var_dict(std::move(var_dict)),
               m_log_dict(std::move(log_dict)) {}
 
@@ -161,9 +165,10 @@ public:
     // Constructor
     VariableStringColumnWriter(
             std::string const& name,
+            int32_t id,
             std::shared_ptr<VariableDictionaryWriter> var_dict
     )
-            : BaseColumnWriter(name),
+            : BaseColumnWriter(name, id),
               m_var_dict(std::move(var_dict)) {}
 
     // Destructor
@@ -184,9 +189,10 @@ public:
     // Constructor
     DateStringColumnWriter(
             std::string const& name,
+            int32_t id,
             std::shared_ptr<TimestampDictionaryWriter> timestamp_dict
     )
-            : BaseColumnWriter(name),
+            : BaseColumnWriter(name, id),
               m_timestamp_dict(std::move(timestamp_dict)) {}
 
     // Destructor
@@ -209,9 +215,10 @@ public:
     // Constructor
     FloatDateStringColumnWriter(
             std::string const& name,
+            int32_t id,
             std::shared_ptr<TimestampDictionaryWriter> timestamp_dict
     )
-            : BaseColumnWriter(name),
+            : BaseColumnWriter(name, id),
               m_timestamp_dict(std::move(timestamp_dict)) {}
 
     // Destructor

--- a/components/core/src/clp_s/ColumnWriter.hpp
+++ b/components/core/src/clp_s/ColumnWriter.hpp
@@ -86,7 +86,8 @@ private:
 class BooleanColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    explicit BooleanColumnWriter(std::string name, int32_t id) : BaseColumnWriter(std::move(name), id) {}
+    explicit BooleanColumnWriter(std::string name, int32_t id)
+            : BaseColumnWriter(std::move(name), id) {}
 
     // Destructor
     ~BooleanColumnWriter() override = default;

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -136,7 +136,8 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                     double double_value = line.get_double();
                     m_current_parsed_message.add_value(node_id, double_value);
                     if (matches_timestamp) {
-                        m_timestamp_dictionary->ingest_entry(m_timestamp_key, node_id, double_value);
+                        m_timestamp_dictionary
+                                ->ingest_entry(m_timestamp_key, node_id, double_value);
                         matches_timestamp = may_match_timestamp = can_match_timestamp = false;
                     }
                 }

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -129,14 +129,14 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
 
                     m_current_parsed_message.add_value(node_id, i64_value);
                     if (matches_timestamp) {
-                        m_timestamp_dictionary->ingest_entry(m_timestamp_key, i64_value);
+                        m_timestamp_dictionary->ingest_entry(m_timestamp_key, node_id, i64_value);
                         matches_timestamp = may_match_timestamp = can_match_timestamp = false;
                     }
                 } else {
                     double double_value = line.get_double();
                     m_current_parsed_message.add_value(node_id, double_value);
                     if (matches_timestamp) {
-                        m_timestamp_dictionary->ingest_entry(m_timestamp_key, double_value);
+                        m_timestamp_dictionary->ingest_entry(m_timestamp_key, node_id, double_value);
                         matches_timestamp = may_match_timestamp = can_match_timestamp = false;
                     }
                 }

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -27,7 +27,7 @@ using namespace simdjson;
 namespace clp_s {
 struct JsonParserOption {
     std::vector<std::string> file_paths;
-    std::vector<std::string> timestamp_column;
+    std::string timestamp_key;
     std::string archives_dir;
     size_t target_encoded_size;
     int compression_level;
@@ -90,6 +90,7 @@ private:
     ParsedMessage m_current_parsed_message;
     std::shared_ptr<TimestampDictionaryWriter> m_timestamp_dictionary;
 
+    std::string m_timestamp_key;
     std::vector<std::string> m_timestamp_column;
 
     boost::uuids::random_generator m_generator;

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -1,5 +1,7 @@
 #include "TimestampDictionaryReader.hpp"
 
+#include <unordered_set>
+
 #include "Utils.hpp"
 
 namespace clp_s {
@@ -43,12 +45,13 @@ void TimestampDictionaryReader::read_new_entries(bool local) {
     }
 
     for (int i = 0; i < range_index_size; ++i) {
-        std::string col;
+        std::string column_name;
+        std::unordered_set<int32_t> column_ids;
         TimestampEntry entry;
-        entry.try_read_from_file(m_dictionary_decompressor, col);
-        TimestampEntry& e = m_column_to_range[col] = entry;
+        entry.try_read_from_file(m_dictionary_decompressor, column_name, column_ids);
+        TimestampEntry& e = m_column_to_range[column_name] = entry;
         std::vector<std::string> tokens;
-        StringUtils::tokenize_column_descriptor(col, tokens);
+        StringUtils::tokenize_column_descriptor(column_name, tokens);
         m_tokenized_column_to_range.emplace_back(std::move(tokens), &e);
     }
 

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -45,10 +45,9 @@ void TimestampDictionaryReader::read_new_entries(bool local) {
     }
 
     for (int i = 0; i < range_index_size; ++i) {
-        std::string column_name;
-        std::unordered_set<int32_t> column_ids;
         TimestampEntry entry;
-        entry.try_read_from_file(m_dictionary_decompressor, column_name, column_ids);
+        entry.try_read_from_file(m_dictionary_decompressor);
+        std::string column_name = entry.get_key_name();
         TimestampEntry& e = m_column_to_range[column_name] = entry;
         std::vector<std::string> tokens;
         StringUtils::tokenize_column_descriptor(column_name, tokens);

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -15,10 +15,7 @@ void TimestampDictionaryWriter::write_timestamp_entries(
 }
 
 void TimestampDictionaryWriter::write_and_flush_to_disk() {
-    write_timestamp_entries(
-            m_global_column_key_to_range,
-            m_dictionary_compressor
-    );
+    write_timestamp_entries(m_global_column_key_to_range, m_dictionary_compressor);
 
     m_dictionary_compressor.write_numeric_value<uint64_t>(m_pattern_to_id.size());
     for (auto& it : m_pattern_to_id) {
@@ -35,10 +32,7 @@ void TimestampDictionaryWriter::write_and_flush_to_disk() {
 }
 
 void TimestampDictionaryWriter::write_local_and_flush_to_disk() {
-    write_timestamp_entries(
-            m_local_column_key_to_range,
-            m_dictionary_compressor_local
-    );
+    write_timestamp_entries(m_local_column_key_to_range, m_dictionary_compressor_local);
 
     m_dictionary_compressor_local.flush();
     m_dictionary_file_writer_local.flush();

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -3,7 +3,7 @@
 
 #include <map>
 #include <string>
-#include <unordered_set>
+#include <unordered_map>
 
 #include "FileWriter.hpp"
 #include "TimestampEntry.hpp"

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -3,7 +3,7 @@
 
 #include <map>
 #include <string>
-#include <unordered_map>
+#include <unordered_set>
 
 #include "FileWriter.hpp"
 #include "TimestampEntry.hpp"
@@ -60,16 +60,22 @@ public:
 
     uint64_t get_pattern_id(TimestampPattern const* pattern);
 
-    epochtime_t ingest_entry(std::string const& key, std::string const& timestamp, uint64_t& id);
+    epochtime_t ingest_entry(
+            std::string const& key,
+            int32_t node_id,
+            std::string const& timestamp,
+            uint64_t& pattern_id
+    );
 
-    void ingest_entry(std::string const& key, double timestamp);
+    void ingest_entry(std::string const& key, int32_t node_id, double timestamp);
 
-    void ingest_entry(std::string const& key, int64_t timestamp);
+    void ingest_entry(std::string const& key, int32_t node_id, int64_t timestamp);
 
 private:
     void merge_local_range();
-    static void write_timestamp_entries(
+    void write_timestamp_entries(
             std::map<std::string, TimestampEntry> const& ranges,
+            std::map<std::string, std::unordered_set<int32_t>> const& column_key_to_ids,
             ZstdCompressor& compressor
     );
 
@@ -87,8 +93,11 @@ private:
 
     pattern_to_id_t m_pattern_to_id;
     uint64_t m_next_id{};
-    std::map<std::string, TimestampEntry> m_global_column_to_range;
-    std::map<std::string, TimestampEntry> m_local_column_to_range;
+    std::map<std::string, TimestampEntry> m_global_column_key_to_range;
+    std::map<std::string, TimestampEntry> m_local_column_key_to_range;
+    std::map<std::string, std::unordered_set<int32_t>> m_global_column_key_to_ids;
+    std::map<std::string, std::unordered_set<int32_t>> m_local_column_key_to_ids;
+    std::unordered_map<int32_t, TimestampEntry> m_local_column_id_to_range;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -75,7 +75,6 @@ private:
     void merge_local_range();
     void write_timestamp_entries(
             std::map<std::string, TimestampEntry> const& ranges,
-            std::map<std::string, std::unordered_set<int32_t>> const& column_key_to_ids,
             ZstdCompressor& compressor
     );
 
@@ -95,8 +94,6 @@ private:
     uint64_t m_next_id{};
     std::map<std::string, TimestampEntry> m_global_column_key_to_range;
     std::map<std::string, TimestampEntry> m_local_column_key_to_range;
-    std::map<std::string, std::unordered_set<int32_t>> m_global_column_key_to_ids;
-    std::map<std::string, std::unordered_set<int32_t>> m_local_column_key_to_ids;
     std::unordered_map<int32_t, TimestampEntry> m_local_column_id_to_range;
 };
 }  // namespace clp_s

--- a/components/core/src/clp_s/TimestampEntry.cpp
+++ b/components/core/src/clp_s/TimestampEntry.cpp
@@ -74,7 +74,11 @@ void TimestampEntry::write_to_file(ZstdCompressor& compressor, std::string const
     }
 }
 
-ErrorCode TimestampEntry::try_read_from_file(ZstdDecompressor& decompressor, std::string& column_name, std::unordered_set<int32_t> &column_ids) {
+ErrorCode TimestampEntry::try_read_from_file(
+        ZstdDecompressor& decompressor,
+        std::string& column_name,
+        std::unordered_set<int32_t>& column_ids
+) {
     ErrorCode error_code;
 
     uint64_t column_len;
@@ -130,7 +134,11 @@ ErrorCode TimestampEntry::try_read_from_file(ZstdDecompressor& decompressor, std
     return error_code;
 }
 
-void TimestampEntry::read_from_file(ZstdDecompressor& decompressor, std::string& column_name, std::unordered_set<int32_t> &column_ids) {
+void TimestampEntry::read_from_file(
+        ZstdDecompressor& decompressor,
+        std::string& column_name,
+        std::unordered_set<int32_t>& column_ids
+) {
     auto error_code = try_read_from_file(decompressor, column_name, column_ids);
     if (ErrorCodeSuccess != error_code) {
         throw OperationFailed(error_code, __FILENAME__, __LINE__);

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -71,7 +71,8 @@ public:
     /**
      * Try to read the timestamp entry from a file
      * @param decompressor
-     * @param column
+     * @param column_name
+     * @param column_ids
      * @return ErrorCode
      */
     ErrorCode try_read_from_file(
@@ -83,9 +84,14 @@ public:
     /**
      * Read the timestamp entry from a file
      * @param decompressor
-     * @param column
+     * @param column_name
+     * @param column_ids
      */
-    void read_from_file(ZstdDecompressor& decompressor, std::string& column);
+    void read_from_file(
+            ZstdDecompressor& decompressor,
+            std::string& column_name,
+            std::unordered_set<int32_t>& column_ids
+    );
 
     /**
      * Check if a timestamp is in the range of this TimestampEntry

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -43,15 +43,22 @@ public:
               m_epoch_start(cEpochTimeMax),
               m_epoch_end(cEpochTimeMin) {}
 
+    TimestampEntry(std::string const& key_name)
+            : m_encoding(UnkownTimestampEncoding),
+              m_epoch_start_double(cDoubleEpochTimeMax),
+              m_epoch_end_double(cDoubleEpochTimeMin),
+              m_epoch_start(cEpochTimeMax),
+              m_epoch_end(cEpochTimeMin),
+              m_key_name(key_name) {}
+
     /**
      * Ingest a timestamp potentially adjusting the start and end bounds for this
      * TimestampEntry.
-     * @param key the key of the timestamp
      * @param timestamp the timestamp to be ingested
      * @return the epoch time corresponding to the string timestamp
      */
-    void ingest_timestamp(std::string const& key, epochtime_t timestamp);
-    void ingest_timestamp(std::string const& key, double timestamp);
+    void ingest_timestamp(epochtime_t timestamp);
+    void ingest_timestamp(double timestamp);
 
     /**
      * Merge a timestamp range potentially adjusting the start and end bounds for this
@@ -66,20 +73,14 @@ public:
      * @param compressor
      * @param column
      */
-    void write_to_file(ZstdCompressor& compressor, std::string const& column) const;
+    void write_to_file(ZstdCompressor& compressor) const;
 
     /**
      * Try to read the timestamp entry from a file
      * @param decompressor
-     * @param column_name
-     * @param column_ids
      * @return ErrorCode
      */
-    ErrorCode try_read_from_file(
-            ZstdDecompressor& decompressor,
-            std::string& column_name,
-            std::unordered_set<int32_t>& column_ids
-    );
+    ErrorCode try_read_from_file(ZstdDecompressor& decompressor);
 
     /**
      * Read the timestamp entry from a file
@@ -87,11 +88,7 @@ public:
      * @param column_name
      * @param column_ids
      */
-    void read_from_file(
-            ZstdDecompressor& decompressor,
-            std::string& column_name,
-            std::unordered_set<int32_t>& column_ids
-    );
+    void read_from_file(ZstdDecompressor& decompressor);
 
     /**
      * Check if a timestamp is in the range of this TimestampEntry
@@ -104,12 +101,21 @@ public:
 
     std::string get_key_name() const { return m_key_name; }
 
+    std::unordered_set<int32_t> const& get_column_ids() const { return m_column_ids; }
+
+    void insert_column_id(int32_t column_id) { m_column_ids.insert(column_id); }
+
+    void insert_column_ids(std::unordered_set<int32_t> const& column_ids) {
+        m_column_ids.insert(column_ids.begin(), column_ids.end());
+    }
+
 private:
     TimestampEncoding m_encoding;
     double m_epoch_start_double, m_epoch_end_double;
     epochtime_t m_epoch_start, m_epoch_end;
 
     std::string m_key_name;
+    std::unordered_set<int32_t> m_column_ids;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_TIMESTAMPENTRY_HPP
 
 #include <string>
+#include <unordered_set>
 #include <variant>
 
 #include "Defs.hpp"
@@ -45,12 +46,12 @@ public:
     /**
      * Ingest a timestamp potentially adjusting the start and end bounds for this
      * TimestampEntry.
-     *
+     * @param key the key of the timestamp
      * @param timestamp the timestamp to be ingested
      * @return the epoch time corresponding to the string timestamp
      */
-    void ingest_timestamp(epochtime_t timestamp);
-    void ingest_timestamp(double timestamp);
+    void ingest_timestamp(std::string const& key, epochtime_t timestamp);
+    void ingest_timestamp(std::string const& key, double timestamp);
 
     /**
      * Merge a timestamp range potentially adjusting the start and end bounds for this
@@ -73,7 +74,11 @@ public:
      * @param column
      * @return ErrorCode
      */
-    ErrorCode try_read_from_file(ZstdDecompressor& decompressor, std::string& column);
+    ErrorCode try_read_from_file(
+            ZstdDecompressor& decompressor,
+            std::string& column_name,
+            std::unordered_set<int32_t>& column_ids
+    );
 
     /**
      * Read the timestamp entry from a file
@@ -91,10 +96,14 @@ public:
     EvaluatedValue evaluate_filter(FilterOperation op, double timestamp);
     EvaluatedValue evaluate_filter(FilterOperation op, epochtime_t timestamp);
 
+    std::string get_key_name() const { return m_key_name; }
+
 private:
     TimestampEncoding m_encoding;
     double m_epoch_start_double, m_epoch_end_double;
     epochtime_t m_epoch_start, m_epoch_end;
+
+    std::string m_key_name;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -55,7 +55,6 @@ int main(int argc, char const* argv[]) {
         option.compression_level = command_line_arguments.get_compression_level();
         option.timestamp_key = command_line_arguments.get_timestamp_key();
 
-
         clp_s::JsonParser parser(option);
         parser.parse();
         parser.store();

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -53,10 +53,8 @@ int main(int argc, char const* argv[]) {
         option.archives_dir = command_line_arguments.get_archives_dir();
         option.target_encoded_size = command_line_arguments.get_target_encoded_size();
         option.compression_level = command_line_arguments.get_compression_level();
-        auto const& timestamp_key = command_line_arguments.get_timestamp_key();
-        if (false == timestamp_key.empty()) {
-            clp_s::StringUtils::tokenize_column_descriptor(timestamp_key, option.timestamp_column);
-        }
+        option.timestamp_key = command_line_arguments.get_timestamp_key();
+
 
         clp_s::JsonParser parser(option);
         parser.parse();


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR fixes the bug of not correctly storing nested timestamp fields. It also adds support for storing column IDs in the timestamp dictionary, which will save effort when extracting timestamps.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Built clp-s and compressed part of [mongodb](https://zenodo.org/records/10516285) dataset.
+ Ran query "id: 23285" and checked mongodb documents.
