### PR TITLE
Add support for clp-s storage engine in clp package

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -78,6 +78,7 @@ tasks:
         "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
         "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
         "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
+        "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
         "{{.PACKAGE_BUILD_DIR}}/bin/"
       # This step must be last since we use this file to detect whether the package was built
       # successfully
@@ -87,6 +88,7 @@ tasks:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
+      - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "components/clp-package-utils/dist/*.whl"
       - "components/clp-py-utils/dist/*.whl"
@@ -103,7 +105,7 @@ tasks:
     cmds:
       - "mkdir -p '{{.CORE_COMPONENT_BUILD_DIR}}'"
       - "cmake -S '{{.SRC_DIR}}' -B '{{.CORE_COMPONENT_BUILD_DIR}}'"
-      - "cmake --build '{{.CORE_COMPONENT_BUILD_DIR}}' --parallel --target clg clo clp"
+      - "cmake --build '{{.CORE_COMPONENT_BUILD_DIR}}' --parallel --target clg clo clp clp-s"
     method: "timestamp"
     sources:
       - "{{.SRC_DIR}}/cmake/**/*"
@@ -116,12 +118,15 @@ tasks:
         test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clg'
         && test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clo'
         && test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clp'
+        && test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clp-s'
       - >-
         test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clg')
         && test {{.TIMESTAMP | unixEpoch}} -lt
         $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clo')
         && test {{.TIMESTAMP | unixEpoch}} -lt
         $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clp')
+        && test {{.TIMESTAMP | unixEpoch}} -lt
+        $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clp-s')
 
   clp-package-utils:
     - task: "python-component"

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -45,7 +45,7 @@ def main(argv):
         "-f", "--input-list", dest="input_list", help="A file listing all paths to compress."
     )
     args_parser.add_argument(
-        "--timestamp-key", help="The authoritative key to use for the timestamp index."
+        "--timestamp-key", help="The key specifying each record's timestamp."
     )
 
     parsed_args = args_parser.parse_args(argv[1:])

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -44,6 +44,9 @@ def main(argv):
     args_parser.add_argument(
         "-f", "--input-list", dest="input_list", help="A file listing all paths to compress."
     )
+    args_parser.add_argument(
+        "--timestamp-key", help="The authoritative key to use for the timestamp index."
+    )
 
     parsed_args = args_parser.parse_args(argv[1:])
 
@@ -102,6 +105,9 @@ def main(argv):
         "--remove-path-prefix", str(CONTAINER_INPUT_LOGS_ROOT_DIR),
     ]
     # fmt: on
+    if parsed_args.timestamp_key is not None:
+        compress_cmd.append("--timestamp-key")
+        compress_cmd.append(parsed_args.timestamp_key)
     for path in parsed_args.paths:
         # Resolve path and prefix it with CONTAINER_INPUT_LOGS_ROOT_DIR
         resolved_path = pathlib.Path(path).resolve()

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -44,9 +44,7 @@ def main(argv):
     args_parser.add_argument(
         "-f", "--input-list", dest="input_list", help="A file listing all paths to compress."
     )
-    args_parser.add_argument(
-        "--timestamp-key", help="The key specifying each record's timestamp."
-    )
+    args_parser.add_argument("--timestamp-key", help="The key specifying each record's timestamp.")
 
     parsed_args = args_parser.parse_args(argv[1:])
 

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -44,7 +44,10 @@ def main(argv):
     args_parser.add_argument(
         "-f", "--input-list", dest="input_list", help="A file listing all paths to compress."
     )
-    args_parser.add_argument("--timestamp-key", help="The key specifying each record's timestamp.")
+    args_parser.add_argument(
+        "--timestamp-key",
+        help="The path (e.g. x.y) for the field containing the log event's timestamp.",
+    )
 
     parsed_args = args_parser.parse_args(argv[1:])
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -154,7 +154,8 @@ def main(argv):
         "--no-progress-reporting", action="store_true", help="Disables progress reporting."
     )
     args_parser.add_argument(
-        "--timestamp-key", help="The authoritative key to use for the timestamp index."
+        "--timestamp-key",
+        help="The path (e.g. x.y) for the field containing the log event's timestamp.",
     )
     parsed_args = args_parser.parse_args(argv[1:])
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -153,6 +153,9 @@ def main(argv):
     args_parser.add_argument(
         "--no-progress-reporting", action="store_true", help="Disables progress reporting."
     )
+    args_parser.add_argument(
+        "--timestamp-key", help="The authoritative key to use for the timestamp index."
+    )
     parsed_args = args_parser.parse_args(argv[1:])
 
     # Validate some input paths were specified
@@ -196,7 +199,9 @@ def main(argv):
         shutil.copy(log_list_path, comp_jobs_dir / log_list_path.name)
 
     mysql_adapter = SQL_Adapter(clp_config.database)
-    clp_input_config = InputConfig(list_path=str(log_list_path))
+    clp_input_config = InputConfig(
+        list_path=str(log_list_path), timestamp_key=parsed_args.timestamp_key
+    )
     if parsed_args.remove_path_prefix:
         clp_input_config.path_prefix_to_remove = parsed_args.remove_path_prefix
     clp_io_config = ClpIoConfig(

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -34,6 +34,7 @@ CLP_METADATA_TABLE_PREFIX = "clp_"
 
 class StorageEngine(KebabCaseStrEnum):
     CLP = auto()
+    CLP_S = auto()
 
 
 VALID_STORAGE_ENGINES = [storage_engine.value for storage_engine in StorageEngine]

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -43,7 +43,7 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
 }
 
 size_t ArchiveWriter::close() {
-    size_t compressed_size = 0ULL;
+    size_t compressed_size{0};
     compressed_size += m_var_dict->close();
     compressed_size += m_log_dict->close();
     compressed_size += m_array_dict->close();

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -43,7 +43,7 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
 }
 
 size_t ArchiveWriter::close() {
-    size_t compressed_size{0ULL};
+    size_t compressed_size = 0ULL;
     compressed_size += m_var_dict->close();
     compressed_size += m_log_dict->close();
     compressed_size += m_array_dict->close();

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -42,20 +42,22 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
     m_timestamp_dict->open_local(timestamp_local_dict_path, m_compression_level);
 }
 
-void ArchiveWriter::close() {
-    m_var_dict->close();
-    m_log_dict->close();
-    m_array_dict->close();
-    m_timestamp_dict->close_local();
+size_t ArchiveWriter::close() {
+    size_t compressed_size{0ULL};
+    compressed_size += m_var_dict->close();
+    compressed_size += m_log_dict->close();
+    compressed_size += m_array_dict->close();
+    compressed_size += m_timestamp_dict->close_local();
 
     for (auto& i : m_schema_id_to_writer) {
         i.second->store();
-        i.second->close();
+        compressed_size += i.second->close();
         delete i.second;
     }
 
     m_schema_id_to_writer.clear();
     m_encoded_message_size = 0UL;
+    return compressed_size;
 }
 
 void ArchiveWriter::append_message(

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -49,8 +49,9 @@ public:
 
     /**
      * Closes the archive writer
+     * @return the compressed size of the archive in bytes
      */
-    void close();
+    [[nodiscard]] size_t close();
 
     /**
      * Appends a message to the archive writer

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -1,6 +1,32 @@
 add_subdirectory(search/kql)
 
 set(
+        CLP_SOURCES
+        ../clp/database_utils.cpp
+        ../clp/database_utils.hpp
+        ../clp/Defs.h
+        ../clp/ErrorCode.hpp
+        ../clp/GlobalMetadataDB.hpp
+        ../clp/GlobalMetadataDBConfig.cpp
+        ../clp/GlobalMetadataDBConfig.hpp
+        ../clp/GlobalMySQLMetadataDB.cpp
+        ../clp/GlobalMySQLMetadataDB.hpp
+        ../clp/MySQLDB.cpp
+        ../clp/MySQLDB.hpp
+        ../clp/MySQLParamBindings.cpp
+        ../clp/MySQLParamBindings.hpp
+        ../clp/MySQLPreparedStatement.cpp
+        ../clp/MySQLPreparedStatement.hpp
+        ../clp/ReaderInterface.cpp
+        ../clp/ReaderInterface.hpp
+        ../clp/WriterInterface.cpp
+        ../clp/WriterInterface.hpp
+        ../clp/streaming_archive/ArchiveMetadata.cpp
+        ../clp/streaming_archive/ArchiveMetadata.hpp
+        ../clp/TraceableException.hpp
+)
+
+set(
         CLP_S_SOURCES
         "${PROJECT_SOURCE_DIR}/submodules/date/include/date/date.h"
         ArchiveReader.cpp
@@ -123,17 +149,20 @@ set(
         search/Value.hpp
 )
 
-add_executable(clp-s clp-s.cpp ${CLP_S_SOURCES} ${CLP_S_SEARCH_SOURCES})
+add_executable(clp-s clp-s.cpp ${CLP_SOURCES} ${CLP_S_SOURCES} ${CLP_S_SEARCH_SOURCES})
 target_compile_features(clp-s PRIVATE cxx_std_17)
 target_link_libraries(
         clp-s
         PRIVATE
         absl::flat_hash_map
         Boost::filesystem Boost::iostreams Boost::program_options
+        clp::string_utils
         kql
+        MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
         simdjson
         spdlog::spdlog
+        yaml-cpp::yaml-cpp
         ZStd::ZStd
 )
 target_include_directories(clp-s PRIVATE "${PROJECT_SOURCE_DIR}/submodules")

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -19,11 +19,11 @@ set(
         ../clp/MySQLPreparedStatement.hpp
         ../clp/ReaderInterface.cpp
         ../clp/ReaderInterface.hpp
-        ../clp/WriterInterface.cpp
-        ../clp/WriterInterface.hpp
         ../clp/streaming_archive/ArchiveMetadata.cpp
         ../clp/streaming_archive/ArchiveMetadata.hpp
         ../clp/TraceableException.hpp
+        ../clp/WriterInterface.cpp
+        ../clp/WriterInterface.hpp
 )
 
 set(

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -134,7 +134,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             po::options_description compression_options("Compression options");
             std::string metadata_db_config_file_path;
-            std::string input_path_list_file;
+            std::string input_path_list_file_path;
             // clang-format off
             compression_options.add_options()(
                     "compression-level",

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -163,6 +163,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                             ->value_name("FILE")
                             ->default_value(input_path_list_file),
                     "Compress files specified in FILE"
+            )(
+                    "print-archive-stats",
+                    po::bool_switch(&m_print_archive_stats),
+                    "Print statistics (json) about the archive after it's compressed."
             );
             // clang-format on
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -46,6 +46,8 @@ public:
 
     size_t get_target_encoded_size() const { return m_target_encoded_size; }
 
+    [[nodiscard]] bool print_archive_stats() const { return m_print_archive_stats; }
+
     bool get_mongodb_enabled() const { return m_mongodb_enabled; }
 
     std::string const& get_mongodb_uri() const { return m_mongodb_uri; }
@@ -85,6 +87,7 @@ private:
     std::string m_timestamp_key;
     int m_compression_level{3};
     size_t m_target_encoded_size{8ULL * 1024 * 1024 * 1024};  // 8 GiB
+    bool m_print_archive_stats{false};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "../clp/GlobalMetadataDBConfig.hpp"
 #include "Defs.hpp"
 
 namespace clp_s {
@@ -59,6 +60,10 @@ public:
 
     std::optional<epochtime_t> get_search_end_ts() const { return m_search_end_ts; }
 
+    std::optional<clp::GlobalMetadataDBConfig> const& get_metadata_db_config() const {
+        return m_metadata_db_config;
+    }
+
 private:
     // Methods
     void print_basic_usage() const;
@@ -80,6 +85,9 @@ private:
     std::string m_timestamp_key;
     int m_compression_level{3};
     size_t m_target_encoded_size{8ULL * 1024 * 1024 * 1024};  // 8 GiB
+
+    // Metadata db variables
+    std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;
 
     // MongoDB configuration variables
     bool m_mongodb_enabled{false};

--- a/components/core/src/clp_s/DictionaryWriter.hpp
+++ b/components/core/src/clp_s/DictionaryWriter.hpp
@@ -33,8 +33,9 @@ public:
 
     /**
      * Closes the dictionary
+     * @return the compressed size of the dictionary in bytes
      */
-    void close();
+    [[nodiscard]] size_t close();
 
     /**
      * Writes the dictionary's header and flushes unwritten content to disk
@@ -124,18 +125,20 @@ void DictionaryWriter<DictionaryIdType, EntryType>::open(
 }
 
 template <typename DictionaryIdType, typename EntryType>
-void DictionaryWriter<DictionaryIdType, EntryType>::close() {
+size_t DictionaryWriter<DictionaryIdType, EntryType>::close() {
     if (false == m_is_open) {
         throw OperationFailed(ErrorCodeNotInit, __FILENAME__, __LINE__);
     }
 
     write_header_and_flush_to_disk();
     m_dictionary_compressor.close();
+    size_t compressed_size = m_dictionary_file_writer.get_pos();
     m_dictionary_file_writer.close();
 
     m_value_to_id.clear();
 
     m_is_open = false;
+    return compressed_size;
 }
 
 template <typename DictionaryIdType, typename EntryType>

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -49,6 +49,11 @@ public:
         return 0;
     }
 
+    /**
+     * @return total number of bytes read from the file
+     */
+    [[nodiscard]] size_t get_num_bytes_read() { return m_bytes_read; }
+
 private:
     /**
      * Reads new JSON into the buffer and initializes iterators into the data.

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -250,6 +250,8 @@ void JsonParser::parse() {
             m_current_parsed_message.clear();
         }
 
+        m_uncompressed_size += json_file_iterator.get_num_bytes_read();
+
         if (json_file_iterator.truncated_bytes() > 0) {
             SPDLOG_ERROR(
                     "Truncated JSON  ({} bytes) at end of file {}",
@@ -279,15 +281,16 @@ void JsonParser::store() {
     }
 
     schema_tree_compressor.close();
+    m_compressed_size += schema_tree_writer.get_pos();
     schema_tree_writer.close();
 
-    m_schema_map->store();
+    m_compressed_size += m_schema_map->store();
 
-    m_timestamp_dictionary->close();
+    m_compressed_size += m_timestamp_dictionary->close();
 }
 
 void JsonParser::split_archive() {
-    m_archive_writer->close();
+    m_compressed_size += m_archive_writer->close();
 
     ArchiveWriterOption archive_writer_option;
     archive_writer_option.archives_dir = m_archives_dir;
@@ -298,6 +301,6 @@ void JsonParser::split_archive() {
 }
 
 void JsonParser::close() {
-    m_archive_writer->close();
+    m_compressed_size += m_archive_writer->close();
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -63,6 +63,16 @@ public:
      */
     void close();
 
+    /**
+     * @return the size data before compression in bytes
+     */
+    [[nodiscard]] size_t get_uncompressed_size() { return m_uncompressed_size; }
+
+    /**
+     * @return the size of the compressed data in bytes
+     */
+    [[nodiscard]] size_t get_compressed_size() { return m_compressed_size; }
+
 private:
     /**
      * Parses a JSON line
@@ -96,6 +106,9 @@ private:
     boost::uuids::random_generator m_generator;
     std::unique_ptr<ArchiveWriter> m_archive_writer;
     size_t m_target_encoded_size;
+
+    size_t m_uncompressed_size{0};
+    size_t m_compressed_size{0};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -73,11 +73,13 @@ public:
      */
     [[nodiscard]] size_t get_compressed_size() { return m_compressed_size; }
 
-    [[nodiscard]] epochtime_t get_epoch_start() {
-        return m_timestamp_dictionary->get_epoch_start();
+    [[nodiscard]] epochtime_t get_begin_timestamp() {
+        return m_timestamp_dictionary->get_begin_timestamp();
     }
 
-    [[nodiscard]] epochtime_t get_epoch_end() { return m_timestamp_dictionary->get_epoch_end(); }
+    [[nodiscard]] epochtime_t get_end_timestamp() {
+        return m_timestamp_dictionary->get_end_timestamp();
+    }
 
 private:
     /**

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -64,7 +64,7 @@ public:
     void close();
 
     /**
-     * @return the size data before compression in bytes
+     * @return the size of the input data before compression in bytes
      */
     [[nodiscard]] size_t get_uncompressed_size() { return m_uncompressed_size; }
 

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -73,6 +73,12 @@ public:
      */
     [[nodiscard]] size_t get_compressed_size() { return m_compressed_size; }
 
+    [[nodiscard]] epochtime_t get_epoch_start() {
+        return m_timestamp_dictionary->get_epoch_start();
+    }
+
+    [[nodiscard]] epochtime_t get_epoch_end() { return m_timestamp_dictionary->get_epoch_end(); }
+
 private:
     /**
      * Parses a JSON line

--- a/components/core/src/clp_s/SchemaMap.cpp
+++ b/components/core/src/clp_s/SchemaMap.cpp
@@ -13,7 +13,7 @@ int32_t SchemaMap::add_schema(Schema const& schema) {
     return m_current_schema_id++;
 }
 
-void SchemaMap::store() {
+size_t SchemaMap::store() {
     FileWriter schema_map_writer;
     ZstdCompressor schema_map_compressor;
 
@@ -31,6 +31,8 @@ void SchemaMap::store() {
     }
 
     schema_map_compressor.close();
+    size_t compressed_size = schema_map_writer.get_pos();
     schema_map_writer.close();
+    return compressed_size;
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/SchemaMap.hpp
+++ b/components/core/src/clp_s/SchemaMap.hpp
@@ -27,8 +27,9 @@ public:
 
     /**
      * Write the contents of the SchemaMap to archives_dir/schema_ids
+     * @return the compressed size of the SchemaMap in bytes
      */
-    void store();
+    [[nodiscard]] size_t store();
 
     /**
      * Get const iterators into the schema map

--- a/components/core/src/clp_s/SchemaWriter.cpp
+++ b/components/core/src/clp_s/SchemaWriter.cpp
@@ -8,8 +8,9 @@ void SchemaWriter::open(std::string path, int compression_level) {
     m_compression_level = compression_level;
 }
 
-void SchemaWriter::close() {
+size_t SchemaWriter::close() {
     m_compressor.close();
+    size_t compressed_size = m_file_writer.get_pos();
     m_file_writer.close();
 
     for (auto i : m_columns) {
@@ -17,6 +18,7 @@ void SchemaWriter::close() {
     }
 
     m_columns.clear();
+    return compressed_size;
 }
 
 void SchemaWriter::append_column(BaseColumnWriter* column_writer) {

--- a/components/core/src/clp_s/SchemaWriter.hpp
+++ b/components/core/src/clp_s/SchemaWriter.hpp
@@ -44,8 +44,9 @@ public:
 
     /**
      * Closes the schema writer.
+     * @return the compressed size of the schema table in bytes
      */
-    void close();
+    [[nodiscard]] size_t close();
 
 private:
     FileWriter m_file_writer;

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -64,7 +64,7 @@ void TimestampDictionaryWriter::open_local(
     m_is_open_local = true;
 }
 
-void TimestampDictionaryWriter::close() {
+size_t TimestampDictionaryWriter::close() {
     if (false == m_is_open) {
         throw OperationFailed(ErrorCodeNotInit, __FILENAME__, __LINE__);
     }
@@ -74,18 +74,21 @@ void TimestampDictionaryWriter::close() {
     merge_local_range();
     write_and_flush_to_disk();
     m_dictionary_compressor.close();
+    size_t compressed_size = m_dictionary_file_writer.get_pos();
     m_dictionary_file_writer.close();
 
     m_is_open = false;
+    return compressed_size;
 }
 
-void TimestampDictionaryWriter::close_local() {
+size_t TimestampDictionaryWriter::close_local() {
     if (false == m_is_open_local) {
         throw OperationFailed(ErrorCodeNotInit, __FILENAME__, __LINE__);
     }
 
     write_local_and_flush_to_disk();
     m_dictionary_compressor_local.close();
+    size_t compressed_size = m_dictionary_file_writer_local.get_pos();
     m_dictionary_file_writer_local.close();
 
     m_is_open_local = false;
@@ -94,6 +97,7 @@ void TimestampDictionaryWriter::close_local() {
     merge_local_range();
     m_local_column_id_to_range.clear();
     m_local_column_key_to_range.clear();
+    return compressed_size;
 }
 
 uint64_t TimestampDictionaryWriter::get_pattern_id(TimestampPattern const* pattern) {

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -201,7 +201,7 @@ void TimestampDictionaryWriter::merge_local_range() {
 
 epochtime_t TimestampDictionaryWriter::get_epoch_start() const {
     auto it = m_global_column_key_to_range.begin();
-    if (it == m_global_column_key_to_range.end()) {
+    if (m_global_column_key_to_range.end() == it) {
         // replicate behaviour of CLP
         return 0;
     }
@@ -211,7 +211,7 @@ epochtime_t TimestampDictionaryWriter::get_epoch_start() const {
 
 epochtime_t TimestampDictionaryWriter::get_epoch_end() const {
     auto it = m_global_column_key_to_range.begin();
-    if (it == m_global_column_key_to_range.end()) {
+    if (m_global_column_key_to_range.end() == it) {
         // replicate behaviour of CLP
         return 0;
     }

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -198,4 +198,24 @@ void TimestampDictionaryWriter::merge_local_range() {
         }
     }
 }
+
+epochtime_t TimestampDictionaryWriter::get_epoch_start() const {
+    auto it = m_global_column_to_range.begin();
+    if (it == m_global_column_to_range.end()) {
+        // replicate behaviour of CLP
+        return 0;
+    }
+
+    return it->second.get_epoch_start();
+}
+
+epochtime_t TimestampDictionaryWriter::get_epoch_end() const {
+    auto it = m_global_column_to_range.begin();
+    if (it == m_global_column_to_range.end()) {
+        // replicate behaviour of CLP
+        return 0;
+    }
+
+    return it->second.get_epoch_end();
+}
 }  // namespace clp_s

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -200,8 +200,8 @@ void TimestampDictionaryWriter::merge_local_range() {
 }
 
 epochtime_t TimestampDictionaryWriter::get_epoch_start() const {
-    auto it = m_global_column_to_range.begin();
-    if (it == m_global_column_to_range.end()) {
+    auto it = m_global_column_key_to_range.begin();
+    if (it == m_global_column_key_to_range.end()) {
         // replicate behaviour of CLP
         return 0;
     }
@@ -210,8 +210,8 @@ epochtime_t TimestampDictionaryWriter::get_epoch_start() const {
 }
 
 epochtime_t TimestampDictionaryWriter::get_epoch_end() const {
-    auto it = m_global_column_to_range.begin();
-    if (it == m_global_column_to_range.end()) {
+    auto it = m_global_column_key_to_range.begin();
+    if (it == m_global_column_key_to_range.end()) {
         // replicate behaviour of CLP
         return 0;
     }

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -199,23 +199,23 @@ void TimestampDictionaryWriter::merge_local_range() {
     }
 }
 
-epochtime_t TimestampDictionaryWriter::get_epoch_start() const {
+epochtime_t TimestampDictionaryWriter::get_begin_timestamp() const {
     auto it = m_global_column_key_to_range.begin();
     if (m_global_column_key_to_range.end() == it) {
         // replicate behaviour of CLP
         return 0;
     }
 
-    return it->second.get_epoch_start();
+    return it->second.get_begin_timestamp();
 }
 
-epochtime_t TimestampDictionaryWriter::get_epoch_end() const {
+epochtime_t TimestampDictionaryWriter::get_end_timestamp() const {
     auto it = m_global_column_key_to_range.begin();
     if (m_global_column_key_to_range.end() == it) {
         // replicate behaviour of CLP
         return 0;
     }
 
-    return it->second.get_epoch_end();
+    return it->second.get_end_timestamp();
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -73,6 +73,24 @@ public:
 
     void ingest_entry(std::string const& key, int32_t node_id, int64_t timestamp);
 
+    /**
+     * Get the beginning of the time range for this archive
+     * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
+     * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
+     * millisecond encoded timestamps.
+     * @return the beginning of the time range in UNIX epoch time
+     */
+    epochtime_t get_epoch_start() const;
+
+    /**
+     * Get the end of the time range for this archive
+     * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
+     * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
+     * millisecond encoded timestamps.
+     * @return the end of the time range in UNIX epoch time
+     */
+    epochtime_t get_epoch_end() const;
+
 private:
     void merge_local_range();
     void write_timestamp_entries(

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -40,13 +40,15 @@ public:
 
     /**
      * Closes the global timestamp dictionary
+     * @return the compressed size of the global timestamp dictionary in bytes
      */
-    void close();
+    [[nodiscard]] size_t close();
 
     /**
      * Closes the local timestamp dictionary
+     * @return the compressed size of the local timestamp dictionary in bytes
      */
-    void close_local();
+    [[nodiscard]] size_t close_local();
 
     /**
      * Writes the global timestamp dictionary to disk

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -79,7 +79,7 @@ public:
      * millisecond encoded timestamps.
      * @return the beginning of this archive's time range as milliseconds since the UNIX epoch
      */
-    epochtime_t get_epoch_start() const;
+    epochtime_t get_begin_timestamp() const;
 
     /**
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
@@ -87,7 +87,7 @@ public:
      * millisecond encoded timestamps.
      * @return the end of this archive's time range as milliseconds since the UNIX epoch
      */
-    epochtime_t get_epoch_end() const;
+    epochtime_t get_end_timestamp() const;
 
 private:
     void merge_local_range();

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -74,20 +74,18 @@ public:
     void ingest_entry(std::string const& key, int32_t node_id, int64_t timestamp);
 
     /**
-     * Get the beginning of the time range for this archive
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
      * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
      * millisecond encoded timestamps.
-     * @return the beginning of the time range in UNIX epoch time
+     * @return the beginning of this archive's time range as milliseconds since the UNIX epoch
      */
     epochtime_t get_epoch_start() const;
 
     /**
-     * Get the end of the time range for this archive
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
      * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
      * millisecond encoded timestamps.
-     * @return the end of the time range in UNIX epoch time
+     * @return the end of this archive's time range as milliseconds since the UNIX epoch
      */
     epochtime_t get_epoch_end() const;
 

--- a/components/core/src/clp_s/TimestampEntry.cpp
+++ b/components/core/src/clp_s/TimestampEntry.cpp
@@ -359,4 +359,22 @@ EvaluatedValue TimestampEntry::evaluate_filter(FilterOperation op, epochtime_t t
         return EvaluatedValue::Unknown;
     }
 }
+
+epochtime_t TimestampEntry::get_epoch_start() const {
+    if (Epoch == m_encoding) {
+        return m_epoch_start;
+    } else if (DoubleEpoch == m_encoding) {
+        return static_cast<epochtime_t>(m_epoch_start_double);
+    }
+    return 0;
+}
+
+epochtime_t TimestampEntry::get_epoch_end() const {
+    if (Epoch == m_encoding) {
+        return m_epoch_end;
+    } else if (DoubleEpoch == m_encoding) {
+        return static_cast<epochtime_t>(std::ceil(m_epoch_end_double));
+    }
+    return 0;
+}
 }  // namespace clp_s

--- a/components/core/src/clp_s/TimestampEntry.cpp
+++ b/components/core/src/clp_s/TimestampEntry.cpp
@@ -360,7 +360,7 @@ EvaluatedValue TimestampEntry::evaluate_filter(FilterOperation op, epochtime_t t
     }
 }
 
-epochtime_t TimestampEntry::get_epoch_start() const {
+epochtime_t TimestampEntry::get_begin_timestamp() const {
     if (Epoch == m_encoding) {
         return m_epoch_start;
     } else if (DoubleEpoch == m_encoding) {
@@ -369,7 +369,7 @@ epochtime_t TimestampEntry::get_epoch_start() const {
     return 0;
 }
 
-epochtime_t TimestampEntry::get_epoch_end() const {
+epochtime_t TimestampEntry::get_end_timestamp() const {
     if (Epoch == m_encoding) {
         return m_epoch_end;
     } else if (DoubleEpoch == m_encoding) {

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -115,7 +115,7 @@ public:
      * millisecond encoded timestamps.
      * @return the beginning of the time range as milliseconds since the UNIX epoch
      */
-    epochtime_t get_epoch_start() const;
+    epochtime_t get_begin_timestamp() const;
 
     /**
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
@@ -123,7 +123,7 @@ public:
      * millisecond encoded timestamps.
      * @return the end of the time range as milliseconds since the UNIX epoch
      */
-    epochtime_t get_epoch_end() const;
+    epochtime_t get_end_timestamp() const;
 
 private:
     TimestampEncoding m_encoding;

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -110,20 +110,18 @@ public:
     }
 
     /**
-     * Get the beginning of this time range
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
      * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
      * millisecond encoded timestamps.
-     * @return the beginning of the time range in UNIX epoch time
+     * @return the beginning of the time range as milliseconds since the UNIX epoch
      */
     epochtime_t get_epoch_start() const;
 
     /**
-     * Get the end of this time range
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
      * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
      * millisecond encoded timestamps.
-     * @return the end of the time range in UNIX epoch time
+     * @return the end of the time range as milliseconds since the UNIX epoch
      */
     epochtime_t get_epoch_end() const;
 

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -109,6 +109,24 @@ public:
         m_column_ids.insert(column_ids.begin(), column_ids.end());
     }
 
+    /**
+     * Get the beginning of this time range
+     * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
+     * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
+     * millisecond encoded timestamps.
+     * @return the beginning of the time range in UNIX epoch time
+     */
+    epochtime_t get_epoch_start() const;
+
+    /**
+     * Get the end of this time range
+     * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and
+     * timestamp ranges makes no effort to convert second and nanosecond encoded timestamps into
+     * millisecond encoded timestamps.
+     * @return the end of the time range in UNIX epoch time
+     */
+    epochtime_t get_epoch_end() const;
+
 private:
     TimestampEncoding m_encoding;
     double m_epoch_start_double, m_epoch_end_double;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -58,16 +58,17 @@ int main(int argc, char const* argv[]) {
 
         boost::uuids::random_generator generator;
         auto archive_id = boost::uuids::to_string(generator());
-        auto archive_path
-                = std::filesystem::path(command_line_arguments.get_archives_dir()) / archive_id;
+        auto archives_dir
+                = std::filesystem::path(command_line_arguments.get_archives_dir()) auto archive_path
+                = archives_dir / archive_id;
 
         // Create output directory in case it doesn't exist
         try {
-            std::filesystem::create_directory(archive_path.parent_path().string());
+            std::filesystem::create_directory(archives_dir.string());
         } catch (std::exception& e) {
             SPDLOG_ERROR(
                     "Failed to create archives directory {} - {}",
-                    archive_path.parent_path().string(),
+                    archives_dir.string(),
                     e.what()
             );
             return 1;
@@ -112,7 +113,7 @@ int main(int argc, char const* argv[]) {
             );
             metadata.increment_static_compressed_size(parser.get_compressed_size());
             metadata.increment_static_uncompressed_size(parser.get_uncompressed_size());
-            metadata.expand_time_range(parser.get_epoch_start(), parser.get_epoch_end());
+            metadata.expand_time_range(parser.get_begin_timestamp(), parser.get_end_timestamp());
             metadata_db.open();
             metadata_db.add_archive(archive_id, metadata);
             metadata_db.close();

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -1,7 +1,9 @@
 #include <filesystem>
+#include <iostream>
 
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <json/single_include/nlohmann/json.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "../clp/GlobalMySQLMetadataDB.hpp"
@@ -82,6 +84,15 @@ int main(int argc, char const* argv[]) {
         parser.parse();
         parser.store();
         parser.close();
+
+        if (command_line_arguments.print_archive_stats()) {
+            nlohmann::json json_msg;
+            json_msg["id"] = archive_id;
+            json_msg["uncompressed_size"] = parser.get_uncompressed_size();
+            json_msg["size"] = parser.get_compressed_size();
+            std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
+                      << std::endl;
+        }
 
         if (command_line_arguments.get_metadata_db_config().has_value()) {
             auto const& db_config = command_line_arguments.get_metadata_db_config().value();

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -57,7 +57,7 @@ int main(int argc, char const* argv[]) {
         clp_s::TimestampPattern::init();
 
         boost::uuids::random_generator generator;
-        std::string archive_id = boost::uuids::to_string(generator());
+        auto archive_id = boost::uuids::to_string(generator());
         auto archive_path
                 = std::filesystem::path(command_line_arguments.get_archives_dir()) / archive_id;
 
@@ -66,7 +66,7 @@ int main(int argc, char const* argv[]) {
             std::filesystem::create_directory(archive_path.parent_path().string());
         } catch (std::exception& e) {
             SPDLOG_ERROR(
-                    "Failed to create archive directory {} - {}",
+                    "Failed to create archives directory {} - {}",
                     archive_path.parent_path().string(),
                     e.what()
             );

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -99,9 +99,7 @@ int main(int argc, char const* argv[]) {
                     "",
                     0ULL
             );
-            metadata.set_dynamic_compressed_size(parser.get_compressed_size());
             metadata.increment_static_compressed_size(parser.get_compressed_size());
-            metadata.set_dynamic_uncompressed_size(parser.get_uncompressed_size());
             metadata.increment_static_uncompressed_size(parser.get_uncompressed_size());
             metadata.expand_time_range(parser.get_epoch_start(), parser.get_epoch_end());
             metadata_db.open();

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -58,9 +58,8 @@ int main(int argc, char const* argv[]) {
 
         boost::uuids::random_generator generator;
         auto archive_id = boost::uuids::to_string(generator());
-        auto archives_dir
-                = std::filesystem::path(command_line_arguments.get_archives_dir()) auto archive_path
-                = archives_dir / archive_id;
+        auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
+        auto archive_path = archives_dir / archive_id;
 
         // Create output directory in case it doesn't exist
         try {

--- a/components/job-orchestration/job_orchestration/executor/compress/fs_compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/fs_compression_task.py
@@ -63,6 +63,7 @@ def make_clp_s_command(
     compression_cmd = [
         str(clp_home / "bin" / "clp-s"),
         "c", str(archive_output_dir),
+        "--print-archive-stats",
         "--target-encoded-size", str(clp_config.output.target_segment_size + clp_config.output.target_dictionaries_size),
         "--db-config-file", str(db_config_file_path),
     ]

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -24,6 +24,7 @@ def make_clo_command(
     results_cache_uri: str,
     results_collection: str,
 ):
+    # fmt: off
     search_cmd = [
         str(clp_home / "bin" / "clo"),
         results_cache_uri,
@@ -31,6 +32,7 @@ def make_clo_command(
         str(archive_path),
         search_config.query_string,
     ]
+    # fmt: on
 
     if search_config.begin_timestamp is not None:
         search_cmd.append("--tge")
@@ -43,6 +45,32 @@ def make_clo_command(
 
     return search_cmd
 
+def make_clp_s_command(
+    clp_home: Path,
+    archive_path: Path,
+    search_config: SearchConfig,
+    results_cache_uri: str,
+    results_collection: str,
+):
+    # fmt: off
+    search_cmd = [
+        str(clp_home / "bin" / "clp-s"),
+        "s",
+        str(archive_path),
+        search_config.query_string,
+        "--mongodb-uri", results_cache_uri,
+        "--mongodb-collection", results_collection,
+    ]
+    # fmt: on
+
+    if search_config.begin_timestamp is not None:
+        search_cmd.append("--tge")
+        search_cmd.append(str(search_config.begin_timestamp))
+    if search_config.end_timestamp is not None:
+        search_cmd.append("--tle")
+        search_cmd.append(str(search_config.end_timestamp))
+
+    return search_cmd
 
 @app.task(bind=True)
 def search(
@@ -73,6 +101,14 @@ def search(
 
     if StorageEngine.CLP == clp_storage_engine:
         search_cmd = make_clo_command(
+            clp_home=clp_home,
+            archive_path=archive_path,
+            search_config=search_config,
+            results_cache_uri=results_cache_uri,
+            results_collection=job_id,
+        )
+    elif StorageEngine.CLP_S == clp_storage_engine:
+        search_cmd = make_clp_s_command(
             clp_home=clp_home,
             archive_path=archive_path,
             search_config=search_config,

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -45,6 +45,7 @@ def make_clo_command(
 
     return search_cmd
 
+
 def make_clp_s_command(
     clp_home: Path,
     archive_path: Path,
@@ -71,6 +72,7 @@ def make_clp_s_command(
         search_cmd.append(str(search_config.end_timestamp))
 
     return search_cmd
+
 
 @app.task(bind=True)
 def search(

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -15,6 +15,7 @@ class PathsToCompress(BaseModel):
 class InputConfig(BaseModel):
     list_path: str
     path_prefix_to_remove: str = None
+    timestamp_key: typing.Optional[str] = None
 
 
 class OutputConfig(BaseModel):


### PR DESCRIPTION
# Description
Adds support for clp-s as a storage engine in the clp package.
* Add StorageEngine configuration parameter for clp-s
* Add option for clp-s to record archive metadata in MySQL database at compression time
* Change clp-s compression behaviour to create an archive in the directory specified by the user instead of as the archive specified by the user
* Add optional timestamp-key argument to compression jobs

# Validation performed
* Ingested data with the clp-s storage engine and timestamp-key argument
* Verified that search using timestamp arguments returns correct results

