### PR TITLE
Add new timestamp formats and refactor timestamp code in clp-s (fixes #261)

### DIFF
--- a/components/core/src/clp/TimestampPattern.cpp
+++ b/components/core/src/clp/TimestampPattern.cpp
@@ -124,38 +124,45 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S.%3");
     // E.g. 2015-01-31T15:50:45,392
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S,%3");
-    // E.g. [2015-01-31T15:50:45
-    patterns.emplace_back(0, "[%Y-%m-%dT%H:%M:%S");
-    // E.g. [20170106-16:56:41]
-    patterns.emplace_back(0, "[%Y%m%d-%H:%M:%S]");
-    // E.g. 2015-01-31 15:50:45,392
-    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. 2015-01-31 15:50:45.392
     patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S.%3");
-    // E.g. [2015-01-31 15:50:45,085]
-    patterns.emplace_back(0, "[%Y-%m-%d %H:%M:%S,%3]");
-    // E.g. 2015-01-31 15:50:45
-    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S");
-    // E.g. Start-Date: 2015-01-31  15:50:45
-    patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
-    // E.g. 2015/01/31 15:50:45
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
-    // E.g. 2015/01/31 15:50:45.123
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
-    // E.g. 2015/01/31 15:50:45,123
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
-    // E.g. 2015/01/31T15:50:45
-    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015-01-31 15:50:45,392
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. 2015/01/31T15:50:45.123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%3");
     // E.g. 2015/01/31T15:50:45,123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S,%3");
+    // E.g. 2015/01/31 15:50:45.123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
+    // E.g. 2015/01/31 15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
+    // E.g. [2015-01-31 15:50:45,085]
+    patterns.emplace_back(0, "[%Y-%m-%d %H:%M:%S,%3]");
+    // E.g. INFO [main] 2015-01-31 15:50:45,085
+    patterns.emplace_back(2, "%Y-%m-%d %H:%M:%S,%3");
+    // E.g. <<<2016-11-10 03:02:29:936
+    patterns.emplace_back(0, "<<<%Y-%m-%d %H:%M:%S:%3");
+    // E.g. 01 Jan 2016 15:50:17,085
+    patterns.emplace_back(0, "%d %b %Y %H:%M:%S,%3");
+
+    // E.g. 2015-01-31T15:50:45
+    patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S");
+    // E.g. 2015-01-31 15:50:45
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S");
+    // E.g. 2015/01/31T15:50:45
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015/01/31 15:50:45
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
+    // E.g. [2015-01-31T15:50:45
+    patterns.emplace_back(0, "[%Y-%m-%dT%H:%M:%S");
+    // E.g. [20170106-16:56:41]
+    patterns.emplace_back(0, "[%Y%m%d-%H:%M:%S]");
+    // E.g. Start-Date: 2015-01-31  15:50:45
+    patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
     // E.g. 15/01/31 15:50:45
     patterns.emplace_back(0, "%y/%m/%d %H:%M:%S");
     // E.g. 150131  9:50:45
     patterns.emplace_back(0, "%y%m%d %k:%M:%S");
-    // E.g. 01 Jan 2016 15:50:17,085
-    patterns.emplace_back(0, "%d %b %Y %H:%M:%S,%3");
     // E.g. Jan 01, 2016 3:50:17 PM
     patterns.emplace_back(0, "%b %d, %Y %l:%M:%S %p");
     // E.g. January 31, 2015 15:50
@@ -167,16 +174,12 @@ void TimestampPattern::init() {
     patterns.emplace_back(3, "[%d/%b/%Y:%H:%M:%S");
     // E.g. 192.168.4.5 - - [01/01/2016:15:50:17
     patterns.emplace_back(3, "[%d/%m/%Y:%H:%M:%S");
-    // E.g. INFO [main] 2015-01-31 15:50:45,085
-    patterns.emplace_back(2, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. Started POST "/api/v3/internal/allowed" for 127.0.0.1 at 2017-06-18 00:20:44
     patterns.emplace_back(6, "%Y-%m-%d %H:%M:%S");
     // E.g. update-alternatives 2015-01-31 15:50:45
     patterns.emplace_back(1, "%Y-%m-%d %H:%M:%S");
     // E.g. ERROR: apport (pid 4557) Sun Jan  1 15:50:45 2015
     patterns.emplace_back(4, "%a %b %e %H:%M:%S %Y");
-    // E.g. <<<2016-11-10 03:02:29:936
-    patterns.emplace_back(0, "<<<%Y-%m-%d %H:%M:%S:%3");
     // E.g. Sun Jan  1 15:50:45 2015
     patterns.emplace_back(0, "%a %b %e %H:%M:%S %Y");
 

--- a/components/core/src/clp/TimestampPattern.cpp
+++ b/components/core/src/clp/TimestampPattern.cpp
@@ -144,7 +144,7 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
     // E.g. 2015/01/31 15:50:45,123
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
-    // E.g. 2015/01/31T15:50:45,123
+    // E.g. 2015/01/31T15:50:45
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
     // E.g. 2015/01/31T15:50:45.123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%3");

--- a/components/core/src/clp/TimestampPattern.cpp
+++ b/components/core/src/clp/TimestampPattern.cpp
@@ -140,6 +140,16 @@ void TimestampPattern::init() {
     patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
     // E.g. 2015/01/31 15:50:45
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
+    // E.g. 2015/01/31 15:50:45.123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
+    // E.g. 2015/01/31 15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
+    // E.g. 2015/01/31T15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015/01/31T15:50:45.123
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%3");
+    // E.g. 2015/01/31T15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S,%3");
     // E.g. 15/01/31 15:50:45
     patterns.emplace_back(0, "%y/%m/%d %H:%M:%S");
     // E.g. 150131  9:50:45

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -112,9 +112,6 @@ void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const&
             case NodeType::DATESTRING:
                 writer->append_column(new DateStringColumnWriter(id));
                 break;
-            case NodeType::FLOATDATESTRING:
-                writer->append_column(new FloatColumnWriter(id));
-                break;
             case NodeType::OBJECT:
             case NodeType::NULLVALUE:
                 break;

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -90,37 +90,30 @@ size_t ArchiveWriter::get_data_size() {
 void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const& schema) {
     for (int32_t id : schema) {
         auto node = m_schema_tree->get_node(id);
-        std::string key_name = node->get_key_name();
         switch (node->get_type()) {
             case NodeType::INTEGER:
-                writer->append_column(new Int64ColumnWriter(key_name, id));
+                writer->append_column(new Int64ColumnWriter(id));
                 break;
             case NodeType::FLOAT:
-                writer->append_column(new FloatColumnWriter(key_name, id));
+                writer->append_column(new FloatColumnWriter(id));
                 break;
             case NodeType::CLPSTRING:
-                writer->append_column(
-                        new ClpStringColumnWriter(key_name, id, m_var_dict, m_log_dict)
-                );
+                writer->append_column(new ClpStringColumnWriter(id, m_var_dict, m_log_dict));
                 break;
             case NodeType::VARSTRING:
-                writer->append_column(new VariableStringColumnWriter(key_name, id, m_var_dict));
+                writer->append_column(new VariableStringColumnWriter(id, m_var_dict));
                 break;
             case NodeType::BOOLEAN:
-                writer->append_column(new BooleanColumnWriter(key_name, id));
+                writer->append_column(new BooleanColumnWriter(id));
                 break;
             case NodeType::ARRAY:
-                writer->append_column(
-                        new ClpStringColumnWriter(key_name, id, m_var_dict, m_array_dict)
-                );
+                writer->append_column(new ClpStringColumnWriter(id, m_var_dict, m_array_dict));
                 break;
             case NodeType::DATESTRING:
-                writer->append_column(new DateStringColumnWriter(key_name, id, m_timestamp_dict));
+                writer->append_column(new DateStringColumnWriter(id));
                 break;
             case NodeType::FLOATDATESTRING:
-                writer->append_column(
-                        new FloatDateStringColumnWriter(key_name, id, m_timestamp_dict)
-                );
+                writer->append_column(new FloatDateStringColumnWriter(id));
                 break;
             case NodeType::OBJECT:
             case NodeType::NULLVALUE:

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -113,7 +113,7 @@ void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const&
                 writer->append_column(new DateStringColumnWriter(id));
                 break;
             case NodeType::FLOATDATESTRING:
-                writer->append_column(new FloatDateStringColumnWriter(id));
+                writer->append_column(new FloatColumnWriter(id));
                 break;
             case NodeType::OBJECT:
             case NodeType::NULLVALUE:

--- a/components/core/src/clp_s/ColumnReader.cpp
+++ b/components/core/src/clp_s/ColumnReader.cpp
@@ -156,22 +156,4 @@ std::variant<int64_t, double, std::string, uint8_t> DateStringColumnReader::extr
 epochtime_t DateStringColumnReader::get_encoded_time(uint64_t cur_message) {
     return m_timestamps[cur_message];
 }
-
-void FloatDateStringColumnReader::load(ZstdDecompressor& decompressor, uint64_t num_messages) {
-    m_timestamps = std::make_unique<double[]>(num_messages);
-    decompressor.try_read_exact_length(
-            reinterpret_cast<char*>(m_timestamps.get()),
-            num_messages * sizeof(double)
-    );
-}
-
-std::variant<int64_t, double, std::string, uint8_t> FloatDateStringColumnReader::extract_value(
-        uint64_t cur_message
-) {
-    return std::to_string(m_timestamps[cur_message]);
-}
-
-double FloatDateStringColumnReader::get_encoded_time(uint64_t cur_message) {
-    return m_timestamps[cur_message];
-}
 }  // namespace clp_s

--- a/components/core/src/clp_s/ColumnReader.hpp
+++ b/components/core/src/clp_s/ColumnReader.hpp
@@ -234,32 +234,6 @@ private:
     std::unique_ptr<int64_t[]> m_timestamps;
     std::unique_ptr<int64_t[]> m_timestamp_encodings;
 };
-
-class FloatDateStringColumnReader : public BaseColumnReader {
-public:
-    // Constructor
-    FloatDateStringColumnReader(std::string const& name, int32_t id) : BaseColumnReader(name, id) {}
-
-    // Destructor
-    ~FloatDateStringColumnReader() override = default;
-
-    // Methods inherited from BaseColumnReader
-    void load(ZstdDecompressor& decompressor, uint64_t num_messages) override;
-
-    std::string get_type() override { return "string"; }
-
-    std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message
-    ) override;
-
-    /**
-     * @param cur_message
-     * @return The encoded time in float epoch time
-     */
-    double get_encoded_time(uint64_t cur_message);
-
-private:
-    std::unique_ptr<double[]> m_timestamps;
-};
 }  // namespace clp_s
 
 #endif  // CLP_S_COLUMNREADER_HPP

--- a/components/core/src/clp_s/ColumnWriter.cpp
+++ b/components/core/src/clp_s/ColumnWriter.cpp
@@ -98,17 +98,4 @@ void DateStringColumnWriter::store(ZstdCompressor& compressor) {
             m_timestamp_encodings.size() * sizeof(int64_t)
     );
 }
-
-void FloatDateStringColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
-    size = sizeof(double);
-    double timestamp = std::get<double>(value);
-    m_timestamps.push_back(timestamp);
-}
-
-void FloatDateStringColumnWriter::store(ZstdCompressor& compressor) {
-    compressor.write(
-            reinterpret_cast<char const*>(m_timestamps.data()),
-            m_timestamps.size() * sizeof(double)
-    );
-}
 }  // namespace clp_s

--- a/components/core/src/clp_s/ColumnWriter.cpp
+++ b/components/core/src/clp_s/ColumnWriter.cpp
@@ -1,10 +1,7 @@
 #include "ColumnWriter.hpp"
 
 namespace clp_s {
-void Int64ColumnWriter::add_value(
-        std::variant<int64_t, double, std::string, bool>& value,
-        size_t& size
-) {
+void Int64ColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
     size = sizeof(int64_t);
     m_values.push_back(std::get<int64_t>(value));
 }
@@ -16,10 +13,7 @@ void Int64ColumnWriter::store(ZstdCompressor& compressor) {
     );
 }
 
-void FloatColumnWriter::add_value(
-        std::variant<int64_t, double, std::string, bool>& value,
-        size_t& size
-) {
+void FloatColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
     size = sizeof(double);
     m_values.push_back(std::get<double>(value));
 }
@@ -31,10 +25,7 @@ void FloatColumnWriter::store(ZstdCompressor& compressor) {
     );
 }
 
-void BooleanColumnWriter::add_value(
-        std::variant<int64_t, double, std::string, bool>& value,
-        size_t& size
-) {
+void BooleanColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
     size = sizeof(uint8_t);
     m_values.push_back(std::get<bool>(value) ? 1 : 0);
 }
@@ -46,10 +37,7 @@ void BooleanColumnWriter::store(ZstdCompressor& compressor) {
     );
 }
 
-void ClpStringColumnWriter::add_value(
-        std::variant<int64_t, double, std::string, bool>& value,
-        size_t& size
-) {
+void ClpStringColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
     size = sizeof(int64_t);
     std::string string_var = std::get<std::string>(value);
     uint64_t id;
@@ -78,10 +66,7 @@ void ClpStringColumnWriter::store(ZstdCompressor& compressor) {
     );
 }
 
-void VariableStringColumnWriter::add_value(
-        std::variant<int64_t, double, std::string, bool>& value,
-        size_t& size
-) {
+void VariableStringColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
     size = sizeof(int64_t);
     std::string string_var = std::get<std::string>(value);
     uint64_t id;
@@ -96,19 +81,11 @@ void VariableStringColumnWriter::store(ZstdCompressor& compressor) {
     );
 }
 
-void DateStringColumnWriter::add_value(
-        std::variant<int64_t, double, std::string, bool>& value,
-        size_t& size
-) {
+void DateStringColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
     size = 2 * sizeof(int64_t);
-    std::string string_timestamp = std::get<std::string>(value);
-
-    uint64_t encoding_id;
-    epochtime_t timestamp
-            = m_timestamp_dict->ingest_entry(m_name, m_id, string_timestamp, encoding_id);
-
-    m_timestamps.push_back(timestamp);
-    m_timestamp_encodings.push_back(encoding_id);
+    auto encoded_timestamp = std::get<std::pair<uint64_t, epochtime_t>>(value);
+    m_timestamps.push_back(encoded_timestamp.second);
+    m_timestamp_encodings.push_back(encoded_timestamp.first);
 }
 
 void DateStringColumnWriter::store(ZstdCompressor& compressor) {
@@ -122,15 +99,9 @@ void DateStringColumnWriter::store(ZstdCompressor& compressor) {
     );
 }
 
-void FloatDateStringColumnWriter::add_value(
-        std::variant<int64_t, double, std::string, bool>& value,
-        size_t& size
-) {
+void FloatDateStringColumnWriter::add_value(ParsedMessage::variable_t& value, size_t& size) {
     size = sizeof(double);
     double timestamp = std::get<double>(value);
-
-    m_timestamp_dict->ingest_entry(m_name, m_id, timestamp);
-
     m_timestamps.push_back(timestamp);
 }
 

--- a/components/core/src/clp_s/ColumnWriter.hpp
+++ b/components/core/src/clp_s/ColumnWriter.hpp
@@ -174,7 +174,7 @@ private:
 class DateStringColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    DateStringColumnWriter(int32_t id) : BaseColumnWriter(id) {}
+    explicit DateStringColumnWriter(int32_t id) : BaseColumnWriter(id) {}
 
     // Destructor
     ~DateStringColumnWriter() override = default;

--- a/components/core/src/clp_s/ColumnWriter.hpp
+++ b/components/core/src/clp_s/ColumnWriter.hpp
@@ -8,6 +8,7 @@
 
 #include "DictionaryWriter.hpp"
 #include "FileWriter.hpp"
+#include "ParsedMessage.hpp"
 #include "TimestampDictionaryWriter.hpp"
 #include "VariableEncoder.hpp"
 #include "ZstdCompressor.hpp"
@@ -18,7 +19,7 @@ namespace clp_s {
 class BaseColumnWriter {
 public:
     // Constructor
-    explicit BaseColumnWriter(std::string name, int32_t id) : m_name(std::move(name)), m_id(id) {}
+    explicit BaseColumnWriter(int32_t id) : m_id(id) {}
 
     // Destructor
     virtual ~BaseColumnWriter() = default;
@@ -28,8 +29,7 @@ public:
      * @param value
      * @param size
      */
-    virtual void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size)
-            = 0;
+    virtual void add_value(ParsedMessage::variable_t& value, size_t& size) = 0;
 
     /**
      * Stores the column to a compressed file
@@ -37,27 +37,20 @@ public:
      */
     virtual void store(ZstdCompressor& compressor) = 0;
 
-    /**
-     * @return Name of the column
-     */
-    std::string get_name() { return m_name; }
-
 protected:
-    std::string m_name;
     int32_t m_id;
 };
 
 class Int64ColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    explicit Int64ColumnWriter(std::string name, int32_t id)
-            : BaseColumnWriter(std::move(name), id) {}
+    explicit Int64ColumnWriter(int32_t id) : BaseColumnWriter(id) {}
 
     // Destructor
     ~Int64ColumnWriter() override = default;
 
     // Methods inherited from BaseColumnWriter
-    void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size) override;
+    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
 
     void store(ZstdCompressor& compressor) override;
 
@@ -68,14 +61,13 @@ private:
 class FloatColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    explicit FloatColumnWriter(std::string name, int32_t id)
-            : BaseColumnWriter(std::move(name), id) {}
+    explicit FloatColumnWriter(int32_t id) : BaseColumnWriter(id) {}
 
     // Destructor
     ~FloatColumnWriter() override = default;
 
     // Methods inherited from BaseColumnWriter
-    void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size) override;
+    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
 
     void store(ZstdCompressor& compressor) override;
 
@@ -86,14 +78,13 @@ private:
 class BooleanColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    explicit BooleanColumnWriter(std::string name, int32_t id)
-            : BaseColumnWriter(std::move(name), id) {}
+    explicit BooleanColumnWriter(int32_t id) : BaseColumnWriter(id) {}
 
     // Destructor
     ~BooleanColumnWriter() override = default;
 
     // Methods inherited from BaseColumnWriter
-    void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size) override;
+    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
 
     void store(ZstdCompressor& compressor) override;
 
@@ -105,12 +96,11 @@ class ClpStringColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
     ClpStringColumnWriter(
-            std::string const& name,
             int32_t id,
             std::shared_ptr<VariableDictionaryWriter> var_dict,
             std::shared_ptr<LogTypeDictionaryWriter> log_dict
     )
-            : BaseColumnWriter(name, id),
+            : BaseColumnWriter(id),
               m_var_dict(std::move(var_dict)),
               m_log_dict(std::move(log_dict)) {}
 
@@ -118,7 +108,7 @@ public:
     ~ClpStringColumnWriter() override = default;
 
     // Methods inherited from BaseColumnWriter
-    void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size) override;
+    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
 
     void store(ZstdCompressor& compressor) override;
 
@@ -164,19 +154,15 @@ private:
 class VariableStringColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    VariableStringColumnWriter(
-            std::string const& name,
-            int32_t id,
-            std::shared_ptr<VariableDictionaryWriter> var_dict
-    )
-            : BaseColumnWriter(name, id),
+    VariableStringColumnWriter(int32_t id, std::shared_ptr<VariableDictionaryWriter> var_dict)
+            : BaseColumnWriter(id),
               m_var_dict(std::move(var_dict)) {}
 
     // Destructor
     ~VariableStringColumnWriter() override = default;
 
     // Methods inherited from BaseColumnWriter
-    void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size) override;
+    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
 
     void store(ZstdCompressor& compressor) override;
 
@@ -188,25 +174,17 @@ private:
 class DateStringColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    DateStringColumnWriter(
-            std::string const& name,
-            int32_t id,
-            std::shared_ptr<TimestampDictionaryWriter> timestamp_dict
-    )
-            : BaseColumnWriter(name, id),
-              m_timestamp_dict(std::move(timestamp_dict)) {}
+    DateStringColumnWriter(int32_t id) : BaseColumnWriter(id) {}
 
     // Destructor
     ~DateStringColumnWriter() override = default;
 
     // Methods inherited from BaseColumnWriter
-    void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size) override;
+    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
 
     void store(ZstdCompressor& compressor) override;
 
 private:
-    std::shared_ptr<TimestampDictionaryWriter> m_timestamp_dict;
-
     std::vector<int64_t> m_timestamps;
     std::vector<int64_t> m_timestamp_encodings;
 };
@@ -214,25 +192,17 @@ private:
 class FloatDateStringColumnWriter : public BaseColumnWriter {
 public:
     // Constructor
-    FloatDateStringColumnWriter(
-            std::string const& name,
-            int32_t id,
-            std::shared_ptr<TimestampDictionaryWriter> timestamp_dict
-    )
-            : BaseColumnWriter(name, id),
-              m_timestamp_dict(std::move(timestamp_dict)) {}
+    FloatDateStringColumnWriter(int32_t id) : BaseColumnWriter(id) {}
 
     // Destructor
     ~FloatDateStringColumnWriter() override = default;
 
     // Methods inherited from BaseColumnWriter
-    void add_value(std::variant<int64_t, double, std::string, bool>& value, size_t& size) override;
+    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
 
     void store(ZstdCompressor& compressor) override;
 
 private:
-    std::shared_ptr<TimestampDictionaryWriter> m_timestamp_dict;
-
     std::vector<double> m_timestamps;
 };
 }  // namespace clp_s

--- a/components/core/src/clp_s/ColumnWriter.hpp
+++ b/components/core/src/clp_s/ColumnWriter.hpp
@@ -188,23 +188,6 @@ private:
     std::vector<int64_t> m_timestamps;
     std::vector<int64_t> m_timestamp_encodings;
 };
-
-class FloatDateStringColumnWriter : public BaseColumnWriter {
-public:
-    // Constructor
-    FloatDateStringColumnWriter(int32_t id) : BaseColumnWriter(id) {}
-
-    // Destructor
-    ~FloatDateStringColumnWriter() override = default;
-
-    // Methods inherited from BaseColumnWriter
-    void add_value(ParsedMessage::variable_t& value, size_t& size) override;
-
-    void store(ZstdCompressor& compressor) override;
-
-private:
-    std::vector<double> m_timestamps;
-};
 }  // namespace clp_s
 
 #endif  // CLP_S_COLUMNWRITER_HPP

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -151,7 +151,9 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                 );
                 if (matches_timestamp) {
                     double ret_double;
-                    if (StringUtils::convert_string_to_double(value, ret_double)) {
+                    if (std::string::npos != value.find('.')
+                        && StringUtils::convert_string_to_double(value, ret_double))
+                    {
                         node_id = m_schema_tree->add_node(
                                 node_id_stack.top(),
                                 NodeType::FLOATDATESTRING,

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -150,32 +150,16 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                         line.raw_json_token().substr(1, line.raw_json_token().size() - 2)
                 );
                 if (matches_timestamp) {
-                    double ret_double;
-                    if (std::string::npos != value.find('.')
-                        && StringUtils::convert_string_to_double(value, ret_double))
-                    {
-                        node_id = m_schema_tree->add_node(
-                                node_id_stack.top(),
-                                NodeType::FLOATDATESTRING,
-                                cur_key
-                        );
-                        m_timestamp_dictionary->ingest_entry(m_timestamp_key, node_id, ret_double);
-                        m_current_parsed_message.add_value(node_id, ret_double);
-                    } else {
-                        node_id = m_schema_tree->add_node(
-                                node_id_stack.top(),
-                                NodeType::DATESTRING,
-                                cur_key
-                        );
-                        uint64_t encoding_id{0};
-                        epochtime_t timestamp = m_timestamp_dictionary->ingest_entry(
-                                m_timestamp_key,
-                                node_id,
-                                value,
-                                encoding_id
-                        );
-                        m_current_parsed_message.add_value(node_id, encoding_id, timestamp);
-                    }
+                    node_id = m_schema_tree->add_node(
+                            node_id_stack.top(),
+                            NodeType::DATESTRING,
+                            cur_key
+                    );
+                    uint64_t encoding_id{0};
+                    epochtime_t timestamp
+                            = m_timestamp_dictionary
+                                      ->ingest_entry(m_timestamp_key, node_id, value, encoding_id);
+                    m_current_parsed_message.add_value(node_id, encoding_id, timestamp);
                     matches_timestamp = may_match_timestamp = can_match_timestamp = false;
                 } else if (value.find(' ') != std::string::npos) {
                     node_id = m_schema_tree

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -157,16 +157,24 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                         node_id = m_schema_tree->add_node(
                                 node_id_stack.top(),
                                 NodeType::FLOATDATESTRING,
-                                m_timestamp_key
+                                cur_key
                         );
+                        m_timestamp_dictionary->ingest_entry(m_timestamp_key, node_id, ret_double);
                         m_current_parsed_message.add_value(node_id, ret_double);
                     } else {
                         node_id = m_schema_tree->add_node(
                                 node_id_stack.top(),
                                 NodeType::DATESTRING,
-                                m_timestamp_key
+                                cur_key
                         );
-                        m_current_parsed_message.add_value(node_id, value);
+                        uint64_t encoding_id{0};
+                        epochtime_t timestamp = m_timestamp_dictionary->ingest_entry(
+                                m_timestamp_key,
+                                node_id,
+                                value,
+                                encoding_id
+                        );
+                        m_current_parsed_message.add_value(node_id, encoding_id, timestamp);
                     }
                     matches_timestamp = may_match_timestamp = can_match_timestamp = false;
                 } else if (value.find(' ') != std::string::npos) {

--- a/components/core/src/clp_s/ParsedMessage.hpp
+++ b/components/core/src/clp_s/ParsedMessage.hpp
@@ -6,9 +6,15 @@
 #include <utility>
 #include <variant>
 
+#include "Defs.hpp"
+
 namespace clp_s {
 class ParsedMessage {
 public:
+    // Types
+    using variable_t
+            = std::variant<int64_t, double, std::string, bool, std::pair<uint64_t, epochtime_t>>;
+
     // Constructor
     ParsedMessage() : m_schema_id(-1) {}
 
@@ -18,17 +24,43 @@ public:
     void set_id(int32_t schema_id) { m_schema_id = schema_id; }
 
     /**
-     * Adds a value with different types to the message
+     * Adds an int64_t value to the message for a given MST node ID.
      * @param node_id
      * @param value
      */
-    inline void add_value(int32_t node_id, int64_t value) { m_message[node_id] = value; }
+    inline void add_value(int32_t node_id, int64_t value) { m_message.emplace(node_id, value); }
 
-    inline void add_value(int32_t node_id, double value) { m_message[node_id] = value; }
+    /**
+     * Adds a double value to the message for a given MST node ID.
+     * @param node_id
+     * @param value
+     */
+    inline void add_value(int32_t node_id, double value) { m_message.emplace(node_id, value); }
 
-    inline void add_value(int32_t node_id, std::string const& value) { m_message[node_id] = value; }
+    /**
+     * Adds a string value to the message for a given MST node ID.
+     * @param node_id
+     * @param value
+     */
+    inline void add_value(int32_t node_id, std::string const& value) {
+        m_message.emplace(node_id, value);
+    }
 
-    inline void add_value(int32_t node_id, bool value) { m_message[node_id] = value; }
+    /**
+     * Adds a boolean value to the message for a given MST node ID.
+     * @param node_id
+     * @param value
+     */
+    inline void add_value(int32_t node_id, bool value) { m_message.emplace(node_id, value); }
+
+    /**
+     * Adds a timestamp value and its encoding to the message for a given MST node ID.
+     * @param node_id
+     * @param value
+     */
+    inline void add_value(int32_t node_id, uint64_t encoding_id, epochtime_t value) {
+        m_message.emplace(node_id, std::make_pair(encoding_id, value));
+    }
 
     /**
      * Clears the message
@@ -41,13 +73,11 @@ public:
     /**
      * @return The content of the message
      */
-    std::map<int32_t, std::variant<int64_t, double, std::string, bool>>& get_content() {
-        return m_message;
-    }
+    std::map<int32_t, variable_t>& get_content() { return m_message; }
 
 private:
     int32_t m_schema_id;
-    std::map<int32_t, std::variant<int64_t, double, std::string, bool>> m_message;
+    std::map<int32_t, variable_t> m_message;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -221,9 +221,6 @@ void ReaderUtils::append_reader_columns(
             case NodeType::DATESTRING:
                 reader->append_column(new DateStringColumnReader(key_name, column, timestamp_dict));
                 break;
-            case NodeType::FLOATDATESTRING:
-                reader->append_column(new FloatDateStringColumnReader(key_name, column));
-                break;
             case NodeType::OBJECT:
             case NodeType::NULLVALUE:
                 reader->append_column(column);

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -271,8 +271,7 @@ void SchemaReader::generate_json_template(int32_t id) {
             }
             case NodeType::CLPSTRING:
             case NodeType::VARSTRING:
-            case NodeType::DATESTRING:
-            case NodeType::FLOATDATESTRING: {
+            case NodeType::DATESTRING: {
                 m_json_serializer->add_op(JsonSerializer::Op::AddStringField);
                 m_reordered_columns.push_back(m_column_map[child_global_id]);
                 break;

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -25,12 +25,6 @@ void SchemaReader::mark_column_as_timestamp(BaseColumnReader* column_reader) {
             return static_cast<DateStringColumnReader*>(m_timestamp_column)
                     ->get_encoded_time(m_cur_message);
         };
-    } else if (m_timestamp_column->get_type() == NodeType::FLOATDATESTRING) {
-        m_get_timestamp = [this]() {
-            double timestamp = static_cast<FloatDateStringColumnReader*>(m_timestamp_column)
-                                       ->get_encoded_time(m_cur_message);
-            return static_cast<epochtime_t>(timestamp);
-        };
     } else if (m_timestamp_column->get_type() == NodeType::INTEGER) {
         m_get_timestamp = [this]() {
             return std::get<epochtime_t>(m_extracted_values[m_timestamp_column->get_id()]);

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -19,8 +19,7 @@ enum class NodeType : uint8_t {
     OBJECT,
     ARRAY,
     NULLVALUE,
-    DATESTRING,
-    FLOATDATESTRING
+    DATESTRING
 };
 
 class SchemaNode {

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -46,13 +46,10 @@ void TimestampDictionaryReader::read_new_entries(bool local) {
 
     for (uint64_t i = 0; i < range_index_size; ++i) {
         TimestampEntry entry;
-        entry.try_read_from_file(m_dictionary_decompressor);
-        m_entries.emplace_back(std::move(entry));
-
-        std::string column_name = entry.get_key_name();
         std::vector<std::string> tokens;
-        StringUtils::tokenize_column_descriptor(column_name, tokens);
-        m_tokenized_column_to_range.emplace_back(std::move(tokens), &m_entries.back());
+        entry.try_read_from_file(m_dictionary_decompressor);
+        StringUtils::tokenize_column_descriptor(entry.get_key_name(), tokens);
+        m_entries.emplace_back(std::move(entry));
 
         // TODO: Currently, we only allow a single authoritative timestamp column at ingestion time,
         // but the timestamp dictionary is designed to store the ranges of several timestamp
@@ -62,6 +59,8 @@ void TimestampDictionaryReader::read_new_entries(bool local) {
             m_authoritative_timestamp_column_ids = m_entries.back().get_column_ids();
             m_authoritative_timestamp_tokenized_column = tokens;
         }
+
+        m_tokenized_column_to_range.emplace_back(std::move(tokens), &m_entries.back());
     }
 
     // Local timestamp dictionaries only contain range indices, and

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -211,6 +211,18 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S.%TZ");
     // E.g. 2022-04-06T03:33:23Z
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%SZ");
+    // E.g. 2022-04-06 03:33:23.476Z ...47, ...4 ...()
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S.%TZ");
+    // E.g. 2022-04-06 03:33:23Z
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%SZ");
+    // E.g. 2022/04/06T03:33:23.476Z ...47, ...4 ...()
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%TZ");
+    // E.g. 2022/04/06T03:33:23Z
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%SZ");
+    // E.g. 2022/04/06 03:33:23.476Z ...47, ...4 ...()
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%TZ");
+    // E.g. 2022/04/06 03:33:23Z
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%SZ");
     // E.g. 2015-01-31T15:50:45.392
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S.%3");
     // E.g. 2015-01-31T15:50:45,392

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -211,6 +211,7 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%E");
     // E.g. 1679711330.789032462
     patterns.emplace_back(0, "%F");
+
     // E.g. 2022-04-06T03:33:23.476Z ...47, ...4 ...()
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S.%TZ");
     // E.g. 2022-04-06T03:33:23Z
@@ -227,42 +228,49 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%TZ");
     // E.g. 2022/04/06 03:33:23Z
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%SZ");
+
     // E.g. 2015-01-31T15:50:45.392
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S.%3");
     // E.g. 2015-01-31T15:50:45,392
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S,%3");
-    // E.g. [2015-01-31T15:50:45
-    patterns.emplace_back(0, "[%Y-%m-%dT%H:%M:%S");
-    // E.g. [20170106-16:56:41]
-    patterns.emplace_back(0, "[%Y%m%d-%H:%M:%S]");
-    // E.g. 2015-01-31 15:50:45,392
-    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. 2015-01-31 15:50:45.392
     patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S.%3");
-    // E.g. [2015-01-31 15:50:45,085]
-    patterns.emplace_back(0, "[%Y-%m-%d %H:%M:%S,%3]");
-    // E.g. 2015-01-31 15:50:45
-    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S");
-    // E.g. Start-Date: 2015-01-31  15:50:45
-    patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
-    // E.g. 2015/01/31 15:50:45
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
-    // E.g. 2015/01/31 15:50:45.123
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
-    // E.g. 2015/01/31 15:50:45,123
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
-    // E.g. 2015/01/31T15:50:45
-    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015-01-31 15:50:45,392
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. 2015/01/31T15:50:45.123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%3");
     // E.g. 2015/01/31T15:50:45,123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S,%3");
+    // E.g. 2015/01/31 15:50:45.123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
+    // E.g. 2015/01/31 15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
+    // E.g. [2015-01-31 15:50:45,085]
+    patterns.emplace_back(0, "[%Y-%m-%d %H:%M:%S,%3]");
+    // E.g. INFO [main] 2015-01-31 15:50:45,085
+    patterns.emplace_back(2, "%Y-%m-%d %H:%M:%S,%3");
+    // E.g. <<<2016-11-10 03:02:29:936
+    patterns.emplace_back(0, "<<<%Y-%m-%d %H:%M:%S:%3");
+    // E.g. 01 Jan 2016 15:50:17,085
+    patterns.emplace_back(0, "%d %b %Y %H:%M:%S,%3");
+    // E.g. 2015-01-31T15:50:45
+    patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S");
+    // E.g. 2015-01-31 15:50:45
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S");
+    // E.g. 2015/01/31T15:50:45
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015/01/31 15:50:45
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
+    // E.g. [2015-01-31T15:50:45
+    patterns.emplace_back(0, "[%Y-%m-%dT%H:%M:%S");
+    // E.g. [20170106-16:56:41]
+    patterns.emplace_back(0, "[%Y%m%d-%H:%M:%S]");
+    // E.g. Start-Date: 2015-01-31  15:50:45
+    patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
     // E.g. 15/01/31 15:50:45
     patterns.emplace_back(0, "%y/%m/%d %H:%M:%S");
     // E.g. 150131  9:50:45
     patterns.emplace_back(0, "%y%m%d %k:%M:%S");
-    // E.g. 01 Jan 2016 15:50:17,085
-    patterns.emplace_back(0, "%d %b %Y %H:%M:%S,%3");
     // E.g. Jan 01, 2016 3:50:17 PM
     patterns.emplace_back(0, "%b %d, %Y %l:%M:%S %p");
     // E.g. January 31, 2015 15:50
@@ -274,16 +282,14 @@ void TimestampPattern::init() {
     patterns.emplace_back(3, "[%d/%b/%Y:%H:%M:%S");
     // E.g. 192.168.4.5 - - [01/01/2016:15:50:17
     patterns.emplace_back(3, "[%d/%m/%Y:%H:%M:%S");
-    // E.g. INFO [main] 2015-01-31 15:50:45,085
-    patterns.emplace_back(2, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. Started POST "/api/v3/internal/allowed" for 127.0.0.1 at 2017-06-18 00:20:44
     patterns.emplace_back(6, "%Y-%m-%d %H:%M:%S");
     // E.g. update-alternatives 2015-01-31 15:50:45
     patterns.emplace_back(1, "%Y-%m-%d %H:%M:%S");
     // E.g. ERROR: apport (pid 4557) Sun Jan  1 15:50:45 2015
     patterns.emplace_back(4, "%a %b %e %H:%M:%S %Y");
-    // E.g. <<<2016-11-10 03:02:29:936
-    patterns.emplace_back(0, "<<<%Y-%m-%d %H:%M:%S:%3");
+    // E.g. Sun Jan  1 15:50:45 2015
+    patterns.emplace_back(0, "%a %b %e %H:%M:%S %Y");
 
     // TODO These patterns are imprecise and will prevent searching by timestamp; but for now,
     // it's no worse than not parsing a timestamp E.g. Jan 21 11:56:42

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -821,7 +821,7 @@ bool TimestampPattern::parse_timestamp(
                     }
                     auto dot_position = line.find('.');
                     auto nanosecond_start = dot_position + 1;
-                    if (std::string::npos == dot_position || dot_position == 0 ||
+                    if (std::string::npos == dot_position || dot_position == 0
                         || cNanosecondDigits != (line.length() - nanosecond_start))
                     {
                         return false;

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -799,8 +799,8 @@ bool TimestampPattern::parse_timestamp(
                     break;
                 }
 
-                case 'E': {  // UNIX epoch milliseconds timestamp
-                    // only allow consuming entire timestamp string
+                case 'E': {  // Millisecond-precision UNIX epoch timestamp
+                    // Only allow consuming entire timestamp string
                     // Note: "timestamp" is how the result is returned by reference
                     // Note: this format will also accept any integer timestamp (including UNIX
                     // epoch seconds and nanoseconds as well)
@@ -812,16 +812,16 @@ bool TimestampPattern::parse_timestamp(
                     return true;
                 }
 
-                case 'F': {  // Nanosecond precision floating point UNIX epoch timestamp
+                case 'F': {  // Nanosecond-precision floating-point UNIX epoch timestamp
                     constexpr auto cNanosecondDigits = 9;
                     constexpr auto cNanosecondMultiplier = 1'000'000'000;
-                    // only allow consuming entire timestamp string
+                    // Only allow consuming entire timestamp string
                     if (line_ix > 0) {
                         return false;
                     }
                     auto dot_position = line.find('.');
                     auto nanosecond_start = dot_position + 1;
-                    if (std::string::npos == dot_position || dot_position == 0
+                    if (std::string::npos == dot_position || 0 == dot_position
                         || cNanosecondDigits != (line.length() - nanosecond_start))
                     {
                         return false;

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -814,7 +814,7 @@ bool TimestampPattern::parse_timestamp(
 
                 case 'F': {  // Nanosecond precision floating point UNIX epoch timestamp
                     constexpr auto cNanosecondDigits = 9;
-                    constexpr auto cNanosecondMultiplier = 1000 * 1000 * 1000;
+                    constexpr auto cNanosecondMultiplier = 1'000'000'000;
                     // only allow consuming entire timestamp string
                     if (line_ix > 0) {
                         return false;

--- a/components/core/src/clp_s/TimestampPattern.hpp
+++ b/components/core/src/clp_s/TimestampPattern.hpp
@@ -42,9 +42,10 @@ namespace clp_s {
  * - M  2-digit 0-padded minute (00-59)
  * - S  2-digit 0-padded second (00-60) (60 to account for leap seconds)
  * - 3  0-padded millisecond (000-999)
- * - T  0-padded millisecond no trailing 0 (000)-999) e.g. (000), 9(00), 99(0), 099
- * - E  N-digit UNIX epoch timestamp in milliseconds
- * - F  N-digit UNIX epoch timestamp in floating point format with 9-digits trailing the decimal
+ * - T  0-padded millisecond no trailing 0 (000-999) e.g. (000), 9(00), 99(0), 099
+ * - E  N-digit millisecond-precision UNIX epoch timestamp
+ * - F  N-digit nanosecond-precision UNIX epoch timestamp in floating-point format with 9 digits
+ *      trailing the decimal
  */
 class TimestampPattern {
 public:

--- a/components/core/src/clp_s/TimestampPattern.hpp
+++ b/components/core/src/clp_s/TimestampPattern.hpp
@@ -43,6 +43,7 @@ namespace clp_s {
  * - S  2-digit 0-padded second (00-60) (60 to account for leap seconds)
  * - 3  0-padded millisecond (000-999)
  * - T  0-padded millisecond no trailing 0 (000)-999) e.g. (000), 9(00), 99(0), 099
+ * - E  N-digit UNIX epoch timestamp in milliseconds
  */
 class TimestampPattern {
 public:

--- a/components/core/src/clp_s/TimestampPattern.hpp
+++ b/components/core/src/clp_s/TimestampPattern.hpp
@@ -44,6 +44,7 @@ namespace clp_s {
  * - 3  0-padded millisecond (000-999)
  * - T  0-padded millisecond no trailing 0 (000)-999) e.g. (000), 9(00), 99(0), 099
  * - E  N-digit UNIX epoch timestamp in milliseconds
+ * - F  N-digit UNIX epoch timestamp in floating point format with 9-digits trailing the decimal
  */
 class TimestampPattern {
 public:

--- a/components/core/src/clp_s/search/DateLiteral.cpp
+++ b/components/core/src/clp_s/search/DateLiteral.cpp
@@ -25,27 +25,13 @@ std::shared_ptr<Literal> DateLiteral::create_from_int(epochtime_t v) {
 }
 
 std::shared_ptr<Literal> DateLiteral::create_from_string(std::string const& v) {
-    std::istringstream ss(v);
-    epochtime_t tmp_int_epoch;
-    double tmp_double_epoch;
-
-    ss >> std::noskipws >> tmp_int_epoch;
-    if (false == ss.fail() && ss.eof()) {
-        return std::shared_ptr<Literal>(static_cast<Literal*>(new DateLiteral(tmp_int_epoch, v)));
-    }
-
-    ss = std::istringstream(v);
-    ss >> std::noskipws >> tmp_double_epoch;
-    if (false == ss.fail() && ss.eof()) {
-        return std::shared_ptr<Literal>(static_cast<Literal*>(new DateLiteral(tmp_double_epoch, v))
-        );
-    }
-
     // begin end arguments are returned only -- their value doesn't matter
-    size_t timestamp_begin_pos = 0, timestamp_end_pos = 0;
+    size_t timestamp_begin_pos{0};
+    size_t timestamp_end_pos{0};
+    epochtime_t timestamp;
     auto pattern = TimestampPattern::search_known_ts_patterns(
             v,
-            tmp_int_epoch,
+            timestamp,
             timestamp_begin_pos,
             timestamp_end_pos
     );
@@ -53,7 +39,7 @@ std::shared_ptr<Literal> DateLiteral::create_from_string(std::string const& v) {
         return std::shared_ptr<Literal>(nullptr);
     }
 
-    return std::shared_ptr<Literal>(static_cast<Literal*>(new DateLiteral(tmp_int_epoch, v)));
+    return std::shared_ptr<Literal>(static_cast<Literal*>(new DateLiteral(timestamp, v)));
 }
 
 void DateLiteral::print() {

--- a/components/core/src/clp_s/search/DateLiteral.hpp
+++ b/components/core/src/clp_s/search/DateLiteral.hpp
@@ -7,7 +7,7 @@
 #include "Integral.hpp"
 
 namespace clp_s::search {
-constexpr LiteralTypeBitmask cDateLiteralTypes = EpochDateT | FloatDateT;
+constexpr LiteralTypeBitmask cDateLiteralTypes = EpochDateT;
 
 /**
  * Class for Date literal in the search AST. Represents time
@@ -45,8 +45,6 @@ public:
     bool matches_exactly(LiteralTypeBitmask mask) override { return mask == cDateLiteralTypes; }
 
     bool as_epoch_date() override { return true; }
-
-    bool as_float_date() override { return true; }
 
     bool as_clp_string(std::string& ret, FilterOperation op) override;
 

--- a/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
+++ b/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
@@ -6,7 +6,7 @@
 #include "OrExpr.hpp"
 
 namespace clp_s::search {
-constexpr LiteralTypeBitmask cDateTypes = cIntegralTypes | EpochDateT | FloatDateT;
+constexpr LiteralTypeBitmask cDateTypes = cIntegralTypes | EpochDateT;
 
 EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& expr) {
     if (std::dynamic_pointer_cast<OrExpr>(expr)) {

--- a/components/core/src/clp_s/search/Integral.hpp
+++ b/components/core/src/clp_s/search/Integral.hpp
@@ -62,8 +62,6 @@ public:
 
     bool as_epoch_date() override { return true; }
 
-    bool as_float_date() override { return true; }
-
     bool as_var_string(std::string& ret, FilterOperation op) override;
 
     bool as_float(double& ret, FilterOperation op) override;

--- a/components/core/src/clp_s/search/Literal.hpp
+++ b/components/core/src/clp_s/search/Literal.hpp
@@ -20,7 +20,6 @@ enum LiteralType : uint32_t {
     ArrayT = 1 << 5,
     NullT = 1 << 6,
     EpochDateT = 1 << 7,
-    FloatDateT = 1 << 8,
     TypesEnd = 1 << 9,
     UnknownT = ((uint32_t)1) << 31
 };
@@ -74,8 +73,6 @@ public:
                 return "null";
             case LiteralType::EpochDateT:
                 return "epochdate";
-            case LiteralType::FloatDateT:
-                return "floatdate";
             default:
                 return "errtype";
         }
@@ -105,8 +102,6 @@ public:
     }
 
     virtual bool as_epoch_date() { return false; }
-
-    virtual bool as_float_date() { return false; }
 
     virtual bool as_any(FilterOperation op) { return false; }
 };

--- a/components/core/src/clp_s/search/NarrowTypes.cpp
+++ b/components/core/src/clp_s/search/NarrowTypes.cpp
@@ -62,9 +62,6 @@ std::shared_ptr<Expression> NarrowTypes::narrow(std::shared_ptr<Expression> cur)
             if (false == literal->as_epoch_date()) {
                 column->remove_matching_type(LiteralType::EpochDateT);
             }
-            if (false == literal->as_float_date()) {
-                column->remove_matching_type(LiteralType::EpochDateT);
-            }
         }
 
         if (false == column->matches_any(cAllTypes)) {

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -78,7 +78,6 @@ void Output::filter() {
             m_wildcard_to_searched_clpstrings.clear();
             m_wildcard_to_searched_varstrings.clear();
             m_wildcard_to_searched_datestrings.clear();
-            m_wildcard_to_searched_floatdatestrings.clear();
             m_schema = schema_id;
 
             populate_searched_wildcard_columns(m_expr);
@@ -147,10 +146,6 @@ void Output::init(
             } else if (auto date_column_reader = dynamic_cast<DateStringColumnReader*>(column.second))
             {
                 m_datestring_readers[column.first] = date_column_reader;
-                m_other_columns.push_back(column.second);
-            } else if (auto float_date_column_reader = dynamic_cast<FloatDateStringColumnReader*>(column.second))
-            {
-                m_floatdatestring_readers[column.first] = float_date_column_reader;
                 m_other_columns.push_back(column.second);
             } else {
                 m_searched_columns.push_back(column.second);
@@ -311,12 +306,6 @@ bool Output::evaluate_wildcard_filter(
         }
     }
 
-    for (int32_t column_id : m_wildcard_to_searched_floatdatestrings[column]) {
-        if (evaluate_float_date_filter(op, m_floatdatestring_readers[column_id], literal)) {
-            return true;
-        }
-    }
-
     m_maybe_number = expr->get_column()->matches_type(LiteralType::FloatT);
     for (int32_t column_id : m_wildcard_to_searched_columns[column]) {
         bool ret = false;
@@ -420,12 +409,6 @@ bool Output::evaluate_filter(
             return evaluate_epoch_date_filter(
                     expr->get_operation(),
                     m_datestring_readers[column_id],
-                    literal
-            );
-        case LiteralType::FloatDateT:
-            return evaluate_float_date_filter(
-                    expr->get_operation(),
-                    m_floatdatestring_readers[column_id],
                     literal
             );
             // case LiteralType::NullT:
@@ -997,8 +980,6 @@ void Output::populate_searched_wildcard_columns(std::shared_ptr<Expression> cons
                     m_wildcard_to_searched_varstrings[col].push_back(node);
                 } else if (tree_node_type == NodeType::DATESTRING) {
                     m_wildcard_to_searched_datestrings[col].push_back(node);
-                } else if (tree_node_type == NodeType::FLOATDATESTRING) {
-                    m_wildcard_to_searched_floatdatestrings[col].push_back(node);
                 } else {
                     // Arrays and basic types
                     m_wildcard_to_searched_columns[col].push_back(node);
@@ -1022,12 +1003,6 @@ void Output::add_wildcard_columns_to_searched_columns() {
     }
 
     for (auto& e : m_wildcard_to_searched_datestrings) {
-        for (int32_t node : e.second) {
-            m_match.add_searched_column_to_schema(m_schema, node);
-        }
-    }
-
-    for (auto& e : m_wildcard_to_searched_floatdatestrings) {
         for (int32_t node : e.second) {
             m_match.add_searched_column_to_schema(m_schema, node);
         }
@@ -1122,8 +1097,7 @@ Output::constant_propagate(std::shared_ptr<Expression> const& expr, int32_t sche
             bool has_clp_string = false;
             bool matches_clp_string = false;
             bool has_other = !m_wildcard_to_searched_columns[wildcard].empty()
-                             || !m_wildcard_to_searched_datestrings[wildcard].empty()
-                             || !m_wildcard_to_searched_floatdatestrings[wildcard].empty();
+                             || !m_wildcard_to_searched_datestrings[wildcard].empty();
             std::string filter_string;
             bool valid
                     = filter->get_operand()->as_var_string(filter_string, filter->get_operation())
@@ -1237,13 +1211,5 @@ bool Output::evaluate_epoch_date_filter(
         std::shared_ptr<Literal>& operand
 ) {
     return evaluate_int_filter(op, reader->get_encoded_time(m_cur_message), operand);
-}
-
-bool Output::evaluate_float_date_filter(
-        FilterOperation op,
-        FloatDateStringColumnReader* reader,
-        std::shared_ptr<Literal>& operand
-) {
-    return evaluate_float_filter(op, reader->get_encoded_time(m_cur_message), operand);
 }
 }  // namespace clp_s::search

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -73,14 +73,12 @@ private:
     std::unordered_map<int32_t, ClpStringColumnReader*> m_clp_string_readers;
     std::unordered_map<int32_t, VariableStringColumnReader*> m_var_string_readers;
     std::unordered_map<int32_t, DateStringColumnReader*> m_datestring_readers;
-    std::unordered_map<int32_t, FloatDateStringColumnReader*> m_floatdatestring_readers;
     uint64_t m_cur_message;
     EvaluatedValue m_expression_value;
 
     std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_clpstrings;
     std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_varstrings;
     std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_datestrings;
-    std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_floatdatestrings;
     std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_columns;
 
     simdjson::ondemand::parser m_array_parser;
@@ -204,19 +202,6 @@ private:
     bool evaluate_epoch_date_filter(
             FilterOperation op,
             DateStringColumnReader* reader,
-            std::shared_ptr<Literal>& operand
-    );
-
-    /**
-     * Evaluates a float date string filter expression
-     * @param op
-     * @param reader
-     * @param operand
-     * @return true if the expression evaluates to true, false otherwise
-     */
-    bool evaluate_float_date_filter(
-            FilterOperation op,
-            FloatDateStringColumnReader* reader,
             std::shared_ptr<Literal>& operand
     );
 

--- a/components/core/src/clp_s/search/SearchUtils.cpp
+++ b/components/core/src/clp_s/search/SearchUtils.cpp
@@ -34,8 +34,6 @@ LiteralType node_to_literal_type(NodeType type) {
             return LiteralType::NullT;
         case NodeType::DATESTRING:
             return LiteralType::EpochDateT;
-        case NodeType::FLOATDATESTRING:
-            return LiteralType::FloatDateT;
         default:
             return LiteralType::UnknownT;
     }

--- a/components/core/src/glt/TimestampPattern.cpp
+++ b/components/core/src/glt/TimestampPattern.cpp
@@ -140,8 +140,6 @@ void TimestampPattern::init() {
     patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
     // E.g. 2015/01/31 15:50:45
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
-    // E.g. 15/01/31 15:50:45
-    patterns.emplace_back(0, "%y/%m/%d %H:%M:%S");
     // E.g. 2015/01/31 15:50:45.123
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
     // E.g. 2015/01/31 15:50:45,123

--- a/components/core/src/glt/TimestampPattern.cpp
+++ b/components/core/src/glt/TimestampPattern.cpp
@@ -124,38 +124,44 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S.%3");
     // E.g. 2015-01-31T15:50:45,392
     patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S,%3");
-    // E.g. [2015-01-31T15:50:45
-    patterns.emplace_back(0, "[%Y-%m-%dT%H:%M:%S");
-    // E.g. [20170106-16:56:41]
-    patterns.emplace_back(0, "[%Y%m%d-%H:%M:%S]");
-    // E.g. 2015-01-31 15:50:45,392
-    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. 2015-01-31 15:50:45.392
     patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S.%3");
-    // E.g. [2015-01-31 15:50:45,085]
-    patterns.emplace_back(0, "[%Y-%m-%d %H:%M:%S,%3]");
-    // E.g. 2015-01-31 15:50:45
-    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S");
-    // E.g. Start-Date: 2015-01-31  15:50:45
-    patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
-    // E.g. 2015/01/31 15:50:45
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
-    // E.g. 2015/01/31 15:50:45.123
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
-    // E.g. 2015/01/31 15:50:45,123
-    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
-    // E.g. 2015/01/31T15:50:45
-    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015-01-31 15:50:45,392
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. 2015/01/31T15:50:45.123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%3");
     // E.g. 2015/01/31T15:50:45,123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S,%3");
+    // E.g. 2015/01/31 15:50:45.123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
+    // E.g. 2015/01/31 15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
+    // E.g. [2015-01-31 15:50:45,085]
+    patterns.emplace_back(0, "[%Y-%m-%d %H:%M:%S,%3]");
+    // E.g. INFO [main] 2015-01-31 15:50:45,085
+    patterns.emplace_back(2, "%Y-%m-%d %H:%M:%S,%3");
+    // E.g. <<<2016-11-10 03:02:29:936
+    patterns.emplace_back(0, "<<<%Y-%m-%d %H:%M:%S:%3");
+    // E.g. 01 Jan 2016 15:50:17,085
+    patterns.emplace_back(0, "%d %b %Y %H:%M:%S,%3");
+    // E.g. 2015-01-31T15:50:45
+    patterns.emplace_back(0, "%Y-%m-%dT%H:%M:%S");
+    // E.g. 2015-01-31 15:50:45
+    patterns.emplace_back(0, "%Y-%m-%d %H:%M:%S");
+    // E.g. 2015/01/31T15:50:45
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015/01/31 15:50:45
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
+    // E.g. [2015-01-31T15:50:45
+    patterns.emplace_back(0, "[%Y-%m-%dT%H:%M:%S");
+    // E.g. [20170106-16:56:41]
+    patterns.emplace_back(0, "[%Y%m%d-%H:%M:%S]");
+    // E.g. Start-Date: 2015-01-31  15:50:45
+    patterns.emplace_back(1, "%Y-%m-%d  %H:%M:%S");
     // E.g. 15/01/31 15:50:45
     patterns.emplace_back(0, "%y/%m/%d %H:%M:%S");
     // E.g. 150131  9:50:45
     patterns.emplace_back(0, "%y%m%d %k:%M:%S");
-    // E.g. 01 Jan 2016 15:50:17,085
-    patterns.emplace_back(0, "%d %b %Y %H:%M:%S,%3");
     // E.g. Jan 01, 2016 3:50:17 PM
     patterns.emplace_back(0, "%b %d, %Y %l:%M:%S %p");
     // E.g. January 31, 2015 15:50
@@ -167,16 +173,12 @@ void TimestampPattern::init() {
     patterns.emplace_back(3, "[%d/%b/%Y:%H:%M:%S");
     // E.g. 192.168.4.5 - - [01/01/2016:15:50:17
     patterns.emplace_back(3, "[%d/%m/%Y:%H:%M:%S");
-    // E.g. INFO [main] 2015-01-31 15:50:45,085
-    patterns.emplace_back(2, "%Y-%m-%d %H:%M:%S,%3");
     // E.g. Started POST "/api/v3/internal/allowed" for 127.0.0.1 at 2017-06-18 00:20:44
     patterns.emplace_back(6, "%Y-%m-%d %H:%M:%S");
     // E.g. update-alternatives 2015-01-31 15:50:45
     patterns.emplace_back(1, "%Y-%m-%d %H:%M:%S");
     // E.g. ERROR: apport (pid 4557) Sun Jan  1 15:50:45 2015
     patterns.emplace_back(4, "%a %b %e %H:%M:%S %Y");
-    // E.g. <<<2016-11-10 03:02:29:936
-    patterns.emplace_back(0, "<<<%Y-%m-%d %H:%M:%S:%3");
     // E.g. Sun Jan  1 15:50:45 2015
     patterns.emplace_back(0, "%a %b %e %H:%M:%S %Y");
 

--- a/components/core/src/glt/TimestampPattern.cpp
+++ b/components/core/src/glt/TimestampPattern.cpp
@@ -142,6 +142,18 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S");
     // E.g. 15/01/31 15:50:45
     patterns.emplace_back(0, "%y/%m/%d %H:%M:%S");
+    // E.g. 2015/01/31 15:50:45.123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
+    // E.g. 2015/01/31 15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
+    // E.g. 2015/01/31T15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
+    // E.g. 2015/01/31T15:50:45.123
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%3");
+    // E.g. 2015/01/31T15:50:45,123
+    patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S,%3");
+    // E.g. 15/01/31 15:50:45
+    patterns.emplace_back(0, "%y/%m/%d %H:%M:%S");
     // E.g. 150131  9:50:45
     patterns.emplace_back(0, "%y%m%d %k:%M:%S");
     // E.g. 01 Jan 2016 15:50:17,085

--- a/components/core/src/glt/TimestampPattern.cpp
+++ b/components/core/src/glt/TimestampPattern.cpp
@@ -146,7 +146,7 @@ void TimestampPattern::init() {
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S.%3");
     // E.g. 2015/01/31 15:50:45,123
     patterns.emplace_back(0, "%Y/%m/%d %H:%M:%S,%3");
-    // E.g. 2015/01/31T15:50:45,123
+    // E.g. 2015/01/31T15:50:45
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S");
     // E.g. 2015/01/31T15:50:45.123
     patterns.emplace_back(0, "%Y/%m/%dT%H:%M:%S.%3");

--- a/components/core/tests/test-TimestampPattern.cpp
+++ b/components/core/tests/test-TimestampPattern.cpp
@@ -476,4 +476,64 @@ TEST_CASE("Test known timestamp patterns", "[KnownTimestampPatterns]") {
     content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
     specific_pattern.insert_formatted_timestamp(timestamp, content);
     REQUIRE("626000000 content after" == content);
+
+    line = "2015/01/31 15:50:45.123 content after";
+    specific_pattern = TimestampPattern{0, "%Y/%m/%d %H:%M:%S.%3"};
+    specific_pattern.parse_timestamp(line, timestamp, timestamp_begin_pos, timestamp_end_pos);
+    REQUIRE(specific_pattern.get_num_spaces_before_ts() == 0);
+    REQUIRE(specific_pattern.get_format() == "%Y/%m/%d %H:%M:%S.%3");
+    REQUIRE(0 == timestamp_begin_pos);
+    REQUIRE(23 == timestamp_end_pos);
+    content.assign(line, 0, timestamp_begin_pos);
+    content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
+    specific_pattern.insert_formatted_timestamp(timestamp, content);
+    REQUIRE(line == content);
+
+    line = "2015/01/31 15:50:45,123 content after";
+    specific_pattern = TimestampPattern{0, "%Y/%m/%d %H:%M:%S,%3"};
+    specific_pattern.parse_timestamp(line, timestamp, timestamp_begin_pos, timestamp_end_pos);
+    REQUIRE(specific_pattern.get_num_spaces_before_ts() == 0);
+    REQUIRE(specific_pattern.get_format() == "%Y/%m/%d %H:%M:%S,%3");
+    REQUIRE(0 == timestamp_begin_pos);
+    REQUIRE(23 == timestamp_end_pos);
+    content.assign(line, 0, timestamp_begin_pos);
+    content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
+    specific_pattern.insert_formatted_timestamp(timestamp, content);
+    REQUIRE(line == content);
+
+    line = "2015/01/31T15:50:45 content after";
+    specific_pattern = TimestampPattern{0, "%Y/%m/%dT%H:%M:%S"};
+    specific_pattern.parse_timestamp(line, timestamp, timestamp_begin_pos, timestamp_end_pos);
+    REQUIRE(specific_pattern.get_num_spaces_before_ts() == 0);
+    REQUIRE(specific_pattern.get_format() == "%Y/%m/%dT%H:%M:%S");
+    REQUIRE(0 == timestamp_begin_pos);
+    REQUIRE(19 == timestamp_end_pos);
+    content.assign(line, 0, timestamp_begin_pos);
+    content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
+    specific_pattern.insert_formatted_timestamp(timestamp, content);
+    REQUIRE(line == content);
+
+    line = "2015/01/31T15:50:45.123 content after";
+    specific_pattern = TimestampPattern{0, "%Y/%m/%dT%H:%M:%S.%3"};
+    specific_pattern.parse_timestamp(line, timestamp, timestamp_begin_pos, timestamp_end_pos);
+    REQUIRE(specific_pattern.get_num_spaces_before_ts() == 0);
+    REQUIRE(specific_pattern.get_format() == "%Y/%m/%dT%H:%M:%S.%3");
+    REQUIRE(0 == timestamp_begin_pos);
+    REQUIRE(23 == timestamp_end_pos);
+    content.assign(line, 0, timestamp_begin_pos);
+    content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
+    specific_pattern.insert_formatted_timestamp(timestamp, content);
+    REQUIRE(line == content);
+
+    line = "2015/01/31T15:50:45,123 content after";
+    specific_pattern = TimestampPattern{0, "%Y/%m/%dT%H:%M:%S,%3"};
+    specific_pattern.parse_timestamp(line, timestamp, timestamp_begin_pos, timestamp_end_pos);
+    REQUIRE(specific_pattern.get_num_spaces_before_ts() == 0);
+    REQUIRE(specific_pattern.get_format() == "%Y/%m/%dT%H:%M:%S,%3");
+    REQUIRE(0 == timestamp_begin_pos);
+    REQUIRE(23 == timestamp_end_pos);
+    content.assign(line, 0, timestamp_begin_pos);
+    content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
+    specific_pattern.insert_formatted_timestamp(timestamp, content);
+    REQUIRE(line == content);
 }

--- a/components/core/tests/test-TimestampPattern.cpp
+++ b/components/core/tests/test-TimestampPattern.cpp
@@ -536,4 +536,16 @@ TEST_CASE("Test known timestamp patterns", "[KnownTimestampPatterns]") {
     content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
     specific_pattern.insert_formatted_timestamp(timestamp, content);
     REQUIRE(line == content);
+
+    line = "2015-01-31T15:50:45 content after";
+    specific_pattern = TimestampPattern{0, "%Y-%m-%dT%H:%M:%S"};
+    specific_pattern.parse_timestamp(line, timestamp, timestamp_begin_pos, timestamp_end_pos);
+    REQUIRE(specific_pattern.get_num_spaces_before_ts() == 0);
+    REQUIRE(specific_pattern.get_format() == "%Y-%m-%dT%H:%M:%S");
+    REQUIRE(0 == timestamp_begin_pos);
+    REQUIRE(19 == timestamp_end_pos);
+    content.assign(line, 0, timestamp_begin_pos);
+    content.append(line, timestamp_end_pos, line.length() - timestamp_end_pos);
+    specific_pattern.insert_formatted_timestamp(timestamp, content);
+    REQUIRE(line == content);
 }


### PR DESCRIPTION
# References
Fixes #261 

# Description
* Add some obvious variations of existing timestamp patterns to clp, clp-s, and glt
* Add "%E" format specifier to clp-s to capture unix epoch millisecond timestamps found in strings
* Refactor and simplify timestamp column compression code in clp-s
* Fix a nested timestamp bug

# Validation performed
* Compressed data with the new timestamp formats and verified that the timestamps were parsed succesfully
* Verified that nested timestamps now exhibit expected behaviour for compression/decompression/search
* Added unit tests in clp for new timestamp formats
* Ingested [cockroachdb](https://zenodo.org/records/10516387) dataset and performed searches on timestamp column

