### PR TITLE
Add missing arm64 dependency

### DIFF
--- a/tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
@@ -11,6 +11,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   checkinstall \
   curl \
   libmariadb-dev \
+  libspdlog-dev \
   python3 \
   rsync \
   zstd


### PR DESCRIPTION
# Description
The spdlog in the arm64 build is dynamically linked (instead of statically) linked by the clp executable. We need to add the install libspdlog in the container so clp's binaries' dependency can be properly resolved. 

# Validation performed
Manually verified on arm machine and confirmed that CLP and run without dependency issue

