### PR TITLE
Clean-up clp-s' CLI error behaviour:

### DIFF
--- a/components/core/src/clp_s/search/kql/kql.cpp
+++ b/components/core/src/clp_s/search/kql/kql.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <antlr4-runtime.h>
+#include <spdlog/spdlog.h>
 
 #include "KqlBaseVisitor.h"
 #include "KqlLexer.h"
@@ -221,7 +222,6 @@ public:
 };
 
 std::shared_ptr<Expression> parse_kql_expression(std::istream& in) {
-    std::shared_ptr<Expression> expr = EmptyExpr::create();
     ErrorListener lexer_error_listener;
     ErrorListener parser_error_listener;
 
@@ -234,15 +234,14 @@ std::shared_ptr<Expression> parse_kql_expression(std::istream& in) {
     KqlParser::StartContext* tree = parser.start();
 
     if (lexer_error_listener.error()) {
-        std::cout << "Lexer Error" << std::endl;
-        return expr;
+        SPDLOG_ERROR("Lexer error");
+        return {};
     } else if (parser_error_listener.error()) {
-        std::cout << "Parser Error" << std::endl;
-        return expr;
+        SPDLOG_ERROR("Parser error");
+        return {};
     }
 
     ParseTreeVisitor visitor;
-    expr = std::any_cast<std::shared_ptr<Expression>>(visitor.visitStart(tree));
-    return expr;
+    return std::any_cast<std::shared_ptr<Expression>>(visitor.visitStart(tree));
 }
 }  // namespace clp_s::search::kql

--- a/components/core/src/clp_s/search/kql/kql.hpp
+++ b/components/core/src/clp_s/search/kql/kql.hpp
@@ -9,7 +9,7 @@ namespace clp_s::search::kql {
 /**
  * Generate a search AST from a Kibana expression in an input stream
  * @param in input stream containing a Kibana expression followed by EOF
- * @return a search AST
+ * @return a search AST on success, nullptr otherwise
  */
 std::shared_ptr<Expression> parse_kql_expression(std::istream& in);
 }  // namespace clp_s::search::kql


### PR DESCRIPTION
- Make no timestamp/schema matches a success return.
- Make error return values consistent.
- Clean-up log messages on lex/parse error.

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

`clp-s` currently treats no timestamp/schema matches as an error which causes searches from the UI (#250) to fail when no records match the user's query. This PR changes them to success returns and performs some other related clean-up of the return values / log messages.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated compression, decompression, and search of a test file.
* Validated that a search that matched no schemas produced a successful return.
* Validated that a search that matched no timestamp ranges produced a successful return.
* Validated that an invalid query only printed a log about the lex/parse error and produced an error return.
* Validated that missing arguments produced an error return.