### PR TITLE
clp-s: Fix incorrect usage of StandardOutputHandler constructor.

### DIFF
--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -205,9 +205,7 @@ int main(int argc, char const* argv[]) {
                     command_line_arguments.get_max_num_results()
             );
         } else {
-            output_handler = std::make_unique<StandardOutputHandler>(
-                    command_line_arguments.get_max_num_results()
-            );
+            output_handler = std::make_unique<StandardOutputHandler>();
         }
 
         // output result


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
We added support for printing timestamps during search. However, it is be disabled by default when printing to stdout. This PR fixes the misuse of StandardOutputHandler constructor, ensuring that timestamps are not printed to stdout.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Built clp-s and compressed part of [mongodb](https://zenodo.org/records/10516285) dataset.
+ Ran query "id: 23285".

