### PR TITLE
clp-s: Add support for decompressing/searching a directory of archives.

### DIFF
--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -266,6 +266,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             );
             // clang-format on
 
+            po::options_description input_options("Input Options");
+            input_options.add_options()(
+                    "archive-id",
+                    po::value<std::string>(&m_archive_id)->value_name("ID"),
+                    "ID of the archive to decompress"
+            );
+            extraction_options.add(input_options);
+
             po::positional_options_description positional_options;
             positional_options.add("archives-dir", 1);
             positional_options.add("output-dir", 1);
@@ -287,13 +295,15 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 print_decompression_usage();
 
                 std::cerr << "Examples:" << std::endl;
-                std::cerr << "  # Decompress all files from archives-dir into output-dir"
+                std::cerr << "  # Decompress all files from archives in archives-dir"
+                             "    into output-dir"
                           << std::endl;
                 std::cerr << "  " << m_program_name << " x archives-dir output-dir" << std::endl;
                 std::cerr << std::endl;
 
                 po::options_description visible_options;
                 visible_options.add(general_options);
+                visible_options.add(input_options);
                 std::cerr << visible_options << std::endl;
                 return ParsingResult::InfoCommand;
             }
@@ -321,6 +331,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "Query to perform"
             );
             // clang-format on
+
+            po::options_description input_options("Input Options");
+            input_options.add_options()(
+                    "archive-id",
+                    po::value<std::string>(&m_archive_id)->value_name("ID"),
+                    "ID of the archive to search"
+            );
+            search_options.add(input_options);
 
             po::options_description match_options("Match Controls");
             // clang-format off
@@ -381,14 +399,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 print_search_usage();
 
                 std::cerr << "Examples:" << std::endl;
-                std::cerr << "  # Search archives-dir for logs matching a KQL query"
+                std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output to stdout)"
                           << std::endl;
                 std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
                           << std::endl;
                 std::cerr << std::endl;
 
-                std::cerr << "  # Search archives-dir for logs matching a KQL query"
+                std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output to MongoDB)"
                           << std::endl;
                 std::cerr << "  " << m_program_name
@@ -398,6 +416,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
                 po::options_description visible_options;
                 visible_options.add(general_options);
+                visible_options.add(input_options);
                 visible_options.add(match_options);
                 visible_options.add(output_options);
                 std::cerr << visible_options << '\n';

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -64,6 +64,8 @@ public:
 
     std::optional<epochtime_t> get_search_end_ts() const { return m_search_end_ts; }
 
+    std::string const& get_archive_id() const { return m_archive_id; }
+
     std::optional<clp::GlobalMetadataDBConfig> const& get_metadata_db_config() const {
         return m_metadata_db_config;
     }
@@ -105,6 +107,9 @@ private:
     std::string m_query;
     std::optional<epochtime_t> m_search_begin_ts;
     std::optional<epochtime_t> m_search_end_ts;
+
+    // Decompression and search variables
+    std::string m_archive_id;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -3,12 +3,15 @@
 
 #include <set>
 #include <string>
+#include <utility>
 
 #include "ArchiveReader.hpp"
 #include "ColumnReader.hpp"
 #include "DictionaryReader.hpp"
+#include "ErrorCode.hpp"
 #include "SchemaReader.hpp"
 #include "SchemaTree.hpp"
+#include "TraceableException.hpp"
 
 namespace clp_s {
 struct JsonConstructorOption {
@@ -21,8 +24,20 @@ public:
     class OperationFailed : public TraceableException {
     public:
         // Constructors
-        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
-                : TraceableException(error_code, filename, line_number) {}
+        OperationFailed(
+                ErrorCode error_code,
+                char const* const filename,
+                int line_number,
+                std::string message
+        )
+                : TraceableException(error_code, filename, line_number),
+                  m_message(std::move(message)) {}
+
+        // Methods
+        [[nodiscard]] char const* what() const noexcept override { return m_message.c_str(); }
+
+    private:
+        std::string m_message;
     };
 
     // Constructors

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -1,12 +1,19 @@
+#include <exception>
 #include <filesystem>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <utility>
 
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <json/single_include/nlohmann/json.hpp>
+#include <mongocxx/instance.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/spdlog.h>
 
 #include "../clp/GlobalMySQLMetadataDB.hpp"
+#include "../clp/streaming_archive/ArchiveMetadata.hpp"
 #include "CommandLineArguments.hpp"
 #include "Defs.hpp"
 #include "JsonConstructor.hpp"
@@ -16,6 +23,7 @@
 #include "search/ConvertToExists.hpp"
 #include "search/EmptyExpr.hpp"
 #include "search/EvaluateTimestampIndex.hpp"
+#include "search/Expression.hpp"
 #include "search/kql/kql.hpp"
 #include "search/NarrowTypes.hpp"
 #include "search/OrOfAndForm.hpp"
@@ -23,6 +31,7 @@
 #include "search/OutputHandler.hpp"
 #include "search/SchemaMatch.hpp"
 #include "TimestampPattern.hpp"
+#include "TraceableException.hpp"
 #include "Utils.hpp"
 
 using namespace clp_s::search;
@@ -30,6 +39,197 @@ using clp_s::cArchiveFormatDevelopmentVersionFlag;
 using clp_s::cEpochTimeMax;
 using clp_s::cEpochTimeMin;
 using clp_s::CommandLineArguments;
+
+namespace {
+/**
+ * Compresses the input files specified by the command line arguments into an archive.
+ * @param command_line_arguments
+ * @return Whether compression was successful
+ */
+bool compress(CommandLineArguments const& command_line_arguments);
+
+/**
+ * Decompresses the archive specified by the given JsonConstructorOption.
+ * @param jsonConstructorOption
+ */
+void decompress_archive(clp_s::JsonConstructorOption const& jsonConstructorOption);
+
+/**
+ * Searches the given archive.
+ * @param command_line_arguments
+ * @param archive_dir
+ * @param expr The search AST
+ * @return Whether the search succeeded
+ */
+bool search_archive(
+        CommandLineArguments const& command_line_arguments,
+        std::string const& archive_dir,
+        std::shared_ptr<Expression>& expr
+);
+
+bool compress(CommandLineArguments const& command_line_arguments) {
+    clp_s::TimestampPattern::init();
+
+    boost::uuids::random_generator generator;
+    auto archive_id = boost::uuids::to_string(generator());
+    auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
+    auto archive_path = archives_dir / archive_id;
+
+    // Create output directory in case it doesn't exist
+    try {
+        std::filesystem::create_directory(archives_dir.string());
+    } catch (std::exception& e) {
+        SPDLOG_ERROR(
+                "Failed to create archives directory {} - {}",
+                archives_dir.string(),
+                e.what()
+        );
+        return false;
+    }
+
+    clp_s::JsonParserOption option;
+    option.file_paths = command_line_arguments.get_file_paths();
+    option.archives_dir = archive_path.string();
+    option.target_encoded_size = command_line_arguments.get_target_encoded_size();
+    option.compression_level = command_line_arguments.get_compression_level();
+    option.timestamp_key = command_line_arguments.get_timestamp_key();
+
+    clp_s::JsonParser parser(option);
+    parser.parse();
+    parser.store();
+    parser.close();
+
+    if (command_line_arguments.print_archive_stats()) {
+        nlohmann::json json_msg;
+        json_msg["id"] = archive_id;
+        json_msg["uncompressed_size"] = parser.get_uncompressed_size();
+        json_msg["size"] = parser.get_compressed_size();
+        std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
+                  << std::endl;
+    }
+
+    auto const& db_config_container = command_line_arguments.get_metadata_db_config();
+    if (db_config_container.has_value()) {
+        auto const& db_config = db_config_container.value();
+        clp::GlobalMySQLMetadataDB metadata_db(
+                db_config.get_metadata_db_host(),
+                db_config.get_metadata_db_port(),
+                db_config.get_metadata_db_username(),
+                db_config.get_metadata_db_password(),
+                db_config.get_metadata_db_name(),
+                db_config.get_metadata_table_prefix()
+        );
+
+        clp::streaming_archive::ArchiveMetadata metadata(
+                cArchiveFormatDevelopmentVersionFlag,
+                "",
+                0ULL
+        );
+        metadata.increment_static_compressed_size(parser.get_compressed_size());
+        metadata.increment_static_uncompressed_size(parser.get_uncompressed_size());
+        metadata.expand_time_range(parser.get_begin_timestamp(), parser.get_end_timestamp());
+        metadata_db.open();
+        metadata_db.add_archive(archive_id, metadata);
+        metadata_db.close();
+    }
+
+    return true;
+}
+
+void decompress_archive(clp_s::JsonConstructorOption const& jsonConstructorOption) {
+    clp_s::JsonConstructor constructor(jsonConstructorOption);
+    constructor.construct();
+    constructor.store();
+    constructor.close();
+}
+
+bool search_archive(
+        CommandLineArguments const& command_line_arguments,
+        std::string const& archive_dir,
+        std::shared_ptr<Expression>& expr
+) {
+    auto const& query = command_line_arguments.get_query();
+
+    auto timestamp_dict = clp_s::ReaderUtils::read_timestamp_dictionary(archive_dir);
+    AddTimestampConditions add_timestamp_conditions(
+            timestamp_dict->get_authoritative_timestamp_tokenized_column(),
+            command_line_arguments.get_search_begin_ts(),
+            command_line_arguments.get_search_end_ts()
+    );
+    if (expr = add_timestamp_conditions.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
+        SPDLOG_ERROR(
+                "Query '{}' specified timestamp filters tge {} tle {}, but no authoritative "
+                "timestamp column was found for this archive",
+                query,
+                command_line_arguments.get_search_begin_ts().value_or(cEpochTimeMin),
+                command_line_arguments.get_search_end_ts().value_or(cEpochTimeMax)
+        );
+        return false;
+    }
+
+    OrOfAndForm standardize_pass;
+    if (expr = standardize_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
+        SPDLOG_ERROR("Query '{}' is logically false", query);
+        return false;
+    }
+
+    NarrowTypes narrow_pass;
+    if (expr = narrow_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
+        SPDLOG_ERROR("Query '{}' is logically false", query);
+        return false;
+    }
+
+    ConvertToExists convert_pass;
+    if (expr = convert_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
+        SPDLOG_ERROR("Query '{}' is logically false", query);
+        return false;
+    }
+
+    // skip decompressing the archive if we won't match based on
+    // the timestamp index
+    EvaluateTimestampIndex timestamp_index(timestamp_dict);
+    if (clp_s::EvaluatedValue::False == timestamp_index.run(expr)) {
+        SPDLOG_INFO("No matching timestamp ranges for query '{}'", query);
+        return true;
+    }
+
+    auto schema_tree = clp_s::ReaderUtils::read_schema_tree(archive_dir);
+    auto schemas = clp_s::ReaderUtils::read_schemas(archive_dir);
+
+    // Narrow against schemas
+    SchemaMatch match_pass(schema_tree, schemas);
+    if (expr = match_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
+        SPDLOG_INFO("No matching schemas for query '{}'", query);
+        return true;
+    }
+
+    std::unique_ptr<OutputHandler> output_handler;
+    if (command_line_arguments.get_mongodb_enabled()) {
+        output_handler = std::make_unique<ResultsCacheOutputHandler>(
+                command_line_arguments.get_mongodb_uri(),
+                command_line_arguments.get_mongodb_collection(),
+                command_line_arguments.get_batch_size(),
+                command_line_arguments.get_max_num_results()
+        );
+    } else {
+        output_handler = std::make_unique<StandardOutputHandler>();
+    }
+
+    // output result
+    Output output(
+            schema_tree,
+            schemas,
+            match_pass,
+            expr,
+            archive_dir,
+            timestamp_dict,
+            std::move(output_handler)
+    );
+    output.filter();
+
+    return true;
+}
+}  // namespace
 
 int main(int argc, char const* argv[]) {
     try {
@@ -54,82 +254,37 @@ int main(int argc, char const* argv[]) {
     }
 
     if (CommandLineArguments::Command::Compress == command_line_arguments.get_command()) {
-        clp_s::TimestampPattern::init();
-
-        boost::uuids::random_generator generator;
-        auto archive_id = boost::uuids::to_string(generator());
-        auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
-        auto archive_path = archives_dir / archive_id;
-
-        // Create output directory in case it doesn't exist
-        try {
-            std::filesystem::create_directory(archives_dir.string());
-        } catch (std::exception& e) {
-            SPDLOG_ERROR(
-                    "Failed to create archives directory {} - {}",
-                    archives_dir.string(),
-                    e.what()
-            );
+        if (false == compress(command_line_arguments)) {
+            return 1;
+        }
+    } else if (CommandLineArguments::Command::Extract == command_line_arguments.get_command()) {
+        auto const& archives_dir = command_line_arguments.get_archives_dir();
+        if (false == std::filesystem::is_directory(archives_dir)) {
+            SPDLOG_ERROR("'{}' is not a directory.", archives_dir);
             return 1;
         }
 
-        clp_s::JsonParserOption option;
-        option.file_paths = command_line_arguments.get_file_paths();
-        option.archives_dir = archive_path.string();
-        option.target_encoded_size = command_line_arguments.get_target_encoded_size();
-        option.compression_level = command_line_arguments.get_compression_level();
-        option.timestamp_key = command_line_arguments.get_timestamp_key();
-
-        clp_s::JsonParser parser(option);
-        parser.parse();
-        parser.store();
-        parser.close();
-
-        if (command_line_arguments.print_archive_stats()) {
-            nlohmann::json json_msg;
-            json_msg["id"] = archive_id;
-            json_msg["uncompressed_size"] = parser.get_uncompressed_size();
-            json_msg["size"] = parser.get_compressed_size();
-            std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
-                      << std::endl;
-        }
-
-        if (command_line_arguments.get_metadata_db_config().has_value()) {
-            auto const& db_config = command_line_arguments.get_metadata_db_config().value();
-            clp::GlobalMySQLMetadataDB metadata_db(
-                    db_config.get_metadata_db_host(),
-                    db_config.get_metadata_db_port(),
-                    db_config.get_metadata_db_username(),
-                    db_config.get_metadata_db_password(),
-                    db_config.get_metadata_db_name(),
-                    db_config.get_metadata_table_prefix()
-            );
-
-            clp::streaming_archive::ArchiveMetadata metadata(
-                    cArchiveFormatDevelopmentVersionFlag,
-                    "",
-                    0ULL
-            );
-            metadata.increment_static_compressed_size(parser.get_compressed_size());
-            metadata.increment_static_uncompressed_size(parser.get_uncompressed_size());
-            metadata.expand_time_range(parser.get_begin_timestamp(), parser.get_end_timestamp());
-            metadata_db.open();
-            metadata_db.add_archive(archive_id, metadata);
-            metadata_db.close();
-        }
-    } else if (CommandLineArguments::Command::Extract == command_line_arguments.get_command()) {
         clp_s::JsonConstructorOption option;
-        option.archives_dir = command_line_arguments.get_archives_dir();
         option.output_dir = command_line_arguments.get_output_dir();
+        try {
+            for (auto const& entry : std::filesystem::directory_iterator(archives_dir)) {
+                if (false == entry.is_directory()) {
+                    // Skip non-directories
+                    continue;
+                }
 
-        clp_s::JsonConstructor constructor(option);
-        constructor.construct();
-        constructor.store();
-        constructor.close();
+                option.archives_dir = entry.path();
+                decompress_archive(option);
+            }
+        } catch (clp_s::TraceableException& e) {
+            SPDLOG_ERROR("{}", e.what());
+            return 1;
+        }
     } else {
-        auto const& archives_dir = command_line_arguments.get_archives_dir();
-        auto const& query = command_line_arguments.get_query();
         clp_s::TimestampPattern::init();
+        mongocxx::instance const mongocxx_instance{};
+
+        auto const& query = command_line_arguments.get_query();
 
         auto query_stream = std::istringstream(query);
         auto expr = kql::parse_kql_expression(query_stream);
@@ -142,83 +297,21 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
 
-        auto timestamp_dict = clp_s::ReaderUtils::read_timestamp_dictionary(archives_dir);
-        AddTimestampConditions add_timestamp_conditions(
-                timestamp_dict->get_authoritative_timestamp_tokenized_column(),
-                command_line_arguments.get_search_begin_ts(),
-                command_line_arguments.get_search_end_ts()
-        );
-        if (expr = add_timestamp_conditions.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
-            SPDLOG_ERROR(
-                    "Query '{}' specified timestamp filters tge {} tle {}, but no authoritative "
-                    "timestamp column was found for this archive",
-                    query,
-                    command_line_arguments.get_search_begin_ts().value_or(cEpochTimeMin),
-                    command_line_arguments.get_search_end_ts().value_or(cEpochTimeMax)
-            );
+        auto const& archives_dir = command_line_arguments.get_archives_dir();
+        if (false == std::filesystem::is_directory(archives_dir)) {
+            SPDLOG_ERROR("'{}' is not a directory.", archives_dir);
             return 1;
         }
 
-        OrOfAndForm standardize_pass;
-        if (expr = standardize_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
-            SPDLOG_ERROR("Query '{}' is logically false", query);
-            return 1;
+        for (auto const& entry : std::filesystem::directory_iterator(archives_dir)) {
+            if (false == entry.is_directory()) {
+                // Skip non-directories
+                continue;
+            }
+            if (false == search_archive(command_line_arguments, entry.path(), expr)) {
+                return 1;
+            }
         }
-
-        NarrowTypes narrow_pass;
-        if (expr = narrow_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
-            SPDLOG_ERROR("Query '{}' is logically false", query);
-            return 1;
-        }
-
-        ConvertToExists convert_pass;
-        if (expr = convert_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
-            SPDLOG_ERROR("Query '{}' is logically false", query);
-            return 1;
-        }
-
-        // skip decompressing the archive if we won't match based on
-        // the timestamp index
-        EvaluateTimestampIndex timestamp_index(timestamp_dict);
-        if (clp_s::EvaluatedValue::False == timestamp_index.run(expr)) {
-            SPDLOG_INFO("No matching timestamp ranges for query '{}'", query);
-            return 0;
-        }
-
-        auto schema_tree = clp_s::ReaderUtils::read_schema_tree(archives_dir);
-        auto schemas = clp_s::ReaderUtils::read_schemas(archives_dir);
-
-        // Narrow against schemas
-        SchemaMatch match_pass(schema_tree, schemas);
-        if (expr = match_pass.run(expr); std::dynamic_pointer_cast<EmptyExpr>(expr)) {
-            SPDLOG_INFO("No matching schemas for query '{}'", query);
-            return 0;
-        }
-
-        std::unique_ptr<OutputHandler> output_handler;
-        mongocxx::instance mongocxx_instance{};
-        if (command_line_arguments.get_mongodb_enabled()) {
-            output_handler = std::make_unique<ResultsCacheOutputHandler>(
-                    command_line_arguments.get_mongodb_uri(),
-                    command_line_arguments.get_mongodb_collection(),
-                    command_line_arguments.get_batch_size(),
-                    command_line_arguments.get_max_num_results()
-            );
-        } else {
-            output_handler = std::make_unique<StandardOutputHandler>();
-        }
-
-        // output result
-        Output output(
-                schema_tree,
-                schemas,
-                match_pass,
-                expr,
-                archives_dir,
-                timestamp_dict,
-                std::move(output_handler)
-        );
-        output.filter();
     }
 
     return 0;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -59,18 +59,16 @@ void decompress_archive(clp_s::JsonConstructorOption const& json_constructor_opt
  * Searches the given archive.
  * @param command_line_arguments
  * @param archive_dir
- * @param expr The search AST
+ * @param expr A copy of the search AST which may be modified
  * @return Whether the search succeeded
  */
 bool search_archive(
         CommandLineArguments const& command_line_arguments,
         std::string const& archive_dir,
-        std::shared_ptr<Expression>& expr
+        std::shared_ptr<Expression> expr
 );
 
 bool compress(CommandLineArguments const& command_line_arguments) {
-    clp_s::TimestampPattern::init();
-
     boost::uuids::random_generator generator;
     auto archive_id = boost::uuids::to_string(generator());
     auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
@@ -147,7 +145,7 @@ void decompress_archive(clp_s::JsonConstructorOption const& json_constructor_opt
 bool search_archive(
         CommandLineArguments const& command_line_arguments,
         std::string const& archive_dir,
-        std::shared_ptr<Expression>& expr
+        std::shared_ptr<Expression> expr
 ) {
     auto const& query = command_line_arguments.get_query();
 
@@ -242,6 +240,8 @@ int main(int argc, char const* argv[]) {
         return 1;
     }
 
+    clp_s::TimestampPattern::init();
+
     CommandLineArguments command_line_arguments("clp-s");
     auto parsing_result = command_line_arguments.parse_arguments(argc, argv);
     switch (parsing_result) {
@@ -288,7 +288,6 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
     } else {
-        clp_s::TimestampPattern::init();
         mongocxx::instance const mongocxx_instance{};
 
         auto const& query = command_line_arguments.get_query();
@@ -324,7 +323,7 @@ int main(int argc, char const* argv[]) {
                     continue;
                 }
 
-                if (false == search_archive(command_line_arguments, entry.path(), expr)) {
+                if (false == search_archive(command_line_arguments, entry.path(), expr->copy())) {
                     return 1;
                 }
             }

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -48,7 +48,8 @@ def make_clo_command(
 
 def make_clp_s_command(
     clp_home: Path,
-    archive_path: Path,
+    archives_dir: Path,
+    archive_id: str,
     search_config: SearchConfig,
     results_cache_uri: str,
     results_collection: str,
@@ -57,7 +58,8 @@ def make_clp_s_command(
     search_cmd = [
         str(clp_home / "bin" / "clp-s"),
         "s",
-        str(archive_path),
+        str(archives_dir),
+        "--archive-id", archive_id,
         search_config.query_string,
         "--mongodb-uri", results_cache_uri,
         "--mongodb-collection", results_collection,
@@ -112,7 +114,8 @@ def search(
     elif StorageEngine.CLP_S == clp_storage_engine:
         search_cmd = make_clp_s_command(
             clp_home=clp_home,
-            archive_path=archive_path,
+            archives_dir=archive_directory,
+            archive_id=archive_id,
             search_config=search_config,
             results_cache_uri=results_cache_uri,
             results_collection=job_id,

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -57,11 +57,14 @@ Usage:
 Usage:
 
 ```bash
-./clp-s x [options] <archives-dir> <output-dir>
+./clp-s x [<options>] <archives-dir> <output-dir>
 ```
 
 * `archives-dir` is a directory containing archives.
 * `output-dir` is the directory that decompressed logs should be written to.
+* `options` allow you to specify things like a specific archive (from within `archives-dir`) to
+  decompress (`--archive-id <archive-id>`).
+  * For a complete list, run `./clp-s x --help`
 
 ### Examples
 
@@ -76,11 +79,14 @@ Usage:
 Usage:
 
 ```bash
-./clp-s s [options] <archives-dir> <kql-query>
+./clp-s s [<options>] <archives-dir> <kql-query>
 ```
 
 * `archives-dir` is a directory containing archives.
 * `kql-query` is a [KQL][1] query.
+* `options` allow you to specify things like a specific archive (from within `archives-dir`) to
+  search (`--archive-id <archive-id>`).
+  * For a complete list, run `./clp-s s --help`
 
 ### Examples
 

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -57,7 +57,7 @@ Usage:
 Usage:
 
 ```bash
-./clp-s x <archives-dir> <output-dir>
+./clp-s x [options] <archives-dir> <output-dir>
 ```
 
 * `archives-dir` is a directory containing archives.
@@ -76,7 +76,7 @@ Usage:
 Usage:
 
 ```bash
-./clp-s s <archives-dir> <kql-query>
+./clp-s s [options] <archives-dir> <kql-query>
 ```
 
 * `archives-dir` is a directory containing archives.


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

#259 added support for `clp-s` to be used in the package by changing its behaviour from creating an archive in the given directory to creating an archive as a subdirectory of the given directory. This meant that users could run `clp-s` to compress into "archives-directory" but then decompressing/searching would require the user to specify a subdirectory of "archives-directory".

This PR adds support for `clp-s` to instead automatically iterate over all subdirectories of the given "archives-directory" by default. The package still requires the ability to search a specific archive (one of the subdirectories), so the PR adds a new flag `--archive-id` that, when specified, will only search a subdirectory with the given name (archive ID).

# Validation performed
<!-- What tests and validation you performed on the change -->

Using `clp-s`:
* Validated compression and decompression of a small dataset.
* Validated compressing two data sets, one after the other, into the same archives directory.
* Validated decompressing one of the datasets by specifying its archive ID.
* Validated search was functional.

Using the `clp-s` package:
* Validated compression and search was functional.
