### PR TITLE
Add case-insensitive search to clp-s source code and the package

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -170,7 +170,7 @@ def main(argv):
     args_parser.add_argument(
         "--ignore-case",
         action="store_true",
-        help="Ignore case when searching for the query.",
+        help="Ignore case distinctions between values in the query and the compressed data.",
     )
     args_parser.add_argument("--file-path", help="File to search.")
     parsed_args = args_parser.parse_args(argv[1:])

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -74,12 +74,14 @@ def create_and_monitor_job_in_db(
     wildcard_query: str,
     begin_timestamp: int | None,
     end_timestamp: int | None,
+    ignore_case: bool,
     path_filter: str,
 ):
     search_config = SearchConfig(
         query_string=wildcard_query,
         begin_timestamp=begin_timestamp,
         end_timestamp=end_timestamp,
+        ignore_case=ignore_case,
         path_filter=path_filter,
     )
 
@@ -125,6 +127,7 @@ async def do_search(
     wildcard_query: str,
     begin_timestamp: int | None,
     end_timestamp: int | None,
+    ignore_case: bool,
     path_filter: str,
 ):
     db_monitor_task = asyncio.ensure_future(
@@ -135,6 +138,7 @@ async def do_search(
             wildcard_query,
             begin_timestamp,
             end_timestamp,
+            ignore_case,
             path_filter,
         )
     )
@@ -162,6 +166,11 @@ def main(argv):
         "--end-time",
         type=int,
         help="Time range filter upper-bound (inclusive) as milliseconds" " from the UNIX epoch.",
+    )
+    args_parser.add_argument(
+        "--ignore-case",
+        action="store_true",
+        help="Ignore case when searching for the query.",
     )
     args_parser.add_argument("--file-path", help="File to search.")
     parsed_args = args_parser.parse_args(argv[1:])
@@ -191,6 +200,7 @@ def main(argv):
             parsed_args.wildcard_query,
             parsed_args.begin_time,
             parsed_args.end_time,
+            parsed_args.ignore_case,
             parsed_args.file_path,
         )
     )

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -53,7 +53,7 @@ def main(argv):
     args_parser.add_argument(
         "--ignore-case",
         action="store_true",
-        help="Ignore case when searching for the query.",
+        help="Ignore case distinctions between values in the query and the compressed data.",
     )
     args_parser.add_argument("--file-path", help="File to search.")
     parsed_args = args_parser.parse_args(argv[1:])

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -50,6 +50,11 @@ def main(argv):
         type=int,
         help="Time range filter upper-bound (inclusive) as milliseconds" " from the UNIX epoch.",
     )
+    args_parser.add_argument(
+        "--ignore-case",
+        action="store_true",
+        help="Ignore case when searching for the query.",
+    )
     args_parser.add_argument("--file-path", help="File to search.")
     parsed_args = args_parser.parse_args(argv[1:])
 
@@ -113,6 +118,8 @@ def main(argv):
     if parsed_args.end_time is not None:
         search_cmd.append("--end-time")
         search_cmd.append(str(parsed_args.end_time))
+    if parsed_args.ignore_case:
+        search_cmd.append("--ignore-case")
     if parsed_args.file_path:
         search_cmd.append("--file-path")
         search_cmd.append(parsed_args.file_path)

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -332,6 +332,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 "tle",
                 po::value<epochtime_t>()->value_name("TS"),
                 "Find records with UNIX epoch timestamp <= TS ms"
+            )(
+                "ignore-case,i",
+                po::bool_switch(&m_ignore_case),
+                "Ignore case distinctions in query values"
             );
             // clang-format on
             search_options.add(match_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -335,7 +335,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                 "ignore-case,i",
                 po::bool_switch(&m_ignore_case),
-                "Ignore case distinctions in query values"
+                "Ignore case distinctions between values in the query and the compressed data"
             );
             // clang-format on
             search_options.add(match_options);

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -64,6 +64,8 @@ public:
 
     std::optional<epochtime_t> get_search_end_ts() const { return m_search_end_ts; }
 
+    bool get_ignore_case() const { return m_ignore_case; }
+
     std::optional<clp::GlobalMetadataDBConfig> const& get_metadata_db_config() const {
         return m_metadata_db_config;
     }
@@ -105,6 +107,7 @@ private:
     std::string m_query;
     std::optional<epochtime_t> m_search_begin_ts;
     std::optional<epochtime_t> m_search_end_ts;
+    bool m_ignore_case{false};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -330,5 +330,6 @@ int main(int argc, char const* argv[]) {
             }
         }
     }
+
     return 0;
 }

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -222,7 +222,8 @@ bool search_archive(
             expr,
             archive_dir,
             timestamp_dict,
-            std::move(output_handler)
+            std::move(output_handler),
+            command_line_arguments.get_ignore_case()
     );
     output.filter();
 
@@ -323,27 +324,10 @@ int main(int argc, char const* argv[]) {
                     continue;
                 }
 
-<<<<<<< HEAD
-        // output result
-        Output output(
-                schema_tree,
-                schemas,
-                match_pass,
-                expr,
-                archives_dir,
-                timestamp_dict,
-                std::move(output_handler),
-                command_line_arguments.get_ignore_case()
-        );
-        output.filter();
-=======
                 if (false == search_archive(command_line_arguments, entry.path(), expr->copy())) {
                     return 1;
                 }
             }
         }
->>>>>>> origin/main
     }
-
-    return 0;
 }

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -330,4 +330,5 @@ int main(int argc, char const* argv[]) {
             }
         }
     }
+    return 0;
 }

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -216,7 +216,8 @@ int main(int argc, char const* argv[]) {
                 expr,
                 archives_dir,
                 timestamp_dict,
-                std::move(output_handler)
+                std::move(output_handler),
+                command_line_arguments.get_ignore_case()
         );
         output.filter();
     }

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -926,9 +926,16 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
                 // if it matches VarStringT then it contains no space, so we
                 // don't't add more wildcards. Likewise if it already contains some wildcards
                 // we do not add more
-                Grep::process_raw_query(m_log_dict, m_var_dict, query_string, false, q, false);
+                Grep::process_raw_query(
+                        m_log_dict,
+                        m_var_dict,
+                        query_string,
+                        m_ignore_case,
+                        q,
+                        false
+                );
             } else {
-                Grep::process_raw_query(m_log_dict, m_var_dict, query_string, false, q);
+                Grep::process_raw_query(m_log_dict, m_var_dict, query_string, m_ignore_case, q);
             }
         }
         SubQuery sub_query;
@@ -941,7 +948,7 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
 
             std::unordered_set<int64_t>& matching_vars = m_string_var_match_map[query_string];
             if (query_string.find('*') == std::string::npos) {
-                auto entry = m_var_dict->get_entry_matching_value(query_string, false);
+                auto entry = m_var_dict->get_entry_matching_value(query_string, m_ignore_case);
 
                 if (entry != nullptr) {
                     matching_vars.insert(entry->get_id());
@@ -950,7 +957,7 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
                                wildcard_search_dictionary_and_get_encoded_matches(
                                        query_string,
                                        *m_var_dict,
-                                       false,
+                                       m_ignore_case,
                                        sub_query
                                ))
             {

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -39,7 +39,7 @@ public:
               m_archives_dir(std::move(archives_dir)),
               m_timestamp_dict(std::move(timestamp_dict)),
               m_output_handler(std::move(output_handler)),
-    m_ignore_case(ignore_case){}
+              m_ignore_case(ignore_case) {}
 
     /**
      * Filters messages from all archives

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -30,14 +30,16 @@ public:
            std::shared_ptr<Expression> expr,
            std::string archives_dir,
            std::shared_ptr<TimestampDictionaryReader> timestamp_dict,
-           std::unique_ptr<OutputHandler> output_handler)
+           std::unique_ptr<OutputHandler> output_handler,
+           bool ignore_case)
             : m_schema_tree(std::move(tree)),
               m_schemas(std::move(schemas)),
               m_match(match),
               m_expr(std::move(expr)),
               m_archives_dir(std::move(archives_dir)),
               m_timestamp_dict(std::move(timestamp_dict)),
-              m_output_handler(std::move(output_handler)) {}
+              m_output_handler(std::move(output_handler)),
+    m_ignore_case(ignore_case){}
 
     /**
      * Filters messages from all archives
@@ -49,6 +51,7 @@ private:
     std::shared_ptr<Expression> m_expr;
     std::string m_archives_dir;
     std::unique_ptr<OutputHandler> m_output_handler;
+    bool m_ignore_case;
 
     // variables for the current schema being filtered
     std::vector<BaseColumnReader*> m_searched_columns;

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -40,6 +40,8 @@ def make_clo_command(
     if search_config.end_timestamp is not None:
         search_cmd.append("--tle")
         search_cmd.append(str(search_config.end_timestamp))
+    if search_config.ignore_case:
+        search_cmd.append("--ignore-case")
     if search_config.path_filter is not None:
         search_cmd.append(search_config.path_filter)
 
@@ -70,6 +72,8 @@ def make_clp_s_command(
     if search_config.end_timestamp is not None:
         search_cmd.append("--tle")
         search_cmd.append(str(search_config.end_timestamp))
+    if search_config.ignore_case:
+        search_cmd.append("--ignore-case")
 
     return search_cmd
 

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -34,4 +34,5 @@ class SearchConfig(BaseModel):
     query_string: str
     begin_timestamp: typing.Optional[int] = None
     end_timestamp: typing.Optional[int] = None
+    ignore_case: bool = False
     path_filter: typing.Optional[str] = None

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -113,8 +113,8 @@ or
 ./clp-s s /mnt/data/archives1 'level: ERROR AND message: "job*"'
 ```
 
-**Find both FATAL and ERROR log events and ignore case distinctions between values in the query and
-the compressed data:**
+**Find FATAL or ERROR log events and ignore case distinctions between values in the query and the
+compressed data:**
 
 ```bash
 ./clp-s s --ignore-case /mnt/data/archives1 'level: FATAL OR level: ERROR'

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -113,7 +113,8 @@ or
 ./clp-s s /mnt/data/archives1 'level: ERROR AND message: "job*"'
 ```
 
-**Find both FATAL and ERROR log events and ignore case distinctions between values in the query and the compressed data:**
+**Find both FATAL and ERROR log events and ignore case distinctions between values in the query and
+the compressed data:**
 
 ```bash
 ./clp-s s --ignore-case /mnt/data/archives1 'level: FATAL OR level: ERROR'

--- a/docs/core/clp-structured.md
+++ b/docs/core/clp-structured.md
@@ -113,10 +113,10 @@ or
 ./clp-s s /mnt/data/archives1 'level: ERROR AND message: "job*"'
 ```
 
-**Find both FATAL and ERROR log events:**
+**Find both FATAL and ERROR log events and ignore case distinctions between values in the query and the compressed data:**
 
 ```bash
-./clp-s s /mnt/data/archives1 'level: FATAL OR level: ERROR'
+./clp-s s --ignore-case /mnt/data/archives1 'level: FATAL OR level: ERROR'
 ```
 
 ## Current limitations

--- a/docs/core/clp-unstructured.md
+++ b/docs/core/clp-unstructured.md
@@ -91,8 +91,7 @@ Usage:
 
 ### Examples
 
-**Search `/mnt/data/archives1` for specific ERROR logs and ignore case distinctions between values
-in the query and the compressed data:**
+**Search `/mnt/data/archives1` for specific ERROR logs and ignore case distinctions:**
 
 ```shell
 ./clg --ignore-case /mnt/data/archives1 " ERROR * container "

--- a/docs/core/clp-unstructured.md
+++ b/docs/core/clp-unstructured.md
@@ -91,7 +91,8 @@ Usage:
 
 ### Examples
 
-**Search `/mnt/data/archives1` for specific ERROR logs and ignore case distinctions between values in the query and the compressed data:**
+**Search `/mnt/data/archives1` for specific ERROR logs and ignore case distinctions between values
+in the query and the compressed data:**
 
 ```shell
 ./clg --ignore-case /mnt/data/archives1 " ERROR * container "

--- a/docs/core/clp-unstructured.md
+++ b/docs/core/clp-unstructured.md
@@ -91,10 +91,10 @@ Usage:
 
 ### Examples
 
-**Search `/mnt/data/archives1` for specific ERROR logs:**
+**Search `/mnt/data/archives1` for specific ERROR logs and ignore case distinctions between values in the query and the compressed data:**
 
 ```shell
-./clg /mnt/data/archives1 " ERROR * container "
+./clg --ignore-case /mnt/data/archives1 " ERROR * container "
 ```
 
 **Search for logs in a time range:**


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR adds case-insensitive search to clp-s souce code and the package

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Compiled clp-s and compressed a portion of [mongodb](https://zenodo.org/records/10516285) dataset.
+ Executed two queries, `msg: "Initialized Wire Specification"` (for logtype dict test) and `c: repl` (for var dict test). These queries yielded no results without the `--ignore-case` flag but returned results when the flag was applied.
+ Built the package and compressed [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset using the package
+ Running `sbin/search.sh "org.apache.hadoop.mapred.Task: using resourcecalculatorprocesstree : [ ]"` resulted in no results, while `sbin/search.sh --ignore-case "org.apache.hadoop.mapred.Task: using resourcecalculatorprocesstree : [ ]"` returned relevant results.
