### PR TITLE
Convert repository names to lowercase before referring to them as docker names.

### DIFF
--- a/.github/actions/clp-core-build-deps-and-binaries/action.yaml
+++ b/.github/actions/clp-core-build-deps-and-binaries/action.yaml
@@ -38,16 +38,16 @@ runs:
         local_registry_port: "${{inputs.local_registry_port}}"
         token: "${{inputs.token}}"
 
-    - id: "generate_image_id"
+    - id: "sanitization"
       shell: "bash"
       run: |
-        # Docker doesn't support repository names with uppercase characters, so we convert to
-        # lowercase here as the image id.
+        # Docker doesn't support repository names with uppercase characters, so we convert the name
+        # to lowercase here.
         echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
           >> "$GITHUB_OUTPUT"
 
     - if: "inputs.deps_image_changed == 'false'"
       uses: "./.github/actions/clp-core-build"
       with:
-        image_name: "ghcr.io/${{steps.generate_image_id.REPOSITORY}}\
+        image_name: "ghcr.io/${{steps.sanitization.REPOSITORY}}\
           /clp-core-dependencies-x86-${{inputs.os_name}}:main"

--- a/.github/actions/clp-core-build-deps-and-binaries/action.yaml
+++ b/.github/actions/clp-core-build-deps-and-binaries/action.yaml
@@ -38,8 +38,16 @@ runs:
         local_registry_port: "${{inputs.local_registry_port}}"
         token: "${{inputs.token}}"
 
+    - id: "generate_image_id"
+      shell: "bash"
+      run: |
+        # Docker doesn't support repository names with uppercase characters, so we convert to
+        # lowercase here as the image id.
+        echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
+          >> "$GITHUB_OUTPUT"
+
     - if: "inputs.deps_image_changed == 'false'"
       uses: "./.github/actions/clp-core-build"
       with:
-        image_name: >-
-          ghcr.io/${{github.repository}}/clp-core-dependencies-x86-${{inputs.os_name}}:main
+        image_name: ghcr.io/${{steps.generate_image_id.REPOSITORY}}\
+          /clp-core-dependencies-x86-${{inputs.os_name}}:main

--- a/.github/actions/clp-core-build-deps-and-binaries/action.yaml
+++ b/.github/actions/clp-core-build-deps-and-binaries/action.yaml
@@ -49,5 +49,5 @@ runs:
     - if: "inputs.deps_image_changed == 'false'"
       uses: "./.github/actions/clp-core-build"
       with:
-        image_name: ghcr.io/${{steps.generate_image_id.REPOSITORY}}\
-          /clp-core-dependencies-x86-${{inputs.os_name}}:main
+        image_name: "ghcr.io/${{steps.generate_image_id.REPOSITORY}}\
+          /clp-core-dependencies-x86-${{inputs.os_name}}:main"

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -33,11 +33,19 @@ jobs:
           username: "${{github.actor}}"
           password: "${{secrets.GITHUB_TOKEN}}"
 
+    - id: "generate_image_id"
+      shell: "bash"
+      run: |
+        # Docker doesn't support repository names with uppercase characters, so we convert to
+        # lowercase here as the image id.
+        echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
+          >> "$GITHUB_OUTPUT"
+
       - id: "meta"
         uses: "docker/metadata-action@v5"
         with:
-          images: >-
-            ${{env.CONTAINER_IMAGE_REGISTRY}}/${{github.repository}}/clp-execution-x86-ubuntu-focal
+          images: ${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.generate_image_id.REPOSITORY}}\
+            /clp-execution-x86-ubuntu-focal
 
       - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
         uses: "docker/build-push-action@v5"

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -33,13 +33,13 @@ jobs:
           username: "${{github.actor}}"
           password: "${{secrets.GITHUB_TOKEN}}"
 
-    - id: "generate_image_id"
-      shell: "bash"
-      run: |
-        # Docker doesn't support repository names with uppercase characters, so we convert to
-        # lowercase here as the image id.
-        echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
-          >> "$GITHUB_OUTPUT"
+      - id: "generate_image_id"
+        shell: "bash"
+        run: |
+          # Docker doesn't support repository names with uppercase characters, so we convert to
+          # lowercase here as the image id.
+          echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
+            >> "$GITHUB_OUTPUT"
 
       - id: "meta"
         uses: "docker/metadata-action@v5"

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -44,8 +44,8 @@ jobs:
       - id: "meta"
         uses: "docker/metadata-action@v5"
         with:
-          images: ${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.generate_image_id.REPOSITORY}}\
-            /clp-execution-x86-ubuntu-focal
+          images: "${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.generate_image_id.REPOSITORY}}\
+            /clp-execution-x86-ubuntu-focal"
 
       - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
         uses: "docker/build-push-action@v5"

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -33,18 +33,18 @@ jobs:
           username: "${{github.actor}}"
           password: "${{secrets.GITHUB_TOKEN}}"
 
-      - id: "generate_image_id"
+      - id: "sanitization"
         shell: "bash"
         run: |
-          # Docker doesn't support repository names with uppercase characters, so we convert to
-          # lowercase here as the image id.
+          # Docker doesn't support repository names with uppercase characters, so we convert the
+          # name to lowercase here.
           echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
             >> "$GITHUB_OUTPUT"
 
       - id: "meta"
         uses: "docker/metadata-action@v5"
         with:
-          images: "${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.generate_image_id.REPOSITORY}}\
+          images: "${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.sanitization.REPOSITORY}}\
             /clp-execution-x86-ubuntu-focal"
 
       - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
In PR (#187 ), we converted the repository names to lowercase before using them. However, there are still two actions using the unconverted repository names. This PR fixes the problem.

# Validation performed
<!-- What tests and validation you performed on the change -->

