### PR TITLE
Build clp-core docker image if source files change.

### DIFF
--- a/.github/actions/clp-core-build-deps-and-binaries/action.yaml
+++ b/.github/actions/clp-core-build-deps-and-binaries/action.yaml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - if: "inputs.deps_image_changed == 'true'"
+    - if: "inputs.deps_image_changed == 'true' || inputs.push_binaries_image == 'true'"
       uses: "./.github/actions/clp-core-build-containers"
       with:
         os_name: "${{inputs.os_name}}"

--- a/.github/actions/clp-core-build-deps-and-binaries/action.yaml
+++ b/.github/actions/clp-core-build-deps-and-binaries/action.yaml
@@ -29,7 +29,8 @@ runs:
         os_name: "${{inputs.os_name}}"
         clp_core_dir: "components/core"
         push_deps_image: >-
-          ${{github.event_name != 'pull_request'
+          ${{inputs.deps_image_changed == 'true'
+          && github.event_name != 'pull_request'
           && github.ref == 'refs/heads/main'}}
         push_binaries_image: >-
           ${{inputs.push_binaries_image == 'true'


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The [clp-core-x86-ubuntu-focal](https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-x86-ubuntu-focal) image is not being (re-)built when only clp-core's source files change since the GH actions step is conditional on the dependencies changing. This means that the latest bug fixes to `clp` and `clp-s` have not been getting published to that container image. This PR changes the GH actions step so that it runs if either the dependencies or source files change.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Merged the change in my fork.
* Merged a source file change in my fork.
* Validated that the action showed that it was being run due to the source files changing and *not* the dependencies changing.
