### PR TITLE
Add missing `outputs` field when referring to the lowered repository names.

### DIFF
--- a/.github/actions/clp-core-build-deps-and-binaries/action.yaml
+++ b/.github/actions/clp-core-build-deps-and-binaries/action.yaml
@@ -46,8 +46,8 @@ runs:
         echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
           >> "$GITHUB_OUTPUT"
 
-    - if: "inputs.deps_image_changed == 'false'"
+    - if: "success()"
       uses: "./.github/actions/clp-core-build"
       with:
-        image_name: "ghcr.io/${{steps.sanitization.REPOSITORY}}\
+        image_name: "ghcr.io/${{steps.sanitization.outputs.REPOSITORY}}\
           /clp-core-dependencies-x86-${{inputs.os_name}}:main"

--- a/.github/actions/clp-core-build-deps-and-binaries/action.yaml
+++ b/.github/actions/clp-core-build-deps-and-binaries/action.yaml
@@ -46,7 +46,7 @@ runs:
         echo "REPOSITORY=$(echo '${{github.repository}}' | tr '[:upper:]' '[:lower:]')" \
           >> "$GITHUB_OUTPUT"
 
-    - if: "success()"
+    - if: "inputs.deps_image_changed == 'false'"
       uses: "./.github/actions/clp-core-build"
       with:
         image_name: "ghcr.io/${{steps.sanitization.outputs.REPOSITORY}}\

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -44,10 +44,11 @@ jobs:
       - id: "meta"
         uses: "docker/metadata-action@v5"
         with:
-          images: "${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.sanitization.REPOSITORY}}\
+          images: "${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.sanitization.outputs.REPOSITORY}}\
             /clp-execution-x86-ubuntu-focal"
 
-      - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
+      # - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
+      - if: success()
         uses: "docker/build-push-action@v5"
         with:
           context: "./"

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -47,8 +47,7 @@ jobs:
           images: "${{env.CONTAINER_IMAGE_REGISTRY}}/${{steps.sanitization.outputs.REPOSITORY}}\
             /clp-execution-x86-ubuntu-focal"
 
-      # - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
-      - if: success()
+      - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
         uses: "docker/build-push-action@v5"
         with:
           context: "./"


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
GitHub action failed: https://github.com/y-scope/clp/actions/runs/7862011912

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
In PR (#273), the change was incorrect since there is a missing `outputs.` field when referring to the repository name generated in `sanitization`. It was not exposed because, during the development, the actual workflow that instantiates the workflow was never executed. This PR fixes the problem.

# Validation performed
<!-- What tests and validation you performed on the change -->
In my forked repo, I manually enabled both workflows to ensure the docker names can be properly generated (`"linzhihao-723"`).
<img width="1233" alt="f8c419a94cd8720c233bf73f19adb7e" src="https://github.com/y-scope/clp/assets/59785146/aa0a4fc6-c49d-45e5-8254-8f6fc8518567">
<img width="1015" alt="image" src="https://github.com/y-scope/clp/assets/59785146/152b409c-9397-4921-b33e-cfccf5747654">


