### PR TITLE
Split webui build into bundling and building to support arm64 builds.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,8 +157,8 @@ tasks:
   nodejs:
     vars:
       NODEJS_VERSION: "14.21.3"
-      TAR_FILE_NAME: "node-v14.21.3-linux-x64.tar.xz"
-      TAR_FILE_PATH: "{{.NODEJS_BUILD_DIR}}/node-v14.21.3-linux-x64.tar.xz"
+      NODEJS_ARCH: "{{ if eq ARCH \"arm64\" }}arm64{{ else }}x64{{ end }}"
+      TAR_FILE_NAME: "node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}.tar.xz"
     cmds:
       - "rm -rf '{{.NODEJS_BUILD_DIR}}/node'"
       - "mkdir -p '{{.NODEJS_BUILD_DIR}}'"
@@ -175,8 +175,18 @@ tasks:
 
   webui:
     deps:
+      - "webui-bundle"
       - "nodejs"
     dir: "components/webui"
+    cmds:
+      - "rm -rf '{{.WEBUI_BUILD_DIR}}/bundle/'"
+      - |-
+        cd "{{.WEBUI_BUILD_DIR}}/programs/server"
+        PATH="{{.NODEJS_BIN_DIR}}":$PATH $(readlink -f "{{.NODEJS_BIN_DIR}}/npm") install
+
+  webui-bundle:
+    dir: "components/webui"
+    platforms: ["386", "amd64"]
     cmds:
       - "rm -rf '{{.WEBUI_BUILD_DIR}}'"
       - "mkdir -p '{{.WEBUI_BUILD_DIR}}'"
@@ -188,10 +198,6 @@ tasks:
         launcher.js
         settings.json
         "{{.WEBUI_BUILD_DIR}}/"
-      - "rm -rf '{{.WEBUI_BUILD_DIR}}/bundle/'"
-      - |-
-        cd "{{.WEBUI_BUILD_DIR}}/programs/server"
-        PATH="{{.NODEJS_BIN_DIR}}":$PATH $(readlink -f "{{.NODEJS_BIN_DIR}}/npm") install
     sources:
       - "./.meteor/*"
       - "./client/**/*"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -176,11 +176,9 @@ tasks:
 
   webui:
     deps:
-      - "webui-bundle"
       - "nodejs"
-    dir: "components/webui"
+      - "webui-bundle"
     cmds:
-      - "rm -rf '{{.WEBUI_BUILD_DIR}}/bundle/'"
       - |-
         cd "{{.WEBUI_BUILD_DIR}}/programs/server"
         PATH="{{.NODEJS_BIN_DIR}}":$PATH $(readlink -f "{{.NODEJS_BIN_DIR}}/npm") install
@@ -199,6 +197,7 @@ tasks:
         launcher.js
         settings.json
         "{{.WEBUI_BUILD_DIR}}/"
+      - "rm -rf '{{.WEBUI_BUILD_DIR}}/bundle/'"
     sources:
       - "./.meteor/*"
       - "./client/**/*"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -168,7 +168,8 @@ tasks:
         -o "{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}"
       - "tar xf '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}' -C '{{.NODEJS_BUILD_DIR}}'"
       - >-
-        mv "{{.NODEJS_BUILD_DIR}}/node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}" "{{.NODEJS_BUILD_DIR}}/node"
+        mv "{{.NODEJS_BUILD_DIR}}/node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}"
+        "{{.NODEJS_BUILD_DIR}}/node"
       - "rm -f '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}'"
     sources:
       - "{{.NODEJS_BUILD_DIR}}/node/**/*"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -168,7 +168,7 @@ tasks:
         -o "{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}"
       - "tar xf '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}' -C '{{.NODEJS_BUILD_DIR}}'"
       - >-
-        mv "{{.NODEJS_BUILD_DIR}}/node-v{{.NODEJS_VERSION}}-linux-x64" "{{.NODEJS_BUILD_DIR}}/node"
+        mv "{{.NODEJS_BUILD_DIR}}/node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}" "{{.NODEJS_BUILD_DIR}}/node"
       - "rm -f '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}'"
     sources:
       - "{{.NODEJS_BUILD_DIR}}/node/**/*"


### PR DESCRIPTION
# Description
Split the webui build process into two stages webui-bundle and webui to support building a package on arm64 architecture. The bundling stage requires meteor which is only available x64 architecture, so the strategy is to bundle the package on x86_64 and build from arm64 machine

# Validation performed
Built AMI with the change and verified that CLP can compress and search results is displayed on webui
