### PR TITLE
Add case sensitivity option to search controls; Fix incorrect logger debug message in `StatsCollectionName`.

### DIFF
--- a/components/webui/imports/api/ingestion/server/publications.js
+++ b/components/webui/imports/api/ingestion/server/publications.js
@@ -78,7 +78,7 @@ const deinitStatsDbManager = () => {
  * @returns {Mongo.Cursor}
  */
 Meteor.publish(Meteor.settings.public.StatsCollectionName, async () => {
-    logger.debug(`Subscription '${Meteor.settings.public.SearchResultsCollectionName}'`);
+    logger.debug(`Subscription '${Meteor.settings.public.StatsCollectionName}'`);
 
     await refreshCompressionStats();
 

--- a/components/webui/imports/api/search/server/methods.js
+++ b/components/webui/imports/api/search/server/methods.js
@@ -82,17 +82,20 @@ Meteor.methods({
      * @param {string} queryString
      * @param {number} timestampBegin
      * @param {number} timestampEnd
+     * @param {boolean} ignoreCase
      * @returns {Object} containing {jobId} of the submitted search job
      */
     async "search.submitQuery"({
         queryString,
         timestampBegin,
         timestampEnd,
+        ignoreCase,
     }) {
         const args = {
             query_string: queryString,
             begin_timestamp: timestampBegin,
             end_timestamp: timestampEnd,
+            ignore_case: ignoreCase,
         };
         logger.info("search.submitQuery args =", args);
 

--- a/components/webui/imports/ui/SearchView/SearchControls.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls.jsx
@@ -42,27 +42,48 @@ const SearchControlsDatePicker = (props) => (<DatePicker
 /**
  * Renders a label for a search filter control.
  *
- * @param {Object} props to be passed to the Form.Label component
+ * @param {Object} props
  * @returns {JSX.Element}
  */
-const SearchControlsFilterLabel = (props) => (<Form.Label
-    {...props}
-    column={"sm"}
-    xs={"auto"}
-    className="search-filter-control-label"
-/>);
+const SearchControlsFilterLabel = (props) => (
+    <Form.Label
+        {...props}
+        className={"search-filter-control-label"}
+        column={"sm"}
+        sm={2}/>
+);
+
+/**
+ * Renders a case sensitivity checkbox.
+ *
+ * @param {Object} props
+ * @param {string} props.label
+ * @returns {JSX.Element}
+ */
+const SearchControlsCaseSensitivityCheck = (props) => (
+    <Form.Check
+        {...props}
+        id={props.label}
+        inline={true}
+        name={"case-sensitivity"}
+        type={"radio"}/>
+);
 
 /**
  * Renders the controls for filtering search results by time range, including a date picker and
  * preset time range options.
  *
- * @param {Object} timeRange for filtering.
- * @param {function} setTimeRange callback to set timeRange
+ * @param {Object} timeRange
+ * @param {function} setTimeRange
+ * @param {boolean} ignoreCase
+ * @param {function} setIgnoreCase
  * @returns {JSX.Element}
  */
 const SearchFilterControlsDrawer = ({
     timeRange,
     setTimeRange,
+    ignoreCase,
+    setIgnoreCase,
 }) => {
     const updateBeginTimestamp = (date) => {
         if (date.getTime() > timeRange.end.getTime()) {
@@ -91,6 +112,16 @@ const SearchFilterControlsDrawer = ({
         const timeRange = computeTimeRange(presetToken);
 
         setTimeRange(timeRange);
+    };
+
+    /**
+     * Handles case sensitivity change.
+     *
+     * @param {InputEvent} event
+     * @returns {void}
+     */
+    const handleCaseSensitivityChange = (event) => {
+        setIgnoreCase("true" === event.target.value);
     };
 
     const timeRangePresetItems = Object.entries(TIME_RANGE_PRESET_LABEL).map(([token, label]) =>
@@ -152,6 +183,23 @@ const SearchFilterControlsDrawer = ({
                     </InputGroup>
                 </Col>
             </Form.Group>
+            <Form.Group as={Row} className={"mb-2"}>
+                <SearchControlsFilterLabel>
+                    Case sensitivity
+                </SearchControlsFilterLabel>
+                <Col className={"mt-1"}>
+                    <SearchControlsCaseSensitivityCheck
+                        checked={false === ignoreCase}
+                        label={"Sensitive"}
+                        value={false}
+                        onChange={handleCaseSensitivityChange}/>
+                    <SearchControlsCaseSensitivityCheck
+                        checked={true === ignoreCase}
+                        label={"Insensitive"}
+                        value={true}
+                        onChange={handleCaseSensitivityChange}/>
+                </Col>
+            </Form.Group>
         </Container>
     </div>);
 };
@@ -160,14 +208,16 @@ const SearchFilterControlsDrawer = ({
  * Renders the search controls including query input, filter drawer toggle, and operation buttons
  * like submit, clear, and cancel. It also manages the state of the drawer.
  *
- * @param {string} queryString for matching logs
- * @param {function} setQueryString callback to set queryString
- * @param {Object} timeRange for filtering
- * @param {function} setTimeRange callback to set timeRange
- * @param {Object} resultsMetadata which includes last request / response signal
- * @param {function} onSubmitQuery callback to submit the search query
- * @param {function} onClearResults callback to clear search results
- * @param {function} onCancelOperation callback to cancel the ongoing search operation
+ * @param {string} queryString
+ * @param {function} setQueryString
+ * @param {Object} timeRange
+ * @param {function} setTimeRange
+ * @param {boolean} ignoreCase
+ * @param {function} setIgnoreCase
+ * @param {Object} resultsMetadata
+ * @param {function} onSubmitQuery
+ * @param {function} onClearResults
+ * @param {function} onCancelOperation
  * @returns {JSX.Element}
  */
 const SearchControls = ({
@@ -175,6 +225,8 @@ const SearchControls = ({
     setQueryString,
     timeRange,
     setTimeRange,
+    ignoreCase,
+    setIgnoreCase,
     resultsMetadata,
     onSubmitQuery,
     onClearResults,
@@ -278,6 +330,8 @@ const SearchControls = ({
         {drawerOpen && <SearchFilterControlsDrawer
             timeRange={timeRange}
             setTimeRange={setTimeRange}
+            ignoreCase={ignoreCase}
+            setIgnoreCase={setIgnoreCase}
         />}
     </>;
 };

--- a/components/webui/imports/ui/SearchView/SearchControls.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls.jsx
@@ -50,7 +50,12 @@ const SearchControlsFilterLabel = (props) => (
         {...props}
         className={"search-filter-control-label"}
         column={"sm"}
-        sm={2}/>
+        xs={3}
+        sm={2}
+        md={2}
+        lg={2}
+        xl={1}
+        xxl={1}/>
 );
 
 /**

--- a/components/webui/imports/ui/SearchView/SearchControls.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls.jsx
@@ -118,7 +118,6 @@ const SearchFilterControlsDrawer = ({
      * Handles case sensitivity change.
      *
      * @param {InputEvent} event
-     * @returns {void}
      */
     const handleCaseSensitivityChange = (event) => {
         setIgnoreCase("true" === event.target.value);

--- a/components/webui/imports/ui/SearchView/SearchControls.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls.jsx
@@ -50,12 +50,8 @@ const SearchControlsFilterLabel = (props) => (
         {...props}
         className={"search-filter-control-label"}
         column={"sm"}
-        xs={3}
         sm={2}
-        md={2}
-        lg={2}
-        xl={1}
-        xxl={1}/>
+        llg={1}/>
 );
 
 /**
@@ -147,8 +143,8 @@ const SearchFilterControlsDrawer = ({
         timestampEndMax = new Date(timeRange.end).setHours(23, 59, 59, 999);
     }
 
-    return (<div className={"search-filter-controls-drawer border-bottom"}>
-        <Container fluid={true}>
+    return (<div className={"search-filter-controls-drawer border-bottom px-2 py-3 w-100"}>
+        <Container fluid={"sm"} className={"mx-0"}>
             <Form.Group as={Row} className={"mb-2"}>
                 <SearchControlsFilterLabel>
                     Time Range
@@ -188,7 +184,7 @@ const SearchFilterControlsDrawer = ({
                     </InputGroup>
                 </Col>
             </Form.Group>
-            <Form.Group as={Row} className={"mb-2"}>
+            <Form.Group as={Row}>
                 <SearchControlsFilterLabel>
                     Case sensitivity
                 </SearchControlsFilterLabel>

--- a/components/webui/imports/ui/SearchView/SearchControls.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls.jsx
@@ -194,14 +194,14 @@ const SearchFilterControlsDrawer = ({
                 </SearchControlsFilterLabel>
                 <Col className={"mt-1"}>
                     <SearchControlsCaseSensitivityCheck
-                        checked={false === ignoreCase}
-                        label={"Sensitive"}
-                        value={false}
-                        onChange={handleCaseSensitivityChange}/>
-                    <SearchControlsCaseSensitivityCheck
                         checked={true === ignoreCase}
                         label={"Insensitive"}
                         value={true}
+                        onChange={handleCaseSensitivityChange}/>
+                    <SearchControlsCaseSensitivityCheck
+                        checked={false === ignoreCase}
+                        label={"Sensitive"}
+                        value={false}
                         onChange={handleCaseSensitivityChange}/>
                 </Col>
             </Form.Group>

--- a/components/webui/imports/ui/SearchView/SearchControls.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls.jsx
@@ -48,10 +48,9 @@ const SearchControlsDatePicker = (props) => (<DatePicker
 const SearchControlsFilterLabel = (props) => (
     <Form.Label
         {...props}
-        className={"search-filter-control-label"}
+        className={"search-filter-control-label text-nowrap"}
         column={"sm"}
-        sm={2}
-        llg={1}/>
+        md={1}/>
 );
 
 /**
@@ -147,7 +146,7 @@ const SearchFilterControlsDrawer = ({
         <Container fluid={"sm"} className={"mx-0"}>
             <Form.Group as={Row} className={"mb-2"}>
                 <SearchControlsFilterLabel>
-                    Time Range
+                    Time range
                 </SearchControlsFilterLabel>
                 <Col>
                     <InputGroup size={"sm"}>

--- a/components/webui/imports/ui/SearchView/SearchControls.scss
+++ b/components/webui/imports/ui/SearchView/SearchControls.scss
@@ -2,10 +2,7 @@
   &-controls-drawer {
     background-color: #efefef;
 
-    padding: 1rem 0 0.5rem 0;
     position: relative;
-
-    width: 100%;
   }
 
   &-control-label {

--- a/components/webui/imports/ui/SearchView/SearchControls.scss
+++ b/components/webui/imports/ui/SearchView/SearchControls.scss
@@ -7,6 +7,8 @@
 
   &-control-label {
     color: #666;
+
+    min-width: 9rem;
   }
 }
 

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -24,6 +24,8 @@ import {VISIBLE_RESULTS_LIMIT_INITIAL} from "./SearchResultsTable.jsx";
 const PROGRESS_INCREMENT = 5;
 const PROGRESS_INTERVAL_MS = 100;
 
+const DEFAULT_IGNORE_CASE_SETTING = true;
+
 /**
  * Provides a search interface, which search queries and visualizes search results.
  */
@@ -40,6 +42,7 @@ const SearchView = () => {
     // Query options
     const [queryString, setQueryString] = useState("");
     const [timeRange, setTimeRange] = useState(DEFAULT_TIME_RANGE);
+    const [ignoreCase, setIgnoreCase] = useState(DEFAULT_IGNORE_CASE_SETTING);
     const [visibleSearchResultsLimit, setVisibleSearchResultsLimit] = useState(
         VISIBLE_RESULTS_LIMIT_INITIAL);
     const [fieldToSortBy, setFieldToSortBy] = useState({
@@ -125,6 +128,7 @@ const SearchView = () => {
             queryString: queryString,
             timestampBegin: timestampBeginMillis,
             timestampEnd: timestampEndMillis,
+            ignoreCase: ignoreCase
         };
         Meteor.call("search.submitQuery", args, (error, result) => {
             if (error) {
@@ -184,6 +188,8 @@ const SearchView = () => {
                 setQueryString={setQueryString}
                 timeRange={timeRange}
                 setTimeRange={setTimeRange}
+                ignoreCase={ignoreCase}
+                setIgnoreCase={setIgnoreCase}
                 resultsMetadata={resultsMetadata}
                 onSubmitQuery={submitQuery}
                 onClearResults={handleClearResults}


### PR DESCRIPTION
# References
1. Search option `ignore_case` was recently added for `clp-s` (#272). 

# Description
1. Add case sensitivity option to search controls.
2. Fix incorrect logger debug message in `StatsCollectionName`.

# Validation performed
1. Loaded Web UI in a browser.
2. In the search controls, observed that `Case sensitivity: Insensitive` as the default option. 
3. With `hadoop-24hrs/logs/i-00c90a0f/` compressed, in the Web UI searched with keyword "downloading", `Time Range` as `All Time`, and `Case sensitivity: Insensitive`, and observed "Results count: 376".
4. In the search controls, changed `Case sensitivity` to be `Sensitive` and restarted the search. Observed "Results count: 0".