### PR TITLE
Allow source package installation scripts to be called from any directory.

### DIFF
--- a/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
@@ -15,18 +15,18 @@ source /opt/rh/rh-git227/enable
 set -u
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-scripts_prefix=$script_dir/..
+lib_install_scripts_dir=$script_dir/..
 
 # NOTE: cmake and boost must be installed first since the remaining packages depend on them
-"$scripts_prefix"/install-cmake.sh 3.21.2
-"$scripts_prefix"/install-boost.sh 1.76.0
+"$lib_install_scripts_dir"/install-cmake.sh 3.21.2
+"$lib_install_scripts_dir"/install-boost.sh 1.76.0
 
-"$scripts_prefix"/fmtlib.sh 8.0.1
-"$scripts_prefix"/libarchive.sh 3.5.1
-"$scripts_prefix"/lz4.sh 1.8.2
-"$scripts_prefix"/mariadb-connector-c.sh 3.2.3
-"$scripts_prefix"/mongoc.sh 1.24.4
-"$scripts_prefix"/mongocxx.sh 3.8.0
-"$scripts_prefix"/msgpack.sh 6.0.0
-"$scripts_prefix"/spdlog.sh 1.9.2
-"$scripts_prefix"/zstandard.sh 1.4.9
+"$lib_install_scripts_dir"/fmtlib.sh 8.0.1
+"$lib_install_scripts_dir"/libarchive.sh 3.5.1
+"$lib_install_scripts_dir"/lz4.sh 1.8.2
+"$lib_install_scripts_dir"/mariadb-connector-c.sh 3.2.3
+"$lib_install_scripts_dir"/mongoc.sh 1.24.4
+"$lib_install_scripts_dir"/mongocxx.sh 3.8.0
+"$lib_install_scripts_dir"/msgpack.sh 6.0.0
+"$lib_install_scripts_dir"/spdlog.sh 1.9.2
+"$lib_install_scripts_dir"/zstandard.sh 1.4.9

--- a/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/centos7.4/install-packages-from-source.sh
@@ -14,16 +14,19 @@ source /opt/rh/rh-git227/enable
 # unbound variables in them.
 set -u
 
-# NOTE: cmake and boost must be installed first since the remaining packages depend on them
-./tools/scripts/lib_install/install-cmake.sh 3.21.2
-./tools/scripts/lib_install/install-boost.sh 1.76.0
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+scripts_prefix=$script_dir/..
 
-./tools/scripts/lib_install/fmtlib.sh 8.0.1
-./tools/scripts/lib_install/libarchive.sh 3.5.1
-./tools/scripts/lib_install/lz4.sh 1.8.2
-./tools/scripts/lib_install/mariadb-connector-c.sh 3.2.3
-./tools/scripts/lib_install/mongoc.sh 1.24.4
-./tools/scripts/lib_install/mongocxx.sh 3.8.0
-./tools/scripts/lib_install/msgpack.sh 6.0.0
-./tools/scripts/lib_install/spdlog.sh 1.9.2
-./tools/scripts/lib_install/zstandard.sh 1.4.9
+# NOTE: cmake and boost must be installed first since the remaining packages depend on them
+"$scripts_prefix"/install-cmake.sh 3.21.2
+"$scripts_prefix"/install-boost.sh 1.76.0
+
+"$scripts_prefix"/fmtlib.sh 8.0.1
+"$scripts_prefix"/libarchive.sh 3.5.1
+"$scripts_prefix"/lz4.sh 1.8.2
+"$scripts_prefix"/mariadb-connector-c.sh 3.2.3
+"$scripts_prefix"/mongoc.sh 1.24.4
+"$scripts_prefix"/mongocxx.sh 3.8.0
+"$scripts_prefix"/msgpack.sh 6.0.0
+"$scripts_prefix"/spdlog.sh 1.9.2
+"$scripts_prefix"/zstandard.sh 1.4.9

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
@@ -7,13 +7,13 @@ set -e
 set -u
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-scripts_prefix=$script_dir/..
+lib_install_scripts_dir=$script_dir/..
 
-"$scripts_prefix"/fmtlib.sh 8.0.1
-"$scripts_prefix"/libarchive.sh 3.5.1
-"$scripts_prefix"/lz4.sh 1.8.2
-"$scripts_prefix"/mongoc.sh 1.24.4
-"$scripts_prefix"/mongocxx.sh 3.8.0
-"$scripts_prefix"/msgpack.sh 6.0.0
-"$scripts_prefix"/spdlog.sh 1.9.2
-"$scripts_prefix"/zstandard.sh 1.4.9
+"$lib_install_scripts_dir"/fmtlib.sh 8.0.1
+"$lib_install_scripts_dir"/libarchive.sh 3.5.1
+"$lib_install_scripts_dir"/lz4.sh 1.8.2
+"$lib_install_scripts_dir"/mongoc.sh 1.24.4
+"$lib_install_scripts_dir"/mongocxx.sh 3.8.0
+"$lib_install_scripts_dir"/msgpack.sh 6.0.0
+"$lib_install_scripts_dir"/spdlog.sh 1.9.2
+"$lib_install_scripts_dir"/zstandard.sh 1.4.9

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
@@ -6,11 +6,14 @@ set -e
 # Error on undefined variable
 set -u
 
-./tools/scripts/lib_install/fmtlib.sh 8.0.1
-./tools/scripts/lib_install/libarchive.sh 3.5.1
-./tools/scripts/lib_install/lz4.sh 1.8.2
-./tools/scripts/lib_install/mongoc.sh 1.24.4
-./tools/scripts/lib_install/mongocxx.sh 3.8.0
-./tools/scripts/lib_install/msgpack.sh 6.0.0
-./tools/scripts/lib_install/spdlog.sh 1.9.2
-./tools/scripts/lib_install/zstandard.sh 1.4.9
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+scripts_prefix=$script_dir/..
+
+"$scripts_prefix"/fmtlib.sh 8.0.1
+"$scripts_prefix"/libarchive.sh 3.5.1
+"$scripts_prefix"/lz4.sh 1.8.2
+"$scripts_prefix"/mongoc.sh 1.24.4
+"$scripts_prefix"/mongocxx.sh 3.8.0
+"$scripts_prefix"/msgpack.sh 6.0.0
+"$scripts_prefix"/spdlog.sh 1.9.2
+"$scripts_prefix"/zstandard.sh 1.4.9

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
@@ -7,13 +7,13 @@ set -e
 set -u
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-scripts_prefix=$script_dir/..
+lib_install_scripts_dir=$script_dir/..
 
-"$scripts_prefix"/fmtlib.sh 8.0.1
-"$scripts_prefix"/libarchive.sh 3.5.1
-"$scripts_prefix"/lz4.sh 1.8.2
-"$scripts_prefix"/mongoc.sh 1.24.4
-"$scripts_prefix"/mongocxx.sh 3.8.0
-"$scripts_prefix"/msgpack.sh 6.0.0
-"$scripts_prefix"/spdlog.sh 1.9.2
-"$scripts_prefix"/zstandard.sh 1.4.9
+"$lib_install_scripts_dir"/fmtlib.sh 8.0.1
+"$lib_install_scripts_dir"/libarchive.sh 3.5.1
+"$lib_install_scripts_dir"/lz4.sh 1.8.2
+"$lib_install_scripts_dir"/mongoc.sh 1.24.4
+"$lib_install_scripts_dir"/mongocxx.sh 3.8.0
+"$lib_install_scripts_dir"/msgpack.sh 6.0.0
+"$lib_install_scripts_dir"/spdlog.sh 1.9.2
+"$lib_install_scripts_dir"/zstandard.sh 1.4.9

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
@@ -6,11 +6,14 @@ set -e
 # Error on undefined variable
 set -u
 
-./tools/scripts/lib_install/fmtlib.sh 8.0.1
-./tools/scripts/lib_install/libarchive.sh 3.5.1
-./tools/scripts/lib_install/lz4.sh 1.8.2
-./tools/scripts/lib_install/mongoc.sh 1.24.4
-./tools/scripts/lib_install/mongocxx.sh 3.8.0
-./tools/scripts/lib_install/msgpack.sh 6.0.0
-./tools/scripts/lib_install/spdlog.sh 1.9.2
-./tools/scripts/lib_install/zstandard.sh 1.4.9
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+scripts_prefix=$script_dir/..
+
+"$scripts_prefix"/fmtlib.sh 8.0.1
+"$scripts_prefix"/libarchive.sh 3.5.1
+"$scripts_prefix"/lz4.sh 1.8.2
+"$scripts_prefix"/mongoc.sh 1.24.4
+"$scripts_prefix"/mongocxx.sh 3.8.0
+"$scripts_prefix"/msgpack.sh 6.0.0
+"$scripts_prefix"/spdlog.sh 1.9.2
+"$scripts_prefix"/zstandard.sh 1.4.9


### PR DESCRIPTION
# Description
Update the install script to use relative path so the script doesn't need to be launched from a specific directory

# Validation performed
Tested with package flow
