### PR TITLE
Remove interactive docker exec calls to allow use in unattended scripts.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -273,10 +273,10 @@ def start_queue(instance_id: str, clp_config: CLPConfig):
 
     # Wait for queue to start up
     # fmt: off
-    rabbitmq_cmd = ["rabbitmqctl", "status"]
+    rabbitmq_cmd = ["rabbitmq-diagnostics", "check_running"]
     # fmt: on
 
-    if not wait_for_container_cmd(container_name, rabbitmq_cmd, 30):
+    if not wait_for_container_cmd(container_name, rabbitmq_cmd, 60):
         raise EnvironmentError(f"{QUEUE_COMPONENT_NAME} did not initialize in time")
 
     logger.info(f"Started {QUEUE_COMPONENT_NAME}.")

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -86,7 +86,7 @@ def wait_for_container_cmd(container_name: str, cmd_to_run: [str], timeout: int)
                 break
             time.sleep(1)
 
-    flatten_cmd = " ".join(cmd_to_run)
+    cmd_str  = " ".join(cmd_to_run)
     logger.error(f"Timeout while waiting for cmd {flatten_cmd} to run after {timeout} seconds")
     return False
 

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -87,7 +87,7 @@ def wait_for_container_cmd(container_name: str, cmd_to_run: [str], timeout: int)
             time.sleep(1)
 
     cmd_str = " ".join(cmd_to_run)
-    logger.error(f"Timeout while waiting for cmd {cmd_str} to run after {timeout} seconds")
+    logger.error(f"Timeout while waiting for command {cmd_str} to run after {timeout} seconds")
     return False
 
 

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -86,7 +86,7 @@ def wait_for_container_cmd(container_name: str, cmd_to_run: [str], timeout: int)
                 break
             time.sleep(1)
 
-    cmd_str  = " ".join(cmd_to_run)
+    cmd_str = " ".join(cmd_to_run)
     logger.error(f"Timeout while waiting for cmd {flatten_cmd} to run after {timeout} seconds")
     return False
 
@@ -272,9 +272,7 @@ def start_queue(instance_id: str, clp_config: CLPConfig):
     subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
 
     # Wait for queue to start up
-    # fmt: off
     rabbitmq_cmd = ["rabbitmq-diagnostics", "check_running"]
-    # fmt: on
 
     if not wait_for_container_cmd(container_name, rabbitmq_cmd, 60):
         raise EnvironmentError(f"{QUEUE_COMPONENT_NAME} did not initialize in time")

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -87,7 +87,7 @@ def wait_for_container_cmd(container_name: str, cmd_to_run: [str], timeout: int)
             time.sleep(1)
 
     cmd_str = " ".join(cmd_to_run)
-    logger.error(f"Timeout while waiting for cmd {flatten_cmd} to run after {timeout} seconds")
+    logger.error(f"Timeout while waiting for cmd {cmd_str} to run after {timeout} seconds")
     return False
 
 
@@ -273,7 +273,6 @@ def start_queue(instance_id: str, clp_config: CLPConfig):
 
     # Wait for queue to start up
     rabbitmq_cmd = ["rabbitmq-diagnostics", "check_running"]
-
     if not wait_for_container_cmd(container_name, rabbitmq_cmd, 60):
         raise EnvironmentError(f"{QUEUE_COMPONENT_NAME} did not initialize in time")
 


### PR DESCRIPTION
# Description
Remove the "-it" from the docker command in the start CLP script because cloud-init doesn't support docker with interactive mode

# Validation performed
Ran the package locally and on the docker and verifed that the script waits for database and queue to start.
