### PR TITLE
Remove unnecessary docker mounts from compress/search launch scripts.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -86,12 +86,7 @@ def main(argv):
         "--mount", str(mounts.clp_home),
     ]
     # fmt: on
-    necessary_mounts = [
-        mounts.input_logs_dir,
-        mounts.data_dir,
-        mounts.logs_dir,
-        mounts.archives_output_dir,
-    ]
+    necessary_mounts = [mounts.input_logs_dir, mounts.data_dir, mounts.logs_dir]
     for mount in necessary_mounts:
         if mount:
             container_start_cmd.append("--mount")

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -89,9 +89,7 @@ def main(argv):
         "--mount", str(mounts.clp_home),
     ]
     # fmt: on
-    necessary_mounts = [
-        mounts.logs_dir
-    ]
+    necessary_mounts = [mounts.logs_dir]
     for mount in necessary_mounts:
         if mount:
             container_start_cmd.append("--mount")

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -90,8 +90,7 @@ def main(argv):
     ]
     # fmt: on
     necessary_mounts = [
-        mounts.logs_dir,
-        mounts.archives_output_dir,
+        mounts.logs_dir
     ]
     for mount in necessary_mounts:
         if mount:


### PR DESCRIPTION
# Description

Remove unnecessary mount from the package_utils scripts. The current docker bind fails if the mount directory doesn't existm but neither compression or decompression script use the mount

The issue can be reproduced by running two CLP packages on two machines, a master package with everything except workers, and a worker package.

Running the compress.sh and search.sh from master package will trigger the error.

# Validation performed

Validated by making sure the above error is fixed, and the input can be compressed by workers
