### PR TITLE
Remove unnecessary files from execution container images.

### DIFF
--- a/tools/docker-images/clp-execution-base-focal/Dockerfile
+++ b/tools/docker-images/clp-execution-base-focal/Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /root
 RUN mkdir -p ./tools/docker-images/clp-execution-base-focal
 ADD ./tools/docker-images/clp-execution-base-focal/setup-scripts ./tools/docker-images/clp-execution-base-focal/setup-scripts
 
-RUN mkdir -p ./tools/scripts/lib_install
-ADD ./components/core/tools/scripts/lib_install ./tools/scripts/lib_install
-
 RUN ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
 
 # Reset the working directory so that it's accessible by any user who runs the

--- a/tools/docker-images/clp-execution-base-jammy/Dockerfile
+++ b/tools/docker-images/clp-execution-base-jammy/Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /root
 RUN mkdir -p ./tools/docker-images/clp-execution-base-jammy
 ADD ./tools/docker-images/clp-execution-base-jammy/setup-scripts ./tools/docker-images/clp-execution-base-jammy/setup-scripts
 
-RUN mkdir -p ./tools/scripts/lib_install
-ADD ./components/core/tools/scripts/lib_install ./tools/scripts/lib_install
-
 RUN ./tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
 
 # Reset the working directory so that it's accessible by any user who runs the


### PR DESCRIPTION
# Description

Remove the lines because the copied script is not used for the docker build

# Validation performed
Tested manually and verified that the docker can be built and run CLP binaries without any issue

