### PR TITLE
Reduce the size of the clp container images.

### DIFF
--- a/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
@@ -5,8 +5,10 @@ FROM ubuntu:focal AS BASE
 RUN apt-get update \
     && apt-get install -y \
     libmariadb-dev \
-    libssl-dev \
-    && apt-get clean \
+    libssl-dev
+
+# Remove cached files
+RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /clp

--- a/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
@@ -1,4 +1,13 @@
-FROM ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-focal:main
+FROM ubuntu:focal AS BASE
+
+# Install runtime dependencies
+# TODO: Investigate why libssl-dev is a hidden dependency of clp-s
+RUN apt-get update \
+    && apt-get install -y \
+    libmariadb-dev \
+    libssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /clp
 
@@ -9,3 +18,7 @@ ADD ./glt ./
 ADD ./make-dictionaries-readable ./
 
 CMD bash
+
+# Flatten the image
+FROM scratch
+COPY --from=BASE / /

--- a/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
@@ -9,16 +9,16 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-WORKDIR /clp
-
 ADD ./clg ./
 ADD ./clp ./
 ADD ./clp-s ./
 ADD ./glt ./
 ADD ./make-dictionaries-readable ./
 
-CMD bash
-
 # Flatten the image
 FROM scratch
 COPY --from=BASE / /
+
+WORKDIR /clp
+
+CMD bash

--- a/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+WORKDIR /clp
+
 ADD ./clg ./
 ADD ./clp ./
 ADD ./clp-s ./

--- a/components/core/tools/docker-images/clp-core-ubuntu-focal/build.sh
+++ b/components/core/tools/docker-images/clp-core-ubuntu-focal/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
+cUsage="Usage: ${BASH_SOURCE[0]} <clp-core-build-dir>"
+if [ "$#" -lt 1 ]; then
+    echo "${cUsage}"
+    exit
+fi
+build_dir="$1"
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+docker build -t clp-core-x86-ubuntu-focal:dev "${build_dir}" --file "${script_dir}/Dockerfile"

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7.4.1708
+FROM centos:centos7.4.1708 AS BASE
 
 WORKDIR /root
 
@@ -21,9 +21,17 @@ RUN ln -s /opt/rh/devtoolset-10/enable /etc/profile.d/devtoolset.sh
 #       cannot be forced to use a bash shell that loads .bashrc
 RUN cp ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/git /usr/bin/git
 
+# Remove cached files
+RUN yum clean \
+    && rm -rf /tmp/* /var/tmp/*
+
 # Load .bashrc for non-interactive bash shells
 ENV BASH_ENV=/etc/bashrc
 
 # Reset the working directory so that it's accessible by any user who runs the
 # container
 WORKDIR /
+
+# Flatten the image
+FROM scratch
+COPY --from=BASE / /

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -22,7 +22,7 @@ RUN ln -s /opt/rh/devtoolset-10/enable /etc/profile.d/devtoolset.sh
 RUN cp ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/git /usr/bin/git
 
 # Remove cached files
-RUN yum clean \
+RUN yum clean all \
     && rm -rf /tmp/* /var/tmp/*
 
 # Load .bashrc for non-interactive bash shells

--- a/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-centos7.4/Dockerfile
@@ -10,9 +10,6 @@ ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
 RUN ./tools/scripts/lib_install/centos7.4/install-all.sh
 
-# Set PKG_CONFIG_PATH since CentOS doesn't look in /usr/local by default
-ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
-
 # Enable gcc 10 in login shells and non-interactive non-login shells
 RUN ln -s /opt/rh/devtoolset-10/enable /etc/profile.d/devtoolset.sh
 
@@ -25,13 +22,12 @@ RUN cp ./tools/docker-images/clp-env-base-centos7.4/setup-scripts/git /usr/bin/g
 RUN yum clean all \
     && rm -rf /tmp/* /var/tmp/*
 
-# Load .bashrc for non-interactive bash shells
-ENV BASH_ENV=/etc/bashrc
-
-# Reset the working directory so that it's accessible by any user who runs the
-# container
-WORKDIR /
-
 # Flatten the image
 FROM scratch
 COPY --from=BASE / /
+
+# Set PKG_CONFIG_PATH since CentOS doesn't look in /usr/local by default
+ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
+
+# Load .bashrc for non-interactive bash shells
+ENV BASH_ENV=/etc/bashrc

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /root
 RUN mkdir -p ./tools/scripts/lib_install
 ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
-RUN ./tools/scripts/lib_install/ubuntu-focal/install-all.sh
+# NOTE: We can't use the `install-all.sh` script since we need to configure the compiler in between
+# `install-prebuilt-packages.sh` and `install-packages-from-source.sh`.
+RUN ./tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
 
 # Set gcc/g++ 10 as the default compiler
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 \
@@ -16,6 +18,8 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 \
     && update-alternatives --set g++ /usr/bin/g++-10 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 20 \
     && update-alternatives --set c++ /usr/bin/g++-10
+
+RUN ./tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
 
 # Remove cached files
 RUN apt-get clean \

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:focal AS BASE
 
 WORKDIR /root
 
@@ -7,12 +7,24 @@ ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
 RUN ./tools/scripts/lib_install/ubuntu-focal/install-all.sh
 
-# Set the compiler to gcc-10
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
-RUN update-alternatives --set gcc /usr/bin/gcc-10
-RUN update-alternatives --set g++ /usr/bin/g++-10
+# Set gcc/g++ 10 as the default compiler
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 \
+    && update-alternatives --set gcc /usr/bin/gcc-10 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 20 \
+    && update-alternatives --set cc /usr/bin/gcc-10 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 \
+    && update-alternatives --set g++ /usr/bin/g++-10 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 20 \
+    && update-alternatives --set c++ /usr/bin/g++-10
+
+# Remove cached files
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Reset the working directory so that it's accessible by any user who runs the
 # container
 WORKDIR /
+
+# Flatten the image
+FROM scratch
+COPY --from=BASE / /

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
@@ -25,10 +25,6 @@ RUN ./tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
 RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Reset the working directory so that it's accessible by any user who runs the
-# container
-WORKDIR /
-
 # Flatten the image
 FROM scratch
 COPY --from=BASE / /

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
@@ -10,14 +10,14 @@ ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 RUN ./tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
 
 # Set gcc/g++ 10 as the default compiler
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 \
-    && update-alternatives --set gcc /usr/bin/gcc-10 \
-    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 20 \
-    && update-alternatives --set cc /usr/bin/gcc-10 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 \
-    && update-alternatives --set g++ /usr/bin/g++-10 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 20 \
-    && update-alternatives --set c++ /usr/bin/g++-10
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+RUN update-alternatives --set gcc /usr/bin/gcc-10
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 20
+RUN update-alternatives --set cc /usr/bin/gcc-10
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+RUN update-alternatives --set g++ /usr/bin/g++-10
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 20
+RUN update-alternatives --set c++ /usr/bin/g++-10
 
 RUN ./tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
 

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/Dockerfile
@@ -11,10 +11,6 @@ RUN ./tools/scripts/lib_install/ubuntu-jammy/install-all.sh
 RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Reset the working directory so that it's accessible by any user who runs the
-# container
-WORKDIR /
-
 # Flatten the image
 FROM scratch
 COPY --from=BASE / /

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:jammy AS BASE
 
 WORKDIR /root
 
@@ -7,6 +7,14 @@ ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 
 RUN ./tools/scripts/lib_install/ubuntu-jammy/install-all.sh
 
+# Remove cached files
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Reset the working directory so that it's accessible by any user who runs the
 # container
 WORKDIR /
+
+# Flatten the image
+FROM scratch
+COPY --from=BASE / /

--- a/components/core/tools/scripts/lib_install/centos7.4/README.md
+++ b/components/core/tools/scripts/lib_install/centos7.4/README.md
@@ -3,17 +3,19 @@ These same steps are used by our Docker containers.
 
 # Installing dependencies
 
-Before you run any commands below, you should review the scripts to ensure they
-will not install any dependencies you don't expect.
+> [!WARNING]
+> Before you run any commands below, you should review the scripts to ensure they will not install
+> any dependencies or apply any configurations that you don't expect.
 
-* Install all dependencies:
-  * ⚠ NOTE: The packages built from source (`install-packages-from-source.sh`) 
-    are installed without using a packager. So if you ever need to uninstall 
-    them, you will need to do so manually.
+To install all dependencies, run:
 
-  ```bash
-  ./install-all.sh
-  ```
+> [!NOTE]
+> The packages built from source (`install-packages-from-source.sh`) are installed without using a
+> packager. So if you ever need to uninstall them, you will need to do so manually.
+
+```bash
+./install-all.sh
+```
 
 # Setup dependencies
 

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/README.md
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/README.md
@@ -3,14 +3,33 @@ These same steps are used by our Docker containers.
 
 # Installing dependencies
 
-Before you run any commands below, you should review the scripts to ensure they
-will not install any dependencies you don't expect.
+> [!WARNING]
+> Before you run any commands below, you should review the scripts to ensure they will not install
+> any dependencies or apply any configurations that you don't expect.
 
-* Install all dependencies:
+To install all dependencies, run:
 
-  ```bash
-  ./install-all.sh
-  ```
+```bash
+./install-all.sh
+```
+
+# Setup dependencies
+
+Enable GCC 10 as the default compiler by running:
+
+```bash
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+update-alternatives --set gcc /usr/bin/gcc-10
+
+update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 20
+update-alternatives --set cc /usr/bin/gcc-10
+
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+update-alternatives --set g++ /usr/bin/g++-10
+
+update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 20
+update-alternatives --set c++ /usr/bin/g++-10
+```
 
 # Building CLP
 

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -7,12 +7,11 @@ set -e
 set -u
 
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   ca-certificates \
   checkinstall \
   cmake \
   curl \
-  build-essential \
   git \
   g++-10 \
   gcc-10 \
@@ -21,9 +20,9 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   libboost-program-options-dev \
   libmariadb-dev \
   libssl-dev \
+  make \
   openjdk-11-jdk \
   pkg-config \
   python3 \
   python3-pip \
-  rsync \
   zlib1g-dev

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/README.md
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/README.md
@@ -3,14 +3,15 @@ These same steps are used by our Docker containers.
 
 # Installing dependencies
 
-Before you run any commands below, you should review the scripts to ensure they
-will not install any dependencies you don't expect.
+> [!WARNING]
+> Before you run any commands below, you should review the scripts to ensure they will not install
+> any dependencies or apply any configurations that you don't expect.
 
-* Install all dependencies:
+To install all dependencies, run:
 
-  ```bash
-  ./install-all.sh
-  ```
+```bash
+./install-all.sh
+```
 
 # Building CLP
 

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
@@ -7,7 +7,7 @@ set -e
 set -u
 
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   ca-certificates \
   checkinstall \
   cmake \
@@ -23,5 +23,4 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
   pkg-config \
   python3 \
   python3-pip \
-  rsync \
   software-properties-common

--- a/tools/docker-images/clp-execution-base-focal/Dockerfile
+++ b/tools/docker-images/clp-execution-base-focal/Dockerfile
@@ -11,10 +11,6 @@ RUN ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuil
 RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Reset the working directory so that it's accessible by any user who runs the
-# container
-WORKDIR /
-
 # Flatten the image
 FROM scratch
 COPY --from=BASE / /

--- a/tools/docker-images/clp-execution-base-focal/Dockerfile
+++ b/tools/docker-images/clp-execution-base-focal/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:focal AS BASE
 
 WORKDIR /root
 
@@ -7,6 +7,14 @@ ADD ./tools/docker-images/clp-execution-base-focal/setup-scripts ./tools/docker-
 
 RUN ./tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
 
+# Remove cached files
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Reset the working directory so that it's accessible by any user who runs the
 # container
 WORKDIR /
+
+# Flatten the image
+FROM scratch
+COPY --from=BASE / /

--- a/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
@@ -7,7 +7,7 @@ set -e
 set -u
 
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   checkinstall \
   curl \
   libmariadb-dev \

--- a/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-focal/setup-scripts/install-prebuilt-packages.sh
@@ -11,6 +11,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   checkinstall \
   curl \
   libmariadb-dev \
+  libssl-dev \
   python3 \
   rsync \
   zstd

--- a/tools/docker-images/clp-execution-base-jammy/Dockerfile
+++ b/tools/docker-images/clp-execution-base-jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:jammy AS BASE
 
 WORKDIR /root
 
@@ -7,6 +7,14 @@ ADD ./tools/docker-images/clp-execution-base-jammy/setup-scripts ./tools/docker-
 
 RUN ./tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
 
+# Remove cached files
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Reset the working directory so that it's accessible by any user who runs the
 # container
 WORKDIR /
+
+# Flatten the image
+FROM scratch
+COPY --from=BASE / /

--- a/tools/docker-images/clp-execution-base-jammy/Dockerfile
+++ b/tools/docker-images/clp-execution-base-jammy/Dockerfile
@@ -11,10 +11,6 @@ RUN ./tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuil
 RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Reset the working directory so that it's accessible by any user who runs the
-# container
-WORKDIR /
-
 # Flatten the image
 FROM scratch
 COPY --from=BASE / /

--- a/tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
@@ -7,7 +7,7 @@ set -e
 set -u
 
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   checkinstall \
   curl \
   libmariadb-dev \

--- a/tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-jammy/setup-scripts/install-prebuilt-packages.sh
@@ -11,6 +11,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   checkinstall \
   curl \
   libmariadb-dev \
+  libssl-dev \
   python3 \
   rsync \
   zstd


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR modifies the generation of the docker images to reduce their final size. This has two benefits:

1. It will be faster for users to pull the containers from GitHub.
2. It will allow us to switch to a GitHub workflow model where we can share container images between jobs.

For (2), our current solution is to build the image and use it all within a single job (e.g., when core's dependencies change in a PR, we need to rebuild the container image before rebuilding core). This requires using a complex set of GitHub actions; besides the complexity, actions are more opaque than jobs and don't allow creation of a DAG of dependencies. Ideally, we should switch to building the container in one job and using it in (multiple) dependent jobs.

Sharing a container image between jobs requires uploading the image in the producer and downloading it in the consumers. GitHub only allows 2GB per upload, so we need to optimize the size of our images to stay under this limit.

This PR reduces the size of images in a few ways:

1. Deleting cached files from the image.
2. No longer installing unnecessary packages in the image.
3. Not installing apt recommended packages.
4. Flattening the image using multistage builds.

To understand (3), recall that each step in a Dockerfile is cached (into what's called a layer) by a Docker registry so that modifications to the later steps in the Dockerfile don't require a full rebuild. However, this means pulling a Docker image requires downloading all of these layers. Docker has a feature to instead reset the state of an image and then copy the filesystem state, essentially flattening the layers.

The effect of this PR is modest (~100 MiB) for most images but for [clp-core-x86-ubuntu-focal](https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-x86-ubuntu-focal), the difference is ~1 GiB since we switched to using `ubuntu:focal` as the base image rather than [clp-core-dependencies-x86-ubuntu-focal](https://github.com/orgs/y-scope/packages/container/package/clp%2Fclp-core-dependencies-x86-ubuntu-focal) (essentially removing the build dependencies).

This PR also configures cc to map to gcc-10 in [clp-core-dependencies-x86-ubuntu-focal](https://github.com/orgs/y-scope/packages/container/package/clp%2Fclp-core-dependencies-x86-ubuntu-focal) since we no longer install the default gcc in the image.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated all images still build
* Validated the binaries in `clp-core-x86-ubuntu-focal` still work
* Validated `clp`, `clp-s`, and `clo` still work in the execution images (`clp-execution-x86-ubuntu-focal` & `clp-execution-x86-ubuntu-jammy`).
* Validated that the image size was reduced for every image using the following steps:

  ```bash
  docker image save <image-name> -o <output-file>
  du -sb <output-file>
  ```