### PR TITLE
Move lint tasks into their own Taskfile.

### DIFF
--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -25,4 +25,4 @@ jobs:
 
       - name: "Run lint task"
         shell: "bash"
-        run: "task lint-check"
+        run: "task lint:check"

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ you can run the [clp-lint](.github/workflows/clp-lint.yaml) workflow in your for
 To perform the linting checks:
 
 ```shell
-task lint-check
+task lint:check
 ```
 
 To also apply any automatic fixes:
 
 ```shell
-task lint-fix
+task lint:fix
 ```
 
 [1]: https://github.com/orgs/y-scope/packages?repo_name=clp

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,9 +1,11 @@
 version: "3"
 
+includes:
+  lint: "lint-tasks.yml"
+
 vars:
   BUILD_DIR: "{{.TASKFILE_DIR}}/build"
   CORE_COMPONENT_BUILD_DIR: "{{.TASKFILE_DIR}}/build/core"
-  LINT_VENV_DIR: "{{.TASKFILE_DIR}}/.lint-venv"
   NODEJS_BIN_DIR: "{{.TASKFILE_DIR}}/build/nodejs/node/bin"
   NODEJS_BUILD_DIR: "{{.TASKFILE_DIR}}/build/nodejs"
   PACKAGE_BUILD_DIR: "{{.TASKFILE_DIR}}/build/clp-package"
@@ -207,96 +209,6 @@ tasks:
       - "./*"
       - "{{.WEBUI_BUILD_DIR}}/**/*"
 
-  lint-check:
-    cmds:
-      - task: "core-lint-check"
-      - task: "py-lint-check"
-      - task: "yamllint"
-
-  lint-fix:
-    cmds:
-      - task: "core-lint-fix"
-      - task: "py-lint-fix"
-      - task: "yamllint"
-
-  core-lint-check:
-    dir: "{{.TASKFILE_DIR}}/components/core"
-    cmds:
-      - task: "core-lint"
-        vars:
-          FLAGS: "--dry-run"
-    sources: &core_lint_source_files
-      - ".clang-format"
-      - "src/**/*.cpp"
-      - "src/**/*.h"
-      - "src/**/*.hpp"
-      - "src/**/*.inc"
-      - "Taskfile.yml"
-      - "tests/**/*.cpp"
-      - "tests/**/*.h"
-      - "tests/**/*.hpp"
-      - "tests/**/*.inc"
-
-  core-lint-fix:
-    dir: "{{.TASKFILE_DIR}}/components/core"
-    cmds:
-      - task: "core-lint"
-        vars:
-          FLAGS: "-i"
-    sources: *core_lint_source_files
-
-  py-lint-check:
-    cmds:
-      - task: "py-lint"
-        vars:
-          BLACK_FLAGS: "--check"
-          RUFF_FLAGS: ""
-
-  py-lint-fix:
-    cmds:
-      - task: "py-lint"
-        vars:
-          BLACK_FLAGS: ""
-          RUFF_FLAGS: "--fix"
-
-  yamllint:
-    deps: ["lint-venv"]
-    cmds:
-      - |-
-        . "{{.LINT_VENV_DIR}}/bin/activate"
-        yamllint .
-
-  core-lint:
-    internal: true
-    requires:
-      vars: ["FLAGS"]
-    deps: ["lint-venv"]
-    dir: "{{.TASKFILE_DIR}}/components/core"
-    cmds:
-      - |-
-        . "{{.LINT_VENV_DIR}}/bin/activate"
-        find src tests \
-          -type f \
-          \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
-          -print0 | \
-            xargs -0 clang-format {{.FLAGS}} -Werror
-
-  py-lint:
-    internal: true
-    requires:
-      vars: ["BLACK_FLAGS", "RUFF_FLAGS"]
-    deps: ["lint-venv"]
-    cmds:
-      - for:
-          - "components/clp-package-utils/clp_package_utils"
-          - "components/clp-py-utils/clp_py_utils"
-          - "components/job-orchestration/job_orchestration"
-        cmd: |-
-          . "{{.LINT_VENV_DIR}}/bin/activate"
-          cd "{{.ITEM}}"
-          black --color --line-length 100 {{.BLACK_FLAGS}} .
-          ruff check {{.RUFF_FLAGS}} .
-
   core-submodules:
     internal: true
     dir: "components/core"
@@ -393,30 +305,3 @@ tasks:
     dir: "components/{{.COMPONENT}}"
     cmds:
       - "rm -rf dist"
-
-  lint-venv:
-    internal: true
-    vars:
-      CREATION_TIMESTAMP_FILE: "{{.LINT_VENV_DIR}}/creation_time.txt"
-    dir: "{{.TASKFILE_DIR}}"
-    cmds:
-      - "rm -rf '{{.LINT_VENV_DIR}}'"
-      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
-      # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
-      # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
-      # shell was one that had the command, but that's not the case in newer versions.
-      - "sed -i 's/^\\s*hash\\s\\+.*/true/g' \"{{.LINT_VENV_DIR}}/bin/activate\""
-      - |-
-        . "{{.LINT_VENV_DIR}}/bin/activate"
-        pip3 install --upgrade pip
-        pip3 install --upgrade -r lint-requirements.txt
-      # This step must be last since we use this file to detect whether the venv was created
-      # successfully
-      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
-    method: "timestamp"
-    sources:
-      - "lint-requirements.txt"
-      - "Taskfile.yml"
-    status:
-      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,0 +1,125 @@
+version: "3"
+
+vars:
+  VENV_DIR: "{{.TASKFILE_DIR}}/.lint-venv"
+
+tasks:
+  check:
+    cmds:
+      - task: "cpp-check"
+      - task: "py-check"
+      - task: "yml-check"
+
+  fix:
+    cmds:
+      - task: "cpp-fix"
+      - task: "py-fix"
+      - task: "yml-fix"
+
+  cpp-check:
+    dir: "{{.TASKFILE_DIR}}/components/core"
+    cmds:
+      - task: "cpp"
+        vars:
+          FLAGS: "--dry-run"
+    sources: &cpp_source_files
+      - ".clang-format"
+      - "src/**/*.cpp"
+      - "src/**/*.h"
+      - "src/**/*.hpp"
+      - "src/**/*.inc"
+      - "Taskfile.yml"
+      - "tests/**/*.cpp"
+      - "tests/**/*.h"
+      - "tests/**/*.hpp"
+      - "tests/**/*.inc"
+
+  cpp-fix:
+    dir: "{{.TASKFILE_DIR}}/components/core"
+    cmds:
+      - task: "cpp"
+        vars:
+          FLAGS: "-i"
+    sources: *cpp_source_files
+
+  py-check:
+    cmds:
+      - task: "py"
+        vars:
+          BLACK_FLAGS: "--check"
+          RUFF_FLAGS: ""
+
+  py-fix:
+    cmds:
+      - task: "py"
+        vars:
+          BLACK_FLAGS: ""
+          RUFF_FLAGS: "--fix"
+
+  yml:
+    aliases:
+      - "yml-check"
+      - "yml-fix"
+    deps: ["venv"]
+    cmds:
+      - |-
+        . "{{.VENV_DIR}}/bin/activate"
+        yamllint .
+
+  cpp:
+    internal: true
+    requires:
+      vars: ["FLAGS"]
+    deps: ["venv"]
+    dir: "{{.TASKFILE_DIR}}/components/core"
+    cmds:
+      - |-
+        . "{{.VENV_DIR}}/bin/activate"
+        find src tests \
+          -type f \
+          \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
+          -print0 | \
+            xargs -0 clang-format {{.FLAGS}} -Werror
+
+  py:
+    internal: true
+    requires:
+      vars: ["BLACK_FLAGS", "RUFF_FLAGS"]
+    deps: ["venv"]
+    cmds:
+      - for:
+          - "components/clp-package-utils/clp_package_utils"
+          - "components/clp-py-utils/clp_py_utils"
+          - "components/job-orchestration/job_orchestration"
+        cmd: |-
+          . "{{.VENV_DIR}}/bin/activate"
+          cd "{{.ITEM}}"
+          black --color --line-length 100 {{.BLACK_FLAGS}} .
+          ruff check {{.RUFF_FLAGS}} .
+
+  venv:
+    internal: true
+    vars:
+      CREATION_TIMESTAMP_FILE: "{{.VENV_DIR}}/creation_time.txt"
+    dir: "{{.TASKFILE_DIR}}"
+    cmds:
+      - "rm -rf '{{.VENV_DIR}}'"
+      - "python3 -m venv '{{.VENV_DIR}}'"
+      # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
+      # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
+      # shell was one that had the command, but that's not the case in newer versions.
+      - "sed -i 's/^\\s*hash\\s\\+.*/true/g' \"{{.VENV_DIR}}/bin/activate\""
+      - |-
+        . "{{.VENV_DIR}}/bin/activate"
+        pip3 install --upgrade pip
+        pip3 install --upgrade -r lint-requirements.txt
+      # This step must be last since we use this file to detect whether the venv was created
+      # successfully
+      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
+    method: "timestamp"
+    sources:
+      - "lint-requirements.txt"
+      - "Taskfile.yml"
+    status:
+      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
+      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

`Taskfile.yml` is getting quite big so this PR moves the lint tasks into their own Taskfile (`lint-tasks.yml`). This means that all the lint tasks are now in the "namespace", `lint`; so a task like `py-lint-check` is now `lint:py-check`.

This PR also renames some lint tasks for consistency:

* core-lint-check/fix -> lint:cpp-check/fix
* yamllint -> lint:yml-check/fix

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated `task`.
* Validated `lint:check`
* Validated `lint:fix`
* Validated lint workflow
