### PR TITLE
Taskfile: Improve tracking of dependencies and generated files.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,7 +11,6 @@ vars:
     --numeric-owner
     --owner=0
     --sort=name
-    --xattrs
   CORE_COMPONENT_BUILD_DIR: "{{.TASKFILE_DIR}}/build/core"
   NODEJS_BIN_DIR: "{{.TASKFILE_DIR}}/build/nodejs/node/bin"
   NODEJS_BUILD_DIR: "{{.TASKFILE_DIR}}/build/nodejs"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -104,7 +104,9 @@ tasks:
         cd "{{.OUTPUT_DIR}}/var/www/programs/server"
         PATH="{{.NODEJS_BIN_DIR}}":$PATH npm install
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
+      - |-
+        cd "{{.OUTPUT_DIR}}"
+        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.BUILD_DIR}}/nodejs.md5"
       - "{{.BUILD_DIR}}/package-venv.md5"
@@ -122,7 +124,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
+        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   core:
@@ -180,14 +182,16 @@ tasks:
         "{{.OUTPUT_DIR}}/node"
       - "rm -f '{{.OUTPUT_DIR}}/{{.TAR_FILE_NAME}}'"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
+      - |-
+        cd "{{.OUTPUT_DIR}}"
+        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     status:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
+        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   webui:
@@ -209,7 +213,9 @@ tasks:
         "{{.OUTPUT_DIR}}/"
       - "rm -rf '{{.OUTPUT_DIR}}/bundle/'"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
+      - |-
+        cd "{{.OUTPUT_DIR}}"
+        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "*"
@@ -222,7 +228,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
+        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   core-submodules:
@@ -234,7 +240,9 @@ tasks:
     cmds:
       - "tools/scripts/deps-download/download-all.sh"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
+      - |-
+        cd "{{.OUTPUT_DIR}}"
+        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - ".gitmodules"
@@ -243,7 +251,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
+        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   package-venv:
@@ -258,7 +266,9 @@ tasks:
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
+      - |-
+        cd "{{.OUTPUT_DIR}}"
+        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
@@ -266,7 +276,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
+        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   python-component:
@@ -315,7 +325,9 @@ tasks:
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
+      - |-
+        cd "{{.OUTPUT_DIR}}"
+        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
@@ -324,7 +336,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
+        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   clean-python-component:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,7 @@ vars:
     --group=0
     --owner=0
     --numeric-owner
+    --xattrs
   CORE_COMPONENT_BUILD_DIR: "{{.TASKFILE_DIR}}/build/core"
   NODEJS_BIN_DIR: "{{.TASKFILE_DIR}}/build/nodejs/node/bin"
   NODEJS_BUILD_DIR: "{{.TASKFILE_DIR}}/build/nodejs"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,7 +119,7 @@ tasks:
       - "components/job-orchestration/dist/*.whl"
       - "components/package-template/src/**/*"
     status:
-      - test -f "{{.CHECKSUM_FILE}}"
+      - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
         <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
@@ -184,7 +184,7 @@ tasks:
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     status:
-      - test -f "{{.CHECKSUM_FILE}}"
+      - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
         <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
@@ -219,7 +219,7 @@ tasks:
       - "server/**/*"
       - "tests/**/*"
     status:
-      - test -f "{{.CHECKSUM_FILE}}"
+      - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
         <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
@@ -240,7 +240,7 @@ tasks:
       - ".gitmodules"
       - "tools/scripts/deps-download/**/*"
     status:
-      - test -f "{{.CHECKSUM_FILE}}"
+      - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
         <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
@@ -263,7 +263,7 @@ tasks:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     status:
-      - test -f "{{.CHECKSUM_FILE}}"
+      - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
         <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
@@ -321,7 +321,7 @@ tasks:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "pyproject.toml"
     status:
-      - test -f "{{.CHECKSUM_FILE}}"
+      - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
         <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,11 +6,11 @@ includes:
 vars:
   BUILD_DIR: "{{.TASKFILE_DIR}}/build"
   CHECKSUM_TAR_BASE_ARGS: >-
-    --sort=name
-    --mtime='UTC 1970-01-01'
     --group=0
-    --owner=0
+    --mtime='UTC 1970-01-01'
     --numeric-owner
+    --owner=0
+    --sort=name
     --xattrs
   CORE_COMPONENT_BUILD_DIR: "{{.TASKFILE_DIR}}/build/core"
   NODEJS_BIN_DIR: "{{.TASKFILE_DIR}}/build/nodejs/node/bin"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,14 +56,14 @@ tasks:
       - "ln -s '{{.PACKAGE_BUILD_DIR}}' '{{.VERSIONED_PACKAGE_NAME}}'"
       - "tar czf '{{.VERSIONED_PACKAGE_NAME}}.tar.gz' --dereference '{{.VERSIONED_PACKAGE_NAME}}'"
     sources:
-      - "{{.BUILD_DIR}}/package.sha256"
+      - "{{.BUILD_DIR}}/package.md5"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:
       - "{{.VERSIONED_PACKAGE_NAME}}.tar.gz"
 
   package:
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.PACKAGE_BUILD_DIR}}"
       PACKAGE_VERSION_FILE: "{{.PACKAGE_BUILD_DIR}}/VERSION"
     deps:
@@ -104,11 +104,11 @@ tasks:
         cd "{{.OUTPUT_DIR}}/var/www/programs/server"
         PATH="{{.NODEJS_BIN_DIR}}":$PATH npm install
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
     sources:
-      - "{{.BUILD_DIR}}/nodejs.sha256"
-      - "{{.BUILD_DIR}}/package-venv.sha256"
-      - "{{.BUILD_DIR}}/webui.sha256"
+      - "{{.BUILD_DIR}}/nodejs.md5"
+      - "{{.BUILD_DIR}}/package-venv.md5"
+      - "{{.BUILD_DIR}}/webui.md5"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
@@ -122,7 +122,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   core:
@@ -134,7 +134,7 @@ tasks:
       - "cmake -S '{{.SRC_DIR}}' -B '{{.CORE_COMPONENT_BUILD_DIR}}'"
       - "cmake --build '{{.CORE_COMPONENT_BUILD_DIR}}' --parallel --target clg clo clp clp-s"
     sources:
-      - "{{.BUILD_DIR}}/core-submodules.sha256"
+      - "{{.BUILD_DIR}}/core-submodules.md5"
       - "{{.SRC_DIR}}/cmake/**/*"
       - "{{.SRC_DIR}}/CMakeLists.txt"
       - "{{.SRC_DIR}}/src/**/*"
@@ -162,7 +162,7 @@ tasks:
 
   nodejs:
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
       NODEJS_VERSION: "14.21.3"
       NODEJS_ARCH: "{{ if eq ARCH \"arm64\" }}arm64{{ else }}x64{{ end }}"
       OUTPUT_DIR: "{{.NODEJS_BUILD_DIR}}"
@@ -180,21 +180,21 @@ tasks:
         "{{.OUTPUT_DIR}}/node"
       - "rm -f '{{.OUTPUT_DIR}}/{{.TAR_FILE_NAME}}'"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     status:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   webui:
     dir: "components/webui"
     platforms: ["386", "amd64"]
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.WEBUI_BUILD_DIR}}"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
@@ -209,7 +209,7 @@ tasks:
         "{{.OUTPUT_DIR}}/"
       - "rm -rf '{{.OUTPUT_DIR}}/bundle/'"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "*"
@@ -222,19 +222,19 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   core-submodules:
     internal: true
     dir: "components/core"
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "submodules"
     cmds:
       - "tools/scripts/deps-download/download-all.sh"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - ".gitmodules"
@@ -243,13 +243,13 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   package-venv:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.PACKAGE_VENV_DIR}}"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
@@ -258,7 +258,7 @@ tasks:
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
@@ -266,7 +266,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   python-component:
@@ -292,7 +292,7 @@ tasks:
         . "{{.VENV_DIR}}/bin/activate"
         poetry build --format wheel
     sources:
-      - "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.sha256"
+      - "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.md5"
       - "{{.PACKAGE}}/**/*"
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
@@ -307,7 +307,7 @@ tasks:
     label: "{{.COMPONENT}}_venv"
     dir: "components/{{.COMPONENT}}"
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.sha256"
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.md5"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "python3 -m venv '{{.OUTPUT_DIR}}'"
@@ -315,7 +315,7 @@ tasks:
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
-      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | md5sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
@@ -324,7 +324,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   clean-python-component:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,6 +65,7 @@ tasks:
       - "clp-py-utils"
       - "job-orchestration"
       - "package-venv"
+      - "nodejs"
       - "webui"
     cmds:
       - task: "clean-package"
@@ -89,9 +90,12 @@ tasks:
         "{{.PACKAGE_BUILD_DIR}}/bin/"
       - "mkdir -p '{{.PACKAGE_BUILD_DIR}}/var/www/'"
       - >-
-        rsync -a --delete
+        rsync -a
         "{{.WEBUI_BUILD_DIR}}/"
         "{{.PACKAGE_BUILD_DIR}}/var/www/"
+      - |-
+        cd "{{.PACKAGE_BUILD_DIR}}/var/www/programs/server"
+        PATH="{{.NODEJS_BIN_DIR}}":$PATH npm install
       # This step must be last since we use this file to detect whether the package was built
       # successfully
       - "echo {{.PACKAGE_VERSION}} > '{{.PACKAGE_VERSION_FILE}}'"
@@ -101,6 +105,7 @@ tasks:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
+      - "{{.NODEJS_BUILD_DIR}}/node/**/*"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "{{.WEBUI_BUILD_DIR}}/**/*"
       - "components/clp-package-utils/dist/*.whl"
@@ -177,15 +182,6 @@ tasks:
       - "{{.NODEJS_BUILD_DIR}}/node/**/*"
 
   webui:
-    deps:
-      - "nodejs"
-      - "webui-bundle"
-    cmds:
-      - |-
-        cd "{{.WEBUI_BUILD_DIR}}/programs/server"
-        PATH="{{.NODEJS_BIN_DIR}}":$PATH $(readlink -f "{{.NODEJS_BIN_DIR}}/npm") install
-
-  webui-bundle:
     dir: "components/webui"
     platforms: ["386", "amd64"]
     cmds:
@@ -201,12 +197,12 @@ tasks:
         "{{.WEBUI_BUILD_DIR}}/"
       - "rm -rf '{{.WEBUI_BUILD_DIR}}/bundle/'"
     sources:
-      - "./.meteor/*"
-      - "./client/**/*"
-      - "./imports/**/*"
-      - "./server/**/*"
-      - "./tests/**/*"
-      - "./*"
+      - ".meteor/*"
+      - "client/**/*"
+      - "imports/**/*"
+      - "server/**/*"
+      - "tests/**/*"
+      - "*"
       - "{{.WEBUI_BUILD_DIR}}/**/*"
 
   core-submodules:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,16 +45,14 @@ tasks:
           source /etc/os-release
           echo "clp-package-${ID}-${VERSION_CODENAME}-$(arch)-v{{.PACKAGE_VERSION}}"
     dir: "{{.BUILD_DIR}}"
-    method: "timestamp"
     cmds:
       - "rm -rf '{{.VERSIONED_PACKAGE_NAME}}' '{{.VERSIONED_PACKAGE_NAME}}.tar.gz'"
       - "ln -s '{{.PACKAGE_BUILD_DIR}}' '{{.VERSIONED_PACKAGE_NAME}}'"
       - "tar czf '{{.VERSIONED_PACKAGE_NAME}}.tar.gz' --dereference '{{.VERSIONED_PACKAGE_NAME}}'"
     sources:
       - "{{.PACKAGE_BUILD_DIR}}/**/*"
-    status:
-      - "test -e {{.VERSIONED_PACKAGE_NAME}}.tar.gz"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y {{.VERSIONED_PACKAGE_NAME}}.tar.gz)"
+    generates:
+      - "{{.VERSIONED_PACKAGE_NAME}}.tar.gz"
 
   package:
     vars:
@@ -96,10 +94,6 @@ tasks:
       - |-
         cd "{{.PACKAGE_BUILD_DIR}}/var/www/programs/server"
         PATH="{{.NODEJS_BIN_DIR}}":$PATH npm install
-      # This step must be last since we use this file to detect whether the package was built
-      # successfully
-      - "echo {{.PACKAGE_VERSION}} > '{{.PACKAGE_VERSION_FILE}}'"
-    method: "timestamp"
     sources:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
@@ -112,9 +106,8 @@ tasks:
       - "components/clp-py-utils/dist/*.whl"
       - "components/job-orchestration/dist/*.whl"
       - "components/package-template/src/**/*"
-    status:
-      - "test -e '{{.PACKAGE_VERSION_FILE}}'"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.PACKAGE_VERSION_FILE}}')"
+    generates:
+      - "{{.PACKAGE_BUILD_DIR}}/**/*"
 
   core:
     deps: ["core-submodules"]
@@ -124,27 +117,17 @@ tasks:
       - "mkdir -p '{{.CORE_COMPONENT_BUILD_DIR}}'"
       - "cmake -S '{{.SRC_DIR}}' -B '{{.CORE_COMPONENT_BUILD_DIR}}'"
       - "cmake --build '{{.CORE_COMPONENT_BUILD_DIR}}' --parallel --target clg clo clp clp-s"
-    method: "timestamp"
     sources:
       - "{{.SRC_DIR}}/cmake/**/*"
       - "{{.SRC_DIR}}/CMakeLists.txt"
       - "{{.SRC_DIR}}/src/**/*"
       - "{{.SRC_DIR}}/submodules/**/*"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
-    status:
-      - >-
-        test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clg'
-        && test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clo'
-        && test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clp'
-        && test -e '{{.CORE_COMPONENT_BUILD_DIR}}/clp-s'
-      - >-
-        test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clg')
-        && test {{.TIMESTAMP | unixEpoch}} -lt
-        $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clo')
-        && test {{.TIMESTAMP | unixEpoch}} -lt
-        $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clp')
-        && test {{.TIMESTAMP | unixEpoch}} -lt
-        $(stat --format %Y '{{.CORE_COMPONENT_BUILD_DIR}}/clp-s')
+    generates:
+      - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
+      - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
+      - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
+      - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
 
   clp-package-utils:
     - task: "python-component"
@@ -178,7 +161,7 @@ tasks:
         mv "{{.NODEJS_BUILD_DIR}}/node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}"
         "{{.NODEJS_BUILD_DIR}}/node"
       - "rm -f '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}'"
-    sources:
+    generates:
       - "{{.NODEJS_BUILD_DIR}}/node/**/*"
 
   webui:
@@ -203,6 +186,7 @@ tasks:
       - "server/**/*"
       - "tests/**/*"
       - "*"
+    generates:
       - "{{.WEBUI_BUILD_DIR}}/**/*"
 
   core-submodules:
@@ -213,27 +197,22 @@ tasks:
     sources:
       - ".gitmodules"
       - "tools/scripts/deps-download/**/*"
+    generates:
+      - "submodules/**/*"
 
   package-venv:
     internal: true
-    vars:
-      CREATION_TIMESTAMP_FILE: "{{.PACKAGE_VENV_DIR}}/creation_time.txt"
     cmds:
       - "rm -rf '{{.PACKAGE_VENV_DIR}}'"
       - "python3 -m venv '{{.PACKAGE_VENV_DIR}}'"
       - |-
         . "{{.PACKAGE_VENV_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
-      # This step must be last since we use this file to detect whether the venv was created
-      # successfully
-      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
-    method: "timestamp"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
-    status:
-      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"
+    generates:
+      - "{{.PACKAGE_VENV_DIR}}/**/*"
 
   python-component:
     internal: true
@@ -257,15 +236,13 @@ tasks:
       - |-
         . "{{.VENV_DIR}}/bin/activate"
         poetry build --format wheel
-    method: "timestamp"
     sources:
       - "{{.PACKAGE}}/**/*"
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "pyproject.toml"
-    status:
-      - "ls dist/*.whl"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y dist/*.whl)"
+    generates:
+      - "dist/*.whl"
 
   component-venv:
     internal: true
@@ -273,25 +250,18 @@ tasks:
       vars: ["COMPONENT", "COMPONENT_VENV_DIR"]
     label: "{{.COMPONENT}}_venv"
     dir: "components/{{.COMPONENT}}"
-    vars:
-      CREATION_TIMESTAMP_FILE: "{{.COMPONENT_VENV_DIR}}/creation_time.txt"
     cmds:
       - "rm -rf '{{.COMPONENT_VENV_DIR}}'"
       - "python3 -m venv '{{.COMPONENT_VENV_DIR}}'"
       - |-
         . "{{.COMPONENT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
-      # This step must be last since we use this file to detect whether the venv was created
-      # successfully
-      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
-    method: "timestamp"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "pyproject.toml"
-    status:
-      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"
+    generates:
+      - "{{.COMPONENT_VENV_DIR}}/**/*"
 
   clean-python-component:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,12 @@ includes:
 
 vars:
   BUILD_DIR: "{{.TASKFILE_DIR}}/build"
+  CHECKSUM_TAR_BASE_ARGS: >-
+    --sort=name
+    --mtime='UTC 1970-01-01'
+    --group=0
+    --owner=0
+    --numeric-owner
   CORE_COMPONENT_BUILD_DIR: "{{.TASKFILE_DIR}}/build/core"
   NODEJS_BIN_DIR: "{{.TASKFILE_DIR}}/build/nodejs/node/bin"
   NODEJS_BUILD_DIR: "{{.TASKFILE_DIR}}/build/nodejs"
@@ -50,13 +56,15 @@ tasks:
       - "ln -s '{{.PACKAGE_BUILD_DIR}}' '{{.VERSIONED_PACKAGE_NAME}}'"
       - "tar czf '{{.VERSIONED_PACKAGE_NAME}}.tar.gz' --dereference '{{.VERSIONED_PACKAGE_NAME}}'"
     sources:
-      - "{{.PACKAGE_BUILD_DIR}}/**/*"
+      - "{{.BUILD_DIR}}/package.sha256"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:
       - "{{.VERSIONED_PACKAGE_NAME}}.tar.gz"
 
   package:
     vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      OUTPUT_DIR: "{{.PACKAGE_BUILD_DIR}}"
       PACKAGE_VERSION_FILE: "{{.PACKAGE_BUILD_DIR}}/VERSION"
     deps:
       - "core"
@@ -68,17 +76,17 @@ tasks:
       - "webui"
     cmds:
       - task: "clean-package"
-      - "mkdir -p '{{.PACKAGE_BUILD_DIR}}'"
-      - "rsync -a components/package-template/src/ '{{.PACKAGE_BUILD_DIR}}'"
-      - "mkdir -p '{{.PACKAGE_BUILD_DIR}}/lib/python3/site-packages'"
+      - "mkdir -p '{{.OUTPUT_DIR}}'"
+      - "rsync -a components/package-template/src/ '{{.OUTPUT_DIR}}'"
+      - "mkdir -p '{{.OUTPUT_DIR}}/lib/python3/site-packages'"
       - |-
         . "{{.PACKAGE_VENV_DIR}}/bin/activate"
         pip3 install --upgrade \
           components/clp-package-utils/dist/*.whl \
           components/clp-py-utils/dist/*.whl \
           components/job-orchestration/dist/*.whl \
-          -t "{{.PACKAGE_BUILD_DIR}}/lib/python3/site-packages"
-      - "mkdir -p '{{.PACKAGE_BUILD_DIR}}/bin'"
+          -t "{{.OUTPUT_DIR}}/lib/python3/site-packages"
+      - "mkdir -p '{{.OUTPUT_DIR}}/bin'"
       - >-
         rsync -a
         "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
@@ -86,30 +94,36 @@ tasks:
         "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
         "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
         "{{.NODEJS_BIN_DIR}}/node"
-        "{{.PACKAGE_BUILD_DIR}}/bin/"
-      - "mkdir -p '{{.PACKAGE_BUILD_DIR}}/var/www/'"
+        "{{.OUTPUT_DIR}}/bin/"
+      - "mkdir -p '{{.OUTPUT_DIR}}/var/www/'"
       - >-
         rsync -a
         "{{.WEBUI_BUILD_DIR}}/"
-        "{{.PACKAGE_BUILD_DIR}}/var/www/"
+        "{{.OUTPUT_DIR}}/var/www/"
       - |-
-        cd "{{.PACKAGE_BUILD_DIR}}/var/www/programs/server"
+        cd "{{.OUTPUT_DIR}}/var/www/programs/server"
         PATH="{{.NODEJS_BIN_DIR}}":$PATH npm install
+      # Checksum the generated files (this command must be last)
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
     sources:
+      - "{{.BUILD_DIR}}/nodejs.sha256"
+      - "{{.BUILD_DIR}}/package-venv.sha256"
+      - "{{.BUILD_DIR}}/webui.sha256"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
-      - "{{.NODEJS_BUILD_DIR}}/node/**/*"
-      - "{{.PACKAGE_VENV_DIR}}/**/*"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
-      - "{{.WEBUI_BUILD_DIR}}/**/*"
       - "components/clp-package-utils/dist/*.whl"
       - "components/clp-py-utils/dist/*.whl"
       - "components/job-orchestration/dist/*.whl"
       - "components/package-template/src/**/*"
-    generates:
-      - "{{.PACKAGE_BUILD_DIR}}/**/*"
+    status:
+      - test -f "{{.CHECKSUM_FILE}}"
+      - >-
+        diff
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        "{{.CHECKSUM_FILE}}"
 
   core:
     deps: ["core-submodules"]
@@ -120,10 +134,10 @@ tasks:
       - "cmake -S '{{.SRC_DIR}}' -B '{{.CORE_COMPONENT_BUILD_DIR}}'"
       - "cmake --build '{{.CORE_COMPONENT_BUILD_DIR}}' --parallel --target clg clo clp clp-s"
     sources:
+      - "{{.BUILD_DIR}}/core-submodules.sha256"
       - "{{.SRC_DIR}}/cmake/**/*"
       - "{{.SRC_DIR}}/CMakeLists.txt"
       - "{{.SRC_DIR}}/src/**/*"
-      - "{{.SRC_DIR}}/submodules/**/*"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
@@ -148,41 +162,54 @@ tasks:
 
   nodejs:
     vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
       NODEJS_VERSION: "14.21.3"
       NODEJS_ARCH: "{{ if eq ARCH \"arm64\" }}arm64{{ else }}x64{{ end }}"
+      OUTPUT_DIR: "{{.NODEJS_BUILD_DIR}}"
       TAR_FILE_NAME: "node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}.tar.xz"
     cmds:
-      - "rm -rf '{{.NODEJS_BUILD_DIR}}/node'"
-      - "mkdir -p '{{.NODEJS_BUILD_DIR}}'"
+      - "rm -rf '{{.OUTPUT_DIR}}/node'"
+      - "mkdir -p '{{.OUTPUT_DIR}}'"
       - >-
         curl -fsSL
         "https://nodejs.org/dist/v{{.NODEJS_VERSION}}/{{.TAR_FILE_NAME}}"
-        -o "{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}"
-      - "tar xf '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}' -C '{{.NODEJS_BUILD_DIR}}'"
+        -o "{{.OUTPUT_DIR}}/{{.TAR_FILE_NAME}}"
+      - "tar xf '{{.OUTPUT_DIR}}/{{.TAR_FILE_NAME}}' -C '{{.OUTPUT_DIR}}'"
       - >-
-        mv "{{.NODEJS_BUILD_DIR}}/node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}"
-        "{{.NODEJS_BUILD_DIR}}/node"
-      - "rm -f '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}'"
+        mv "{{.OUTPUT_DIR}}/node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}"
+        "{{.OUTPUT_DIR}}/node"
+      - "rm -f '{{.OUTPUT_DIR}}/{{.TAR_FILE_NAME}}'"
+      # Checksum the generated files (this command must be last)
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
-    generates:
-      - "{{.NODEJS_BUILD_DIR}}/node/**/*"
+    status:
+      - test -f "{{.CHECKSUM_FILE}}"
+      - >-
+        diff
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        "{{.CHECKSUM_FILE}}"
 
   webui:
     dir: "components/webui"
     platforms: ["386", "amd64"]
+    vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      OUTPUT_DIR: "{{.WEBUI_BUILD_DIR}}"
     cmds:
-      - "rm -rf '{{.WEBUI_BUILD_DIR}}'"
-      - "mkdir -p '{{.WEBUI_BUILD_DIR}}'"
+      - "rm -rf '{{.OUTPUT_DIR}}'"
+      - "mkdir -p '{{.OUTPUT_DIR}}'"
       - "meteor npm install --production"
-      - "meteor build --directory '{{.WEBUI_BUILD_DIR}}'"
+      - "meteor build --directory '{{.OUTPUT_DIR}}'"
       - >-
         rsync -a
-        "{{.WEBUI_BUILD_DIR}}/bundle/"
+        "{{.OUTPUT_DIR}}/bundle/"
         launcher.js
         settings.json
-        "{{.WEBUI_BUILD_DIR}}/"
-      - "rm -rf '{{.WEBUI_BUILD_DIR}}/bundle/'"
+        "{{.OUTPUT_DIR}}/"
+      - "rm -rf '{{.OUTPUT_DIR}}/bundle/'"
+      # Checksum the generated files (this command must be last)
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "*"
@@ -191,34 +218,56 @@ tasks:
       - "imports/**/*"
       - "server/**/*"
       - "tests/**/*"
-    generates:
-      - "{{.WEBUI_BUILD_DIR}}/**/*"
+    status:
+      - test -f "{{.CHECKSUM_FILE}}"
+      - >-
+        diff
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        "{{.CHECKSUM_FILE}}"
 
   core-submodules:
     internal: true
     dir: "components/core"
+    vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      OUTPUT_DIR: "submodules"
     cmds:
       - "tools/scripts/deps-download/download-all.sh"
+      # Checksum the generated files (this command must be last)
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - ".gitmodules"
       - "tools/scripts/deps-download/**/*"
-    generates:
-      - "submodules/**/*"
+    status:
+      - test -f "{{.CHECKSUM_FILE}}"
+      - >-
+        diff
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        "{{.CHECKSUM_FILE}}"
 
   package-venv:
     internal: true
+    vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.sha256"
+      OUTPUT_DIR: "{{.PACKAGE_VENV_DIR}}"
     cmds:
-      - "rm -rf '{{.PACKAGE_VENV_DIR}}'"
-      - "python3 -m venv '{{.PACKAGE_VENV_DIR}}'"
+      - "rm -rf '{{.OUTPUT_DIR}}'"
+      - "python3 -m venv '{{.OUTPUT_DIR}}'"
       - |-
-        . "{{.PACKAGE_VENV_DIR}}/bin/activate"
+        . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
+      # Checksum the generated files (this command must be last)
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
-    generates:
-      - "{{.PACKAGE_VENV_DIR}}/**/*"
+    status:
+      - test -f "{{.CHECKSUM_FILE}}"
+      - >-
+        diff
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        "{{.CHECKSUM_FILE}}"
 
   python-component:
     internal: true
@@ -229,7 +278,7 @@ tasks:
       - task: "component-venv"
         vars:
           COMPONENT: "{{.COMPONENT}}"
-          COMPONENT_VENV_DIR: "{{.VENV_DIR}}"
+          OUTPUT_DIR: "{{.VENV_DIR}}"
     vars:
       PACKAGE:
         sh: "echo {{.COMPONENT}} | tr - _"
@@ -243,10 +292,10 @@ tasks:
         . "{{.VENV_DIR}}/bin/activate"
         poetry build --format wheel
     sources:
+      - "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.sha256"
       - "{{.PACKAGE}}/**/*"
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
-      - "{{.VENV_DIR}}/**/*"
       - "pyproject.toml"
     generates:
       - "dist/*.whl"
@@ -254,21 +303,29 @@ tasks:
   component-venv:
     internal: true
     requires:
-      vars: ["COMPONENT", "COMPONENT_VENV_DIR"]
+      vars: ["COMPONENT", "OUTPUT_DIR"]
     label: "{{.COMPONENT}}_venv"
     dir: "components/{{.COMPONENT}}"
+    vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.sha256"
     cmds:
-      - "rm -rf '{{.COMPONENT_VENV_DIR}}'"
-      - "python3 -m venv '{{.COMPONENT_VENV_DIR}}'"
+      - "rm -rf '{{.OUTPUT_DIR}}'"
+      - "python3 -m venv '{{.OUTPUT_DIR}}'"
       - |-
-        . "{{.COMPONENT_VENV_DIR}}/bin/activate"
+        . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
+      # Checksum the generated files (this command must be last)
+      - "tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} '{{.OUTPUT_DIR}}' | sha256sum > '{{.CHECKSUM_FILE}}'"
     sources:
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "pyproject.toml"
-    generates:
-      - "{{.COMPONENT_VENV_DIR}}/**/*"
+    status:
+      - test -f "{{.CHECKSUM_FILE}}"
+      - >-
+        diff
+        <(tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} "{{.OUTPUT_DIR}}" | sha256sum)
+        "{{.CHECKSUM_FILE}}"
 
   clean-python-component:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,6 +51,7 @@ tasks:
       - "tar czf '{{.VERSIONED_PACKAGE_NAME}}.tar.gz' --dereference '{{.VERSIONED_PACKAGE_NAME}}'"
     sources:
       - "{{.PACKAGE_BUILD_DIR}}/**/*"
+      - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:
       - "{{.VERSIONED_PACKAGE_NAME}}.tar.gz"
 
@@ -162,6 +163,8 @@ tasks:
         mv "{{.NODEJS_BUILD_DIR}}/node-v{{.NODEJS_VERSION}}-linux-{{.NODEJS_ARCH}}"
         "{{.NODEJS_BUILD_DIR}}/node"
       - "rm -f '{{.NODEJS_BUILD_DIR}}/{{.TAR_FILE_NAME}}'"
+    sources:
+      - "{{.TASKFILE_DIR}}/Taskfile.yml"
     generates:
       - "{{.NODEJS_BUILD_DIR}}/node/**/*"
 
@@ -181,12 +184,13 @@ tasks:
         "{{.WEBUI_BUILD_DIR}}/"
       - "rm -rf '{{.WEBUI_BUILD_DIR}}/bundle/'"
     sources:
+      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "*"
       - ".meteor/*"
       - "client/**/*"
       - "imports/**/*"
       - "server/**/*"
       - "tests/**/*"
-      - "*"
     generates:
       - "{{.WEBUI_BUILD_DIR}}/**/*"
 
@@ -196,6 +200,7 @@ tasks:
     cmds:
       - "tools/scripts/deps-download/download-all.sh"
     sources:
+      - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - ".gitmodules"
       - "tools/scripts/deps-download/**/*"
     generates:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,6 +100,7 @@ tasks:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
       - "{{.NODEJS_BUILD_DIR}}/node/**/*"
+      - "{{.PACKAGE_VENV_DIR}}/**/*"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
       - "{{.WEBUI_BUILD_DIR}}/**/*"
       - "components/clp-package-utils/dist/*.whl"
@@ -240,6 +241,7 @@ tasks:
       - "{{.PACKAGE}}/**/*"
       - "{{.TASKFILE_DIR}}/requirements.txt"
       - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.VENV_DIR}}/**/*"
       - "pyproject.toml"
     generates:
       - "dist/*.whl"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -24,11 +24,11 @@ tasks:
           FLAGS: "--dry-run"
     sources: &cpp_source_files
       - ".clang-format"
+      - "lint-tasks.yml"
       - "src/**/*.cpp"
       - "src/**/*.h"
       - "src/**/*.hpp"
       - "src/**/*.inc"
-      - "Taskfile.yml"
       - "tests/**/*.cpp"
       - "tests/**/*.h"
       - "tests/**/*.hpp"
@@ -113,6 +113,6 @@ tasks:
         pip3 install --upgrade -r lint-requirements.txt
     sources:
       - "lint-requirements.txt"
-      - "Taskfile.yml"
+      - "lint-tasks.yml"
     generates:
       - "{{.VENV_DIR}}/**/*"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -99,8 +99,6 @@ tasks:
 
   venv:
     internal: true
-    vars:
-      CREATION_TIMESTAMP_FILE: "{{.VENV_DIR}}/creation_time.txt"
     dir: "{{.TASKFILE_DIR}}"
     cmds:
       - "rm -rf '{{.VENV_DIR}}'"
@@ -113,13 +111,8 @@ tasks:
         . "{{.VENV_DIR}}/bin/activate"
         pip3 install --upgrade pip
         pip3 install --upgrade -r lint-requirements.txt
-      # This step must be last since we use this file to detect whether the venv was created
-      # successfully
-      - "date +%s > '{{.CREATION_TIMESTAMP_FILE}}'"
-    method: "timestamp"
     sources:
       - "lint-requirements.txt"
       - "Taskfile.yml"
-    status:
-      - "test -e '{{.CREATION_TIMESTAMP_FILE}}'"
-      - "test {{.TIMESTAMP | unixEpoch}} -lt $(stat --format %Y '{{.CREATION_TIMESTAMP_FILE}}')"
+    generates:
+      - "{{.VENV_DIR}}/**/*"


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR addresses a few issues with the tasks in the Taskfile:

* For tasks whose generated files are tracked using the [`status`](https://taskfile.dev/api/#task) method, if a generated file is deleted and that file wasn't in the status check, the task will not be re-run.
* For tasks whose generated files are tracked by listing them as sources:
  * The task is only marked complete after two runs (from a clean state).
  * If the generated files are deleted after the first run, the task won't detect that it needs to re-run.
* Some tasks were not being re-run when their steps in the Taskfile were changed.
* Some tasks wouldn't be re-run even though the generated files in their dependencies had changed.

Ideally, the solution to most of these issues would be to use the [`generates`](https://taskfile.dev/api/#task) field of a task to denote what files it generates. Task will then keep track of the files generated (after running a task) and re-run the task if a generated file is deleted. We didn't use this solution in the past since Task's docs indicate that `generates` only applies when using the `timestamp` method of dependency tracking, but go-task/task#228 made it so that it also applies when using the `checksum` method as well.

Unfortunately, `generates` only tracks existence rather than contents, and its handling of glob patterns means it still may miss deleted files: E.g., if the `generates` glob is `build/nodejs/node/**/*`, Task will re-run the task if the `node` or `nodejs` directory is deleted or if they're empty, but it won't re-run the task if all but one file inside `node` is deleted.

So instead, this PR (manually) checksums the generated files at the end of each task and then uses Task's `status` method to detect if any file has changed or been deleted. Note that, contrary to the docs which say that `status` overrides `sources`, Task will still re-run the task if the source files change OR the status check fails.

This PR also moves the `npm install` step of the webui component into the package task. This reduces the build time since copying `node_modules` is actually slower than installing them in-place in the package.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated that running `task` twice shows that no tasks need to re-run:
  ```shell
  task clean
  rm -r .task
  task
  task
  ```
* Validated that deleting a generated file causes the corresponding task to re-run (none of its dependents will re-run if the generated contents are identical):
  ```shell
  # This should re-run the `nodejs` task only
  rm -r build/nodejs/node/bin/npm
  task
  ```
* Validated permission changes to generated files also trigger a rebuild.
  ```shell
  chmod u-x build/nodejs/node/bin/node
  task
  ```
* Validated that changing a source file and then re-running `task` caused the component and the package to be rebuilt.
* Validated `task package-tar`.