### PR TITLE
clp-s: Use constants for core filenames in archive; fix a bug with inconsistent filenames on reader and writer side

### DIFF
--- a/components/core/src/clp_s/ArchiveConstants.hpp
+++ b/components/core/src/clp_s/ArchiveConstants.hpp
@@ -1,0 +1,14 @@
+#ifndef CLP_S_ARCHIVE_CONSTANTS_HPP
+#define CLP_S_ARCHIVE_CONSTANTS_HPP
+
+namespace clp_s::constants {
+constexpr char cArchiveSchemaMapFile[] = "/schema_ids";
+constexpr char cArchiveSchemaTreeFile[] = "/schema_tree";
+constexpr char cArchiveTablesFile[] = "/tables";
+constexpr char cArchiveTableMetadataFile[] = "/table_metadata";
+constexpr char cArchiveVarDictFile[] = "/var.dict";
+constexpr char cArchiveLogDictFile[] = "/log.dict";
+constexpr char cArchiveArrayDictFile[] = "/array.dict";
+constexpr char cArchiveTimestampDictFile[] = "/timestamp.dict";
+}  // namespace clp_s::constants
+#endif  // CLP_S_ARCHIVE_CONSTANTS_HPP

--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -1,6 +1,6 @@
 #include "ArchiveReader.hpp"
 
-#include "ArchiveConstants.hpp"
+#include "archive_constants.hpp"
 #include "ReaderUtils.hpp"
 
 namespace clp_s {

--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -1,5 +1,6 @@
 #include "ArchiveReader.hpp"
 
+#include "ArchiveConstants.hpp"
 #include "ReaderUtils.hpp"
 
 namespace clp_s {
@@ -14,8 +15,8 @@ void ArchiveReader::open(std::string const& archive_path) {
     m_log_dict = ReaderUtils::get_log_type_dictionary_reader(m_archive_path);
     m_array_dict = ReaderUtils::get_array_dictionary_reader(m_archive_path);
 
-    m_tables_file_reader.open(m_archive_path + "/table");
-    m_table_metadata_file_reader.open(m_archive_path + "/metadata");
+    m_tables_file_reader.open(m_archive_path + constants::cArchiveTablesFile);
+    m_table_metadata_file_reader.open(m_archive_path + constants::cArchiveTableMetadataFile);
 }
 
 void ArchiveReader::read_metadata() {
@@ -87,7 +88,7 @@ ArchiveReader::read_table(int32_t schema_id, bool should_extract_timestamp) {
 
 std::shared_ptr<TimestampDictionaryReader> ArchiveReader::read_timestamp_dictionary() {
     auto reader = std::make_shared<TimestampDictionaryReader>();
-    reader->open(m_archive_path + "/timestamp.dict");
+    reader->open(m_archive_path + constants::cArchiveTimestampDictFile);
     reader->read_local_entries();
     reader->close();
 

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -1,6 +1,6 @@
 #include "ArchiveWriter.hpp"
 
-#include "ArchiveConstants.hpp"
+#include "archive_constants.hpp"
 #include "SchemaTree.hpp"
 
 namespace clp_s {

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -1,5 +1,6 @@
 #include "ArchiveWriter.hpp"
 
+#include "ArchiveConstants.hpp"
 #include "SchemaTree.hpp"
 
 namespace clp_s {
@@ -21,19 +22,19 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
         throw OperationFailed(ErrorCodeErrno, __FILENAME__, __LINE__);
     }
 
-    std::string var_dict_path = m_archive_path + "/var.dict";
+    std::string var_dict_path = m_archive_path + constants::cArchiveVarDictFile;
     m_var_dict = std::make_shared<VariableDictionaryWriter>();
     m_var_dict->open(var_dict_path, m_compression_level, UINT64_MAX);
 
-    std::string log_dict_path = m_archive_path + "/log.dict";
+    std::string log_dict_path = m_archive_path + constants::cArchiveLogDictFile;
     m_log_dict = std::make_shared<LogTypeDictionaryWriter>();
     m_log_dict->open(log_dict_path, m_compression_level, UINT64_MAX);
 
-    std::string array_dict_path = m_archive_path + "/array.dict";
+    std::string array_dict_path = m_archive_path + constants::cArchiveArrayDictFile;
     m_array_dict = std::make_shared<LogTypeDictionaryWriter>();
     m_array_dict->open(array_dict_path, m_compression_level, UINT64_MAX);
 
-    std::string timestamp_local_dict_path = m_archive_path + "/timestamp.dict";
+    std::string timestamp_local_dict_path = m_archive_path + constants::cArchiveTimestampDictFile;
     m_timestamp_dict->open_local(timestamp_local_dict_path, m_compression_level);
 }
 
@@ -44,9 +45,12 @@ size_t ArchiveWriter::close() {
     compressed_size += m_array_dict->close();
     compressed_size += m_timestamp_dict->close_local();
 
-    m_tables_file_writer.open(m_archive_path + "/tables", FileWriter::OpenMode::CreateForWriting);
+    m_tables_file_writer.open(
+            m_archive_path + constants::cArchiveTablesFile,
+            FileWriter::OpenMode::CreateForWriting
+    );
     m_table_metadata_file_writer.open(
-            m_archive_path + "/table_metadata",
+            m_archive_path + constants::cArchiveTableMetadataFile,
             FileWriter::OpenMode::CreateForWriting
     );
     m_table_metadata_compressor.open(m_table_metadata_file_writer, m_compression_level);

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -29,6 +29,7 @@ set(
 set(
         CLP_S_SOURCES
         "${PROJECT_SOURCE_DIR}/submodules/date/include/date/date.h"
+        ArchiveConstants.hpp
         ArchiveReader.cpp
         ArchiveReader.hpp
         ArchiveWriter.cpp

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -29,7 +29,7 @@ set(
 set(
         CLP_S_SOURCES
         "${PROJECT_SOURCE_DIR}/submodules/date/include/date/date.h"
-        ArchiveConstants.hpp
+        archive_constants.hpp
         ArchiveReader.cpp
         ArchiveReader.hpp
         ArchiveWriter.cpp

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <stack>
 
-#include "ArchiveConstants.hpp"
+#include "archive_constants.hpp"
 #include "JsonFileIterator.hpp"
 
 namespace clp_s {

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <stack>
 
+#include "ArchiveConstants.hpp"
 #include "JsonFileIterator.hpp"
 
 namespace clp_s {
@@ -30,12 +31,15 @@ JsonParser::JsonParser(JsonParserOption const& option)
     }
 
     m_schema_tree = std::make_shared<SchemaTree>();
-    m_schema_tree_path = m_archives_dir + "/schema_tree";
+    m_schema_tree_path = m_archives_dir + constants::cArchiveSchemaTreeFile;
 
     m_schema_map = std::make_shared<SchemaMap>(m_archives_dir, m_compression_level);
 
     m_timestamp_dictionary = std::make_shared<TimestampDictionaryWriter>();
-    m_timestamp_dictionary->open(m_archives_dir + "/timestamp.dict", option.compression_level);
+    m_timestamp_dictionary->open(
+            m_archives_dir + constants::cArchiveTimestampDictFile,
+            option.compression_level
+    );
 
     ArchiveWriterOption archive_writer_option;
     archive_writer_option.archives_dir = m_archives_dir;

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -1,5 +1,7 @@
 #include "ReaderUtils.hpp"
 
+#include "ArchiveConstants.hpp"
+
 namespace clp_s {
 std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(std::string const& archives_dir) {
     FileReader schema_tree_reader;
@@ -7,7 +9,7 @@ std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(std::string const& arc
 
     std::shared_ptr<SchemaTree> tree = std::make_shared<SchemaTree>();
 
-    schema_tree_reader.open(archives_dir + "/schema_tree");
+    schema_tree_reader.open(archives_dir + constants::cArchiveSchemaTreeFile);
     schema_tree_decompressor.open(schema_tree_reader, cDecompressorFileReadBufferCapacity);
 
     size_t num_nodes;
@@ -55,7 +57,7 @@ std::shared_ptr<VariableDictionaryReader> ReaderUtils::get_variable_dictionary_r
         std::string const& archive_path
 ) {
     auto reader = std::make_shared<VariableDictionaryReader>();
-    reader->open(archive_path + "/var.dict");
+    reader->open(archive_path + constants::cArchiveVarDictFile);
     return reader;
 }
 
@@ -63,7 +65,7 @@ std::shared_ptr<LogTypeDictionaryReader> ReaderUtils::get_log_type_dictionary_re
         std::string const& archive_path
 ) {
     auto reader = std::make_shared<LogTypeDictionaryReader>();
-    reader->open(archive_path + "/log.dict");
+    reader->open(archive_path + constants::cArchiveLogDictFile);
     return reader;
 }
 
@@ -71,7 +73,7 @@ std::shared_ptr<LogTypeDictionaryReader> ReaderUtils::get_array_dictionary_reade
         std::string const& archive_path
 ) {
     auto reader = std::make_shared<LogTypeDictionaryReader>();
-    reader->open(archive_path + "/array.dict");
+    reader->open(archive_path + constants::cArchiveArrayDictFile);
     return reader;
 }
 
@@ -81,7 +83,7 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
     FileReader schema_id_reader;
     ZstdDecompressor schema_id_decompressor;
 
-    schema_id_reader.open(archives_dir + "/schema_ids");
+    schema_id_reader.open(archives_dir + constants::cArchiveSchemaMapFile);
     schema_id_decompressor.open(schema_id_reader, cDecompressorFileReadBufferCapacity);
 
     size_t schema_size;
@@ -128,7 +130,7 @@ std::shared_ptr<TimestampDictionaryReader> ReaderUtils::read_timestamp_dictionar
         std::string const& archives_dir
 ) {
     auto reader = std::make_shared<TimestampDictionaryReader>();
-    reader->open(archives_dir + "/timestamp.dict");
+    reader->open(archives_dir + constants::cArchiveTimestampDictFile);
     reader->read_new_entries();
     reader->close();
 

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -1,6 +1,6 @@
 #include "ReaderUtils.hpp"
 
-#include "ArchiveConstants.hpp"
+#include "archive_constants.hpp"
 
 namespace clp_s {
 std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(std::string const& archives_dir) {

--- a/components/core/src/clp_s/SchemaMap.cpp
+++ b/components/core/src/clp_s/SchemaMap.cpp
@@ -1,5 +1,6 @@
 #include "SchemaMap.hpp"
 
+#include "ArchiveConstants.hpp"
 #include "FileWriter.hpp"
 #include "ZstdCompressor.hpp"
 
@@ -18,7 +19,10 @@ size_t SchemaMap::store() {
     ZstdCompressor schema_map_compressor;
 
     // TODO: rename schema_ids -> schema_map, and use int32_t for schema size
-    schema_map_writer.open(m_archives_dir + "/schema_ids", FileWriter::OpenMode::CreateForWriting);
+    schema_map_writer.open(
+            m_archives_dir + constants::cArchiveSchemaMapFile,
+            FileWriter::OpenMode::CreateForWriting
+    );
     schema_map_compressor.open(schema_map_writer, m_compression_level);
     schema_map_compressor.write_numeric_value(m_schema_map.size());
     for (auto const& schema_mapping : m_schema_map) {

--- a/components/core/src/clp_s/SchemaMap.cpp
+++ b/components/core/src/clp_s/SchemaMap.cpp
@@ -1,6 +1,6 @@
 #include "SchemaMap.hpp"
 
-#include "ArchiveConstants.hpp"
+#include "archive_constants.hpp"
 #include "FileWriter.hpp"
 #include "ZstdCompressor.hpp"
 

--- a/components/core/src/clp_s/SchemaMap.hpp
+++ b/components/core/src/clp_s/SchemaMap.hpp
@@ -26,7 +26,7 @@ public:
     int32_t add_schema(Schema const& schema);
 
     /**
-     * Write the contents of the SchemaMap to archives_dir/schema_ids
+     * Write the contents of the SchemaMap to the schema map file
      * @return the compressed size of the SchemaMap in bytes
      */
     [[nodiscard]] size_t store();

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -2,13 +2,18 @@
 #define CLP_S_ARCHIVE_CONSTANTS_HPP
 
 namespace clp_s::constants {
+// Schema files
 constexpr char cArchiveSchemaMapFile[] = "/schema_ids";
 constexpr char cArchiveSchemaTreeFile[] = "/schema_tree";
-constexpr char cArchiveTablesFile[] = "/tables";
+
+// Encoded record table files
 constexpr char cArchiveTableMetadataFile[] = "/table_metadata";
-constexpr char cArchiveVarDictFile[] = "/var.dict";
-constexpr char cArchiveLogDictFile[] = "/log.dict";
+constexpr char cArchiveTablesFile[] = "/tables";
+
+// Dictionary files
 constexpr char cArchiveArrayDictFile[] = "/array.dict";
+constexpr char cArchiveLogDictFile[] = "/log.dict";
 constexpr char cArchiveTimestampDictFile[] = "/timestamp.dict";
+constexpr char cArchiveVarDictFile[] = "/var.dict";
 }  // namespace clp_s::constants
 #endif  // CLP_S_ARCHIVE_CONSTANTS_HPP


### PR DESCRIPTION
# Description
This PR introduces constants for the names of each of the core files in clp-s in order to eliminate the possibility of trivial bugs caused by incorrect filenames. This fixes a bug where the tables and table_metdata files were being referred to by different filenames on the reader and writer side.

# Validation performed
* validated that compression/decompression/search work as expected

