### PR TITLE
clp-s: Fix incorrect parsing of strings followed by spaces (fixes #297).

### DIFF
--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -150,9 +150,9 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
             }
             case ondemand::json_type::string: {
                 // TODO (Rui): Take a look
-                std::string value = std::string(
-                        line.raw_json_token().substr(1, line.raw_json_token().size() - 2)
-                );
+                auto raw_json_token = line.raw_json_token();
+                std::string value = std::string(raw_json_token.substr(1, raw_json_token.rfind('"') - 1));
+
                 if (matches_timestamp) {
                     node_id = m_schema_tree->add_node(
                             node_id_stack.top(),

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -151,7 +151,8 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
             case ondemand::json_type::string: {
                 // TODO (Rui): Take a look
                 auto raw_json_token = line.raw_json_token();
-                std::string value = std::string(raw_json_token.substr(1, raw_json_token.rfind('"') - 1));
+                std::string value
+                        = std::string(raw_json_token.substr(1, raw_json_token.rfind('"') - 1));
 
                 if (matches_timestamp) {
                     node_id = m_schema_tree->add_node(

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -149,7 +149,6 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                 break;
             }
             case ondemand::json_type::string: {
-                // TODO (Rui): Take a look
                 auto raw_json_token = line.raw_json_token();
                 std::string value
                         = std::string(raw_json_token.substr(1, raw_json_token.rfind('"') - 1));


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#297 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR fixes the bug mentioned in #297 by finding the position of the second quote and extracting the substring.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Compressed the log below. The first log message does not contain spaces between `"` and `,`, while the second log message contains 1 or 2 spaces between`"` and `,`.
```
{"t":{"$date":"2023-03-21T23:34:54.576-04:00"},"s":"I",  "c":"NETWORK",  "id":4915701, "ctx":"-","msg":"Initialized wire specification","attr":{"spec":{"incomingExternalClient":{"minWireVersion":0,"maxWireVersion":17},"incomingInternalClient":{"minWireVersion":0,"maxWireVersion":17},"outgoing":{"minWireVersion":6,"maxWireVersion":17},"isInternalClient":true}}}
{"a" : "string clp" , "b": "clp string"  }
```
+ Decompressed the archive. The second log message does not show the bug in #297
```
{"t":{"$date":"2023-03-21T23:34:54.576-04:00"},"s":"I","c":"NETWORK","id":4915701,"ctx":"-","msg":"Initialized wire specification","attr":{"spec":{"incomingExternalClient":{"minWireVersion":0,"maxWireVersion":17},"incomingInternalClient":{"minWireVersion":0,"maxWireVersion":17},"outgoing":{"minWireVersion":6,"maxWireVersion":17},"isInternalClient":true}}}
{"a":"string clp","b":"clp string"}
```