### PR TITLE
clp-s: Add support for sending query results to a network destination.

### DIFF
--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -58,6 +58,12 @@ public:
 
     uint64_t get_max_num_results() const { return m_max_num_results; }
 
+    bool get_network_destination_enabled() const { return m_network_destination_enabled; }
+
+    std::string const& get_host() const { return m_host; }
+
+    std::string const& get_port() const { return m_port; }
+
     std::string const& get_query() const { return m_query; }
 
     std::optional<epochtime_t> get_search_begin_ts() const { return m_search_begin_ts; }
@@ -104,6 +110,11 @@ private:
     std::string m_mongodb_collection;
     uint64_t m_batch_size{1000};
     uint64_t m_max_num_results{1000};
+
+    // Network configuration variables
+    bool m_network_destination_enabled{false};
+    std::string m_host;
+    std::string m_port;
 
     // Search variables
     std::string m_query;

--- a/components/core/src/clp_s/ErrorCode.hpp
+++ b/components/core/src/clp_s/ErrorCode.hpp
@@ -24,7 +24,8 @@ typedef enum {
     ErrorCodeFailure,
     ErrorCodeFailureMetadataCorrupted,
     ErrorCodeMetadataCorrupted,
-    ErrorCodeFailureDbBulkWrite
+    ErrorCodeFailureDbBulkWrite,
+    ErrorCodeFailureNetwork,
 } ErrorCode;
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -209,6 +209,11 @@ bool search_archive(
                 command_line_arguments.get_batch_size(),
                 command_line_arguments.get_max_num_results()
         );
+    } else if (command_line_arguments.get_network_destination_enabled()) {
+        output_handler = std::make_unique<NetworkOutputHandler>(
+                command_line_arguments.get_host(),
+                command_line_arguments.get_port()
+        );
     } else {
         output_handler = std::make_unique<StandardOutputHandler>();
     }

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -1,6 +1,54 @@
 #include "OutputHandler.hpp"
 
+#include <sstream>
+
+#include <spdlog/spdlog.h>
+
 namespace clp_s::search {
+NetworkOutputHandler::NetworkOutputHandler(
+        std::string const& host,
+        std::string const& port,
+        bool should_output_timestamp
+)
+        : OutputHandler(should_output_timestamp) {
+    struct addrinfo hints = {};
+    // Address can be IPv4 or IPV6
+    hints.ai_family = AF_UNSPEC;
+    // TCP socket
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = 0;
+    hints.ai_protocol = 0;
+    struct addrinfo* addresses_head = nullptr;
+    int error = getaddrinfo(host.c_str(), port.c_str(), &hints, &addresses_head);
+    if (0 != error) {
+        SPDLOG_ERROR("Failed to get address information for the server, error={}", error);
+        throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
+    }
+
+    // Try each address until a socket can be created and connected to
+    for (auto curr = addresses_head; nullptr != curr; curr = curr->ai_next) {
+        // Create socket
+        m_socket_fd = socket(curr->ai_family, curr->ai_socktype, curr->ai_protocol);
+        if (-1 == m_socket_fd) {
+            continue;
+        }
+
+        // Connect to address
+        if (connect(m_socket_fd, curr->ai_addr, curr->ai_addrlen) != -1) {
+            break;
+        }
+
+        // Failed to connect, so close socket
+        close(m_socket_fd);
+        m_socket_fd = -1;
+    }
+    freeaddrinfo(addresses_head);
+    if (-1 == m_socket_fd) {
+        SPDLOG_ERROR("Failed to connect to the server, errno={}", errno);
+        throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
+    }
+}
+
 ResultsCacheOutputHandler::ResultsCacheOutputHandler(
         std::string const& uri,
         std::string const& collection,

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -1,6 +1,10 @@
 #ifndef CLP_S_SEARCH_OUTPUTHANDLER_HPP
 #define CLP_S_SEARCH_OUTPUTHANDLER_HPP
 
+#include <netdb.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <queue>
 #include <string>
 
@@ -68,6 +72,57 @@ public:
     void write(std::string const& message) override { printf("%s", message.c_str()); }
 
     void flush() override {}
+};
+
+/**
+ * Output handler that writes to a network destination.
+ */
+class NetworkOutputHandler : public OutputHandler {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
+    };
+
+    // Constructors
+    explicit NetworkOutputHandler(
+            std::string const& host,
+            std::string const& port,
+            bool should_output_timestamp = false
+    );
+
+    // Destructor
+    ~NetworkOutputHandler() override {
+        if (-1 != m_socket_fd) {
+            close(m_socket_fd);
+        }
+    }
+
+    // Methods inherited from OutputHandler
+    void write(std::string const& message, epochtime_t timestamp) override {
+        std::string message_with_timestamp(std::to_string(timestamp) + " " + message);
+        if (-1
+            == send(m_socket_fd, message_with_timestamp.c_str(), message_with_timestamp.size(), 0))
+        {
+            throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
+        }
+    }
+
+    void write(std::string const& message) override {
+        if (-1 == send(m_socket_fd, message.c_str(), message.size(), 0)) {
+            throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
+        }
+    }
+
+    void flush() override{};
+
+private:
+    std::string m_host;
+    std::string m_port;
+    int m_socket_fd;
 };
 
 /**


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR adds a `NetworkOutputHandler` to support sending query results to a network destination for clp-s.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Built clp-s and compressed part of [mongodb](https://zenodo.org/records/10516285) dataset.
+ Wrote a server in Python to receive data and print it out. Started the server and got the host and the port.
+ Executed the query `c: REPL` and output the results to stdout and the server. Compared the results.

