### PR TITLE
webui: Replace `react-visibility-sensor` with `IntersectionObserver` for infinite scrolling.

### DIFF
--- a/components/webui/imports/ui/SearchView/SearchResults.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResults.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from "react";
+import React from "react";
 
 import SearchResultsHeader from "./SearchResultsHeader.jsx";
 import SearchResultsTable from "./SearchResultsTable.jsx";

--- a/components/webui/imports/ui/SearchView/SearchResults.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResults.jsx
@@ -1,8 +1,24 @@
-import React from "react";
+import React, {useCallback} from "react";
 
 import SearchResultsHeader from "./SearchResultsHeader.jsx";
-import {SearchResultsTable} from "./SearchResultsTable.jsx";
+import SearchResultsTable from "./SearchResultsTable.jsx";
 
+
+/**
+ * The initial visible results limit.
+ *
+ * @type {number}
+ * @constant
+ */
+const VISIBLE_RESULTS_LIMIT_INITIAL = 10;
+
+/**
+ * The increment value for the visible results limit.
+ *
+ * @type {number}
+ * @constant
+ */
+const VISIBLE_RESULTS_LIMIT_INCREMENT = 10;
 
 /**
  * Renders the search results, which includes the search results header and the search results
@@ -31,12 +47,17 @@ const SearchResults = ({
     setMaxLinesPerResult,
 }) => {
     const numResultsOnServer = resultsMetadata["numTotalResults"] || searchResults.length;
+    const hasMoreResults = visibleSearchResultsLimit < numResultsOnServer;
+
+    const handleLoadMoreResults = () => {
+        setVisibleSearchResultsLimit((v) =>
+            (v + VISIBLE_RESULTS_LIMIT_INCREMENT));
+    };
 
     return <>
         <div className={"flex-column"}>
             <SearchResultsHeader
                 jobId={jobId}
-                resultsMetadata={resultsMetadata}
                 numResultsOnServer={numResultsOnServer}
                 maxLinesPerResult={maxLinesPerResult}
                 setMaxLinesPerResult={setMaxLinesPerResult}
@@ -49,12 +70,12 @@ const SearchResults = ({
                 setMaxLinesPerResult={setMaxLinesPerResult}
                 fieldToSortBy={fieldToSortBy}
                 setFieldToSortBy={setFieldToSortBy}
-                numResultsOnServer={numResultsOnServer}
-                visibleSearchResultsLimit={visibleSearchResultsLimit}
-                setVisibleSearchResultsLimit={setVisibleSearchResultsLimit}
+                hasMoreResults={hasMoreResults}
+                onLoadMoreResults={handleLoadMoreResults}
             />
         </div>}
     </>;
 };
 
 export default SearchResults;
+export {VISIBLE_RESULTS_LIMIT_INITIAL};

--- a/components/webui/imports/ui/SearchView/SearchResultsHeader.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsHeader.jsx
@@ -12,7 +12,6 @@ import {
     Popover,
     Row,
 } from "react-bootstrap";
-import {SearchSignal} from "../../api/search/constants";
 
 import "./SearchResultsHeader.scss";
 
@@ -22,7 +21,6 @@ import "./SearchResultsHeader.scss";
  * found, and a control for setting the maximum number of lines per search result.
  *
  * @param {number} jobId of the search job
- * @param {Object} resultsMetadata which includes last request / response signal
  * @param {number} numResultsOnServer of the search job
  * @param {number} maxLinesPerResult to display
  * @param {function} setMaxLinesPerResult callback to set setMaxLinesPerResult
@@ -30,7 +28,6 @@ import "./SearchResultsHeader.scss";
  */
 const SearchResultsHeader = ({
     jobId,
-    resultsMetadata,
     numResultsOnServer,
     maxLinesPerResult,
     setMaxLinesPerResult,
@@ -42,17 +39,6 @@ const SearchResultsHeader = ({
             setMaxLinesPerResult(value);
         }
     };
-
-    let numResultsText = `Job ID ${jobId}: `;
-    if (0 === numResultsOnServer) {
-        numResultsText += SearchSignal.RESP_DONE !== resultsMetadata["lastSignal"] ?
-            "Query is running" :
-            "No results found";
-    } else if (1 === numResultsOnServer) {
-        numResultsText += "1 result found";
-    } else {
-        numResultsText += `${numResultsOnServer} results found`;
-    }
 
     return (<>
         <Container fluid={true}>

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -8,8 +8,8 @@ import "./SearchResultsTable.scss";
 
 
 /**
- * Senses if the user has requested to load more results by scrolling till this
- * element becomes partially visible.
+ * Senses if the user has requested to load more results by scrolling until
+ * this element becomes partially visible.
  *
  * @param {boolean} hasMoreResults
  * @param {function} onLoadMoreResults
@@ -28,10 +28,7 @@ const SearchResultsLoadSensor = ({
 
         const observer = new IntersectionObserver(
             (entries) => {
-                if (
-                    (true === entries[0].isIntersecting) &&
-                    (true === hasMoreResults)
-                ) {
+                if (entries[0].isIntersecting && hasMoreResults) {
                     onLoadMoreResults();
                 }
             }

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.scss
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.scss
@@ -32,3 +32,12 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+#search-results-load-sensor {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-inline: 10px;
+  padding-bottom: 12px;
+  font-size: 1.3rem;
+}

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -16,8 +16,7 @@ import {LOCAL_STORAGE_KEYS} from "../constants";
 import {changeTimezoneToUtcWithoutChangingTime, DEFAULT_TIME_RANGE} from "./datetime";
 
 import SearchControls from "./SearchControls.jsx";
-import SearchResults from "./SearchResults.jsx";
-import {VISIBLE_RESULTS_LIMIT_INITIAL} from "./SearchResultsTable.jsx";
+import SearchResults, {VISIBLE_RESULTS_LIMIT_INITIAL} from "./SearchResults.jsx";
 
 
 // for pseudo progress bar
@@ -106,10 +105,6 @@ const SearchView = () => {
     }, [localLastSearchSignal]);
 
     // Handlers
-    const resetVisibleResultSettings = () => {
-        setVisibleSearchResultsLimit(VISIBLE_RESULTS_LIMIT_INITIAL);
-    };
-
     const submitQuery = () => {
         if (INVALID_JOB_ID !== jobId) {
             // Clear result caches before starting a new query
@@ -118,7 +113,7 @@ const SearchView = () => {
 
         setOperationErrorMsg("");
         setLocalLastSearchSignal(SearchSignal.REQ_QUERYING);
-        resetVisibleResultSettings();
+        setVisibleSearchResultsLimit(VISIBLE_RESULTS_LIMIT_INITIAL);
 
         const timestampBeginMillis = changeTimezoneToUtcWithoutChangingTime(timeRange.begin)
             .getTime();
@@ -147,7 +142,7 @@ const SearchView = () => {
         setJobId(INVALID_JOB_ID);
         setOperationErrorMsg("");
         setLocalLastSearchSignal(SearchSignal.REQ_CLEARING);
-        resetVisibleResultSettings();
+        setVisibleSearchResultsLimit(VISIBLE_RESULTS_LIMIT_INITIAL);
 
         const args = {
             jobId: jobId,

--- a/components/webui/package-lock.json
+++ b/components/webui/package-lock.json
@@ -1533,14 +1533,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-visibility-sensor": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
-      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
     "readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",

--- a/components/webui/package.json
+++ b/components/webui/package.json
@@ -25,7 +25,6 @@
     "react-dom": "^17.0.2",
     "react-router": "^5.3.4",
     "react-router-dom": "^5.3.4",
-    "react-visibility-sensor": "^5.1.1",
     "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1"


### PR DESCRIPTION
# References
1. Internally it was reported that in the Web UI, occasionally no results are loaded when the results "Loading" block becomes visible.

# Description
1. Remove `react-visibility-sensor` from `package.json` "dependencies".
2. Detect if the "Loading" block is visible by [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) ([Can I use...](https://caniuse.com/intersectionobserver)). 
3. Clean up dead code. 

# Validation performed
1. Built and started the clp-package by `<PROJECT_ROOT>/build/clp-package/start.sh`. 
2. Compressed sample logs `hadoop-24hrs/logs/i-00c90a0f` by `<PROJECT_ROOT>/build/clp-package/compress.sh`. 
3. Searched with query string "123" with `Time range` being "All Time" and observed `Job ID <JOB_ID> | Results count: 176` in the results status bar. Initially there were only 10 results displayed, which matches `VISIBLE_RESULTS_LIMIT_INITIAL=10`. Scrolling down to the bottom of the page triggered more results to be loaded. Kept scrolling until no new results are available. Observed no "Loading" text at the bottom of the page and counted the number of results as `176` which matched the number in the status bar. 
4. Repeated Step 3 with a 10s delay added in the Meteor.js `results` subscription handler, which allowed the "Loading" block to be visible, when scrolled to the bottom of the page, for at least 10s before new results are loaded. Observed the "Loading" text was properly centered together with the loading spinner animation. 
5. Changed query string to "1234" and restarted the query. Observed `Job ID <JOB_ID> | Results count: 7` in the results status bar, which was less than `VISIBLE_RESULTS_LIMIT_INITIAL=10`. The "Loading" block was invisible at all time. 