### PR TITLE
Iet clp_package_util not remove exited container

### DIFF
--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -109,6 +109,7 @@ def check_dependencies():
 
 
 def is_container_running(container_name):
+    # use -q to let the command return the container id
     cmd = ["docker", "ps", "-q", "-f", f"name={container_name}"]
     proc = subprocess.run(cmd, stdout=subprocess.PIPE)
     if proc.stdout.decode("utf-8"):
@@ -118,7 +119,7 @@ def is_container_running(container_name):
 
 
 def is_container_exited(container_name):
-    # use -a to list all containers including the stopped ones
+    # use -q to let the command return the container id
     cmd = ["docker", "ps", "-q", "-f", f"name={container_name}", "-f", f"status=exited"]
     proc = subprocess.run(cmd, stdout=subprocess.PIPE)
     if proc.stdout.decode("utf-8"):

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -108,12 +108,21 @@ def check_dependencies():
         raise EnvironmentError("docker cannot run without superuser privileges (sudo).")
 
 
-def container_exists(container_name):
+def is_container_running(container_name):
     cmd = ["docker", "ps", "-q", "-f", f"name={container_name}"]
     proc = subprocess.run(cmd, stdout=subprocess.PIPE)
-    for line in proc.stdout.decode("utf-8"):
-        if line != "":
-            return True
+    if proc.stdout.decode("utf-8"):
+        return True
+
+    return False
+
+
+def is_container_exited(container_name):
+    # use -a to list all containers including the stopped ones
+    cmd = ["docker", "ps", "-q", "-f", f"name={container_name}", "-f", f"status=exited"]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE)
+    if proc.stdout.decode("utf-8"):
+        return True
 
     return False
 

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -110,7 +110,14 @@ def check_dependencies():
 
 def is_container_running(container_name):
     # use -q to let the command return the container id
-    cmd = ["docker", "ps", "-q", "-f", f"name={container_name}"]
+    # fmt: off
+    cmd = [
+        "docker", "ps",
+        # Only return container IDs
+        "--quiet",
+        "--filter", f"name={container_name}"
+    ]
+    # fmt: on
     proc = subprocess.run(cmd, stdout=subprocess.PIPE)
     if proc.stdout.decode("utf-8"):
         return True
@@ -119,8 +126,15 @@ def is_container_running(container_name):
 
 
 def is_container_exited(container_name):
-    # use -q to let the command return the container id
-    cmd = ["docker", "ps", "-q", "-f", f"name={container_name}", "-f", f"status=exited"]
+    # fmt: off
+    cmd = [
+        "docker", "ps",
+        # Only return container IDs
+        "--quiet",
+        "--filter", f"name={container_name}"
+        "--filter", "status=exited"
+    ]
+    # fmt: on
     proc = subprocess.run(cmd, stdout=subprocess.PIPE)
     if proc.stdout.decode("utf-8"):
         return True

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -109,7 +109,6 @@ def check_dependencies():
 
 
 def is_container_running(container_name):
-    # use -q to let the command return the container id
     # fmt: off
     cmd = [
         "docker", "ps",

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -343,7 +343,7 @@ def start_redis(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path)
     cmd.append(str(config_file_path))
     subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
 
-    logger.info(f"Started {REDIS_COMPONENT_NAME}.")
+    logger.info(f"Started {component_name}.")
 
 
 def start_results_cache(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path):

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -36,11 +36,12 @@ from clp_package_utils.general import (
     CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH,
     CLPDockerMounts,
     CONTAINER_CLP_HOME,
-    container_exists,
     DockerMount,
     DockerMountType,
     generate_container_config,
     get_clp_home,
+    is_container_exited,
+    is_container_running,
     validate_and_load_config_file,
     validate_and_load_db_credentials_file,
     validate_and_load_queue_credentials_file,
@@ -62,6 +63,16 @@ logging_console_handler = logging.StreamHandler()
 logging_formatter = logging.Formatter("%(asctime)s [%(levelname)s] [%(name)s] %(message)s")
 logging_console_handler.setFormatter(logging_formatter)
 logger.addHandler(logging_console_handler)
+
+
+def container_exists(container_name):
+    if is_container_running(container_name):
+        logger.info(f"{container_name} already running.")
+        return True
+    elif is_container_exited(container_name):
+        logger.info(f"{container_name} stopped but not removed.")
+        return True
+    return False
 
 
 def append_docker_port_settings_for_host_ips(
@@ -94,15 +105,15 @@ def wait_for_container_cmd(container_name: str, cmd_to_run: [str], timeout: int)
 
 
 def start_db(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path):
-    logger.info(f"Starting {DB_COMPONENT_NAME}...")
+    component_name = DB_COMPONENT_NAME
+    logger.info(f"Starting {component_name}...")
 
-    container_name = f"clp-{DB_COMPONENT_NAME}-{instance_id}"
+    container_name = f"clp-{component_name}-{instance_id}"
     if container_exists(container_name):
-        logger.info(f"{DB_COMPONENT_NAME} already running.")
         return
 
-    db_data_dir = clp_config.data_directory / DB_COMPONENT_NAME
-    db_logs_dir = clp_config.logs_directory / DB_COMPONENT_NAME
+    db_data_dir = clp_config.data_directory / component_name
+    db_logs_dir = clp_config.logs_directory / component_name
 
     validate_db_config(clp_config, db_data_dir, db_logs_dir)
 
@@ -125,7 +136,6 @@ def start_db(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path):
     cmd = [
         "docker", "run",
         "-d",
-        "--rm",
         "--name", container_name,
         "-e", f"MYSQL_ROOT_PASSWORD={clp_config.database.password}",
         "-e", f"MYSQL_USER={clp_config.database.username}",
@@ -156,10 +166,10 @@ def start_db(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path):
     ]
     # fmt: on
 
-    if not wait_for_container_cmd(container_name, mysqladmin_cmd, 30):
-        raise EnvironmentError(f"{DB_COMPONENT_NAME} did not initialize in time")
+    if not wait_for_container_cmd(container_name, mysqladmin_cmd, 180):
+        raise EnvironmentError(f"{component_name} did not initialize in time")
 
-    logger.info(f"Started {DB_COMPONENT_NAME}.")
+    logger.info(f"Started {component_name}.")
 
 
 def create_db_tables(
@@ -168,9 +178,10 @@ def create_db_tables(
     container_clp_config: CLPConfig,
     mounts: CLPDockerMounts,
 ):
-    logger.info(f"Creating {DB_COMPONENT_NAME} tables...")
+    component_name = DB_COMPONENT_NAME
+    logger.info(f"Creating {component_name} tables...")
 
-    container_name = f"clp-{DB_COMPONENT_NAME}-table-creator-{instance_id}"
+    container_name = f"clp-{component_name}-table-creator-{instance_id}"
 
     # Create database config file
     db_config_filename = f"{container_name}.yml"
@@ -213,18 +224,18 @@ def create_db_tables(
 
     db_config_file_path.unlink()
 
-    logger.info(f"Created {DB_COMPONENT_NAME} tables.")
+    logger.info(f"Created {component_name} tables.")
 
 
 def start_queue(instance_id: str, clp_config: CLPConfig):
-    logger.info(f"Starting {QUEUE_COMPONENT_NAME}...")
+    component_name = QUEUE_COMPONENT_NAME
+    logger.info(f"Starting {component_name}...")
 
-    container_name = f"clp-{QUEUE_COMPONENT_NAME}-{instance_id}"
+    container_name = f"clp-{component_name}-{instance_id}"
     if container_exists(container_name):
-        logger.info(f"{QUEUE_COMPONENT_NAME} already running.")
         return
 
-    queue_logs_dir = clp_config.logs_directory / QUEUE_COMPONENT_NAME
+    queue_logs_dir = clp_config.logs_directory / component_name
     validate_queue_config(clp_config, queue_logs_dir)
 
     log_filename = "rabbitmq.log"
@@ -256,7 +267,6 @@ def start_queue(instance_id: str, clp_config: CLPConfig):
     cmd = [
         "docker", "run",
         "-d",
-        "--rm",
         "--name", container_name,
         # Override RABBITMQ_LOGS since the image sets it to *only* log to stdout
         "-e", f"RABBITMQ_LOGS={rabbitmq_logs_dir / log_filename}",
@@ -276,21 +286,21 @@ def start_queue(instance_id: str, clp_config: CLPConfig):
     # Wait for queue to start up
     rabbitmq_cmd = ["rabbitmq-diagnostics", "check_running"]
     if not wait_for_container_cmd(container_name, rabbitmq_cmd, 60):
-        raise EnvironmentError(f"{QUEUE_COMPONENT_NAME} did not initialize in time")
+        raise EnvironmentError(f"{component_name} did not initialize in time")
 
-    logger.info(f"Started {QUEUE_COMPONENT_NAME}.")
+    logger.info(f"Started {component_name}.")
 
 
 def start_redis(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path):
-    logger.info(f"Starting {REDIS_COMPONENT_NAME}...")
+    component_name = REDIS_COMPONENT_NAME
+    logger.info(f"Starting {component_name}...")
 
-    container_name = f"clp-{REDIS_COMPONENT_NAME}-{instance_id}"
+    container_name = f"clp-{component_name}-{instance_id}"
     if container_exists(container_name):
-        logger.info(f"{REDIS_COMPONENT_NAME} already running.")
         return
 
-    redis_logs_dir = clp_config.logs_directory / REDIS_COMPONENT_NAME
-    redis_data_dir = clp_config.data_directory / REDIS_COMPONENT_NAME
+    redis_logs_dir = clp_config.logs_directory / component_name
+    redis_data_dir = clp_config.data_directory / component_name
 
     base_config_file_path = conf_dir / "redis" / "redis.conf"
     validate_redis_config(clp_config, redis_data_dir, redis_logs_dir, base_config_file_path)
@@ -318,7 +328,6 @@ def start_redis(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path)
     cmd = [
         "docker", "run",
         "-d",
-        "--rm",
         "--name", container_name,
         "-u", f"{os.getuid()}:{os.getgid()}",
     ]
@@ -338,15 +347,15 @@ def start_redis(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path)
 
 
 def start_results_cache(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path):
-    logger.info(f"Starting {RESULTS_CACHE_COMPONENT_NAME}...")
+    component_name = RESULTS_CACHE_COMPONENT_NAME
+    logger.info(f"Starting {component_name}...")
 
-    container_name = f"clp-{RESULTS_CACHE_COMPONENT_NAME}-{instance_id}"
+    container_name = f"clp-{component_name}-{instance_id}"
     if container_exists(container_name):
-        logger.info(f"{RESULTS_CACHE_COMPONENT_NAME} already running.")
         return
 
-    data_dir = clp_config.data_directory / RESULTS_CACHE_COMPONENT_NAME
-    logs_dir = clp_config.logs_directory / RESULTS_CACHE_COMPONENT_NAME
+    data_dir = clp_config.data_directory / component_name
+    logs_dir = clp_config.logs_directory / component_name
 
     validate_results_cache_config(clp_config, data_dir, logs_dir)
 
@@ -364,7 +373,6 @@ def start_results_cache(instance_id: str, clp_config: CLPConfig, conf_dir: pathl
     cmd = [
         "docker", "run",
         "-d",
-        "--rm",
         "--name", container_name,
         "-u", f"{os.getuid()}:{os.getgid()}",
     ]
@@ -380,7 +388,7 @@ def start_results_cache(instance_id: str, clp_config: CLPConfig, conf_dir: pathl
     cmd.append(str(pathlib.Path("/") / "etc" / "mongo" / "mongod.conf"))
     subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
 
-    logger.info(f"Started {RESULTS_CACHE_COMPONENT_NAME}.")
+    logger.info(f"Started {component_name}.")
 
 
 def start_compression_scheduler(
@@ -429,7 +437,6 @@ def generic_start_scheduler(
 
     container_name = f"clp-{component_name}-{instance_id}"
     if container_exists(container_name):
-        logger.info(f"{component_name} already running.")
         return
 
     container_config_filename = f"{container_name}.yml"
@@ -448,7 +455,6 @@ def generic_start_scheduler(
         "-di",
         "--network", "host",
         "-w", str(CONTAINER_CLP_HOME),
-        "--rm",
         "--name", container_name,
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-e", (
@@ -553,7 +559,6 @@ def generic_start_worker(
 
     container_name = f"clp-{component_name}-{instance_id}"
     if container_exists(container_name):
-        logger.info(f"{component_name} already running.")
         return
 
     validate_worker_config(clp_config)
@@ -572,7 +577,6 @@ def generic_start_worker(
         "-di",
         "--network", "host",
         "-w", str(CONTAINER_CLP_HOME),
-        "--rm",
         "--name", container_name,
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-e", (
@@ -653,14 +657,14 @@ def update_meteor_settings(
 
 
 def start_webui(instance_id: str, clp_config: CLPConfig, mounts: CLPDockerMounts):
-    logger.info(f"Starting {WEBUI_COMPONENT_NAME}...")
+    component_name = WEBUI_COMPONENT_NAME
+    logger.info(f"Starting {component_name}...")
 
-    container_name = f"clp-{WEBUI_COMPONENT_NAME}-{instance_id}"
+    container_name = f"clp-{component_name}-{instance_id}"
     if container_exists(container_name):
-        logger.info(f"{WEBUI_COMPONENT_NAME} already running.")
         return
 
-    webui_logs_dir = clp_config.logs_directory / WEBUI_COMPONENT_NAME
+    webui_logs_dir = clp_config.logs_directory / component_name
     node_path = str(
         CONTAINER_CLP_HOME / "var" / "www" / "programs" / "server" / "npm" / "node_modules"
     )
@@ -671,7 +675,7 @@ def start_webui(instance_id: str, clp_config: CLPConfig, mounts: CLPDockerMounts
     # Create directories
     webui_logs_dir.mkdir(exist_ok=True, parents=True)
 
-    container_webui_logs_dir = pathlib.Path("/") / "var" / "log" / WEBUI_COMPONENT_NAME
+    container_webui_logs_dir = pathlib.Path("/") / "var" / "log" / component_name
     with open(settings_json_path, "r") as settings_json_file:
         meteor_settings = json.loads(settings_json_file.read())
     meteor_settings_updates = {
@@ -692,7 +696,6 @@ def start_webui(instance_id: str, clp_config: CLPConfig, mounts: CLPDockerMounts
         "docker", "run",
         "-d",
         "--network", "host",
-        "--rm",
         "--name", container_name,
         "-e", f"NODE_PATH={node_path}",
         "-e", f"MONGO_URL={clp_config.results_cache.get_uri()}",
@@ -724,7 +727,7 @@ def start_webui(instance_id: str, clp_config: CLPConfig, mounts: CLPDockerMounts
     cmd = container_cmd + node_cmd
     subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
 
-    logger.info(f"Started {WEBUI_COMPONENT_NAME}.")
+    logger.info(f"Started {component_name}.")
 
 
 def main(argv):
@@ -872,9 +875,6 @@ def main(argv):
             start_webui(instance_id, clp_config, mounts)
 
     except Exception as ex:
-        # Stop CLP
-        subprocess.run([str(clp_home / "sbin" / "stop-clp.sh")], check=True)
-
         if type(ex) == ValueError:
             logger.error(f"Failed to start CLP: {ex}")
         else:

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -70,7 +70,7 @@ def container_exists(container_name):
         logger.info(f"{container_name} already running.")
         return True
     elif is_container_exited(container_name):
-        logger.info(f"{container_name} stopped but not removed.")
+        logger.info(f"{container_name} exited but not removed.")
         return True
     return False
 

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -186,7 +186,7 @@ def main(argv):
             logger.warning(
                 f"The following containers have exited and were not removed: {container_list}"
             )
-            logger.warning(f"Run docker rm {container_list} to manually remove them")
+            logger.warning(f"Run with --force to manually remove them")
         elif target in ALL_TARGET_NAME:
             # NOTE: We can only remove the instance ID file if all containers have been stopped.
             # Currently, we only remove the instance file when all containers are stopped at once.

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -51,7 +51,7 @@ def stop_running_container(container_name: str, exited_container: list, force: b
         logger.info(f"Stopped and Removed {container_name}.")
     elif is_container_exited(container_name):
         if force:
-            logger.info(f"Force removing failed {container_name}...")
+            logger.info(f"Force removing exited {container_name}...")
             cmd = ["docker", "rm", container_name]
             subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
             logger.info(f"Removed {container_name}...")
@@ -74,7 +74,7 @@ def main(argv):
         "--force",
         "-f",
         action="store_true",
-        help="Force remove failed containers",
+        help="Force remove exited containers",
     )
 
     component_args_parser = args_parser.add_subparsers(dest="target")
@@ -184,7 +184,7 @@ def main(argv):
         if exited_container:
             container_list = " ".join(exited_container)
             logger.warning(
-                f"The following containers potentially failed and were not removed: {container_list}"
+                f"The following containers have exited and were not removed: {container_list}"
             )
             logger.warning(f"Run docker rm {container_list} to manually remove them")
         elif target in ALL_TARGET_NAME:

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -39,7 +39,7 @@ logging_console_handler.setFormatter(logging_formatter)
 logger.addHandler(logging_console_handler)
 
 
-def stop_running_container(container_name: str, already_exited_container: list[str], force: bool):
+def stop_running_container(container_name: str, already_exited_containers: list[str], force: bool):
     if is_container_running(container_name):
         logger.info(f"Stopping {container_name}...")
         cmd = ["docker", "stop", container_name]
@@ -57,7 +57,7 @@ def stop_running_container(container_name: str, already_exited_container: list[s
             subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
             logger.info(f"Removed {container_name}...")
         else:
-            already_exited_container.append(container_name)
+            already_exited_containers.append(container_name)
 
 
 def main(argv):
@@ -131,20 +131,20 @@ def main(argv):
         with open(instance_id_file_path, "r") as f:
             instance_id = f.readline()
 
-        already_exited_container = []
+        already_exited_containers = []
         force = parsed_args.force
         if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, WEBUI_COMPONENT_NAME):
             container_name = f"clp-{WEBUI_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
         if target in (ALL_TARGET_NAME, SEARCH_WORKER_COMPONENT_NAME):
             container_name = f"clp-{SEARCH_WORKER_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
         if target in (ALL_TARGET_NAME, COMPRESSION_WORKER_COMPONENT_NAME):
             container_name = f"clp-{COMPRESSION_WORKER_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
         if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, SEARCH_SCHEDULER_COMPONENT_NAME):
             container_name = f"clp-{SEARCH_SCHEDULER_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
 
             container_config_file_path = logs_dir / f"{container_name}.yml"
             if container_config_file_path.exists():
@@ -155,34 +155,34 @@ def main(argv):
             COMPRESSION_SCHEDULER_COMPONENT_NAME,
         ):
             container_name = f"clp-{COMPRESSION_SCHEDULER_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
 
             container_config_file_path = logs_dir / f"{container_name}.yml"
             if container_config_file_path.exists():
                 container_config_file_path.unlink()
         if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, REDIS_COMPONENT_NAME):
             container_name = f"clp-{REDIS_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
 
             redis_config_file_path = logs_dir / f"{container_name}.conf"
             if redis_config_file_path.exists():
                 redis_config_file_path.unlink()
         if target in (ALL_TARGET_NAME, RESULTS_CACHE_COMPONENT_NAME):
             container_name = f"clp-{RESULTS_CACHE_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
         if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, QUEUE_COMPONENT_NAME):
             container_name = f"clp-{QUEUE_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
 
             queue_config_file_path = logs_dir / f"{container_name}.conf"
             if queue_config_file_path.exists():
                 queue_config_file_path.unlink()
         if target in (ALL_TARGET_NAME, DB_COMPONENT_NAME):
             container_name = f"clp-{DB_COMPONENT_NAME}-{instance_id}"
-            stop_running_container(container_name, already_exited_container, force)
+            stop_running_container(container_name, already_exited_containers, force)
 
-        if already_exited_container:
-            container_list = " ".join(already_exited_container)
+        if already_exited_containers:
+            container_list = " ".join(already_exited_containers)
             logger.warning(
                 f"The following containers have already exited and were not removed:"
                 f" {container_list}"

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -187,7 +187,7 @@ def main(argv):
                 f"The following containers have already exited and were not removed:"
                 f" {container_list}"
             )
-            logger.warning(f"Run with --force to manually remove them")
+            logger.warning(f"Run with --force to remove them")
         elif target in ALL_TARGET_NAME:
             # NOTE: We can only remove the instance ID file if all containers have been stopped.
             # Currently, we only remove the instance file when all containers are stopped at once.

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -39,7 +39,7 @@ logging_console_handler.setFormatter(logging_formatter)
 logger.addHandler(logging_console_handler)
 
 
-def stop_running_container(container_name: str, exited_container: list, force: bool):
+def stop_running_container(container_name: str, exited_container: list[str], force: bool):
     if is_container_running(container_name):
         logger.info(f"Stopping {container_name}...")
         cmd = ["docker", "stop", container_name]
@@ -48,10 +48,11 @@ def stop_running_container(container_name: str, exited_container: list, force: b
         logger.info(f"Removing {container_name}...")
         cmd = ["docker", "rm", container_name]
         subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
-        logger.info(f"Stopped and Removed {container_name}.")
+
+        logger.info(f"Stopped and removed {container_name}.")
     elif is_container_exited(container_name):
         if force:
-            logger.info(f"Force removing exited {container_name}...")
+            logger.info(f"Forcibly removing exited {container_name}...")
             cmd = ["docker", "rm", container_name]
             subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
             logger.info(f"Removed {container_name}...")
@@ -74,7 +75,7 @@ def main(argv):
         "--force",
         "-f",
         action="store_true",
-        help="Force remove exited containers",
+        help="Forcibly remove exited containers",
     )
 
     component_args_parser = args_parser.add_subparsers(dest="target")
@@ -130,7 +131,7 @@ def main(argv):
         with open(instance_id_file_path, "r") as f:
             instance_id = f.readline()
 
-        exited_container = list()
+        exited_container = []
         force = parsed_args.force
         if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, WEBUI_COMPONENT_NAME):
             container_name = f"clp-{WEBUI_COMPONENT_NAME}-{instance_id}"
@@ -184,7 +185,8 @@ def main(argv):
         if exited_container:
             container_list = " ".join(exited_container)
             logger.warning(
-                f"The following containers have exited and were not removed: {container_list}"
+                f"The following containers have already exited and were not removed:"
+                f" {container_list}"
             )
             logger.warning(f"Run with --force to manually remove them")
         elif target in ALL_TARGET_NAME:


### PR DESCRIPTION
# Description

The previous package script let docker automatically remove a container if it fails. This makes the debugging harder as the log in the failed container will be removed together, making it harder to identity the cause of failure.

This change:
- Let docker not remove the failed container by default
- Updated utility functions to distinguish if a docker container is running or has exited
- Updated the stop-clp script to not remove failed container by default and warns user about the failed container

The change also includes an update to the MySQL timeout since on some machines 30 seconds are not enough for the database to start

# Validation performed
Manually validated the change.

