### PR TITLE
clp-package: Fix Python-typing syntax error in stop_clp.py.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import subprocess
 import sys
+from typing import List
 
 from clp_py_utils.clp_config import (
     ALL_TARGET_NAME,
@@ -39,7 +40,7 @@ logging_console_handler.setFormatter(logging_formatter)
 logger.addHandler(logging_console_handler)
 
 
-def stop_running_container(container_name: str, already_exited_containers: list[str], force: bool):
+def stop_running_container(container_name: str, already_exited_containers: List[str], force: bool):
     if is_container_running(container_name):
         logger.info(f"Stopping {container_name}...")
         cmd = ["docker", "stop", container_name]


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

stop_clp.py is failing to stop the clp package due to:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/user/clp/build/clp-package/lib/python3/site-packages/clp_package_utils/scripts/stop_clp.py", line 42, in <module>
    def stop_running_container(container_name: str, already_exited_containers: list[str], force: bool):
TypeError: 'type' object is not subscriptable
```

This occurred because one of my previous code review suggestions was accidentally merged without testing on Python 3.8 (the default on Ubuntu 20.04).

# Validation performed
<!-- What tests and validation you performed on the change -->

* Built the package
* Validated that starting and stopping the package worked:

    ```bash
    sbin/start-clp.sh
    sbin/stop-clp.sh
    ```