### PR TITLE
clp-package: Remove faulty and unnecessary validation

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -123,13 +123,14 @@ def main(argv):
             if not output_list_path.exists():
                 break
 
-        with open(parsed_args.input_list, 'r') as input_list_file:
-            with open(output_list_path, 'w') as output_list_file:
+        with open(parsed_args.input_list, "r") as input_list_file:
+            with open(output_list_path, "w") as output_list_file:
                 for line in input_list_file:
                     resolved_path = pathlib.Path(line.rstrip()).resolve()
                     path = CONTAINER_INPUT_LOGS_ROOT_DIR / resolved_path.relative_to(
-                        resolved_path.anchor)
-                    output_list_file.write(f'{path}\n')
+                        resolved_path.anchor
+                    )
+                    output_list_file.write(f"{path}\n")
 
         compress_cmd.append("--input-list")
         compress_cmd.append(container_clp_config.logs_directory / output_list_filename)

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -123,24 +123,13 @@ def main(argv):
             if not output_list_path.exists():
                 break
 
-        try:
-            with open(output_list_path, "w") as output_list:
-                # Validate all paths in input list
-                all_paths_valid = True
-                with open(parsed_args.input_list, "r") as f:
-                    for line in f:
-                        resolved_path = pathlib.Path(line.rstrip()).resolve()
-                        if not resolved_path.is_absolute():
-                            logger.error(f"Invalid relative path in input list: {resolved_path}")
-                            all_paths_valid = False
-                        path = CONTAINER_INPUT_LOGS_ROOT_DIR / resolved_path.relative_to(
-                            resolved_path.anchor
-                        )
-                        output_list.write(f"{path}\n")
-                if not all_paths_valid:
-                    raise ValueError("--input-list must only contain absolute paths")
-        finally:
-            output_list_path.unlink()
+        with open(parsed_args.input_list, 'r') as input_list_file:
+            with open(output_list_path, 'w') as output_list_file:
+                for line in input_list_file:
+                    resolved_path = pathlib.Path(line.rstrip()).resolve()
+                    path = CONTAINER_INPUT_LOGS_ROOT_DIR / resolved_path.relative_to(
+                        resolved_path.anchor)
+                    output_list_file.write(f'{path}\n')
 
         compress_cmd.append("--input-list")
         compress_cmd.append(container_clp_config.logs_directory / output_list_filename)


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

#305 is caused by an erroneous `finally` statement which *always* removed the container-internal list of paths for compression after it was generated. The reasoning for having a `finally` at all was to remove the generated file if validation of an input path failed. However, the validation (which tried to determine if a path was relative) was pointless since we resolve all input paths before writing them to the output file.

This PR gets rid of the unnecessary validation and the `finally` block.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that the reproduction instructions in #305 didn't cause a failure.