### PR TITLE
clp-package: Pass input paths to compression scheduler through database rather than file.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -42,7 +42,7 @@ def main(argv):
     )
     args_parser.add_argument("paths", metavar="PATH", nargs="*", help="Paths to compress.")
     args_parser.add_argument(
-        "-f", "--input-list", dest="input_list", help="A file listing all paths to compress."
+        "-f", "--path-list", dest="path_list", help="A file listing all paths to compress."
     )
     args_parser.add_argument(
         "--timestamp-key",
@@ -115,25 +115,25 @@ def main(argv):
         resolved_path = pathlib.Path(path).resolve()
         path = str(CONTAINER_INPUT_LOGS_ROOT_DIR / resolved_path.relative_to(resolved_path.anchor))
         compress_cmd.append(path)
-    if parsed_args.input_list is not None:
+    if parsed_args.path_list is not None:
         # Get unused output path
         while True:
-            output_list_filename = f"{uuid.uuid4()}.txt"
-            output_list_path = clp_config.logs_directory / output_list_filename
-            if not output_list_path.exists():
+            container_path_list_filename = f"{uuid.uuid4()}.txt"
+            container_path_list = clp_config.logs_directory / container_path_list_filename
+            if not container_path_list.exists():
                 break
 
-        with open(parsed_args.input_list, "r") as input_list_file:
-            with open(output_list_path, "w") as output_list_file:
-                for line in input_list_file:
+        with open(parsed_args.path_list, "r") as path_list_file:
+            with open(container_path_list, "w") as container_path_list_file:
+                for line in path_list_file:
                     resolved_path = pathlib.Path(line.rstrip()).resolve()
                     path = CONTAINER_INPUT_LOGS_ROOT_DIR / resolved_path.relative_to(
                         resolved_path.anchor
                     )
-                    output_list_file.write(f"{path}\n")
+                    container_path_list_file.write(f"{path}\n")
 
-        compress_cmd.append("--input-list")
-        compress_cmd.append(container_clp_config.logs_directory / output_list_filename)
+        compress_cmd.append("--path-list")
+        compress_cmd.append(container_clp_config.logs_directory / container_path_list_filename)
 
     cmd = container_start_cmd + compress_cmd
     subprocess.run(cmd, check=True)

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -119,12 +119,12 @@ def main(argv):
         # Get unused output path
         while True:
             container_path_list_filename = f"{uuid.uuid4()}.txt"
-            container_path_list = clp_config.logs_directory / container_path_list_filename
-            if not container_path_list.exists():
+            container_path_list_path = clp_config.logs_directory / container_path_list_filename
+            if not container_path_list_path.exists():
                 break
 
         with open(parsed_args.path_list, "r") as path_list_file:
-            with open(container_path_list, "w") as container_path_list_file:
+            with open(container_path_list_path, "w") as container_path_list_file:
                 for line in path_list_file:
                     resolved_path = pathlib.Path(line.rstrip()).resolve()
                     path = CONTAINER_INPUT_LOGS_ROOT_DIR / resolved_path.relative_to(

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -198,8 +198,8 @@ def main(argv):
             paths_to_compress.append(resolved_path_str)
     else:
         # Read paths from the input file
-        log_paths_to_compress = pathlib.Path(compress_path_list_arg).resolve()
-        with open(log_paths_to_compress, "r") as f:
+        compress_path_list_path = pathlib.Path(compress_path_list_arg).resolve()
+        with open(compress_path_list_path, "r") as f:
             for path in f:
                 stripped_path = path.strip()
                 if "" == stripped_path:

--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -106,7 +106,7 @@ def search_and_schedule_new_tasks(db_conn, db_cursor, clp_metadata_db_connection
             clp_metadata_db_connection_config=clp_metadata_db_connection_config,
         )
 
-        for path_idx, path in enumerate(clp_io_config.input.list_path, start=1):
+        for path_idx, path in enumerate(clp_io_config.input.paths_to_compress, start=1):
             path = Path(path)
 
             try:

--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -106,44 +106,39 @@ def search_and_schedule_new_tasks(db_conn, db_cursor, clp_metadata_db_connection
             clp_metadata_db_connection_config=clp_metadata_db_connection_config,
         )
 
-        with open(Path(clp_io_config.input.list_path).resolve(), "r") as f:
-            for path_idx, path in enumerate(f, start=1):
-                stripped_path = path.strip()
-                if "" == stripped_path:
-                    # Skip empty paths
-                    continue
-                path = Path(stripped_path)
+        for path_idx, path in enumerate(clp_io_config.input.list_path, start=1):
+            path = Path(path)
 
-                try:
-                    file, empty_directory = validate_path_and_get_info(
-                        CONTAINER_INPUT_LOGS_ROOT_DIR, path
-                    )
-                except ValueError as ex:
-                    logger.error(str(ex))
-                    continue
+            try:
+                file, empty_directory = validate_path_and_get_info(
+                    CONTAINER_INPUT_LOGS_ROOT_DIR, path
+                )
+            except ValueError as ex:
+                logger.error(str(ex))
+                continue
 
-                if file:
-                    paths_to_compress_buffer.add_file(file)
-                elif empty_directory:
-                    paths_to_compress_buffer.add_empty_directory(empty_directory)
+            if file:
+                paths_to_compress_buffer.add_file(file)
+            elif empty_directory:
+                paths_to_compress_buffer.add_empty_directory(empty_directory)
 
-                if path.is_dir():
-                    for internal_path in path.rglob("*"):
-                        try:
-                            file, empty_directory = validate_path_and_get_info(
-                                CONTAINER_INPUT_LOGS_ROOT_DIR, internal_path
-                            )
-                        except ValueError as ex:
-                            logger.error(str(ex))
-                            continue
+            if path.is_dir():
+                for internal_path in path.rglob("*"):
+                    try:
+                        file, empty_directory = validate_path_and_get_info(
+                            CONTAINER_INPUT_LOGS_ROOT_DIR, internal_path
+                        )
+                    except ValueError as ex:
+                        logger.error(str(ex))
+                        continue
 
-                        if file:
-                            paths_to_compress_buffer.add_file(file)
-                        elif empty_directory:
-                            paths_to_compress_buffer.add_empty_directory(empty_directory)
+                    if file:
+                        paths_to_compress_buffer.add_file(file)
+                    elif empty_directory:
+                        paths_to_compress_buffer.add_empty_directory(empty_directory)
 
-                if path_idx % 10000 == 0:
-                    db_conn.commit()
+            if path_idx % 10000 == 0:
+                db_conn.commit()
 
         paths_to_compress_buffer.flush()
         tasks = paths_to_compress_buffer.get_tasks()

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -13,7 +13,7 @@ class PathsToCompress(BaseModel):
 
 
 class InputConfig(BaseModel):
-    list_path: str
+    list_path: typing.List[str]
     path_prefix_to_remove: str = None
     timestamp_key: typing.Optional[str] = None
 

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -13,7 +13,7 @@ class PathsToCompress(BaseModel):
 
 
 class InputConfig(BaseModel):
-    list_path: typing.List[str]
+    paths_to_compress: typing.List[str]
     path_prefix_to_remove: str = None
     timestamp_key: typing.Optional[str] = None
 


### PR DESCRIPTION
# Description

The current way of argument passing uses an on-disk file and doesn't handle the case when compress.sh is on a different machine from compression scheduler. This change replace the on-disk file with a list of file paths. 

# Validation performed

Manually ran compress.sh with file and input-list arguments and confirmed no error.

