### PR TITLE
Limit number of results in subscription `results` by `SEARCH_MAX_NUM_RESULTS`.

### DIFF
--- a/components/webui/imports/api/search/collections.js
+++ b/components/webui/imports/api/search/collections.js
@@ -24,19 +24,7 @@ const initSearchEventCollection = () => {
     }
 };
 
-/**
- * Adds the given sort to the find options for a MongoDB collection.
- * @param {Object|null} fieldToSortBy An object mapping field names to the direction to sort by
- * (ASC = 1, DESC = -1).
- * @param {Object} findOptions
- */
-const addSortToMongoFindOptions = (fieldToSortBy, findOptions) => {
-    if (fieldToSortBy) {
-        findOptions["sort"] = {
-            [fieldToSortBy.name]: fieldToSortBy.direction,
-            _id: fieldToSortBy.direction,
-        };
-    }
+export {
+    initSearchEventCollection,
+    SearchResultsMetadataCollection,
 };
-
-export {addSortToMongoFindOptions, initSearchEventCollection, SearchResultsMetadataCollection};

--- a/components/webui/imports/api/search/collections.js
+++ b/components/webui/imports/api/search/collections.js
@@ -1,5 +1,8 @@
 import {Mongo} from "meteor/mongo";
-import {INVALID_JOB_ID, SearchSignal} from "./constants";
+import {
+    INVALID_JOB_ID,
+    SEARCH_SIGNAL
+} from "./constants";
 
 
 /**
@@ -17,7 +20,7 @@ const initSearchEventCollection = () => {
     if (SearchResultsMetadataCollection.countDocuments() === 0) {
         SearchResultsMetadataCollection.insert({
             _id: INVALID_JOB_ID.toString(),
-            lastEvent: SearchSignal.NONE,
+            lastEvent: SEARCH_SIGNAL.NONE,
             errorMsg: null,
             numTotalResults: -1,
         });

--- a/components/webui/imports/api/search/constants.js
+++ b/components/webui/imports/api/search/constants.js
@@ -37,7 +37,7 @@ let enumJobStatus;
  *
  * @type {Object}
  */
-const JobStatus = Object.freeze({
+const SearchJobStatus = Object.freeze({
     PENDING: (enumJobStatus = 0),
     RUNNING: ++enumJobStatus,
     SUCCEEDED: ++enumJobStatus,
@@ -49,9 +49,9 @@ const JobStatus = Object.freeze({
 
 
 const JOB_STATUS_WAITING_STATES = [
-    JobStatus.PENDING,
-    JobStatus.RUNNING,
-    JobStatus.CANCELLING,
+    SearchJobStatus.PENDING,
+    SearchJobStatus.RUNNING,
+    SearchJobStatus.CANCELLING,
 ];
 
 const INVALID_JOB_ID = -1;
@@ -64,7 +64,7 @@ export {
     isSearchSignalReq,
     isSearchSignalResp,
     JOB_STATUS_WAITING_STATES,
-    JobStatus,
     SEARCH_MAX_NUM_RESULTS,
+    SearchJobStatus,
     SearchSignal,
 };

--- a/components/webui/imports/api/search/constants.js
+++ b/components/webui/imports/api/search/constants.js
@@ -7,7 +7,7 @@ let enumSearchSignal;
  *
  * @type {Object}
  */
-const SearchSignal = Object.freeze({
+const SEARCH_SIGNAL = Object.freeze({
     NONE: (enumSearchSignal = 0),
 
     REQ_MASK: (enumSearchSignal = 0x10000000),
@@ -20,12 +20,12 @@ const SearchSignal = Object.freeze({
     RESP_QUERYING: ++enumSearchSignal,
 });
 
-const isSearchSignalReq = (s) => (0 !== (SearchSignal.REQ_MASK & s));
-const isSearchSignalResp = (s) => (0 !== (SearchSignal.RESP_MASK & s));
+const isSearchSignalReq = (s) => (0 !== (SEARCH_SIGNAL.REQ_MASK & s));
+const isSearchSignalResp = (s) => (0 !== (SEARCH_SIGNAL.RESP_MASK & s));
 const isSearchSignalQuerying = (s) => (
     [
-        SearchSignal.REQ_QUERYING,
-        SearchSignal.RESP_QUERYING,
+        SEARCH_SIGNAL.REQ_QUERYING,
+        SEARCH_SIGNAL.RESP_QUERYING,
     ].includes(s)
 );
 
@@ -80,6 +80,9 @@ const SEARCH_RESULTS_FIELDS = Object.freeze({
 
 const INVALID_JOB_ID = -1;
 
+/**
+ * The maximum number of results to retrieve for a search.
+ */
 const SEARCH_MAX_NUM_RESULTS = 1000;
 
 export {
@@ -92,5 +95,5 @@ export {
     SEARCH_MAX_NUM_RESULTS,
     SEARCH_RESULTS_FIELDS,
     SearchJobStatus,
-    SearchSignal,
+    SEARCH_SIGNAL,
 };

--- a/components/webui/imports/api/search/constants.js
+++ b/components/webui/imports/api/search/constants.js
@@ -38,7 +38,7 @@ let enumSearchJobStatus;
  * @readonly
  * @enum {number}
  */
-const SearchJobStatus = Object.freeze({
+const SEARCH_JOB_STATUS = Object.freeze({
     PENDING: (enumSearchJobStatus = 0),
     RUNNING: ++enumSearchJobStatus,
     SUCCEEDED: ++enumSearchJobStatus,
@@ -50,9 +50,9 @@ const SearchJobStatus = Object.freeze({
 
 
 const JOB_STATUS_WAITING_STATES = [
-    SearchJobStatus.PENDING,
-    SearchJobStatus.RUNNING,
-    SearchJobStatus.CANCELLING,
+    SEARCH_JOB_STATUS.PENDING,
+    SEARCH_JOB_STATUS.RUNNING,
+    SEARCH_JOB_STATUS.CANCELLING,
 ];
 
 /**
@@ -92,8 +92,8 @@ export {
     isSearchSignalResp,
     JOB_STATUS_WAITING_STATES,
     MONGO_SORT_ORDER,
+    SEARCH_JOB_STATUS,
     SEARCH_MAX_NUM_RESULTS,
     SEARCH_RESULTS_FIELDS,
-    SearchJobStatus,
     SEARCH_SIGNAL,
 };

--- a/components/webui/imports/api/search/constants.js
+++ b/components/webui/imports/api/search/constants.js
@@ -30,20 +30,21 @@ const isSearchSignalQuerying = (s) => (
 );
 
 /* eslint-disable sort-keys */
-let enumJobStatus;
+let enumSearchJobStatus;
 /**
  * Enum of job statuses, matching the `SearchJobStatus` class in
  * `job_orchestration.search_scheduler.constants`.
  *
- * @type {Object}
+ * @readonly
+ * @enum {number}
  */
 const SearchJobStatus = Object.freeze({
-    PENDING: (enumJobStatus = 0),
-    RUNNING: ++enumJobStatus,
-    SUCCEEDED: ++enumJobStatus,
-    FAILED: ++enumJobStatus,
-    CANCELLING: ++enumJobStatus,
-    CANCELLED: ++enumJobStatus,
+    PENDING: (enumSearchJobStatus = 0),
+    RUNNING: ++enumSearchJobStatus,
+    SUCCEEDED: ++enumSearchJobStatus,
+    FAILED: ++enumSearchJobStatus,
+    CANCELLING: ++enumSearchJobStatus,
+    CANCELLED: ++enumSearchJobStatus,
 });
 /* eslint-enable sort-keys */
 
@@ -53,6 +54,29 @@ const JOB_STATUS_WAITING_STATES = [
     SearchJobStatus.RUNNING,
     SearchJobStatus.CANCELLING,
 ];
+
+/**
+ * Enum of Mongo Collection sort orders.
+ *
+ * @readonly
+ * @enum {string}
+ */
+const MONGO_SORT_ORDER = Object.freeze({
+    ASCENDING: "asc",
+    DESCENDING: "desc",
+});
+
+/**
+ * Enum of search results cache fields.
+ *
+ * @readonly
+ * @enum {string}
+ */
+const SEARCH_RESULTS_FIELDS = Object.freeze({
+    ID: "_id",
+    TIMESTAMP: "timestamp",
+});
+
 
 const INVALID_JOB_ID = -1;
 
@@ -64,7 +88,9 @@ export {
     isSearchSignalReq,
     isSearchSignalResp,
     JOB_STATUS_WAITING_STATES,
+    MONGO_SORT_ORDER,
     SEARCH_MAX_NUM_RESULTS,
+    SEARCH_RESULTS_FIELDS,
     SearchJobStatus,
     SearchSignal,
 };

--- a/components/webui/imports/api/search/constants.js
+++ b/components/webui/imports/api/search/constants.js
@@ -29,6 +29,7 @@ const isSearchSignalQuerying = (s) => (
     ].includes(s)
 );
 
+/* eslint-disable sort-keys */
 let enumJobStatus;
 /**
  * Enum of job statuses, matching the `SearchJobStatus` class in
@@ -39,11 +40,13 @@ let enumJobStatus;
 const JobStatus = Object.freeze({
     PENDING: (enumJobStatus = 0),
     RUNNING: ++enumJobStatus,
-    SUCCESS: ++enumJobStatus,
+    SUCCEEDED: ++enumJobStatus,
     FAILED: ++enumJobStatus,
     CANCELLING: ++enumJobStatus,
     CANCELLED: ++enumJobStatus,
 });
+/* eslint-enable sort-keys */
+
 
 const JOB_STATUS_WAITING_STATES = [
     JobStatus.PENDING,
@@ -53,12 +56,15 @@ const JOB_STATUS_WAITING_STATES = [
 
 const INVALID_JOB_ID = -1;
 
+const SEARCH_MAX_NUM_RESULTS = 1000;
+
 export {
-    SearchSignal,
+    INVALID_JOB_ID,
+    isSearchSignalQuerying,
     isSearchSignalReq,
     isSearchSignalResp,
-    isSearchSignalQuerying,
-    JobStatus,
     JOB_STATUS_WAITING_STATES,
-    INVALID_JOB_ID,
+    JobStatus,
+    SEARCH_MAX_NUM_RESULTS,
+    SearchSignal,
 };

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -1,7 +1,10 @@
 import msgpack from "@msgpack/msgpack";
 
 import {sleep} from "../../../utils/misc";
-import {JOB_STATUS_WAITING_STATES, JobStatus} from "../constants";
+import {
+    JOB_STATUS_WAITING_STATES,
+    SearchJobStatus,
+} from "../constants";
 
 
 const SEARCH_JOBS_TABLE_COLUMN_NAMES = {
@@ -52,7 +55,7 @@ class SearchJobsDbManager {
     async submitQueryCancellation(jobId) {
         await this.#sqlDbConnection.query(
             `UPDATE ${this.#searchJobsTableName}
-             SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${JobStatus.CANCELLING}
+             SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${SearchJobStatus.CANCELLING}
              WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?`,
             jobId,
         );
@@ -85,11 +88,11 @@ class SearchJobsDbManager {
             const status = rows[0][SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS];
 
             if (false === JOB_STATUS_WAITING_STATES.includes(status)) {
-                if (JobStatus.CANCELLED === status) {
+                if (SearchJobStatus.CANCELLED === status) {
                     throw new Error(`Job ${jobId} was cancelled.`);
-                } else if (JobStatus.SUCCEEDED !== status) {
+                } else if (SearchJobStatus.SUCCEEDED !== status) {
                     throw new Error(`Job ${jobId} exited with unexpected status=${status}: `
-                        + `${Object.keys(JobStatus)[status]}.`);
+                        + `${Object.keys(SearchJobStatus)[status]}.`);
                 }
                 break;
             }

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -3,7 +3,7 @@ import msgpack from "@msgpack/msgpack";
 import {sleep} from "../../../utils/misc";
 import {
     JOB_STATUS_WAITING_STATES,
-    SearchJobStatus,
+    SEARCH_JOB_STATUS,
 } from "../constants";
 
 
@@ -55,7 +55,7 @@ class SearchJobsDbManager {
     async submitQueryCancellation(jobId) {
         await this.#sqlDbConnection.query(
             `UPDATE ${this.#searchJobsTableName}
-             SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${SearchJobStatus.CANCELLING}
+             SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${SEARCH_JOB_STATUS.CANCELLING}
              WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?`,
             jobId,
         );
@@ -88,11 +88,11 @@ class SearchJobsDbManager {
             const status = rows[0][SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS];
 
             if (false === JOB_STATUS_WAITING_STATES.includes(status)) {
-                if (SearchJobStatus.CANCELLED === status) {
+                if (SEARCH_JOB_STATUS.CANCELLED === status) {
                     throw new Error(`Job ${jobId} was cancelled.`);
-                } else if (SearchJobStatus.SUCCEEDED !== status) {
+                } else if (SEARCH_JOB_STATUS.SUCCEEDED !== status) {
                     throw new Error(`Job ${jobId} exited with unexpected status=${status}: `
-                        + `${Object.keys(SearchJobStatus)[status]}.`);
+                        + `${Object.keys(SEARCH_JOB_STATUS)[status]}.`);
                 }
                 break;
             }

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -87,7 +87,7 @@ class SearchJobsDbManager {
             if (false === JOB_STATUS_WAITING_STATES.includes(status)) {
                 if (JobStatus.CANCELLED === status) {
                     throw new Error(`Job ${jobId} was cancelled.`);
-                } else if (JobStatus.SUCCESS !== status) {
+                } else if (JobStatus.SUCCEEDED !== status) {
                     throw new Error(`Job ${jobId} exited with unexpected status=${status}: `
                         + `${Object.keys(JobStatus)[status]}.`);
                 }

--- a/components/webui/imports/api/search/server/methods.js
+++ b/components/webui/imports/api/search/server/methods.js
@@ -40,7 +40,7 @@ const updateSearchEventWhenJobFinishes = async (jobId) => {
     const filter = {
         _id: jobId.toString(),
     };
-    const countedNumTotalResults = await searchJobCollectionsManager
+    const numResultsInCollection = await searchJobCollectionsManager
         .getOrCreateCollection(jobId)
         .countDocuments();
     const modifier = {
@@ -48,7 +48,7 @@ const updateSearchEventWhenJobFinishes = async (jobId) => {
             lastSignal: SearchSignal.RESP_DONE,
             errorMsg: errorMsg,
             numTotalResults: Math.min(
-                countedNumTotalResults,
+                numResultsInCollection,
                 SEARCH_MAX_NUM_RESULTS
             ),
         },

--- a/components/webui/imports/api/search/server/methods.js
+++ b/components/webui/imports/api/search/server/methods.js
@@ -3,7 +3,7 @@ import {Meteor} from "meteor/meteor";
 import {SearchResultsMetadataCollection} from "../collections";
 import {
     SEARCH_MAX_NUM_RESULTS,
-    SearchSignal
+    SEARCH_SIGNAL,
 } from "../constants";
 import {searchJobCollectionsManager} from "./collections";
 import SearchJobsDbManager from "./SearchJobsDbManager";
@@ -45,7 +45,7 @@ const updateSearchEventWhenJobFinishes = async (jobId) => {
         .countDocuments();
     const modifier = {
         $set: {
-            lastSignal: SearchSignal.RESP_DONE,
+            lastSignal: SEARCH_SIGNAL.RESP_DONE,
             errorMsg: errorMsg,
             numTotalResults: Math.min(
                 numResultsInCollection,
@@ -120,7 +120,7 @@ Meteor.methods({
 
         SearchResultsMetadataCollection.insert({
             _id: jobId.toString(),
-            lastSignal: SearchSignal.RESP_QUERYING,
+            lastSignal: SEARCH_SIGNAL.RESP_QUERYING,
             errorMsg: null,
         });
 

--- a/components/webui/imports/api/search/server/publications.js
+++ b/components/webui/imports/api/search/server/publications.js
@@ -2,7 +2,11 @@ import {logger} from "/imports/utils/logger";
 import {Meteor} from "meteor/meteor";
 
 import {SearchResultsMetadataCollection} from "../collections";
-import {SEARCH_MAX_NUM_RESULTS} from "../constants";
+import {
+    MONGO_SORT_ORDER,
+    SEARCH_MAX_NUM_RESULTS,
+    SEARCH_RESULTS_FIELDS,
+} from "../constants";
 import {searchJobCollectionsManager} from "./collections";
 
 
@@ -44,7 +48,8 @@ Meteor.publish(Meteor.settings.public.SearchResultsCollectionName, ({
 
     const findOptions = {
         sort: [
-            ["timestamp", "desc"],
+            [SEARCH_RESULTS_FIELDS.TIMESTAMP, MONGO_SORT_ORDER.DESCENDING],
+            [SEARCH_RESULTS_FIELDS.ID, MONGO_SORT_ORDER.DESCENDING],
         ],
         limit: SEARCH_MAX_NUM_RESULTS,
         disableOplog: true,

--- a/components/webui/imports/api/search/server/publications.js
+++ b/components/webui/imports/api/search/server/publications.js
@@ -1,7 +1,8 @@
 import {logger} from "/imports/utils/logger";
 import {Meteor} from "meteor/meteor";
 
-import {addSortToMongoFindOptions, SearchResultsMetadataCollection} from "../collections";
+import {SearchResultsMetadataCollection} from "../collections";
+import {SEARCH_MAX_NUM_RESULTS} from "../constants";
 import {searchJobCollectionsManager} from "./collections";
 
 
@@ -29,28 +30,26 @@ Meteor.publish(Meteor.settings.public.SearchResultsMetadataCollectionName, ({job
  *
  * @param {string} publicationName
  * @param {string} jobId of the search operation
- * @param {Object} [fieldToSortBy] used for sorting results
- * @param {number} visibleSearchResultsLimit limit of visible search results
- *
  * @returns {Mongo.Cursor} cursor that provides access to the search results
  */
 Meteor.publish(Meteor.settings.public.SearchResultsCollectionName, ({
     jobId,
-    fieldToSortBy,
-    visibleSearchResultsLimit,
 }) => {
-    logger.debug(`Subscription '${Meteor.settings.public.SearchResultsCollectionName}'`,
-        `jobId=${jobId}, fieldToSortBy=${fieldToSortBy}, ` +
-        `visibleSearchResultsLimit=${visibleSearchResultsLimit}`);
+    logger.debug(
+        `Subscription '${Meteor.settings.public.SearchResultsCollectionName}'`,
+        `jobId=${jobId}`
+    );
 
     const collection = searchJobCollectionsManager.getOrCreateCollection(jobId);
 
     const findOptions = {
-        limit: visibleSearchResultsLimit,
+        sort: [
+            ["timestamp", "desc"],
+        ],
+        limit: SEARCH_MAX_NUM_RESULTS,
         disableOplog: true,
         pollingIntervalMs: 250,
     };
-    addSortToMongoFindOptions(fieldToSortBy, findOptions);
 
     return collection.find({}, findOptions);
 });

--- a/components/webui/imports/ui/SearchView/SearchControls.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls.jsx
@@ -13,7 +13,11 @@ import {
     Row,
 } from "react-bootstrap";
 import DatePicker from "react-datepicker";
-import {isSearchSignalQuerying, isSearchSignalReq, SearchSignal} from "../../api/search/constants";
+import {
+    SEARCH_SIGNAL,
+    isSearchSignalQuerying,
+    isSearchSignalReq,
+} from "../../api/search/constants";
 
 import {computeTimeRange, TIME_RANGE_PRESET_LABEL} from "./datetime";
 import {LOCAL_STORAGE_KEYS} from "../constants";
@@ -293,7 +297,7 @@ const SearchControls = ({
                         onChange={queryChangeHandler}
                     />
                     {
-                        (SearchSignal.RESP_DONE === resultsMetadata["lastSignal"]) &&
+                        (SEARCH_SIGNAL.RESP_DONE === resultsMetadata["lastSignal"]) &&
                         <Button
                             className={"border-top-0 border-bottom-0 rounded-0"}
                             disabled={true === isSearchSignalReq(resultsMetadata["lastSignal"])}
@@ -304,7 +308,7 @@ const SearchControls = ({
                         </Button>
                     }
                     {
-                        (SearchSignal.RESP_QUERYING === resultsMetadata["lastSignal"]) ?
+                        (SEARCH_SIGNAL.RESP_QUERYING === resultsMetadata["lastSignal"]) ?
                             <Button
                                 className={"border-top-0 border-bottom-0 rounded-0"}
                                 disabled={true === canceling}

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -5,6 +5,10 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {Spinner, Table} from "react-bootstrap";
 
 import "./SearchResultsTable.scss";
+import {
+    MONGO_SORT_ORDER,
+    SEARCH_RESULTS_FIELDS,
+} from "../../api/search/constants";
 
 
 /**
@@ -76,7 +80,7 @@ const SearchResultsTable = ({
 }) => {
     const getSortIcon = (fieldToSortBy, fieldName) => {
         if ((null !== fieldToSortBy) && (fieldName === fieldToSortBy.name)) {
-            return (("asc" === fieldToSortBy.direction) ?
+            return ((MONGO_SORT_ORDER.ASCENDING === fieldToSortBy.direction) ?
                 faSortUp :
                 faSortDown);
         }
@@ -89,15 +93,15 @@ const SearchResultsTable = ({
         if (null === fieldToSortBy || fieldToSortBy.name !== columnName) {
             setFieldToSortBy({
                 name: columnName,
-                direction: "asc",
+                direction: MONGO_SORT_ORDER.ASCENDING,
             });
-        } else if ("asc" === fieldToSortBy.direction) {
+        } else if (MONGO_SORT_ORDER.ASCENDING === fieldToSortBy.direction) {
             // Switch to descending
             setFieldToSortBy({
                 name: columnName,
-                direction: "desc",
+                direction: MONGO_SORT_ORDER.DESCENDING,
             });
-        } else if ("desc" === fieldToSortBy.direction) {
+        } else if (MONGO_SORT_ORDER.DESCENDING === fieldToSortBy.direction) {
             // Switch to unsorted
             setFieldToSortBy(null);
         }
@@ -127,12 +131,12 @@ const SearchResultsTable = ({
             <tr>
                 <th style={{"width": "144px"}}
                     className={"search-results-th search-results-th-sortable"}
-                    data-column-name={"timestamp"}
-                    key={"timestamp"}
+                    data-column-name={SEARCH_RESULTS_FIELDS.TIMESTAMP}
+                    key={SEARCH_RESULTS_FIELDS.TIMESTAMP}
                     onClick={toggleSortDirection}
                 >
                     <div className={"search-results-table-header"}>
-                        <FontAwesomeIcon icon={getSortIcon(fieldToSortBy, "timestamp")}/> Timestamp
+                        <FontAwesomeIcon icon={getSortIcon(fieldToSortBy, SEARCH_RESULTS_FIELDS.TIMESTAMP)}/> Timestamp
                     </div>
                 </th>
                 <th className={"search-results-th"} key={"message"}>

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -75,11 +75,13 @@ const SearchResultsTable = ({
     onLoadMoreResults,
 }) => {
     const getSortIcon = (fieldToSortBy, fieldName) => {
-        if (fieldToSortBy && fieldName === fieldToSortBy.name) {
-            return (1 === fieldToSortBy.direction ? faSortDown : faSortUp);
-        } else {
-            return faSort;
+        if ((null !== fieldToSortBy) && (fieldName === fieldToSortBy.name)) {
+            return (("asc" === fieldToSortBy.direction) ?
+                faSortUp :
+                faSortDown);
         }
+
+        return faSort;
     };
 
     const toggleSortDirection = (event) => {
@@ -87,15 +89,15 @@ const SearchResultsTable = ({
         if (null === fieldToSortBy || fieldToSortBy.name !== columnName) {
             setFieldToSortBy({
                 name: columnName,
-                direction: 1,
+                direction: "asc",
             });
-        } else if (1 === fieldToSortBy.direction) {
+        } else if ("asc" === fieldToSortBy.direction) {
             // Switch to descending
             setFieldToSortBy({
                 name: columnName,
-                direction: -1,
+                direction: "desc",
             });
-        } else if (-1 === fieldToSortBy.direction) {
+        } else if ("desc" === fieldToSortBy.direction) {
             // Switch to unsorted
             setFieldToSortBy(null);
         }

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -136,7 +136,9 @@ const SearchResultsTable = ({
                     onClick={toggleSortDirection}
                 >
                     <div className={"search-results-table-header"}>
-                        <FontAwesomeIcon icon={getSortIcon(fieldToSortBy, SEARCH_RESULTS_FIELDS.TIMESTAMP)}/> Timestamp
+                        <FontAwesomeIcon
+                            icon={getSortIcon(fieldToSortBy, SEARCH_RESULTS_FIELDS.TIMESTAMP)}/>
+                        <span> Timestamp</span>
                     </div>
                 </th>
                 <th className={"search-results-th"} key={"message"}>

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -9,6 +9,8 @@ import {ProgressBar} from "react-bootstrap";
 import {SearchResultsMetadataCollection} from "../../api/search/collections";
 import {
     INVALID_JOB_ID,
+    MONGO_SORT_ORDER,
+    SEARCH_RESULTS_FIELDS,
     SearchSignal,
     isSearchSignalQuerying,
 } from "../../api/search/constants";
@@ -46,8 +48,8 @@ const SearchView = () => {
     const [visibleSearchResultsLimit, setVisibleSearchResultsLimit] = useState(
         VISIBLE_RESULTS_LIMIT_INITIAL);
     const [fieldToSortBy, setFieldToSortBy] = useState({
-        name: "timestamp",
-        direction: "desc",
+        name: SEARCH_RESULTS_FIELDS.TIMESTAMP,
+        direction: MONGO_SORT_ORDER.DESCENDING,
     });
 
     // Visuals

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -11,7 +11,7 @@ import {
     INVALID_JOB_ID,
     MONGO_SORT_ORDER,
     SEARCH_RESULTS_FIELDS,
-    SearchSignal,
+    SEARCH_SIGNAL,
     isSearchSignalQuerying,
 } from "../../api/search/constants";
 import SearchJobCollectionsManager from "../../api/search/SearchJobCollectionsManager";
@@ -35,7 +35,7 @@ const SearchView = () => {
     // Query states
     const [jobId, setJobId] = useState(INVALID_JOB_ID);
     const [operationErrorMsg, setOperationErrorMsg] = useState("");
-    const [localLastSearchSignal, setLocalLastSearchSignal] = useState(SearchSignal.NONE);
+    const [localLastSearchSignal, setLocalLastSearchSignal] = useState(SEARCH_SIGNAL.NONE);
     const dbRef = useRef(new SearchJobCollectionsManager());
     // gets updated as soon as localLastSearchSignal is updated
     // to avoid reading old localLastSearchSignal value from Closures
@@ -127,7 +127,7 @@ const SearchView = () => {
         }
 
         setOperationErrorMsg("");
-        setLocalLastSearchSignal(SearchSignal.REQ_QUERYING);
+        setLocalLastSearchSignal(SEARCH_SIGNAL.REQ_QUERYING);
         setVisibleSearchResultsLimit(VISIBLE_RESULTS_LIMIT_INITIAL);
 
         const timestampBeginMillis = changeTimezoneToUtcWithoutChangingTime(timeRange.begin)
@@ -156,7 +156,7 @@ const SearchView = () => {
 
         setJobId(INVALID_JOB_ID);
         setOperationErrorMsg("");
-        setLocalLastSearchSignal(SearchSignal.REQ_CLEARING);
+        setLocalLastSearchSignal(SEARCH_SIGNAL.REQ_CLEARING);
         setVisibleSearchResultsLimit(VISIBLE_RESULTS_LIMIT_INITIAL);
 
         const args = {
@@ -168,17 +168,17 @@ const SearchView = () => {
                 return;
             }
 
-            if (SearchSignal.REQ_CLEARING === localLastSearchSignalRef.current) {
+            if (SEARCH_SIGNAL.REQ_CLEARING === localLastSearchSignalRef.current) {
                 // The check prevents clearing `localLastSearchSignal = SearchSignal.REQ_QUERYING`
                 // when `handleClearResults` is called by submitQuery.
-                setLocalLastSearchSignal(SearchSignal.NONE);
+                setLocalLastSearchSignal(SEARCH_SIGNAL.NONE);
             }
         });
     };
 
     const cancelOperation = () => {
         setOperationErrorMsg("");
-        setLocalLastSearchSignal(SearchSignal.REQ_CANCELLING);
+        setLocalLastSearchSignal(SEARCH_SIGNAL.REQ_CANCELLING);
 
         const args = {
             jobId: jobId,
@@ -265,10 +265,10 @@ const SearchStatus = ({
     } else {
         let message = null;
         switch (resultsMetadata["lastSignal"]) {
-            case SearchSignal.NONE:
+            case SEARCH_SIGNAL.NONE:
                 message = "Ready";
                 break;
-            case SearchSignal.REQ_CLEARING:
+            case SEARCH_SIGNAL.REQ_CLEARING:
                 message = "Clearing...";
                 break;
             default:

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -95,7 +95,7 @@ const SearchView = () => {
                     fieldToSortBy.direction,
                 ],
                 [
-                    "_id",
+                    SEARCH_RESULTS_FIELDS.ID,
                     fieldToSortBy.direction,
                 ],
             ];
@@ -169,7 +169,7 @@ const SearchView = () => {
             }
 
             if (SEARCH_SIGNAL.REQ_CLEARING === localLastSearchSignalRef.current) {
-                // The check prevents clearing `localLastSearchSignal = SearchSignal.REQ_QUERYING`
+                // The check prevents clearing `localLastSearchSignal = SEARCH_SIGNAL.REQ_QUERYING`
                 // when `handleClearResults` is called by submitQuery.
                 setLocalLastSearchSignal(SEARCH_SIGNAL.NONE);
             }


### PR DESCRIPTION
# References
The number of search results in MongoDB might be higher than request argument `max_num_results` due to concurrency between workers, but we still want to restrict the view to the latest `max_num_results` of results and handle sorting. 

# Description
1. Limit number of results in subscription `results` by `SEARCH_MAX_NUM_RESULTS`.
   1. In the `results` subscription handler, instead of setting MongoDB collection find options `limit=visibleSearchResultsLimit` and `sort={...fieldToSortBy}`, always set `limit=SEARCH_MAX_NUM_RESULTS=1000` and `sort=[["timestamp", "desc"]]` so that the subscription always provide the latest `SEARCH_MAX_NUM_RESULTS=1000` results to its subscribers.
   2. In the `results` subscriber, set MongoDB collection find options `limit=visibleSearchResultsLimit` and `sort={...fieldToSortBy}` to manipulate the results returned by the `results` subscription handler.
2. Correct results table sort icon directions:
   `▲`: "ascending", as the triangle tip points upwards.
   `▼`: "descending", as the triangle tip points downwards.
3. Update enum `JobStatus.SUCCESS` -> `SearchJobStatus.SUCCEEDED` to match https://github.com/y-scope/clp/blob/83a168154e2af3395161bca0dc5ac3310983fa88/components/job-orchestration/job_orchestration/scheduler/constants.py#L35C1-L41C23 .

# Validation performed
1. Built and started `clp-package`. Compressed sample logs.
2. Open the WebUI address http://localhost:4000 in a browser.
3. Started a search query with string `1` and time range "All Time". 
4. Observed the initial results to be sorted in timestamp descending order.
5. Toggled the table `timestamp` header sort button and observed the button shows the logs are not sorted by timestamp. Observed no change in the logs order as the default is to sorting the logs by descending timestamp when users do not provide a sort condition. 
6. Toggled the `timestamp` header sort button and observed the button shows the logs are sorted by ascending timestamp. Kept scrolling down to load more results and observed the logs to be presented in ascending timestamp order.

To ensure the latest `SEARCH_MAX_NUM_RESULTS` are returned:
1. `./stop-clp.sh webui` and launch WebUI in debug mode as specified by `<PROJECT_ROOT>/components/webui/README.md`.
2. Modified `SEARCH_MAX_NUM_RESULTS` from `1000` to `3`.
3. Started a search query with string `1` and time range "All Time". 
4. Observed the latest 3 results to be presented in the results table. 
5. Toggled the `timestamp` header sort button twice to sort in "ascending" timestamp mode. Observed the 3 logs' timestamp and content do not change, except their listing order. 