### PR TITLE
clp-s: Fix a bug caused by not clearing m_schema_ids

### DIFF
--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -187,6 +187,7 @@ void ArchiveReader::close() {
     m_table_metadata_file_reader.close();
 
     m_id_to_table_metadata.clear();
+    m_schema_ids.clear();
 }
 
 }  // namespace clp_s


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#313

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Currently, when searching on multiple archives, `m_schema_ids` is not cleared in `ArchiveReader::close()`. It is likely that some matching schema ids in `m_schema_ids` is not valid for the next archive, which leads to an exception when reading tables. This PR fixes this bug.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Built clp-s and compressed part of [mongodb](https://zenodo.org/records/10516285) dataset to 1) multiple archives 2) a single archive
+ Executed the query `c: REPL` and compared the results of the two setups.
