### PR TITLE
webui: Fix sorting mechanism in search result table.

### DIFF
--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -78,32 +78,32 @@ const SearchResultsTable = ({
     hasMoreResults,
     onLoadMoreResults,
 }) => {
-    const getSortIcon = (fieldToSortBy, fieldName) => {
-        if ((null !== fieldToSortBy) && (fieldName === fieldToSortBy.name)) {
-            return ((MONGO_SORT_ORDER.ASCENDING === fieldToSortBy.direction) ?
+    const getSortIcon = (fieldName) => {
+        if (fieldName === fieldToSortBy.name) {
+            return (MONGO_SORT_ORDER.ASCENDING === fieldToSortBy.direction) ?
                 faSortUp :
-                faSortDown);
+                faSortDown;
         }
 
         return faSort;
     };
 
     const toggleSortDirection = (event) => {
-        const columnName = event.currentTarget.dataset.columnName;
-        if (null === fieldToSortBy || fieldToSortBy.name !== columnName) {
+        const {columnName} = event.currentTarget.dataset;
+        if (fieldToSortBy.name !== columnName) {
             setFieldToSortBy({
                 name: columnName,
-                direction: MONGO_SORT_ORDER.ASCENDING,
+                direction: (SEARCH_RESULTS_FIELDS.TIMESTAMP === columnName) ?
+                    MONGO_SORT_ORDER.DESCENDING :
+                    MONGO_SORT_ORDER.ASCENDING,
             });
-        } else if (MONGO_SORT_ORDER.ASCENDING === fieldToSortBy.direction) {
-            // Switch to descending
+        } else {
             setFieldToSortBy({
                 name: columnName,
-                direction: MONGO_SORT_ORDER.DESCENDING,
+                direction: (MONGO_SORT_ORDER.ASCENDING === fieldToSortBy.direction) ?
+                    MONGO_SORT_ORDER.DESCENDING :
+                    MONGO_SORT_ORDER.ASCENDING,
             });
-        } else if (MONGO_SORT_ORDER.DESCENDING === fieldToSortBy.direction) {
-            // Switch to unsorted
-            setFieldToSortBy(null);
         }
     };
 
@@ -137,7 +137,7 @@ const SearchResultsTable = ({
                 >
                     <div className={"search-results-table-header"}>
                         <FontAwesomeIcon
-                            icon={getSortIcon(fieldToSortBy, SEARCH_RESULTS_FIELDS.TIMESTAMP)}/>
+                            icon={getSortIcon(SEARCH_RESULTS_FIELDS.TIMESTAMP)}/>
                         <span> Timestamp</span>
                     </div>
                 </th>

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -86,10 +86,7 @@ const SearchView = () => {
 
         const findOptions = {
             limit: visibleSearchResultsLimit,
-        };
-
-        if (null !== fieldToSortBy) {
-            findOptions.sort = [
+            sort: [
                 [
                     fieldToSortBy.name,
                     fieldToSortBy.direction,
@@ -98,8 +95,8 @@ const SearchView = () => {
                     SEARCH_RESULTS_FIELDS.ID,
                     fieldToSortBy.direction,
                 ],
-            ];
-        }
+            ],
+        };
 
         // NOTE: Although we publish and subscribe using the name
         // `Meteor.settings.public.SearchResultsCollectionName`, the rows are still returned in the


### PR DESCRIPTION
# References
The current sorting mechanism in search results table header is a bit unintuitive - clicking on a descending sorted column removes all sorting conditions, which defaults to sorted-by-timestamp. However, the results have been initially descending sorted by timestamps, which means users need to click the timestamp table header twice to display the logs in ascending timestamp order. 

# Description
1. Remove ambiguous `fieldToSortBy` value `null`. 
2. Change the sorting condition UI logics to toggle between `ASCENDING` and `DESCENDING` on the same field. 
3. Change initial sort toggle behaviour - when user requests to sort by some field other than `TIMESTAMP`, set the sorting condition to be the field with `ASCENDING` order; if the field is `TIMESTAMP`, set the sorting condition to be the field with `DESCENDING` order.

# Validation performed
1. Built and started `clp-package`.
2. Loaded WebUI in a browser and confirmed the behaviour matching Description items 2 & 3 above. 
