### PR TITLE
webui: Display estimated results count in realtime as the query progresses.

### DIFF
--- a/components/webui/imports/ui/SearchView/SearchResults.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResults.jsx
@@ -25,20 +25,20 @@ const VISIBLE_RESULTS_LIMIT_INCREMENT = 10;
  * table.
  *
  * @param {number} jobId of the search job
- * @param {Object[]} searchResults results to display
- * @param {Object} resultsMetadata which includes total results count and last request / response signal
- * @param {Object} fieldToSortBy used for sorting results
- * @param {function} setFieldToSortBy callback to set fieldToSortBy
- * @param {number} visibleSearchResultsLimit limit of visible search results
- * @param {function} setVisibleSearchResultsLimit callback to set visibleSearchResultsLimit
- * @param {number} maxLinesPerResult to display
- * @param {function} setMaxLinesPerResult callback to set maxLinesPerResult
+ * @param {Object[]} searchResults
+ * @param {number} numResultsOnServer
+ * @param {Object} fieldToSortBy
+ * @param {function} setFieldToSortBy
+ * @param {number} visibleSearchResultsLimit
+ * @param {function} setVisibleSearchResultsLimit
+ * @param {number} maxLinesPerResult
+ * @param {function} setMaxLinesPerResult
  * @returns {JSX.Element}
  */
 const SearchResults = ({
     jobId,
+    numResultsOnServer,
     searchResults,
-    resultsMetadata,
     fieldToSortBy,
     setFieldToSortBy,
     visibleSearchResultsLimit,
@@ -46,7 +46,6 @@ const SearchResults = ({
     maxLinesPerResult,
     setMaxLinesPerResult,
 }) => {
-    const numResultsOnServer = resultsMetadata["numTotalResults"] || searchResults.length;
     const hasMoreResults = visibleSearchResultsLimit < numResultsOnServer;
 
     const handleLoadMoreResults = () => {

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -108,13 +108,19 @@ const SearchView = () => {
         };
 
         if (SEARCH_SIGNAL.RESP_DONE !== resultsMetadata.lastSignal) {
-            // avoid refreshing estimatedNumResults after job is DONE
-            // since the count would have been already available in
+            // Only refresh estimatedNumResults if the job isn't DONE;
+            // otherwise the count would already be available in
             // `resultsMetadata.numTotalResults`
             resultsCollection.estimatedDocumentCount()
                 .then((count) => {
                     setEstimatedNumResults(
                         Math.min(count, SEARCH_MAX_NUM_RESULTS)
+                    );
+                })
+                .catch((e) => {
+                    console.log(
+                        `Error occurs in resultsCollection<${jobId}>.estimatedDocumentCount()`,
+                        e,
                     );
                 });
         }
@@ -204,6 +210,16 @@ const SearchView = () => {
     };
 
     const showSearchResults = (INVALID_JOB_ID !== jobId);
+
+    /**
+     * @param {number|null} resultsMetadata.numTotalResults
+     * The total count in the results cache when the job finishes.
+     * @param {number|null} estimatedNumResults
+     * The `estimatedDocumentCount()` from the results cache Mongo collection metadata.
+     * @param {number} searchResults.length
+     * The length of the array containing visible results.
+     * @return {number}
+     */
     const numResultsOnServer =
         resultsMetadata.numTotalResults ||
         estimatedNumResults ||

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -10,9 +10,10 @@ import {SearchResultsMetadataCollection} from "../../api/search/collections";
 import {
     INVALID_JOB_ID,
     MONGO_SORT_ORDER,
+    SEARCH_MAX_NUM_RESULTS,
     SEARCH_RESULTS_FIELDS,
     SEARCH_SIGNAL,
-    isSearchSignalQuerying, SEARCH_MAX_NUM_RESULTS,
+    isSearchSignalQuerying,
 } from "../../api/search/constants";
 import SearchJobCollectionsManager from "../../api/search/SearchJobCollectionsManager";
 import {LOCAL_STORAGE_KEYS} from "../constants";

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -200,8 +200,11 @@ const SearchView = () => {
         });
     };
 
-    const showSearchResults = INVALID_JOB_ID !== jobId;
-    const numResultsOnServer = resultsMetadata.numTotalResults || estimatedNumResults || searchResults.length;
+    const showSearchResults = (INVALID_JOB_ID !== jobId);
+    const numResultsOnServer =
+        resultsMetadata.numTotalResults ||
+        estimatedNumResults ||
+        searchResults.length;
 
     return (<div className="d-flex flex-column h-100">
         <div className={"flex-column"}>

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -82,12 +82,17 @@ const SearchView = () => {
             return [];
         }
 
-        const resultsCollection = dbRef.current.getOrCreateCollection(jobId);
-
         Meteor.subscribe(Meteor.settings.public.SearchResultsCollectionName, {
             jobId: jobId,
         });
 
+        // NOTE: Although we publish and subscribe using the name
+        // `Meteor.settings.public.SearchResultsCollectionName`, the rows are still returned in the
+        // job-specific collection (e.g., "1"); this is because on the server, we're returning a
+        // cursor from the job-specific collection and Meteor creates a collection with the same
+        // name on the client rather than returning the rows in a collection with the published
+        // name.
+        const resultsCollection = dbRef.current.getOrCreateCollection(jobId);
         const findOptions = {
             limit: visibleSearchResultsLimit,
         };
@@ -112,12 +117,6 @@ const SearchView = () => {
                 );
             });
 
-        // NOTE: Although we publish and subscribe using the name
-        // `Meteor.settings.public.SearchResultsCollectionName`, the rows are still returned in the
-        // job-specific collection (e.g., "1"); this is because on the server, we're returning a
-        // cursor from the job-specific collection and Meteor creates a collection with the same
-        // name on the client rather than returning the rows in a collection with the published
-        // name.
         return resultsCollection.find({}, findOptions).fetch();
     }, [jobId, fieldToSortBy, visibleSearchResultsLimit]);
 

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -119,7 +119,7 @@ const SearchView = () => {
                 })
                 .catch((e) => {
                     console.log(
-                        `Error occurs in resultsCollection<${jobId}>.estimatedDocumentCount()`,
+                        `Error occurred in resultsCollection<${jobId}>.estimatedDocumentCount()`,
                         e,
                     );
                 });
@@ -211,15 +211,11 @@ const SearchView = () => {
 
     const showSearchResults = (INVALID_JOB_ID !== jobId);
 
-    /**
-     * @param {number|null} resultsMetadata.numTotalResults
-     * The total count in the results cache when the job finishes.
-     * @param {number|null} estimatedNumResults
-     * The `estimatedDocumentCount()` from the results cache Mongo collection metadata.
-     * @param {number} searchResults.length
-     * The length of the array containing visible results.
-     * @return {number}
-     */
+    // The number of results on the server is available in different variables at different times:
+    // - when the query ends, it will be in resultsMetadata.numTotalResults.
+    // - while the query is in progress, it will be in estimatedNumResults.
+    // - when the query starts, the other two variables will be null, so searchResults.length is the
+    //   best estimate.
     const numResultsOnServer =
         resultsMetadata.numTotalResults ||
         estimatedNumResults ||

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -108,8 +108,8 @@ const SearchView = () => {
         };
 
         if (SEARCH_SIGNAL.RESP_DONE !== resultsMetadata.lastSignal) {
-            // avoid getting estimatedDocumentCount after job is DONE
-            // since the count is already available in
+            // avoid refreshing estimatedNumResults after job is DONE
+            // since the count would have been already available in
             // `resultsMetadata.numTotalResults`
             resultsCollection.estimatedDocumentCount()
                 .then((count) => {

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -108,9 +108,7 @@ const SearchView = () => {
         resultsCollection.estimatedDocumentCount()
             .then((count) => {
                 setEstimatedNumResults(
-                    (count > SEARCH_MAX_NUM_RESULTS) ?
-                        SEARCH_MAX_NUM_RESULTS :
-                        count
+                    Math.min(count, SEARCH_MAX_NUM_RESULTS)
                 );
             });
 


### PR DESCRIPTION
# References
Internally, it was discovered that in the WebUI search results header, the "Results count" is not updated in real time when there are more than `VISIBLE_RESULTS_LIMIT_INITIAL=10` results. Further investigation found that calculation of the count does not reflect real-time number of results in the results cache.
https://github.com/y-scope/clp/blob/00d9835642a3b3b86c366014819e933ee38c8281/components/webui/imports/ui/SearchView/SearchResults.jsx#L49
In the above code, the `resultsMetadata["numTotalResults"]` does not get updated until the job finishes, and that the `searchResults` only contains a number of `visibleSearchResultsLimit` results. 

# Description
1. Add a new React state variable which stores the estimated count of documents returned by [Mongo.Collection#estimatedDocumentCount()](https://docs.meteor.com/api/collections#Mongo-Collection-estimatedDocumentCount).
2. Aggregate the number with `resultsMetadata["numTotalResults"]` and `searchResults.length`.
3. Remove `resultsMetadata` from `<SearchResults/>` props and add `numResultsOnServer`. 

# Validation performed
1. Built and started `clp-package`. Compressed sample logs `hive-24hr/i-00c90a0f`. 
2. Loaded WebUI in a browser client, started a query with search string "1" and time range "All Time".
3. In the search results header, observed `Job ID <JOB_ID> | Results count: <numResultsOnServer>` with `numResultsOnServer` **gradually** increasing from 0 till 1000 (e.g., `0 -> 208 -> 750 -> 1000`), rather than `0 -> 10 -> 1000`.
