### PR TITLE
clp: Add option to control sorting input files for compression.

### DIFF
--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -321,6 +321,7 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
 
                 po::options_description visible_options;
                 visible_options.add(options_general);
+                visible_options.add(options_functional);
                 visible_options.add(options_compression);
                 cerr << visible_options << endl;
                 return ParsingResult::InfoCommand;

--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -237,6 +237,9 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
 
             // Define compression-specific options
             po::options_description options_compression("Compression Options");
+            // boost::program_options doesn't support boolean flags. Parse the string by
+            // ourselves
+            std::string sort_input_flag_str = "true";
             options_compression.add_options()(
                     "remove-path-prefix",
                     po::value<string>(&m_path_prefix_to_remove)
@@ -282,6 +285,12 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                             ->default_value(m_schema_file_path),
                     "Path to a schema file. If not specified, heuristics are used to determine "
                     "dictionary variables. See README-Schema.md for details."
+            )(
+                    "sort-input-files",
+                    po::value<string>(&sort_input_flag_str)
+                            ->value_name("VALUE")
+                            ->default_value(sort_input_flag_str),
+                    "whether to sort input files based on their last modified time"
             );
 
             po::options_description all_compression_options;
@@ -354,6 +363,15 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                             + "' is not a regular file."
                     );
                 }
+            }
+
+            if (sort_input_flag_str != "true" && sort_input_flag_str != "false") {
+                throw invalid_argument(
+                        "value of --sort-input-files must be either \"true\" or \"false\""
+                );
+            }
+            if ("false" == sort_input_flag_str) {
+                m_sort_input_files = false;
             }
         }
 

--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -239,13 +239,20 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             po::options_description options_compression("Compression Options");
             // boost::program_options doesn't support boolean flags which can be set to false, so
             // we use a string argument to set the flag manually.
-            string sort_input_flag_str = "true";
+            string sort_input_files_str = "true";
             options_compression.add_options()(
                     "remove-path-prefix",
                     po::value<string>(&m_path_prefix_to_remove)
                             ->value_name("DIR")
                             ->default_value(m_path_prefix_to_remove),
                     "Remove the given path prefix from each compressed file/dir."
+            )(
+                    "sort-input-files",
+                    po::value<string>(&sort_input_files_str)
+                            ->value_name("BOOL")
+                            ->default_value(sort_input_files_str),
+                    "Whether to compress input files in descending order of their last modified"
+                    " time"
             )(
                     "target-encoded-file-size",
                     po::value<size_t>(&m_target_encoded_file_size)
@@ -285,13 +292,6 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                             ->default_value(m_schema_file_path),
                     "Path to a schema file. If not specified, heuristics are used to determine "
                     "dictionary variables. See README-Schema.md for details."
-            )(
-                    "sort-input-files",
-                    po::value<string>(&sort_input_flag_str)
-                            ->value_name("BOOL")
-                            ->default_value(sort_input_flag_str),
-                    "Whether to compress input files in descending order of their last modified"
-                    " time"
             );
 
             po::options_description all_compression_options;
@@ -355,6 +355,11 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                 }
             }
 
+            if (sort_input_files_str != "true" && sort_input_files_str != "false") {
+                throw invalid_argument(R"(sort-input-files must be either "true" or "false")");
+            }
+            m_sort_input_files = "true" == sort_input_files_str;
+
             if (false == m_schema_file_path.empty()) {
                 if (false == boost::filesystem::exists(m_schema_file_path)) {
                     throw invalid_argument("Specified schema file does not exist.");
@@ -367,10 +372,6 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                 }
             }
 
-            if (sort_input_flag_str != "true" && sort_input_flag_str != "false") {
-                throw invalid_argument(R"(sort-input-files must be either "true" or "false")");
-            }
-            m_sort_input_files = "true" == sort_input_files_str;
         }
 
         // Validate an output directory was specified

--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -371,7 +371,6 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                     );
                 }
             }
-
         }
 
         // Validate an output directory was specified

--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -237,9 +237,9 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
 
             // Define compression-specific options
             po::options_description options_compression("Compression Options");
-            // boost::program_options doesn't support boolean flags. Parse the string by
-            // ourselves
-            std::string sort_input_flag_str = "true";
+            // boost::program_options doesn't support boolean flags which can be set to false, so
+            // we use a string argument to set the flag manually.
+            string sort_input_flag_str = "true";
             options_compression.add_options()(
                     "remove-path-prefix",
                     po::value<string>(&m_path_prefix_to_remove)
@@ -288,9 +288,10 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             )(
                     "sort-input-files",
                     po::value<string>(&sort_input_flag_str)
-                            ->value_name("VALUE")
+                            ->value_name("BOOL")
                             ->default_value(sort_input_flag_str),
-                    "whether to sort input files based on their last modified time"
+                    "Whether to compress input files in descending order of their last modified"
+                    " time"
             );
 
             po::options_description all_compression_options;
@@ -367,13 +368,9 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             }
 
             if (sort_input_flag_str != "true" && sort_input_flag_str != "false") {
-                throw invalid_argument(
-                        "value of --sort-input-files must be either \"true\" or \"false\""
-                );
+                throw invalid_argument(R"(sort-input-files must be either "true" or "false")");
             }
-            if ("false" == sort_input_flag_str) {
-                m_sort_input_files = false;
-            }
+            m_sort_input_files = "true" == sort_input_files_str;
         }
 
         // Validate an output directory was specified

--- a/components/core/src/clp/clp/CommandLineArguments.hpp
+++ b/components/core/src/clp/clp/CommandLineArguments.hpp
@@ -77,10 +77,10 @@ private:
     // Variables
     std::string m_path_list_path;
     std::string m_path_prefix_to_remove;
+    bool m_sort_input_files;
     std::string m_output_dir;
     std::string m_schema_file_path;
     bool m_show_progress;
-    bool m_sort_input_files;
     bool m_print_archive_stats_progress;
     size_t m_target_encoded_file_size;
     size_t m_target_segment_uncompressed_size;

--- a/components/core/src/clp/clp/CommandLineArguments.hpp
+++ b/components/core/src/clp/clp/CommandLineArguments.hpp
@@ -22,6 +22,7 @@ public:
     explicit CommandLineArguments(std::string const& program_name)
             : CommandLineArgumentsBase(program_name),
               m_show_progress(false),
+              m_sort_input_files(true),
               m_print_archive_stats_progress(false),
               m_target_segment_uncompressed_size(1L * 1024 * 1024 * 1024),
               m_target_encoded_file_size(512L * 1024 * 1024),
@@ -42,6 +43,8 @@ public:
     bool get_use_heuristic() const { return (m_schema_file_path.empty()); }
 
     bool show_progress() const { return m_show_progress; }
+
+    bool sort_input_files() const { return m_sort_input_files; }
 
     bool print_archive_stats_progress() const { return m_print_archive_stats_progress; }
 
@@ -77,6 +80,7 @@ private:
     std::string m_output_dir;
     std::string m_schema_file_path;
     bool m_show_progress;
+    bool m_sort_input_files;
     bool m_print_archive_stats_progress;
     size_t m_target_encoded_file_size;
     size_t m_target_segment_uncompressed_size;

--- a/components/core/src/clp/clp/compression.cpp
+++ b/components/core/src/clp/clp/compression.cpp
@@ -36,19 +36,19 @@ static bool file_group_id_comparator(FileToCompress const& lhs, FileToCompress c
  * Comparator to sort files based on their last write time
  * @param lhs
  * @param rhs
- * @return true if lhs' last write time is less than rhs' last write time, false otherwise
+ * @return true if lhs' last write time is greater than rhs' last write time, false otherwise
  */
 static bool
-file_lt_last_write_time_comparator(FileToCompress const& lhs, FileToCompress const& rhs);
+file_gt_last_write_time_comparator(FileToCompress const& lhs, FileToCompress const& rhs);
 
 static bool file_group_id_comparator(FileToCompress const& lhs, FileToCompress const& rhs) {
     return lhs.get_group_id() < rhs.get_group_id();
 }
 
 static bool
-file_lt_last_write_time_comparator(FileToCompress const& lhs, FileToCompress const& rhs) {
+file_gt_last_write_time_comparator(FileToCompress const& lhs, FileToCompress const& rhs) {
     return boost::filesystem::last_write_time(lhs.get_path())
-           < boost::filesystem::last_write_time(rhs.get_path());
+           > boost::filesystem::last_write_time(rhs.get_path());
 }
 
 bool compress(
@@ -128,10 +128,10 @@ bool compress(
         num_files_to_compress = files_to_compress.size() + grouped_files_to_compress.size();
     }
     if (command_line_args.sort_input_files()) {
-        sort(files_to_compress.begin(), files_to_compress.end(), file_lt_last_write_time_comparator
+        sort(files_to_compress.begin(), files_to_compress.end(), file_gt_last_write_time_comparator
         );
     }
-    for (auto rit = files_to_compress.crbegin(); rit != files_to_compress.crend(); ++rit) {
+    for (auto it = files_to_compress.cbegin(); it != files_to_compress.cend(); ++it) {
         if (archive_writer.get_data_size_of_dictionaries() >= target_data_size_of_dictionaries) {
             split_archive(archive_user_config, archive_writer);
         }
@@ -140,7 +140,7 @@ bool compress(
                     target_data_size_of_dictionaries,
                     archive_user_config,
                     target_encoded_file_size,
-                    *rit,
+                    *it,
                     archive_writer,
                     use_heuristic
             ))

--- a/components/core/src/clp/clp/compression.cpp
+++ b/components/core/src/clp/clp/compression.cpp
@@ -127,7 +127,10 @@ bool compress(
     if (command_line_args.show_progress()) {
         num_files_to_compress = files_to_compress.size() + grouped_files_to_compress.size();
     }
-    sort(files_to_compress.begin(), files_to_compress.end(), file_lt_last_write_time_comparator);
+    if (command_line_args.sort_input_files()) {
+        sort(files_to_compress.begin(), files_to_compress.end(), file_lt_last_write_time_comparator
+        );
+    }
     for (auto rit = files_to_compress.crbegin(); rit != files_to_compress.crend(); ++rit) {
         if (archive_writer.get_data_size_of_dictionaries() >= target_data_size_of_dictionaries) {
             split_archive(archive_user_config, archive_writer);


### PR DESCRIPTION
# Description
Add an option to CLP so it doesn't sort the input files. The change is intended to let CLP compress the input paths in the original order so it's easier to write prefetching logic

# Validation performed
Manually verified that with flag = "false", files are compressed in the original order. when flag = "true", files are compressed in the ascending order of the last modified time. other inputs will cause CLP to return a warning message

