### PR TITLE
webui: Correct command-line instructions in README.md

### DIFF
--- a/components/webui/README.md
+++ b/components/webui/README.md
@@ -25,7 +25,7 @@ package:
 3. Stop the webui instance started by the package: `<clp-package>/sbin/stop-clp.sh webui`
 4. Start the webui using meteor (refer to `<clp-package>/etc/clp-config.yml` for the config values):
    ```shell
-   MONGO_URL="mongodb://localhost:<results_cache.port>/<results_cache.db_name>" \
+   MONGO_URL="mongodb://<results_cache.host>:<results_cache.port>/<results_cache.db_name>" \
    ROOT_URL="http://<webui.host>:<webui.port>"                                  \
    CLP_DB_USER="<database.user>"                                                \
    CLP_DB_PASS="<database.password>"                                            \

--- a/components/webui/README.md
+++ b/components/webui/README.md
@@ -26,10 +26,7 @@ package:
 4. Start the webui using meteor (refer to `<clp-package>/etc/clp-config.yml` for the config values):
    ```shell
    MONGO_URL="mongodb://localhost:<results_cache.port>/<results_cache.db_name>" \
-   ROOT_URL="http://<webui.host>"                                               \
-   CLP_DB_HOST="<database.host>"                                                \
-   CLP_DB_PORT=<database.port>                                                  \
-   CLP_DB_NAME="<database.name>"                                                \
+   ROOT_URL="http://<webui.host>:<webui.port>"                                  \
    CLP_DB_USER="<database.user>"                                                \
    CLP_DB_PASS="<database.password>"                                            \
      meteor --port <webui.port> --settings settings.json
@@ -37,13 +34,10 @@ package:
    
    Here is an example based on the default `clp-config.yml`:
    ```shell
-   # Please update `<database.password>` accordingly
+   # Please update `<database.password>` accordingly.
    
    MONGO_URL="mongodb://localhost:27017/clp-search" \
-   ROOT_URL="http://localhost"                      \
-   CLP_DB_HOST="localhost"                          \
-   CLP_DB_PORT=3306                                 \
-   CLP_DB_NAME="clp-db"                             \
+   ROOT_URL="http://localhost:4000"                 \
    CLP_DB_USER="clp-user"                           \
    CLP_DB_PASS="<database.password>"                \
      meteor --port 4000 --settings settings.json


### PR DESCRIPTION
# References
1. The webui docs command-line instructions contains redundant environment variable settings that have been moved into [`components/webui/settings.json`](https://github.com/y-scope/clp/blob/74ac2949a4a34a4687d945229270f2b9d2900e51/components/webui/settings.json). 
2. In the webui docs command-line instructions, environment variable `ROOT_URL` is missing a port number, which can cause [Hot Module Replacement (HMR)](https://docs.meteor.com/packages/hot-module-replacement) to fail when the debug server is not launched on default HTTP port (80). When HMR fails, the browser client does not automatically re-render as the client code changes until developers manually refresh the page inconveniently.

# Description
1. Remove redundant environment variables from the webui docs command-line instructions.
2. Add missing port number in environment variable `ROOT_URL` in the webui docs command-line instructions.

# Validation performed
1. Built and started `clp-package`. (`cd build/clp-package/sbin; ./start-clp.sh`)
2. Stopped component `webui` in the package. (`./stop-clp.sh webui`)
3. Followed the updated instructions to launch component `webui` for debug purposes. Validated the basic functionalities by performing a simple query. 
4. Made a simple change in the code (e.g. in the sidebar, changed `CLP` to `CLP-S`) and observed the change to be reflected in the browser client without manual refresh. 
