### PR TITLE
Relocate `clp_config.execution_container` name loading call.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -250,6 +250,7 @@ def validate_and_load_config_file(
         clp_config = CLPConfig()
 
     clp_config.make_config_paths_absolute(clp_home)
+    clp_config.load_execution_container_name()
 
     # Make data and logs directories node-specific
     hostname = socket.gethostname()

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -785,8 +785,6 @@ def main(argv):
             config_file_path, default_config_file_path, clp_home
         )
 
-        clp_config.load_execution_container_name()
-
         # Validate and load necessary credentials
         if target in (
             ALL_TARGET_NAME,


### PR DESCRIPTION
# References
1. Internally it was found the `compress.sh` and `decompress.sh` scripts are failing because `clp_config.execution_container` is not loaded correctly, when the config is being referenced in scripts other than `start-clp.sh`.

# Description
1. Relocate `clp_config.execution_container` name loading call from `start-clp.py` to `general.py`.

# Validation performed
1. Manually tested all scripts that references `clp_config.execution_container` in `clp-package` and observed no failure:
   - `start-clp.sh`
   - `compress.sh`
   - `decompress.sh`
   - `search.sh`