### PR TITLE
core: Check for static spdlog library installation to ensure static linking.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -107,14 +107,21 @@ else()
 endif()
 
 # Find and setup spdlog
-# NOTE: spdlog only builds a static library
+if(CLP_USE_STATIC_LIBS)
+    # NOTE: some Linux distribution (e.g. Ubuntu) spdlog packages only contains a dynamic library.
+    # If below `find_package(spdlog)` fails, re-run
+    # `tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh` to build spdlog from
+    # source.
+    set(spdlog_USE_STATIC_LIBS ON)
+endif()
 find_package(spdlog 1.9.2 REQUIRED)
 # Don't use spdlog's internal fmtlib since it will conflict with the external fmtlib
 add_definitions(-DSPDLOG_FMT_EXTERNAL=1)
 if(spdlog_FOUND)
     message(STATUS "Found spdlog ${spdlog_VERSION}")
 else()
-    message(FATAL_ERROR "Could not find static libraries for spdlog")
+    message(FATAL_ERROR "Could not find static libraries for spdlog. You may want to re-run
+    `components/core/tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh`")
 endif()
 
 # Find and setup libarchive

--- a/components/core/cmake/Modules/Findspdlog.cmake
+++ b/components/core/cmake/Modules/Findspdlog.cmake
@@ -1,0 +1,108 @@
+# Try to find spdlog
+#
+# Set spdlog_USE_STATIC_LIBS=ON to look for static libraries.
+#
+# Once done this will define:
+#  spdlog_FOUND - Whether spdlog was found on the system
+#  spdlog_INCLUDE_DIR - The spdlog include directories
+#  spdlog_VERSION - The version of spdlog installed on the system
+#
+# Conventions:
+# - Variables only for use within the script are prefixed with "spdlog_"
+# - Variables that should be externally visible are prefixed with "spdlog_"
+
+set(spdlog_LIBNAME "spdlog")
+
+include(cmake/Modules/FindLibraryDependencies.cmake)
+
+# Run pkg-config
+find_package(PkgConfig)
+pkg_check_modules(spdlog_PKGCONF QUIET spdlog)
+
+# Set include directory
+unset(spdlog_INCLUDE_DIR CACHE) # unset the variable so it can be set by `find_path`
+find_path(spdlog_INCLUDE_DIR spdlog.h
+        HINTS ${spdlog_PKGCONF_INCLUDEDIR}
+        PATH_SUFFIXES spdlog
+        )
+
+# Handle static libraries
+if(spdlog_USE_STATIC_LIBS)
+    # Save current value of CMAKE_FIND_LIBRARY_SUFFIXES
+    set(spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+    # Temporarily change CMAKE_FIND_LIBRARY_SUFFIXES to static library suffix
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+endif()
+
+# Find library
+find_library(spdlog_LIBRARY
+        NAMES spdlog
+        HINTS ${spdlog_PKGCONF_LIBDIR}
+        PATH_SUFFIXES lib
+        )
+if (spdlog_LIBRARY)
+    # NOTE: This must be set for find_package_handle_standard_args to work
+    set(spdlog_FOUND ON)
+endif()
+
+if(spdlog_USE_STATIC_LIBS)
+    FindStaticLibraryDependencies(${spdlog_LIBNAME} spdlog "${spdlog_PKGCONF_STATIC_LIBRARIES}")
+
+    # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+    unset(spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+endif()
+
+FindDynamicLibraryDependencies(spdlog "${spdlog_DYNAMIC_LIBS}")
+
+# Set version
+set(spdlog_VERSION ${spdlog_PKGCONF_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(spdlog
+        REQUIRED_VARS spdlog_INCLUDE_DIR
+        VERSION_VAR spdlog_VERSION
+        )
+
+if(NOT TARGET spdlog::spdlog)
+    # Add library to build
+    if (spdlog_FOUND)
+        if (spdlog_USE_STATIC_LIBS)
+            add_library(spdlog::spdlog STATIC IMPORTED)
+        else()
+            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
+            # libraries installed, we can still use the STATIC libraries
+            add_library(spdlog::spdlog UNKNOWN IMPORTED)
+        endif()
+    endif()
+
+    # Set include directories for library
+    if(EXISTS "${spdlog_INCLUDE_DIR}")
+        set_target_properties(spdlog::spdlog
+                PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
+                )
+    else()
+        set(spdlog_FOUND OFF)
+    endif()
+
+    # Set location of library
+    if(EXISTS "${spdlog_LIBRARY}")
+        set_target_properties(spdlog::spdlog
+                PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${spdlog_LIBRARY}"
+                )
+
+        # Add component's dependencies for linking
+        if(spdlog_LIBRARY_DEPENDENCIES)
+            set_target_properties(spdlog::spdlog
+                    PROPERTIES
+                    INTERFACE_LINK_LIBRARIES "${spdlog_LIBRARY_DEPENDENCIES}"
+                    )
+        endif()
+    else()
+        set(spdlog_FOUND OFF)
+    endif()
+endif()

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -29,8 +29,16 @@ fi
 
 # Check if already installed
 set +e
-dpkg -l ${package_name} | grep ${version}
-installed=$?
+pkg-config --modversion "spdlog = 1.9.2" >/dev/null 2>&1
+pkg_found=$?
+if [ $pkg_found -eq 0 ] ; then
+  find /usr/lib/ /usr/local/lib/ -name 'libspdlog.a' | grep . >/dev/null 2>&1
+  static_lib_found=$?
+fi
+if [ $static_lib_found -eq 0 ] ; then
+  dpkg -l ${package_name} | grep ${version}
+fi
+installed=$(($? | pkg_found | static_lib_found))
 set -e
 if [ $installed -eq 0 ] ; then
   # Nothing to do


### PR DESCRIPTION
# References
Internally it was found that when the building environment has `libspdlog` pre-installed, the built executables dynamically links to `libspdlog.so`, which is absent in the execution containers and makes the executables non-runnable inside the execution containers. Further investigations have found that:
1. `libspdlog-dev` packages installed by default Ubuntu Jammy & Focal `apt` source only contain a dynamic library (`libspdlog.so`) and does not contain a static one (`libspdlog.a`).
2. CMake command `find_package(spdlog)` finds target `spdlog::spdlog`, but the target is only `SHARED` rather than `STATIC`. When the `SHARED` target is used in `target_link_libraries`, `spdlog` gets linked dynamically, which can be confirmed by command `ldd` on the built executables. Also, the default `spdlog` find script does not provide a way to enforce finding static libraries. 

# Description
1. Add a custom `spdlog` CMake find script which find static libraries for `spdlog` when `spdlog_USE_STATIC_LIBS=ON`.
2. Define `spdlog_USE_STATIC_LIBS=ON` in `components/core/CMakeLists.txt`.
3. Check for `spdlog` static library installation in `components/core/tools/scripts/lib_install/spdlog.sh`.

# Validation performed
## Environment
```
> lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.4 LTS
Release:        22.04
Codename:       jammy
```
## Steps
1. **Without the changes**, ran container `ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-jammy:main` and built (`cd <PROJECT_ROOT>; task`) the whole project.
2. Ran `ldd ./build/core/clp | grep spdlog` and observed no dynamic linkage of `libspdlog.so`.
3. Installed `libspdlog-dev` provided by default `apt` source: `sudo apt update && sudo apt install libspdlog-dev -y`.
4. Ran `task --force core` to force rebuild component `core`.
5. Ran `ldd ./build/core/clp | grep spdlog` and observed dynamic linkage of `libspdlog.so`:
   ```
           libspdlog.so.1 => /lib/x86_64-linux-gnu/libspdlog.so.1 (0x00007fd6d0ee0000)
   ```
6. **Applied the changes**.
7. Note the environment still had the dynamic-library-only `libspdlog-dev` installed. Ran `task --force core` to force rebuild component `core` and observed CMake reported failure:
   ```
   CMake Error at CMakeLists.txt:123 (message):
     Could not find static libraries for spdlog.  You may want to re-run

         `components/core/tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh`


   -- Configuring incomplete, errors occurred!
   ```
8. As instructed by the error prompt, ran script `install-packages-from-source.sh` to correct the dependencies.
9. Re-ran `task core`. Observed the task to be completed successfully.
10. Ran `ldd ./build/core/clp | grep spdlog` and observed no dynamic linkage of `libspdlog.so`.