### PR TITLE
core: Check for static spdlog library installation to ensure static linking.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 
 # Find and setup spdlog
 if(CLP_USE_STATIC_LIBS)
-    # NOTE: On some Linux distribution (e.g. Ubuntu), the spdlog package only contains a dynamic
+    # NOTE: On some Linux distributions (e.g. Ubuntu), the spdlog package only contains a dynamic
     # library. If the `find_package(spdlog)` call below fails, re-run
     # `tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh` to build spdlog from
     # source.

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -108,8 +108,8 @@ endif()
 
 # Find and setup spdlog
 if(CLP_USE_STATIC_LIBS)
-    # NOTE: some Linux distribution (e.g. Ubuntu) spdlog packages only contains a dynamic library.
-    # If below `find_package(spdlog)` fails, re-run
+    # NOTE: On some Linux distribution (e.g. Ubuntu), the spdlog package only contains a dynamic
+    # library. If the `find_package(spdlog)` call below fails, re-run
     # `tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh` to build spdlog from
     # source.
     set(spdlog_USE_STATIC_LIBS ON)

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -120,8 +120,12 @@ add_definitions(-DSPDLOG_FMT_EXTERNAL=1)
 if(spdlog_FOUND)
     message(STATUS "Found spdlog ${spdlog_VERSION}")
 else()
-    message(FATAL_ERROR "Could not find static libraries for spdlog. You may want to re-run
-    `components/core/tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh`")
+    if (CLP_USE_STATIC_LIBS)
+        message(FATAL_ERROR "Could not find static libraries for spdlog. You may want to re-run
+            `components/core/tools/scripts/lib_install/<dist>/install-packages-from-source.sh`")
+    else()
+        message(FATAL_ERROR "Could not find libraries for spdlog.")
+    endif()
 endif()
 
 # Find and setup libarchive

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -115,8 +115,6 @@ if(CLP_USE_STATIC_LIBS)
     set(spdlog_USE_STATIC_LIBS ON)
 endif()
 find_package(spdlog 1.9.2 REQUIRED)
-# Don't use spdlog's internal fmtlib since it will conflict with the external fmtlib
-add_definitions(-DSPDLOG_FMT_EXTERNAL=1)
 if(spdlog_FOUND)
     message(STATUS "Found spdlog ${spdlog_VERSION}")
 else()

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -107,14 +107,21 @@ else()
 endif()
 
 # Find and setup spdlog
-# NOTE: spdlog only builds a static library
+if(CLP_USE_STATIC_LIBS)
+    # NOTE: some Linux distribution (e.g. Ubuntu) spdlog packages only contains a dynamic library.
+    # If below `find_package(spdlog)` fails, re-run
+    # `tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh` to build spdlog from
+    # source.
+    set(spdlog_USE_STATIC_LIBS ON)
+endif()
 find_package(spdlog 1.9.2 REQUIRED)
 # Don't use spdlog's internal fmtlib since it will conflict with the external fmtlib
 add_definitions(-DSPDLOG_FMT_EXTERNAL=1)
 if(spdlog_FOUND)
     message(STATUS "Found spdlog ${spdlog_VERSION}")
 else()
-    message(FATAL_ERROR "Could not find static libraries for spdlog")
+    message(FATAL_ERROR "Could not find static libraries for spdlog. You may want to re-run
+    `components/core/tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh`")
 endif()
 
 # Find and setup libarchive

--- a/components/core/cmake/Modules/Findspdlog.cmake
+++ b/components/core/cmake/Modules/Findspdlog.cmake
@@ -1,0 +1,108 @@
+# Try to find spdlog
+#
+# Set spdlog_USE_STATIC_LIBS=ON to look for static libraries.
+#
+# Once done this will define:
+#  spdlog_FOUND - Whether spdlog was found on the system
+#  spdlog_INCLUDE_DIR - The spdlog include directories
+#  spdlog_VERSION - The version of spdlog installed on the system
+#
+# Conventions:
+# - Variables only for use within the script are prefixed with "spdlog_"
+# - Variables that should be externally visible are prefixed with "spdlog_"
+
+set(spdlog_LIBNAME "spdlog")
+
+include(cmake/Modules/FindLibraryDependencies.cmake)
+
+# Run pkg-config
+find_package(PkgConfig)
+pkg_check_modules(spdlog_PKGCONF QUIET spdlog)
+
+# Set include directory
+unset(spdlog_INCLUDE_DIR CACHE) # unset the variable so it can be set by `find_path`
+find_path(spdlog_INCLUDE_DIR spdlog.h
+        HINTS ${spdlog_PKGCONF_INCLUDEDIR}
+        PATH_SUFFIXES spdlog
+        )
+
+# Handle static libraries
+if(spdlog_USE_STATIC_LIBS)
+    # Save current value of CMAKE_FIND_LIBRARY_SUFFIXES
+    set(spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+    # Temporarily change CMAKE_FIND_LIBRARY_SUFFIXES to static library suffix
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+endif()
+
+# Find library
+find_library(spdlog_LIBRARY
+        NAMES spdlog
+        HINTS ${spdlog_PKGCONF_LIBDIR}
+        PATH_SUFFIXES lib
+        )
+if (spdlog_LIBRARY)
+    # NOTE: This must be set for find_package_handle_standard_args to work
+    set(spdlog_FOUND ON)
+endif()
+
+if(spdlog_USE_STATIC_LIBS)
+    FindStaticLibraryDependencies(${spdlog_LIBNAME} spdlog "${spdlog_PKGCONF_STATIC_LIBRARIES}")
+
+    # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+    unset(spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+endif()
+
+FindDynamicLibraryDependencies(spdlog "${spdlog_DYNAMIC_LIBS}")
+
+# Set version
+set(spdlog_VERSION ${spdlog_PKGCONF_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(spdlog
+        REQUIRED_VARS spdlog_INCLUDE_DIR
+        VERSION_VAR spdlog_VERSION
+        )
+
+if(NOT TARGET spdlog::spdlog)
+    # Add library to build
+    if (spdlog_FOUND)
+        if (spdlog_USE_STATIC_LIBS)
+            add_library(spdlog::spdlog STATIC IMPORTED)
+        else()
+            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
+            # libraries installed, we can still use the STATIC libraries
+            add_library(spdlog::spdlog UNKNOWN IMPORTED)
+        endif()
+    endif()
+
+    # Set include directories for library
+    if(EXISTS "${spdlog_INCLUDE_DIR}")
+        set_target_properties(spdlog::spdlog
+                PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
+                )
+    else()
+        set(spdlog_FOUND OFF)
+    endif()
+
+    # Set location of library
+    if(EXISTS "${spdlog_LIBRARY}")
+        set_target_properties(spdlog::spdlog
+                PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${spdlog_LIBRARY}"
+                )
+
+        # Add component's dependencies for linking
+        if(spdlog_LIBRARY_DEPENDENCIES)
+            set_target_properties(spdlog::spdlog
+                    PROPERTIES
+                    INTERFACE_LINK_LIBRARIES "${spdlog_LIBRARY_DEPENDENCIES}"
+                    )
+        endif()
+    else()
+        set(spdlog_FOUND OFF)
+    endif()
+endif()

--- a/components/core/cmake/Modules/Findspdlog.cmake
+++ b/components/core/cmake/Modules/Findspdlog.cmake
@@ -17,13 +17,15 @@ include(cmake/Modules/FindLibraryDependencies.cmake)
 
 # Run pkg-config
 find_package(PkgConfig)
-pkg_check_modules(spdlog_PKGCONF QUIET spdlog)
+pkg_check_modules(spdlog_PKGCONF QUIET ${spdlog_LIBNAME})
 
 # Set include directory
-find_path(spdlog_INCLUDE_DIR spdlog.h
+find_path(
+        spdlog_INCLUDE_DIR
+        spdlog.h
         HINTS ${spdlog_PKGCONF_INCLUDEDIR}
         PATH_SUFFIXES spdlog
-        )
+)
 
 # Handle static libraries
 if(spdlog_USE_STATIC_LIBS)
@@ -35,11 +37,12 @@ if(spdlog_USE_STATIC_LIBS)
 endif()
 
 # Find library
-find_library(spdlog_LIBRARY
-        NAMES spdlog
+find_library(
+        spdlog_LIBRARY
+        NAMES ${spdlog_LIBNAME}
         HINTS ${spdlog_PKGCONF_LIBDIR}
         PATH_SUFFIXES lib
-        )
+)
 if (spdlog_LIBRARY)
     # NOTE: This must be set for find_package_handle_standard_args to work
     set(spdlog_FOUND ON)
@@ -63,10 +66,11 @@ FindDynamicLibraryDependencies(spdlog "${spdlog_DYNAMIC_LIBS}")
 set(spdlog_VERSION ${spdlog_PKGCONF_VERSION})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(spdlog
+find_package_handle_standard_args(
+        spdlog
         REQUIRED_VARS spdlog_INCLUDE_DIR
         VERSION_VAR spdlog_VERSION
-        )
+)
 
 if(NOT TARGET spdlog::spdlog)
     # Add library to build
@@ -74,7 +78,7 @@ if(NOT TARGET spdlog::spdlog)
         if (spdlog_USE_STATIC_LIBS)
             add_library(spdlog::spdlog STATIC IMPORTED)
         else()
-            # NOTE: libspdlog is only available as a static library or a dynamic one.
+            # NOTE: spdlog is only available as a static library or a dynamic one.
             add_library(spdlog::spdlog SHARED IMPORTED)
         endif()
     endif()
@@ -83,9 +87,10 @@ if(NOT TARGET spdlog::spdlog)
     if (NOT EXISTS "${spdlog_INCLUDE_DIR}")
         set(spdlog_FOUND OFF)
     else()
-        set_target_properties(spdlog::spdlog
-            PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
+        set_target_properties(
+                spdlog::spdlog
+                PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
         )
     endif()
 
@@ -93,17 +98,19 @@ if(NOT TARGET spdlog::spdlog)
     if(NOT EXISTS "${spdlog_LIBRARY}")
         set(spdlog_FOUND OFF)
     else()
-        set_target_properties(spdlog::spdlog
-            PROPERTIES
-            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-            IMPORTED_LOCATION "${spdlog_LIBRARY}"
+        set_target_properties(
+                spdlog::spdlog
+                PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${spdlog_LIBRARY}"
         )
 
         # Add component's dependencies for linking
         if(spdlog_LIBRARY_DEPENDENCIES)
-            set_target_properties(spdlog::spdlog
-                PROPERTIES
-                INTERFACE_LINK_LIBRARIES "${spdlog_LIBRARY_DEPENDENCIES}"
+            set_target_properties(
+                    spdlog::spdlog
+                    PROPERTIES
+                    INTERFACE_LINK_LIBRARIES "${spdlog_LIBRARY_DEPENDENCIES}"
             )
         endif()
     endif()

--- a/components/core/cmake/Modules/Findspdlog.cmake
+++ b/components/core/cmake/Modules/Findspdlog.cmake
@@ -20,7 +20,6 @@ find_package(PkgConfig)
 pkg_check_modules(spdlog_PKGCONF QUIET spdlog)
 
 # Set include directory
-unset(spdlog_INCLUDE_DIR CACHE) # unset the variable so it can be set by `find_path`
 find_path(spdlog_INCLUDE_DIR spdlog.h
         HINTS ${spdlog_PKGCONF_INCLUDEDIR}
         PATH_SUFFIXES spdlog
@@ -52,8 +51,12 @@ if(spdlog_USE_STATIC_LIBS)
     # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
     unset(spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+else()
+    # Add dependencies manually since spdlog's pkgconfig doesn't include it
+    list(APPEND spdlog_DYNAMIC_LIBS "fmt")
 endif()
 
+list(APPEND spdlog_DYNAMIC_LIBS "pthread")
 FindDynamicLibraryDependencies(spdlog "${spdlog_DYNAMIC_LIBS}")
 
 # Set version
@@ -71,9 +74,8 @@ if(NOT TARGET spdlog::spdlog)
         if (spdlog_USE_STATIC_LIBS)
             add_library(spdlog::spdlog STATIC IMPORTED)
         else()
-            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
-            # libraries installed, we can still use the STATIC libraries
-            add_library(spdlog::spdlog UNKNOWN IMPORTED)
+            # NOTE: libspdlog is only available as a static library or a dynamic one.
+            add_library(spdlog::spdlog SHARED IMPORTED)
         endif()
     endif()
 

--- a/components/core/cmake/Modules/Findspdlog.cmake
+++ b/components/core/cmake/Modules/Findspdlog.cmake
@@ -8,29 +8,30 @@
 #  spdlog_VERSION - The version of spdlog installed on the system
 #
 # Conventions:
-# - Variables only for use within the script are prefixed with "spdlog_"
+# - Variables only for use within the script are prefixed with "SPDLOG_"
 # - Variables that should be externally visible are prefixed with "spdlog_"
 
-set(spdlog_LIBNAME "spdlog")
+set(SPDLOG_LIBNAME "spdlog")
+set(SPDLOG_TARGET_NAME "spdlog::spdlog")
 
 include(cmake/Modules/FindLibraryDependencies.cmake)
 
 # Run pkg-config
 find_package(PkgConfig)
-pkg_check_modules(spdlog_PKGCONF QUIET ${spdlog_LIBNAME})
+pkg_check_modules(SPDLOG_PKGCONF QUIET ${SPDLOG_LIBNAME})
 
 # Set include directory
 find_path(
-        spdlog_INCLUDE_DIR
-        spdlog.h
-        HINTS ${spdlog_PKGCONF_INCLUDEDIR}
-        PATH_SUFFIXES spdlog
+    spdlog_INCLUDE_DIR
+    spdlog.h
+    HINTS ${SPDLOG_PKGCONF_INCLUDEDIR}
+    PATH_SUFFIXES spdlog
 )
 
 # Handle static libraries
-if(spdlog_USE_STATIC_LIBS)
+if(SPDLOG_USE_STATIC_LIBS)
     # Save current value of CMAKE_FIND_LIBRARY_SUFFIXES
-    set(spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    set(SPDLOG_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
     # Temporarily change CMAKE_FIND_LIBRARY_SUFFIXES to static library suffix
     set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
@@ -38,48 +39,55 @@ endif()
 
 # Find library
 find_library(
-        spdlog_LIBRARY
-        NAMES ${spdlog_LIBNAME}
-        HINTS ${spdlog_PKGCONF_LIBDIR}
-        PATH_SUFFIXES lib
+    SPDLOG_LIBRARY
+    NAMES ${SPDLOG_LIBNAME}
+    HINTS ${SPDLOG_PKGCONF_LIBDIR}
+    PATH_SUFFIXES lib
 )
-if (spdlog_LIBRARY)
+if (SPDLOG_LIBRARY)
     # NOTE: This must be set for find_package_handle_standard_args to work
     set(spdlog_FOUND ON)
 endif()
 
-if(spdlog_USE_STATIC_LIBS)
-    FindStaticLibraryDependencies(${spdlog_LIBNAME} spdlog "${spdlog_PKGCONF_STATIC_LIBRARIES}")
+if(SPDLOG_USE_STATIC_LIBS)
+    FindStaticLibraryDependencies(${SPDLOG_LIBNAME} SPDLOG "${SPDLOG_PKGCONF_STATIC_LIBRARIES}")
 
     # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
-    unset(spdlog_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
-else()
-    # Add dependencies manually since spdlog's pkgconfig doesn't include it
-    list(APPEND spdlog_DYNAMIC_LIBS "fmt")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${SPDLOG_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+    unset(SPDLOG_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
 endif()
 
-list(APPEND spdlog_DYNAMIC_LIBS "pthread")
-FindDynamicLibraryDependencies(spdlog "${spdlog_DYNAMIC_LIBS}")
+FindDynamicLibraryDependencies(SPDLOG "${SPDLOG_PKGCONF_LIBRARIES}")
 
 # Set version
-set(spdlog_VERSION ${spdlog_PKGCONF_VERSION})
+set(spdlog_VERSION ${SPDLOG_PKGCONF_VERSION})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-        spdlog
-        REQUIRED_VARS spdlog_INCLUDE_DIR
-        VERSION_VAR spdlog_VERSION
+    ${SPDLOG_LIBNAME}
+    REQUIRED_VARS spdlog_INCLUDE_DIR
+    VERSION_VAR spdlog_VERSION
 )
 
-if(NOT TARGET spdlog::spdlog)
+if(NOT TARGET ${SPDLOG_TARGET_NAME})
     # Add library to build
     if (spdlog_FOUND)
-        if (spdlog_USE_STATIC_LIBS)
-            add_library(spdlog::spdlog STATIC IMPORTED)
+        if (SPDLOG_USE_STATIC_LIBS)
+            add_library(${SPDLOG_TARGET_NAME} STATIC IMPORTED)
+            set_target_properties(
+                ${SPDLOG_TARGET_NAME}
+                PROPERTIES
+                COMPILE_FLAGS "${SPDLOG_PKGCONF_CFLAGS}"
+            )
         else()
-            # NOTE: spdlog is only available as a static library or a dynamic one.
-            add_library(spdlog::spdlog SHARED IMPORTED)
+            # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
+            # libraries installed, we can still use the STATIC libraries.
+            add_library(${SPDLOG_TARGET_NAME} UNKNOWN IMPORTED)
+            set_target_properties(
+                ${SPDLOG_TARGET_NAME}
+                PROPERTIES
+                COMPILE_FLAGS "${SPDLOG_PKGCONF_STATIC_CFLAGS}"
+            )
         endif()
     endif()
 
@@ -88,29 +96,29 @@ if(NOT TARGET spdlog::spdlog)
         set(spdlog_FOUND OFF)
     else()
         set_target_properties(
-                spdlog::spdlog
-                PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
+            ${SPDLOG_TARGET_NAME}
+            PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
         )
     endif()
 
     # Set location of library
-    if(NOT EXISTS "${spdlog_LIBRARY}")
+    if(NOT EXISTS "${SPDLOG_LIBRARY}")
         set(spdlog_FOUND OFF)
     else()
         set_target_properties(
-                spdlog::spdlog
+                ${SPDLOG_TARGET_NAME}
                 PROPERTIES
                 IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-                IMPORTED_LOCATION "${spdlog_LIBRARY}"
+                IMPORTED_LOCATION "${SPDLOG_LIBRARY}"
         )
 
         # Add component's dependencies for linking
-        if(spdlog_LIBRARY_DEPENDENCIES)
+        if(SPDLOG_LIBRARY_DEPENDENCIES)
             set_target_properties(
-                    spdlog::spdlog
+                    ${SPDLOG_TARGET_NAME}
                     PROPERTIES
-                    INTERFACE_LINK_LIBRARIES "${spdlog_LIBRARY_DEPENDENCIES}"
+                    INTERFACE_LINK_LIBRARIES "${SPDLOG_LIBRARY_DEPENDENCIES}"
             )
         endif()
     endif()

--- a/components/core/cmake/Modules/Findspdlog.cmake
+++ b/components/core/cmake/Modules/Findspdlog.cmake
@@ -80,31 +80,31 @@ if(NOT TARGET spdlog::spdlog)
     endif()
 
     # Set include directories for library
-    if(EXISTS "${spdlog_INCLUDE_DIR}")
-        set_target_properties(spdlog::spdlog
-                PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
-                )
-    else()
+    if (NOT EXISTS "${spdlog_INCLUDE_DIR}")
         set(spdlog_FOUND OFF)
+    else()
+        set_target_properties(spdlog::spdlog
+            PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${spdlog_INCLUDE_DIR}"
+        )
     endif()
 
     # Set location of library
-    if(EXISTS "${spdlog_LIBRARY}")
+    if(NOT EXISTS "${spdlog_LIBRARY}")
+        set(spdlog_FOUND OFF)
+    else()
         set_target_properties(spdlog::spdlog
-                PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-                IMPORTED_LOCATION "${spdlog_LIBRARY}"
-                )
+            PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${spdlog_LIBRARY}"
+        )
 
         # Add component's dependencies for linking
         if(spdlog_LIBRARY_DEPENDENCIES)
             set_target_properties(spdlog::spdlog
-                    PROPERTIES
-                    INTERFACE_LINK_LIBRARIES "${spdlog_LIBRARY_DEPENDENCIES}"
-                    )
+                PROPERTIES
+                INTERFACE_LINK_LIBRARIES "${spdlog_LIBRARY_DEPENDENCIES}"
+            )
         endif()
-    else()
-        set(spdlog_FOUND OFF)
     endif()
 endif()

--- a/components/core/cmake/Modules/Findspdlog.cmake
+++ b/components/core/cmake/Modules/Findspdlog.cmake
@@ -29,7 +29,7 @@ find_path(
 )
 
 # Handle static libraries
-if(SPDLOG_USE_STATIC_LIBS)
+if(spdlog_USE_STATIC_LIBS)
     # Save current value of CMAKE_FIND_LIBRARY_SUFFIXES
     set(SPDLOG_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
@@ -49,7 +49,7 @@ if (SPDLOG_LIBRARY)
     set(spdlog_FOUND ON)
 endif()
 
-if(SPDLOG_USE_STATIC_LIBS)
+if(spdlog_USE_STATIC_LIBS)
     FindStaticLibraryDependencies(${SPDLOG_LIBNAME} SPDLOG "${SPDLOG_PKGCONF_STATIC_LIBRARIES}")
 
     # Restore original value of CMAKE_FIND_LIBRARY_SUFFIXES
@@ -72,12 +72,12 @@ find_package_handle_standard_args(
 if(NOT TARGET ${SPDLOG_TARGET_NAME})
     # Add library to build
     if (spdlog_FOUND)
-        if (SPDLOG_USE_STATIC_LIBS)
+        if (spdlog_USE_STATIC_LIBS)
             add_library(${SPDLOG_TARGET_NAME} STATIC IMPORTED)
             set_target_properties(
                 ${SPDLOG_TARGET_NAME}
                 PROPERTIES
-                COMPILE_FLAGS "${SPDLOG_PKGCONF_CFLAGS}"
+                COMPILE_FLAGS "${SPDLOG_PKGCONF_STATIC_CFLAGS}"
             )
         else()
             # NOTE: We use UNKNOWN so that if the user doesn't have the SHARED
@@ -86,7 +86,7 @@ if(NOT TARGET ${SPDLOG_TARGET_NAME})
             set_target_properties(
                 ${SPDLOG_TARGET_NAME}
                 PROPERTIES
-                COMPILE_FLAGS "${SPDLOG_PKGCONF_STATIC_CFLAGS}"
+                COMPILE_FLAGS "${SPDLOG_PKGCONF_CFLAGS}"
             )
         endif()
     endif()

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -16,6 +16,7 @@ if [ "$#" -lt 1 ] ; then
 fi
 version=$1
 
+lib_name=spdlog
 package_name=libspdlog-dev
 temp_dir=/tmp/${package_name}-installation
 deb_output_dir=${temp_dir}
@@ -29,18 +30,16 @@ fi
 
 # Check if already installed
 set +e
-pkg-config --exact-version="${version}" "spdlog"
+pkg-config --exact-version="${version}" "${lib_name}"
 pkg_found=$?
 if [ $pkg_found -eq 0 ] ; then
   find /usr/lib/ /usr/local/lib/ -name "libspdlog.a" | grep -q "."
   static_lib_found=$?
 fi
-if [ $static_lib_found -eq 0 ] ; then
-  dpkg -l ${package_name} | grep ${version}
-fi
-installed=$(($? | pkg_found | static_lib_found))
+installed=$((pkg_found | static_lib_found))
 set -e
 if [ $installed -eq 0 ] ; then
+  echo "Found library ${lib_name}=${version} ."
   # Nothing to do
   exit
 fi

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -29,8 +29,16 @@ fi
 
 # Check if already installed
 set +e
-dpkg -l ${package_name} | grep ${version}
-installed=$?
+pkg-config --modversion "spdlog = 1.9.2" >/dev/null 2>&1
+pkg_found=$?
+if [ $pkg_found -eq 0 ] ; then
+  find /usr/lib/ /usr/local/lib/ -name 'libspdlog.a' | grep . >/dev/null 2>&1
+  static_lib_found=$?
+fi
+if [ $static_lib_found -eq 0 ] ; then
+  dpkg -l ${package_name} | grep ${version}
+fi
+installed=$(($? | pkg_found | static_lib_found))
 set -e
 if [ $installed -eq 0 ] ; then
   # Nothing to do

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -29,10 +29,10 @@ fi
 
 # Check if already installed
 set +e
-pkg-config --modversion "spdlog = 1.9.2" >/dev/null 2>&1
+pkg-config --exact-version="${version}" "spdlog"
 pkg_found=$?
 if [ $pkg_found -eq 0 ] ; then
-  find /usr/lib/ /usr/local/lib/ -name 'libspdlog.a' | grep . >/dev/null 2>&1
+  find /usr/lib/ /usr/local/lib/ -name "libspdlog.a" | grep -q "."
   static_lib_found=$?
 fi
 if [ $static_lib_found -eq 0 ] ; then

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -39,7 +39,7 @@ fi
 installed=$((pkg_found | static_lib_found))
 set -e
 if [ $installed -eq 0 ] ; then
-  echo "Found library ${lib_name}=${version} ."
+  echo "Found ${lib_name}=${version}."
   # Nothing to do
   exit
 fi


### PR DESCRIPTION
# References
Internally it was found that when the building environment has `libspdlog` pre-installed, the built executables dynamically links to `libspdlog.so`, which is absent in the execution containers and makes the executables non-runnable inside the execution containers. Further investigations have found that:
1. `libspdlog-dev` packages installed by default Ubuntu Jammy & Focal `apt` source only contain a dynamic library (`libspdlog.so`) and does not contain a static one (`libspdlog.a`).
2. CMake command `find_package(spdlog)` finds target `spdlog::spdlog`, but the target is only `SHARED` rather than `STATIC`. When the `SHARED` target is used in `target_link_libraries`, `spdlog` gets linked dynamically, which can be confirmed by command `ldd` on the built executables. Also, the default `spdlog` find script does not provide a way to enforce finding static libraries. 

# Description
1. Add a custom `spdlog` CMake find script which find static libraries for `spdlog` when `spdlog_USE_STATIC_LIBS=ON`.
2. Define `spdlog_USE_STATIC_LIBS=ON` in `components/core/CMakeLists.txt`.
3. Check for `spdlog` static library installation in `components/core/tools/scripts/lib_install/spdlog.sh`.

# Validation performed
## Environment
```
> lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.4 LTS
Release:        22.04
Codename:       jammy
```
## Steps
1. **Without the changes**, ran container `ghcr.io/y-scope/clp/clp-core-dependencies-x86-ubuntu-jammy:main` and built (`cd <PROJECT_ROOT>; task`) the whole project.
2. Ran `ldd ./build/core/clp | grep spdlog` and observed no dynamic linkage of `libspdlog.so`.
3. Installed `libspdlog-dev` provided by default `apt` source: `sudo apt update && sudo apt install libspdlog-dev -y`.
4. Ran `task --force core` to force rebuild component `core`.
5. Ran `ldd ./build/core/clp | grep spdlog` and observed dynamic linkage of `libspdlog.so`:
   ```
           libspdlog.so.1 => /lib/x86_64-linux-gnu/libspdlog.so.1 (0x00007fd6d0ee0000)
   ```
6. **Applied the changes**.
7. Note the environment still had the dynamic-library-only `libspdlog-dev` installed. Ran `task --force core` to force rebuild component `core` and observed CMake reported failure:
   ```
   CMake Error at CMakeLists.txt:123 (message):
     Could not find static libraries for spdlog.  You may want to re-run

         `components/core/tools/scripts/lib_install/<dist_name>/install-packages-from-source.sh`


   -- Configuring incomplete, errors occurred!
   ```
8. As instructed by the error prompt, ran script `install-packages-from-source.sh` to correct the dependencies.
9. Re-ran `task core`. Observed the task to be completed successfully.
10. Ran `ldd ./build/core/clp | grep spdlog` and observed no dynamic linkage of `libspdlog.so`.