### PR TITLE
clp-package: Add support for the time bucketed count aggregation.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -227,13 +227,13 @@ def main(argv):
     args_parser.add_argument(
         "--count",
         action="store_const",
-        help="Perform the query and count the number of results.",
+        help="Count the number of results.",
         const=True,
     )
     args_parser.add_argument(
         "--count-by-time",
         type=int,
-        help="Perform the query and count the number of results in each time bucket (ms).",
+        help="Count the number of results in each time span of the given size (ms).",
     )
     parsed_args = args_parser.parse_args(argv[1:])
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -93,8 +93,10 @@ def create_and_monitor_job_in_db(
         search_config.aggregation_config = AggregationConfig(
             do_count_aggregation=do_count_aggregation
         )
-        if count_by_time_bucket_size is not None:
-            search_config.aggregation_config.count_by_time_bucket_size = count_by_time_bucket_size
+    if count_by_time_bucket_size is not None:
+        search_config.aggregation_config = AggregationConfig(
+            count_by_time_bucket_size=count_by_time_bucket_size
+        )
     if tags:
         tag_list = [tag.strip().lower() for tag in tags.split(",") if tag]
         if len(tag_list) > 0:
@@ -139,7 +141,7 @@ def create_and_monitor_job_in_db(
                     search_results_collection.find().sort("timestamp", -1).limit(max_num_results)
                 )
 
-            if do_count_aggregation is not None and count_by_time_bucket_size is not None:
+            if count_by_time_bucket_size is not None:
                 for document in cursor:
                     print(f"timestamp: {document['timestamp']} count: {document['count']}")
             elif do_count_aggregation is not None:
@@ -265,7 +267,7 @@ def main(argv):
             parsed_args.max_num_results,
             parsed_args.file_path,
             parsed_args.count,
-            parsed_args.count_by_time_bucket_size,
+            parsed_args.count_by_time,
         )
     )
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -79,7 +79,7 @@ def create_and_monitor_job_in_db(
     max_num_results: int,
     path_filter: str | None,
     do_count_aggregation: bool | None,
-    time_bucket_size: int | None,
+    count_by_time_bucket_size: int | None,
 ):
     search_config = SearchConfig(
         query_string=wildcard_query,
@@ -93,8 +93,8 @@ def create_and_monitor_job_in_db(
         search_config.aggregation_config = AggregationConfig(
             do_count_aggregation=do_count_aggregation
         )
-        if time_bucket_size is not None:
-            search_config.aggregation_config.time_bucket_size = time_bucket_size
+        if count_by_time_bucket_size is not None:
+            search_config.aggregation_config.count_by_time_bucket_size = count_by_time_bucket_size
     if tags:
         tag_list = [tag.strip().lower() for tag in tags.split(",") if tag]
         if len(tag_list) > 0:
@@ -139,7 +139,7 @@ def create_and_monitor_job_in_db(
                     search_results_collection.find().sort("timestamp", -1).limit(max_num_results)
                 )
 
-            if do_count_aggregation is not None and time_bucket_size is not None:
+            if do_count_aggregation is not None and count_by_time_bucket_size is not None:
                 for document in cursor:
                     print(f"timestamp: {document['timestamp']} count: {document['count']}")
             elif do_count_aggregation is not None:
@@ -163,7 +163,7 @@ async def do_search(
     max_num_results: int,
     path_filter: str | None,
     do_count_aggregation: bool | None,
-    time_bucket_size: int | None,
+    count_by_time_bucket_size: int | None,
 ):
     db_monitor_task = asyncio.ensure_future(
         run_function_in_process(
@@ -178,7 +178,7 @@ async def do_search(
             max_num_results,
             path_filter,
             do_count_aggregation,
-            time_bucket_size,
+            count_by_time_bucket_size,
         )
     )
 
@@ -229,9 +229,9 @@ def main(argv):
         const=True,
     )
     args_parser.add_argument(
-        "--time-bucket-size",
+        "--count-by-time",
         type=int,
-        help="Optional time bucket size (ms) for count aggregations.",
+        help="Perform the query and count the number of results in each time bucket (ms).",
     )
     parsed_args = args_parser.parse_args(argv[1:])
 
@@ -265,7 +265,7 @@ def main(argv):
             parsed_args.max_num_results,
             parsed_args.file_path,
             parsed_args.count,
-            parsed_args.time_bucket_size,
+            parsed_args.count_by_time_bucket_size,
         )
     )
 

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -66,13 +66,11 @@ def main(argv):
         help="Maximum number of latest results to return.",
     )
     args_parser.add_argument("--file-path", help="File to search.")
-    args_parser.add_argument(
-        "--count", action="store_true", help="Perform the query and count the number of results."
-    )
+    args_parser.add_argument("--count", action="store_true", help="Count the number of results.")
     args_parser.add_argument(
         "--count-by-time",
         type=int,
-        help="Perform the query and count the number of results in each time bucket (ms).",
+        help="Count the number of results in each time span of the given size (ms).",
     )
     parsed_args = args_parser.parse_args(argv[1:])
 

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -70,9 +70,9 @@ def main(argv):
         "--count", action="store_true", help="Perform the query and count the number of results."
     )
     args_parser.add_argument(
-        "--time-bucket-size",
+        "--count-by-time",
         type=int,
-        help="Optional time bucket size (ms) for count aggregations.",
+        help="Perform the query and count the number of results in each time bucket (ms).",
     )
     parsed_args = args_parser.parse_args(argv[1:])
 
@@ -144,9 +144,9 @@ def main(argv):
         search_cmd.append(parsed_args.file_path)
     if parsed_args.count:
         search_cmd.append("--count")
-    if parsed_args.time_bucket_size is not None:
-        search_cmd.append("--time-bucket-size")
-        search_cmd.append(str(parsed_args.time_bucket_size))
+    if parsed_args.count_by_time is not None:
+        search_cmd.append("--count-by-time")
+        search_cmd.append(str(parsed_args.count_by_time))
     cmd = container_start_cmd + search_cmd
     subprocess.run(cmd, check=True)
 

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -69,6 +69,11 @@ def main(argv):
     args_parser.add_argument(
         "--count", action="store_true", help="Perform the query and count the number of results."
     )
+    args_parser.add_argument(
+        "--time-bucket-size",
+        type=int,
+        help="Optional time bucket size (ms) for count aggregations.",
+    )
     parsed_args = args_parser.parse_args(argv[1:])
 
     # Validate and load config file
@@ -139,6 +144,9 @@ def main(argv):
         search_cmd.append(parsed_args.file_path)
     if parsed_args.count:
         search_cmd.append("--count")
+    if parsed_args.time_bucket_size is not None:
+        search_cmd.append("--time-bucket-size")
+        search_cmd.append(str(parsed_args.time_bucket_size))
     cmd = container_start_cmd + search_cmd
     subprocess.run(cmd, check=True)
 

--- a/components/core/src/clp/ErrorCode.hpp
+++ b/components/core/src/clp/ErrorCode.hpp
@@ -22,7 +22,8 @@ typedef enum {
     ErrorCode_Failure,
     ErrorCode_Failure_Metadata_Corrupted,
     ErrorCode_MetadataCorrupted,
-    ErrorCode_Failure_DB_Bulk_Write
+    ErrorCode_Failure_DB_Bulk_Write,
+    ErrorCode_NetworkError
 } ErrorCode;
 }  // namespace clp
 

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -96,7 +96,7 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             "Perform a count aggregation (count the number of results)"
     )(
             "count-by-time",
-            po::value<int64_t>(&m_count_by_time_bucket_size),
+            po::value<int64_t>(&m_count_by_time_bucket_size)->value_name("SIZE"),
             "Perform the query and count the number of results in each time bucket (ms)"
     );
     // clang-format on
@@ -346,10 +346,10 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
         }
 
         // Validate count by time bucket size
-        if (parsed_command_line_options.count("count-by-time")) {
+        if (parsed_command_line_options.count("count-by-time") > 0) {
             m_do_count_by_time_aggregation = true;
             if (m_count_by_time_bucket_size <= 0) {
-                throw std::invalid_argument("Count by time argument must be greater than zero.");
+                throw std::invalid_argument("Value for count-by-time must be greater than zero.");
             }
         }
 
@@ -414,7 +414,7 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
 
         if (m_do_count_by_time_aggregation && m_do_count_results_aggregation) {
             throw std::invalid_argument(
-                    "The --count-by-time and --count arguments are mutually exclusive."
+                    "The --count-by-time and --count options are mutually exclusive."
             );
         }
     } catch (exception& e) {

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -96,9 +96,9 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             po::bool_switch(&m_do_count_results_aggregation),
             "Perform a count aggregation (count the number of results)"
     )(
-            "time-bucket-size",
-            po::value<int64_t>(&m_time_bucket_size),
-            "Optional time bucket size (ms) for count aggregations"
+            "count-by-time",
+            po::value<int64_t>(&m_count_by_time_bucket_size),
+            "Perform the query and count the number of results in each time bucket (ms)"
     );
     // clang-format on
 
@@ -260,11 +260,6 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             throw invalid_argument("Wildcard string not specified or empty.");
         }
 
-        // Validate bucket size
-        if (parsed_command_line_options.count("time-bucket-size") && m_time_bucket_size <= 0) {
-            throw std::invalid_argument("Bucket size argument must be greater than zero.");
-        }
-
         // Validate timestamp range and compute m_search_begin_ts and m_search_end_ts
         if (parsed_command_line_options.count("teq")) {
             if (parsed_command_line_options.count("tgt") + parsed_command_line_options.count("tge")
@@ -318,6 +313,14 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             throw invalid_argument("file-path cannot be an empty string.");
         }
 
+        // Validate count by time bucket size
+        if (parsed_command_line_options.count("count-by-time")) {
+            m_do_count_by_time_bucket_aggregation = true;
+            if (m_count_by_time_bucket_size <= 0) {
+                throw std::invalid_argument("Count by time argument must be greater than zero.");
+            }
+        }
+
         // Validate output-handler
         if (parsed_command_line_options.count("output-handler") == 0) {
             throw invalid_argument("OUTPUT_HANDLER not specified.");
@@ -367,11 +370,11 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             );
         }
 
-        if (parsed_command_line_options.count("time-bucket-size")
-            && false == m_do_count_results_aggregation)
+        if (parsed_command_line_options.count("count-by-time")
+            && parsed_command_line_options.count("count"))
         {
             throw std::invalid_argument(
-                    "The --time-bucket-size argument must be used with the --count argument."
+                    "The --count-by-time and --count arguments are mutually exclusive."
             );
         }
     } catch (exception& e) {

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -95,6 +95,10 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             "count",
             po::bool_switch(&m_do_count_results_aggregation),
             "Perform a count aggregation (count the number of results)"
+    )(
+            "time-bucket-size",
+            po::value<int64_t>(&m_time_bucket_size),
+            "Optional time bucket size (ms) for count aggregations"
     );
     // clang-format on
 
@@ -256,6 +260,11 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             throw invalid_argument("Wildcard string not specified or empty.");
         }
 
+        // Validate bucket size
+        if (parsed_command_line_options.count("time-bucket-size") && m_time_bucket_size <= 0) {
+            throw std::invalid_argument("Bucket size argument must be greater than zero.");
+        }
+
         // Validate timestamp range and compute m_search_begin_ts and m_search_end_ts
         if (parsed_command_line_options.count("teq")) {
             if (parsed_command_line_options.count("tgt") + parsed_command_line_options.count("tge")
@@ -355,6 +364,14 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
         {
             throw invalid_argument(
                     "The reducer output handler currently only supports the count aggregation."
+            );
+        }
+
+        if (parsed_command_line_options.count("time-bucket-size")
+            && false == m_do_count_results_aggregation)
+        {
+            throw std::invalid_argument(
+                    "The --time-bucket-size argument must be used with the --count argument."
             );
         }
     } catch (exception& e) {

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -399,13 +399,13 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                 );
         }
 
-        bool aggregtion_was_specified
+        bool aggregation_was_specified
                 = m_do_count_by_time_aggregation || m_do_count_results_aggregation;
-        if (aggregtion_was_specified && OutputHandlerType::Reducer != m_output_handler_type) {
+        if (aggregation_was_specified && OutputHandlerType::Reducer != m_output_handler_type) {
             throw invalid_argument(
                     "Aggregations are only supported with the reducer output handler."
             );
-        } else if ((false == aggregtion_was_specified
+        } else if ((false == aggregation_was_specified
                     && OutputHandlerType::Reducer == m_output_handler_type))
         {
             throw invalid_argument("The reducer output handler currently only supports count and "

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -315,7 +315,7 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
 
         // Validate count by time bucket size
         if (parsed_command_line_options.count("count-by-time")) {
-            m_do_count_by_time_bucket_aggregation = true;
+            m_do_count_by_time_aggregation = true;
             if (m_count_by_time_bucket_size <= 0) {
                 throw std::invalid_argument("Count by time argument must be greater than zero.");
             }
@@ -358,21 +358,20 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                 );
         }
 
-        if (m_do_count_results_aggregation && OutputHandlerType::Reducer != m_output_handler_type) {
+        bool aggregtion_was_specified
+                = m_do_count_by_time_aggregation || m_do_count_results_aggregation;
+        if (aggregtion_was_specified && OutputHandlerType::Reducer != m_output_handler_type) {
             throw invalid_argument(
                     "Aggregations are only supported with the reducer output handler."
             );
-        } else if ((false == m_do_count_results_aggregation
+        } else if ((false == aggregtion_was_specified
                     && OutputHandlerType::Reducer == m_output_handler_type))
         {
-            throw invalid_argument(
-                    "The reducer output handler currently only supports the count aggregation."
-            );
+            throw invalid_argument("The reducer output handler currently only supports count and "
+                                   "count-by-time aggregations.");
         }
 
-        if (parsed_command_line_options.count("count-by-time")
-            && parsed_command_line_options.count("count"))
-        {
+        if (m_do_count_by_time_aggregation && m_do_count_results_aggregation) {
             throw std::invalid_argument(
                     "The --count-by-time and --count arguments are mutually exclusive."
             );

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -93,11 +93,11 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
     options_aggregation.add_options()(
             "count",
             po::bool_switch(&m_do_count_results_aggregation),
-            "Perform a count aggregation (count the number of results)"
+            "Count the number of results"
     )(
             "count-by-time",
             po::value<int64_t>(&m_count_by_time_bucket_size)->value_name("SIZE"),
-            "Perform the query and count the number of results in each time bucket (ms)"
+            "Count the number of results in each time span of the given size (ms)"
     );
     // clang-format on
 

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -140,7 +140,7 @@ private:
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
     bool m_do_count_by_time_aggregation{false};
-    int64_t m_count_by_time_bucket_size{0};
+    int64_t m_count_by_time_bucket_size{0};  // Milliseconds
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::ResultsCache};
 };

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -63,7 +63,9 @@ public:
 
     bool do_count_results_aggregation() const { return m_do_count_results_aggregation; }
 
-    int64_t get_time_bucket_size() const { return m_time_bucket_size; }
+    bool do_count_by_time_aggregation() const { return m_do_count_by_time_bucket_aggregation; }
+
+    int64_t get_count_by_time_bucket_size() const { return m_count_by_time_bucket_size; }
 
     OutputHandlerType get_output_handler_type() const { return m_output_handler_type; }
 
@@ -111,7 +113,8 @@ private:
     int m_reducer_port{-1};
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
-    int64_t m_time_bucket_size{0};
+    bool m_do_count_by_time_bucket_aggregation{false};
+    int64_t m_count_by_time_bucket_size{0};
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::ResultsCache};
 };

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -63,6 +63,8 @@ public:
 
     bool do_count_results_aggregation() const { return m_do_count_results_aggregation; }
 
+    int64_t get_time_bucket_size() const { return m_time_bucket_size; }
+
     OutputHandlerType get_output_handler_type() const { return m_output_handler_type; }
 
 private:
@@ -109,6 +111,7 @@ private:
     int m_reducer_port{-1};
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
+    int64_t m_time_bucket_size{0};
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::ResultsCache};
 };

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -63,7 +63,7 @@ public:
 
     bool do_count_results_aggregation() const { return m_do_count_results_aggregation; }
 
-    bool do_count_by_time_aggregation() const { return m_do_count_by_time_bucket_aggregation; }
+    bool do_count_by_time_aggregation() const { return m_do_count_by_time_aggregation; }
 
     int64_t get_count_by_time_bucket_size() const { return m_count_by_time_bucket_size; }
 
@@ -113,7 +113,7 @@ private:
     int m_reducer_port{-1};
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
-    bool m_do_count_by_time_bucket_aggregation{false};
+    bool m_do_count_by_time_aggregation{false};
     int64_t m_count_by_time_bucket_size{0};
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::ResultsCache};

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -92,7 +92,7 @@ void CountOutputHandler::flush() {
     reducer::send_pipeline_results(m_reducer_socket_fd, std::move(m_pipeline.finish()));
 }
 
-void BucketOutputHandler::flush() {
+void CountByTimeOutputHandler::flush() {
     if (false
         == reducer::send_pipeline_results(
                 m_reducer_socket_fd,

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -98,7 +98,7 @@ void CountByTimeOutputHandler::flush() {
                 m_reducer_socket_fd,
                 std::make_unique<reducer::Int64Int64MapRecordGroupIterator>(
                         m_bucket_counts,
-                        "count"
+                        reducer::CountOperator::cRecordElementKey
                 )
         ))
     {

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -91,4 +91,18 @@ void CountOutputHandler::add_result(
 void CountOutputHandler::flush() {
     reducer::send_pipeline_results(m_reducer_socket_fd, std::move(m_pipeline.finish()));
 }
+
+void BucketOutputHandler::flush() {
+    if (false
+        == reducer::send_pipeline_results(
+                m_reducer_socket_fd,
+                std::make_unique<reducer::Int64Int64MapRecordGroupIterator>(
+                        m_bucket_counts,
+                        "count"
+                )
+        ))
+    {
+        SPDLOG_ERROR("Failed to send results to reducer");
+    }
+}
 }  // namespace clp::clo

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -93,6 +93,10 @@ public:
             epochtime_t timestamp
     ) override;
 
+    /**
+     * Closes the connection.
+     * @return ErrorCode_Success
+     */
     ErrorCode flush() override {
         close(m_socket_fd);
         return ErrorCode::ErrorCode_Success;
@@ -163,6 +167,11 @@ public:
             epochtime_t timestamp
     ) override;
 
+    /**
+     * Flushes any buffered output.
+     * @return ErrorCode_Success on success
+     * @return ErrorCode_Failure_DB_Bulk_Write on failure to write results to the results cache
+     */
     ErrorCode flush() override;
 
     [[nodiscard]] bool can_skip_file(clp::streaming_archive::MetadataDB::FileIterator const& it
@@ -220,6 +229,11 @@ public:
             epochtime_t timestamp
     ) override;
 
+    /**
+     * Flushes the count.
+     * @return ErrorCode_Success on success
+     * @return ErrorCode_Failure_Network on network error
+     */
     ErrorCode flush() override;
 
 private:
@@ -249,6 +263,11 @@ public:
         return ErrorCode::ErrorCode_Success;
     }
 
+    /**
+     * Flushes the counts.
+     * @return ErrorCode_Success on success
+     * @return ErrorCode_Failure_Network on network error
+     */
     ErrorCode flush() override;
 
 private:

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -36,8 +36,9 @@ public:
 
     /**
      * Flushes any buffered output. Called once at the end of search.
+     * @return ErrorCode_Success on success or relevant error code on error
      */
-    virtual void flush() = 0;
+    virtual ErrorCode flush() = 0;
 
     /**
      * @param it
@@ -117,7 +118,7 @@ public:
             epochtime_t timestamp
     ) override;
 
-    void flush() override;
+    ErrorCode flush() override;
 
     [[nodiscard]] bool can_skip_file(clp::streaming_archive::MetadataDB::FileIterator const& it
     ) override {
@@ -150,7 +151,7 @@ public:
             epochtime_t timestamp
     ) override;
 
-    void flush() override;
+    ErrorCode flush() override;
 
 private:
     int m_reducer_socket_fd;
@@ -178,7 +179,7 @@ public:
         m_bucket_counts[bucket] += 1;
     }
 
-    void flush() override;
+    ErrorCode flush() override;
 
 private:
     int m_reducer_socket_fd;

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -161,12 +161,12 @@ private:
  * Output handler that performs a count aggregation bucketed by time and sends the results to a
  * reducer.
  */
-class BucketOutputHandler : public OutputHandler {
+class CountByTimeOutputHandler : public OutputHandler {
 public:
     // Constructors
-    BucketOutputHandler(int reducer_socket_fd, int64_t time_bucket_size)
+    CountByTimeOutputHandler(int reducer_socket_fd, int64_t count_by_time_bucket_size)
             : m_reducer_socket_fd{reducer_socket_fd},
-              m_time_bucket_size{time_bucket_size} {}
+              m_count_by_time_bucket_size{count_by_time_bucket_size} {}
 
     // Methods inherited from OutputHandler
     void add_result(
@@ -174,7 +174,7 @@ public:
             std::string const& message,
             epochtime_t timestamp
     ) override {
-        int64_t bucket = (timestamp / m_time_bucket_size) * m_time_bucket_size;
+        int64_t bucket = (timestamp / m_count_by_time_bucket_size) * m_count_by_time_bucket_size;
         m_bucket_counts[bucket] += 1;
     }
 
@@ -183,7 +183,7 @@ public:
 private:
     int m_reducer_socket_fd;
     std::map<int64_t, int64_t> m_bucket_counts;
-    int64_t m_time_bucket_size;
+    int64_t m_count_by_time_bucket_size;
 };
 }  // namespace clp::clo
 

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -15,6 +15,7 @@
 #include "CommandLineArguments.hpp"
 #include "OutputHandler.hpp"
 
+using clp::clo::BucketOutputHandler;
 using clp::clo::CommandLineArguments;
 using clp::clo::CountOutputHandler;
 using clp::clo::OutputHandler;
@@ -264,7 +265,15 @@ int main(int argc, char const* argv[]) {
                 }
 
                 if (command_line_args.do_count_results_aggregation()) {
-                    output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
+                    int64_t time_bucket_size = command_line_args.get_time_bucket_size();
+                    if (time_bucket_size > 0) {
+                        output_handler = std::make_unique<BucketOutputHandler>(
+                                reducer_socket_fd,
+                                time_bucket_size
+                        );
+                    } else {
+                        output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
+                    }
                 } else {
                     SPDLOG_ERROR("Unhandled aggregation type.");
                     return -1;

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -15,8 +15,8 @@
 #include "CommandLineArguments.hpp"
 #include "OutputHandler.hpp"
 
-using clp::clo::BucketOutputHandler;
 using clp::clo::CommandLineArguments;
+using clp::clo::CountByTimeOutputHandler;
 using clp::clo::CountOutputHandler;
 using clp::clo::OutputHandler;
 using clp::clo::ResultsCacheClient;
@@ -265,15 +265,12 @@ int main(int argc, char const* argv[]) {
                 }
 
                 if (command_line_args.do_count_results_aggregation()) {
-                    int64_t time_bucket_size = command_line_args.get_time_bucket_size();
-                    if (time_bucket_size > 0) {
-                        output_handler = std::make_unique<BucketOutputHandler>(
-                                reducer_socket_fd,
-                                time_bucket_size
-                        );
-                    } else {
-                        output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
-                    }
+                    output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
+                } else if (command_line_args.do_count_by_time_aggregation()) {
+                    output_handler = std::make_unique<CountByTimeOutputHandler>(
+                            reducer_socket_fd,
+                            command_line_args.get_count_by_time_bucket_size()
+                    );
                 } else {
                     SPDLOG_ERROR("Unhandled aggregation type.");
                     return -1;

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -232,7 +232,7 @@ static bool search_archive(
     auto ecode = output_handler->flush();
     if (ErrorCode::ErrorCode_Success != ecode) {
         SPDLOG_ERROR(
-                "Encoutered error '{}' while trying to flush output handler.",
+                "Failed to flush output handler, error={}",
                 clp::enum_to_underlying_type(ecode)
         );
         return false;

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -218,9 +218,16 @@ static bool search_archive(
     );
     file_metadata_ix_ptr.reset(nullptr);
 
-    output_handler->flush();
     archive_reader.close();
 
+    auto ecode = output_handler->flush();
+    if (ErrorCode::ErrorCode_Success != ecode) {
+        SPDLOG_ERROR(
+                "Encoutered error '{}' while trying to flush output handler.",
+                clp::enum_to_underlying_type(ecode)
+        );
+        return false;
+    }
     return true;
 }
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -546,7 +546,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             }
 
             if (parsed_command_line_options.count("count-by-time")) {
-                m_do_count_by_time_bucket_aggregation = true;
+                m_do_count_by_time_aggregation = true;
                 if (m_count_by_time_bucket_size <= 0) {
                     throw std::invalid_argument("Bucket size argument must be greater than zero.");
                 }
@@ -599,23 +599,20 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
-            if (m_do_count_results_aggregation
-                && OutputHandlerType::Reducer != m_output_handler_type)
-            {
+            bool aggregtion_was_specified
+                    = m_do_count_by_time_aggregation || m_do_count_results_aggregation;
+            if (aggregtion_was_specified && OutputHandlerType::Reducer != m_output_handler_type) {
                 throw std::invalid_argument(
                         "Aggregations are only supported with the reducer output handler."
                 );
-            } else if ((false == m_do_count_results_aggregation
+            } else if ((false == aggregtion_was_specified
                         && OutputHandlerType::Reducer == m_output_handler_type))
             {
-                throw std::invalid_argument(
-                        "The reducer output handler currently only supports the count aggregation."
-                );
+                throw std::invalid_argument("The reducer output handler currently only supports "
+                                            "count and count-by-time aggregations.");
             }
 
-            if (parsed_command_line_options.count("count-by-time")
-                && parsed_command_line_options.count("count"))
-            {
+            if (m_do_count_by_time_aggregation && m_do_count_results_aggregation) {
                 throw std::invalid_argument(
                         "The --count-by-time and --count arguments are mutually exclusive."
                 );

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -382,7 +382,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "Perform a count aggregation (count the number of results)"
             )(
                     "count-by-time",
-                    po::value<int64_t>(&m_count_by_time_bucket_size),
+                    po::value<int64_t>(&m_count_by_time_bucket_size)->value_name("SIZE"),
                     "Perform the query and count the number of results in each time bucket (ms)"
             );
             // clang-format on
@@ -545,10 +545,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
-            if (parsed_command_line_options.count("count-by-time")) {
+            if (parsed_command_line_options.count("count-by-time") > 0) {
                 m_do_count_by_time_aggregation = true;
                 if (m_count_by_time_bucket_size <= 0) {
-                    throw std::invalid_argument("Bucket size argument must be greater than zero.");
+                    throw std::invalid_argument("Value for count-by-time must be greater than zero."
+                    );
                 }
             }
 
@@ -614,7 +615,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             if (m_do_count_by_time_aggregation && m_do_count_results_aggregation) {
                 throw std::invalid_argument(
-                        "The --count-by-time and --count arguments are mutually exclusive."
+                        "The --count-by-time and --count options are mutually exclusive."
                 );
             }
         }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -379,11 +379,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             aggregation_options.add_options()(
                     "count",
                     po::bool_switch(&m_do_count_results_aggregation),
-                    "Perform a count aggregation (count the number of results)"
+                    "Count the number of results"
             )(
                     "count-by-time",
                     po::value<int64_t>(&m_count_by_time_bucket_size)->value_name("SIZE"),
-                    "Perform the query and count the number of results in each time bucket (ms)"
+                    "Count the number of results in each time span of the given size (ms)"
             );
             // clang-format on
             search_options.add(aggregation_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -381,9 +381,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::bool_switch(&m_do_count_results_aggregation),
                     "Perform a count aggregation (count the number of results)"
             )(
-                    "time-bucket-size",
-                    po::value<int64_t>(&m_time_bucket_size),
-                    "Optional time bucket size (ms) for count aggregations"
+                    "count-by-time",
+                    po::value<int64_t>(&m_count_by_time_bucket_size),
+                    "Perform the query and count the number of results in each time bucket (ms)"
             );
             // clang-format on
             search_options.add(aggregation_options);
@@ -545,8 +545,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
-            if (parsed_command_line_options.count("time-bucket-size") && m_time_bucket_size <= 0) {
-                throw std::invalid_argument("Bucket size argument must be greater than zero.");
+            if (parsed_command_line_options.count("count-by-time")) {
+                m_do_count_by_time_bucket_aggregation = true;
+                if (m_count_by_time_bucket_size <= 0) {
+                    throw std::invalid_argument("Bucket size argument must be greater than zero.");
+                }
             }
 
             if (parsed_command_line_options.count("output-handler") > 0) {
@@ -610,11 +613,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
-            if (parsed_command_line_options.count("time-bucket-size")
-                && false == m_do_count_results_aggregation)
+            if (parsed_command_line_options.count("count-by-time")
+                && parsed_command_line_options.count("count"))
             {
                 throw std::invalid_argument(
-                        "The --time-bucket-size argument must be used with the --count argument."
+                        "The --count-by-time and --count arguments are mutually exclusive."
                 );
             }
         }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -600,13 +600,13 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
-            bool aggregtion_was_specified
+            bool aggregation_was_specified
                     = m_do_count_by_time_aggregation || m_do_count_results_aggregation;
-            if (aggregtion_was_specified && OutputHandlerType::Reducer != m_output_handler_type) {
+            if (aggregation_was_specified && OutputHandlerType::Reducer != m_output_handler_type) {
                 throw std::invalid_argument(
                         "Aggregations are only supported with the reducer output handler."
                 );
-            } else if ((false == aggregtion_was_specified
+            } else if ((false == aggregation_was_specified
                         && OutputHandlerType::Reducer == m_output_handler_type))
             {
                 throw std::invalid_argument("The reducer output handler currently only supports "

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -380,6 +380,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "count",
                     po::bool_switch(&m_do_count_results_aggregation),
                     "Perform a count aggregation (count the number of results)"
+            )(
+                    "time-bucket-size",
+                    po::value<int64_t>(&m_time_bucket_size),
+                    "Optional time bucket size (ms) for count aggregations"
             );
             // clang-format on
             search_options.add(aggregation_options);
@@ -541,6 +545,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
+            if (parsed_command_line_options.count("time-bucket-size") && m_time_bucket_size <= 0) {
+                throw std::invalid_argument("Bucket size argument must be greater than zero.");
+            }
+
             if (parsed_command_line_options.count("output-handler") > 0) {
                 if (static_cast<char const*>(cNetworkOutputHandlerName) == output_handler_name) {
                     m_output_handler_type = OutputHandlerType::Network;
@@ -599,6 +607,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             {
                 throw std::invalid_argument(
                         "The reducer output handler currently only supports the count aggregation."
+                );
+            }
+
+            if (parsed_command_line_options.count("time-bucket-size")
+                && false == m_do_count_results_aggregation)
+            {
+                throw std::invalid_argument(
+                        "The --time-bucket-size argument must be used with the --count argument."
                 );
             }
         }

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -96,6 +96,8 @@ public:
 
     bool do_count_results_aggregation() const { return m_do_count_results_aggregation; }
 
+    int64_t get_time_bucket_size() const { return m_time_bucket_size; }
+
     OutputHandlerType get_output_handler_type() const { return m_output_handler_type; }
 
 private:
@@ -188,6 +190,7 @@ private:
     int m_reducer_port{-1};
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
+    int64_t m_time_bucket_size{0};
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::Stdout};
 };

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -193,7 +193,7 @@ private:
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
     bool m_do_count_by_time_aggregation{false};
-    int64_t m_count_by_time_bucket_size{0};
+    int64_t m_count_by_time_bucket_size{0};  // Milliseconds
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::Stdout};
 };

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -96,7 +96,9 @@ public:
 
     bool do_count_results_aggregation() const { return m_do_count_results_aggregation; }
 
-    int64_t get_time_bucket_size() const { return m_time_bucket_size; }
+    bool do_count_by_time_aggregation() const { return m_do_count_by_time_bucket_aggregation; }
+
+    int64_t get_count_by_time_bucket_size() const { return m_count_by_time_bucket_size; }
 
     OutputHandlerType get_output_handler_type() const { return m_output_handler_type; }
 
@@ -190,7 +192,8 @@ private:
     int m_reducer_port{-1};
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
-    int64_t m_time_bucket_size{0};
+    bool m_do_count_by_time_bucket_aggregation{false};
+    int64_t m_count_by_time_bucket_size{0};
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::Stdout};
 };

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -96,7 +96,7 @@ public:
 
     bool do_count_results_aggregation() const { return m_do_count_results_aggregation; }
 
-    bool do_count_by_time_aggregation() const { return m_do_count_by_time_bucket_aggregation; }
+    bool do_count_by_time_aggregation() const { return m_do_count_by_time_aggregation; }
 
     int64_t get_count_by_time_bucket_size() const { return m_count_by_time_bucket_size; }
 
@@ -192,7 +192,7 @@ private:
     int m_reducer_port{-1};
     reducer::job_id_t m_job_id{-1};
     bool m_do_count_results_aggregation{false};
-    bool m_do_count_by_time_bucket_aggregation{false};
+    bool m_do_count_by_time_aggregation{false};
     int64_t m_count_by_time_bucket_size{0};
 
     OutputHandlerType m_output_handler_type{OutputHandlerType::Stdout};

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -229,9 +229,7 @@ bool search_archive(
             std::move(output_handler),
             command_line_arguments.get_ignore_case()
     );
-    output.filter();
-
-    return true;
+    return output.filter();
 }
 }  // namespace
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -189,7 +189,15 @@ bool search_archive(
                 break;
             case CommandLineArguments::OutputHandlerType::Reducer:
                 if (command_line_arguments.do_count_results_aggregation()) {
-                    output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
+                    int64_t time_bucket_size = command_line_arguments.get_time_bucket_size();
+                    if (time_bucket_size > 0) {
+                        output_handler = std::make_unique<BucketOutputHandler>(
+                                reducer_socket_fd,
+                                time_bucket_size
+                        );
+                    } else {
+                        output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
+                    }
                 } else {
                     SPDLOG_ERROR("Unhandled aggregation type.");
                     return false;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -189,15 +189,12 @@ bool search_archive(
                 break;
             case CommandLineArguments::OutputHandlerType::Reducer:
                 if (command_line_arguments.do_count_results_aggregation()) {
-                    int64_t time_bucket_size = command_line_arguments.get_time_bucket_size();
-                    if (time_bucket_size > 0) {
-                        output_handler = std::make_unique<BucketOutputHandler>(
-                                reducer_socket_fd,
-                                time_bucket_size
-                        );
-                    } else {
-                        output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
-                    }
+                    output_handler = std::make_unique<CountOutputHandler>(reducer_socket_fd);
+                } else if (command_line_arguments.do_count_by_time_aggregation()) {
+                    output_handler = std::make_unique<CountByTimeOutputHandler>(
+                            reducer_socket_fd,
+                            command_line_arguments.get_count_by_time_bucket_size()
+                    );
                 } else {
                     SPDLOG_ERROR("Unhandled aggregation type.");
                     return false;

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -107,7 +107,7 @@ bool Output::filter() {
         auto ecode = m_output_handler->flush();
         if (ErrorCode::ErrorCodeSuccess != ecode) {
             SPDLOG_ERROR(
-                    "Encoutered error '{}' while trying to flush output handler.",
+                    "Failed to flush output handler, error={}.",
                     clp::enum_to_underlying_type(ecode)
             );
             return false;
@@ -116,7 +116,7 @@ bool Output::filter() {
     auto ecode = m_output_handler->finish();
     if (ErrorCode::ErrorCodeSuccess != ecode) {
         SPDLOG_ERROR(
-                "Encoutered error '{}' while trying to finish output handler.",
+                "Failed to flush output handler, error={}.",
                 clp::enum_to_underlying_type(ecode)
         );
         return false;

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -3,6 +3,7 @@
 #include <regex>
 #include <stack>
 
+#include "../../clp/type_utils.hpp"
 #include "../ArchiveReader.hpp"
 #include "../FileWriter.hpp"
 #include "../ReaderUtils.hpp"
@@ -18,7 +19,7 @@
 #define eval(op, a, b) (((op) == FilterOperation::EQ) ? ((a) == (b)) : ((a) != (b)))
 
 namespace clp_s::search {
-void Output::filter() {
+bool Output::filter() {
     auto top_level_expr = m_expr;
 
     std::vector<int32_t> matched_schemas;
@@ -41,7 +42,7 @@ void Output::filter() {
     // Skip decompressing archive if it contains no
     // relevant schemas
     if (matched_schemas.empty()) {
-        return;
+        return true;
     }
 
     // Skip decompressing archive if it won't match based on the timestamp
@@ -49,7 +50,7 @@ void Output::filter() {
     EvaluateTimestampIndex timestamp_index(m_archive_reader->get_timestamp_dictionary());
     if (timestamp_index.run(top_level_expr) == EvaluatedValue::False) {
         m_archive_reader->close();
-        return;
+        return true;
     }
 
     m_var_dict = m_archive_reader->read_variable_dictionary();
@@ -103,9 +104,24 @@ void Output::filter() {
                 m_output_handler->write(message);
             }
         }
-        m_output_handler->flush();
+        auto ecode = m_output_handler->flush();
+        if (ErrorCode::ErrorCodeSuccess != ecode) {
+            SPDLOG_ERROR(
+                    "Encoutered error '{}' while trying to flush output handler.",
+                    clp::enum_to_underlying_type(ecode)
+            );
+            return false;
+        }
     }
-    m_output_handler->finish();
+    auto ecode = m_output_handler->finish();
+    if (ErrorCode::ErrorCodeSuccess != ecode) {
+        SPDLOG_ERROR(
+                "Encoutered error '{}' while trying to finish output handler.",
+                clp::enum_to_underlying_type(ecode)
+        );
+        return false;
+    }
+    return true;
 }
 
 void Output::init(

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -43,7 +43,7 @@ public:
 
     /**
      * Filters messages from all archives
-     * @return whether the filter was performed succesfully
+     * @return Whether the filter was performed successfully
      */
     bool filter();
 

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -43,8 +43,9 @@ public:
 
     /**
      * Filters messages from all archives
+     * @return whether the filter was performed succesfully
      */
-    void filter();
+    bool filter();
 
 private:
     std::shared_ptr<ArchiveReader> m_archive_reader;

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -104,4 +104,19 @@ void CountOutputHandler::finish() {
         SPDLOG_ERROR("Failed to send aggregated results to reducer");
     }
 }
+
+void BucketOutputHandler::finish() {
+    if (false
+        == reducer::send_pipeline_results(
+                m_reducer_socket_fd,
+                std::make_unique<reducer::Int64Int64MapRecordGroupIterator>(
+                        m_bucket_counts,
+                        "count"
+                )
+        ))
+    {
+        SPDLOG_ERROR("Failed to send results to reducer");
+    }
+}
+
 }  // namespace clp_s::search

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -105,7 +105,7 @@ void CountOutputHandler::finish() {
     }
 }
 
-void BucketOutputHandler::finish() {
+void CountByTimeOutputHandler::finish() {
     if (false
         == reducer::send_pipeline_results(
                 m_reducer_socket_fd,

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -111,7 +111,7 @@ void CountByTimeOutputHandler::finish() {
                 m_reducer_socket_fd,
                 std::make_unique<reducer::Int64Int64MapRecordGroupIterator>(
                         m_bucket_counts,
-                        "count"
+                        reducer::CountOperator::cRecordElementKey
                 )
         ))
     {

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -179,6 +179,11 @@ public:
     );
 
     // Methods inherited from OutputHandler
+    /**
+     * Flushes the output handler after each table that gets searched.
+     * @return ErrorCodeSuccess on success
+     * @return ErrorCodeFailureDbBulkWrite on failure to write results to the results cache
+     */
     ErrorCode flush() override;
 
     void write(std::string const& message, epochtime_t timestamp) override;
@@ -211,6 +216,11 @@ public:
 
     void write(std::string const& message) override;
 
+    /**
+     * Flushes the count.
+     * @return ErrorCodeSuccess on success
+     * @return ErrorCodeFailureNetwork on network error
+     */
     ErrorCode finish() override;
 
 private:
@@ -238,6 +248,11 @@ public:
 
     void write(std::string const& message) override {}
 
+    /**
+     * Flushes the counts.
+     * @return ErrorCodeSuccess on success
+     * @return ErrorCodeFailureNetwork on network error
+     */
     ErrorCode finish() override;
 
 private:

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -50,13 +50,15 @@ public:
 
     /**
      * Flushes the output handler after each table that gets searched.
+     * @return ErrorCodeSuccess on success or relevant error code on error
      */
-    virtual void flush() = 0;
+    virtual ErrorCode flush() { return ErrorCode::ErrorCodeSuccess; }
 
     /**
      * Performs any final operations after all tables have been searched.
+     * @return ErrorCodeSuccess on success or relevant error code on error
      */
-    virtual void finish() {}
+    virtual ErrorCode finish() { return ErrorCode::ErrorCodeSuccess; }
 
     [[nodiscard]] bool should_output_timestamp() const { return m_should_output_timestamp; }
 
@@ -82,8 +84,6 @@ public:
     }
 
     void write(std::string const& message) override { printf("%s", message.c_str()); }
-
-    void flush() override {}
 };
 
 /**
@@ -128,8 +128,6 @@ public:
             throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
         }
     }
-
-    void flush() override{};
 
 private:
     std::string m_host;
@@ -181,7 +179,7 @@ public:
     );
 
     // Methods inherited from OutputHandler
-    void flush() override;
+    ErrorCode flush() override;
 
     void write(std::string const& message, epochtime_t timestamp) override;
 
@@ -209,13 +207,11 @@ public:
     CountOutputHandler(int reducer_socket_fd);
 
     // Methods inherited from OutputHandler
-    void flush() override {}
-
     void write(std::string const& message, epochtime_t timestamp) override {}
 
     void write(std::string const& message) override;
 
-    void finish() override;
+    ErrorCode finish() override;
 
 private:
     int m_reducer_socket_fd;
@@ -235,8 +231,6 @@ public:
               m_count_by_time_bucket_size{count_by_time_bucket_size} {}
 
     // Methods inherited from OutputHandler
-    void flush() override {}
-
     void write(std::string const& message, epochtime_t timestamp) override {
         int64_t bucket = (timestamp / m_count_by_time_bucket_size) * m_count_by_time_bucket_size;
         m_bucket_counts[bucket] += 1;
@@ -244,7 +238,7 @@ public:
 
     void write(std::string const& message) override {}
 
-    void finish() override;
+    ErrorCode finish() override;
 
 private:
     int m_reducer_socket_fd;

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -226,19 +226,19 @@ private:
  * Output handler that performs a count aggregation bucketed by time and sends the results to a
  * reducer.
  */
-class BucketOutputHandler : public OutputHandler {
+class CountByTimeOutputHandler : public OutputHandler {
 public:
     // Constructors
-    BucketOutputHandler(int reducer_socket_fd, int64_t time_bucket_size)
+    CountByTimeOutputHandler(int reducer_socket_fd, int64_t count_by_time_bucket_size)
             : OutputHandler{true, false},
               m_reducer_socket_fd{reducer_socket_fd},
-              m_time_bucket_size{time_bucket_size} {}
+              m_count_by_time_bucket_size{count_by_time_bucket_size} {}
 
     // Methods inherited from OutputHandler
     void flush() override {}
 
     void write(std::string const& message, epochtime_t timestamp) override {
-        int64_t bucket = (timestamp / m_time_bucket_size) * m_time_bucket_size;
+        int64_t bucket = (timestamp / m_count_by_time_bucket_size) * m_count_by_time_bucket_size;
         m_bucket_counts[bucket] += 1;
     }
 
@@ -249,7 +249,7 @@ public:
 private:
     int m_reducer_socket_fd;
     std::map<int64_t, int64_t> m_bucket_counts;
-    int64_t m_time_bucket_size;
+    int64_t m_count_by_time_bucket_size;
 };
 }  // namespace clp_s::search
 

--- a/components/core/src/reducer/ConstRecordIterator.hpp
+++ b/components/core/src/reducer/ConstRecordIterator.hpp
@@ -48,6 +48,8 @@ public:
 
     bool done() override { return m_done; }
 
+    void reset() { m_done = false; }
+
 private:
     Record const* m_record;
     bool m_done{false};

--- a/components/core/src/reducer/RecordGroup.hpp
+++ b/components/core/src/reducer/RecordGroup.hpp
@@ -40,6 +40,8 @@ public:
 
     void set_record(Record const& record) { m_iterator = SingleRecordIterator(record); }
 
+    void reset_record_iterator() { m_iterator.reset(); }
+
     [[nodiscard]] ConstRecordIterator& record_iter() override { return m_iterator; }
 
 private:

--- a/components/core/src/reducer/RecordGroupIterator.hpp
+++ b/components/core/src/reducer/RecordGroupIterator.hpp
@@ -49,6 +49,7 @@ public:
     RecordGroup& get() override {
         m_record.set_record_value(m_map_it->second);
         m_group.set_tags(&m_map_it->first);
+        m_group.set_record(m_record);
         return m_group;
     }
 
@@ -78,6 +79,7 @@ public:
         m_tags = {std::to_string(m_map_it->first)};
         m_record.set_record_value(m_map_it->second);
         m_group.set_tags(&m_tags);
+        m_group.set_record(m_record);
         return m_group;
     }
 
@@ -126,6 +128,7 @@ public:
     RecordGroup& get() override {
         m_record.set_record_value(m_map_end_it->second);
         m_group.set_tags(&m_map_end_it->first);
+        m_group.set_record(m_record);
         return m_group;
     }
 

--- a/components/core/src/reducer/RecordGroupIterator.hpp
+++ b/components/core/src/reducer/RecordGroupIterator.hpp
@@ -49,7 +49,7 @@ public:
     RecordGroup& get() override {
         m_record.set_record_value(m_map_it->second);
         m_group.set_tags(&m_map_it->first);
-        m_group.set_record(m_record);
+        m_group.reset_record_iterator();
         return m_group;
     }
 
@@ -79,7 +79,7 @@ public:
         m_tags = {std::to_string(m_map_it->first)};
         m_record.set_record_value(m_map_it->second);
         m_group.set_tags(&m_tags);
-        m_group.set_record(m_record);
+        m_group.reset_record_iterator();
         return m_group;
     }
 
@@ -128,7 +128,7 @@ public:
     RecordGroup& get() override {
         m_record.set_record_value(m_map_end_it->second);
         m_group.set_tags(&m_map_end_it->first);
-        m_group.set_record(m_record);
+        m_group.reset_record_iterator();
         return m_group;
     }
 

--- a/components/core/src/reducer/ServerContext.cpp
+++ b/components/core/src/reducer/ServerContext.cpp
@@ -41,9 +41,9 @@ vector<uint8_t> serialize_timeline_result(GroupTags const& tags, ConstRecordIter
 
     int64_t count = 0;
     for (; false == record_it.done(); record_it.next()) {
-        count = record_it.get().get_int64_value("count");
+        count = record_it.get().get_int64_value(CountOperator::cRecordElementKey);
     }
-    json["count"] = count;
+    json[CountOperator::cRecordElementKey] = count;
 
     return nlohmann::json::to_bson(json);
 }

--- a/components/core/src/reducer/ServerContext.cpp
+++ b/components/core/src/reducer/ServerContext.cpp
@@ -152,7 +152,11 @@ void ServerContext::set_up_pipeline(nlohmann::json const& query_config) {
     m_pipeline = std::make_unique<Pipeline>(PipelineInputMode::IntraStage);
     m_pipeline->add_pipeline_stage(std::make_shared<CountOperator>());
 
-    m_is_timeline_aggregation = query_config.count(cJobAttributes::BucketSize) > 0;
+    if (query_config.count(cJobAttributes::TimeBucketSize) > 0
+        && false == query_config[cJobAttributes::TimeBucketSize].is_null())
+    {
+        m_is_timeline_aggregation = true;
+    }
 
     auto collection_name = std::to_string(m_job_id);
     m_mongodb_results_collection = m_mongodb_results_database[collection_name];

--- a/components/core/src/reducer/ServerContext.hpp
+++ b/components/core/src/reducer/ServerContext.hpp
@@ -25,7 +25,7 @@ enum class ServerStatus : uint8_t {
 
 namespace cJobAttributes {
 constexpr char JobId[] = "job_id";
-constexpr char TimeBucketSize[] = "time_bucket_size";
+constexpr char TimeBucketSize[] = "count_by_time_bucket_size";
 }  // namespace cJobAttributes
 
 /**

--- a/components/core/src/reducer/ServerContext.hpp
+++ b/components/core/src/reducer/ServerContext.hpp
@@ -25,7 +25,7 @@ enum class ServerStatus : uint8_t {
 
 namespace cJobAttributes {
 constexpr char JobId[] = "job_id";
-constexpr char BucketSize[] = "bucket_size";
+constexpr char TimeBucketSize[] = "time_bucket_size";
 }  // namespace cJobAttributes
 
 /**

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -49,9 +49,9 @@ def make_clo_command(
 
         if aggregation_config.do_count_aggregation is not None:
             search_cmd.append("--count")
-        if aggregation_config.time_bucket_size is not None:
-            search_cmd.append("--time-bucket-size")
-            search_cmd.append(str(aggregation_config.time_bucket_size))
+        if aggregation_config.count_by_time_bucket_size is not None:
+            search_cmd.append("--count-by-time")
+            search_cmd.append(str(aggregation_config.count_by_time_bucket_size))
 
         search_cmd.append("reducer")
         search_cmd.append("--host")
@@ -104,9 +104,9 @@ def make_clp_s_command(
 
         if aggregation_config.do_count_aggregation is not None:
             search_cmd.append("--count")
-        if aggregation_config.time_bucket_size is not None:
-            search_cmd.append("--time-bucket-size")
-            search_cmd.append(str(aggregation_config.time_bucket_size))
+        if aggregation_config.count_by_time_bucket_size is not None:
+            search_cmd.append("--count-by-time")
+            search_cmd.append(str(aggregation_config.count_by_time_bucket_size))
 
         search_cmd.append("reducer")
         search_cmd.append("--host")

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -49,6 +49,9 @@ def make_clo_command(
 
         if aggregation_config.do_count_aggregation is not None:
             search_cmd.append("--count")
+        if aggregation_config.time_bucket_size is not None:
+            search_cmd.append("--time-bucket-size")
+            search_cmd.append(str(aggregation_config.time_bucket_size))
 
         search_cmd.append("reducer")
         search_cmd.append("--host")
@@ -101,6 +104,9 @@ def make_clp_s_command(
 
         if aggregation_config.do_count_aggregation is not None:
             search_cmd.append("--count")
+        if aggregation_config.time_bucket_size is not None:
+            search_cmd.append("--time-bucket-size")
+            search_cmd.append(str(aggregation_config.time_bucket_size))
 
         search_cmd.append("reducer")
         search_cmd.append("--host")

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -36,6 +36,7 @@ class AggregationConfig(BaseModel):
     reducer_host: typing.Optional[str] = None
     reducer_port: typing.Optional[int] = None
     do_count_aggregation: typing.Optional[bool] = None
+    time_bucket_size: typing.Optional[int] = None
 
 
 class SearchConfig(BaseModel):

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -36,7 +36,7 @@ class AggregationConfig(BaseModel):
     reducer_host: typing.Optional[str] = None
     reducer_port: typing.Optional[int] = None
     do_count_aggregation: typing.Optional[bool] = None
-    count_by_time_bucket_size: typing.Optional[int] = None  // Milliseconds
+    count_by_time_bucket_size: typing.Optional[int] = None // Milliseconds
 
 
 class SearchConfig(BaseModel):

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -36,7 +36,7 @@ class AggregationConfig(BaseModel):
     reducer_host: typing.Optional[str] = None
     reducer_port: typing.Optional[int] = None
     do_count_aggregation: typing.Optional[bool] = None
-    time_bucket_size: typing.Optional[int] = None
+    count_by_time_bucket_size: typing.Optional[int] = None
 
 
 class SearchConfig(BaseModel):

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -36,7 +36,7 @@ class AggregationConfig(BaseModel):
     reducer_host: typing.Optional[str] = None
     reducer_port: typing.Optional[int] = None
     do_count_aggregation: typing.Optional[bool] = None
-    count_by_time_bucket_size: typing.Optional[int] = None // Milliseconds
+    count_by_time_bucket_size: typing.Optional[int] = None  # Milliseconds
 
 
 class SearchConfig(BaseModel):

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -36,7 +36,7 @@ class AggregationConfig(BaseModel):
     reducer_host: typing.Optional[str] = None
     reducer_port: typing.Optional[int] = None
     do_count_aggregation: typing.Optional[bool] = None
-    count_by_time_bucket_size: typing.Optional[int] = None
+    count_by_time_bucket_size: typing.Optional[int] = None  // Milliseconds
 
 
 class SearchConfig(BaseModel):

--- a/components/job-orchestration/job_orchestration/scheduler/search/reducer_handler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/reducer_handler.py
@@ -148,11 +148,13 @@ async def handle_reducer_connection(
                         current_wait_state, msg.msg_type, msg_queues
                     )
                 aggregation_config: AggregationConfig = msg.payload
+                job_id = aggregation_config.job_id
+                time_bucket_size = aggregation_config.count_by_time_bucket_size
                 await _send_msg_to_reducer(
                     msgpack.packb(
                         {
-                            "job_id": aggregation_config.job_id,
-                            "count_by_time_bucket_size": aggregation_config.count_by_time_bucket_size,
+                            "job_id": job_id,
+                            "count_by_time_bucket_size": time_bucket_size,
                         }
                     ),
                     writer,

--- a/components/job-orchestration/job_orchestration/scheduler/search/reducer_handler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/reducer_handler.py
@@ -152,7 +152,7 @@ async def handle_reducer_connection(
                     msgpack.packb(
                         {
                             "job_id": aggregation_config.job_id,
-                            "time_bucket_size": aggregation_config.time_bucket_size,
+                            "count_by_time_bucket_size": aggregation_config.count_by_time_bucket_size,
                         }
                     ),
                     writer,

--- a/components/job-orchestration/job_orchestration/scheduler/search/reducer_handler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/reducer_handler.py
@@ -149,7 +149,13 @@ async def handle_reducer_connection(
                     )
                 aggregation_config: AggregationConfig = msg.payload
                 await _send_msg_to_reducer(
-                    msgpack.packb({"job_id": aggregation_config.job_id}), writer
+                    msgpack.packb(
+                        {
+                            "job_id": aggregation_config.job_id,
+                            "time_bucket_size": aggregation_config.time_bucket_size,
+                        }
+                    ),
+                    writer,
                 )
 
                 recv_listener_msg_task = asyncio.create_task(msg_queues.get_from_listeners())


### PR DESCRIPTION
# Description
This PR adds support for performing count aggregations grouped by time buckets. From the command line users can provide the `--time-bucket-size <ms>`  alongside the `--count` option to `/sbin/search.sh` to trigger timeline count aggregations.

This feature will be used to support a result timeline view in the webui.

# Validation performed
- Validated that time bucketed count aggregation works correctly with clp and clp-s

