### PR TITLE
gh-actions: Replace nproc call with getconf to support macOS.

### DIFF
--- a/components/core/tools/scripts/utils/build-and-run-unit-tests.sh
+++ b/components/core/tools/scripts/utils/build-and-run-unit-tests.sh
@@ -17,7 +17,7 @@ if [ "$#" -gt 2 ]; then
 fi
 
 cmake -S "$src_dir" -B "$build_dir"
-cmake --build "$build_dir" --parallel "$(nproc)"
+cmake --build "$build_dir" --parallel "$(getconf _NPROCESSORS_ONLN)"
 cd "$build_dir"
 if [ -z "${unit_tests_filter+x}" ]; then
     ./unitTest


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The last few build-macos GH workflows runs have been timing out without a clear reason. One thing we did notice is this log:

`./tools/scripts/utils/build-and-run-unit-tests.sh: line 20: nproc: command not found`

This PR replaces `nproc` with `getconf _NPROCESSORS_ONLN` which seems to be supported on both Linux and macOS.

The subsequent workflow run seemed to succeed---which may be a fluke or may have resolved the issue. Either way, it's worth fixing the `nproc` issue.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated all clp-core build workflows succeeded.
* Validated `_NPROCESSORS_ONLN` is also available in WSL's Ubuntu.
