### PR TITLE
Add a network server to the package to receive query results 

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -78,7 +78,7 @@ def create_and_monitor_job_in_db(
     end_timestamp: int | None,
     ignore_case: bool,
     path_filter: str | None,
-    network_address: tuple[str, int],
+    network_address: tuple[str, int] | None,
     do_count_aggregation: bool | None,
 ):
     search_config = SearchConfig(
@@ -169,58 +169,79 @@ async def do_search(
     path_filter: str | None,
     do_count_aggregation: bool | None,
 ):
-    host = None
-    for ip in set(socket.gethostbyname_ex(socket.gethostname())[2]):
-        host = ip
-        break
-    if host is None:
-        logger.error("Could not determine IP of local machine.")
-        return -1
-    try:
-        server = await asyncio.start_server(
-            client_connected_cb=worker_connection_handler,
-            host=host,
-            port=0,
-            family=socket.AF_INET,
+    if do_count_aggregation is None:
+        host = None
+        for ip in set(socket.gethostbyname_ex(socket.gethostname())[2]):
+            host = ip
+            break
+        if host is None:
+            logger.error("Could not determine IP of local machine.")
+            return -1
+        try:
+            server = await asyncio.start_server(
+                client_connected_cb=worker_connection_handler,
+                host=host,
+                port=0,
+                family=socket.AF_INET,
+            )
+        except asyncio.CancelledError:
+            # Search cancelled
+            return
+        port = int(server.sockets[0].getsockname()[1])
+
+        server_task = asyncio.ensure_future(server.serve_forever())
+
+        db_monitor_task = asyncio.ensure_future(
+            run_function_in_process(
+                create_and_monitor_job_in_db,
+                db_config,
+                results_cache,
+                wildcard_query,
+                tags,
+                begin_timestamp,
+                end_timestamp,
+                ignore_case,
+                path_filter,
+                (host, port),
+                do_count_aggregation,
+            )
         )
-    except asyncio.CancelledError:
-        # Search cancelled
-        return
-    port = int(server.sockets[0].getsockname()[1])
 
-    server_task = asyncio.ensure_future(server.serve_forever())
-
-    db_monitor_task = asyncio.ensure_future(
-        run_function_in_process(
-            create_and_monitor_job_in_db,
-            db_config,
-            results_cache,
-            wildcard_query,
-            tags,
-            begin_timestamp,
-            end_timestamp,
-            ignore_case,
-            path_filter,
-            (host, port),
-            do_count_aggregation,
-        )
-    )
-
-    # Wait for the job to complete or an error to occur
-    pending = [server_task, db_monitor_task]
-    try:
-        done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
-        if db_monitor_task in done:
+        # Wait for the job to complete or an error to occur
+        pending = [server_task, db_monitor_task]
+        try:
+            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+            if db_monitor_task in done:
+                server.close()
+                await server.wait_closed()
+            else:
+                logger.error("server task unexpectedly returned")
+                db_monitor_task.cancel()
+                await db_monitor_task
+        except asyncio.CancelledError:
             server.close()
             await server.wait_closed()
-        else:
-            logger.error("server task unexpectedly returned")
-            db_monitor_task.cancel()
             await db_monitor_task
-    except asyncio.CancelledError:
-        server.close()
-        await server.wait_closed()
-        await db_monitor_task
+    else:
+        db_monitor_task = asyncio.ensure_future(
+            run_function_in_process(
+                create_and_monitor_job_in_db,
+                db_config,
+                results_cache,
+                wildcard_query,
+                tags,
+                begin_timestamp,
+                end_timestamp,
+                ignore_case,
+                path_filter,
+                None,
+                do_count_aggregation,
+            )
+        )
+        try:
+            await db_monitor_task
+        except asyncio.CancelledError:
+            pass
 
 
 def main(argv):

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -226,6 +226,10 @@ async def do_search_without_aggregation(
             await server.wait_closed()
         else:
             logger.error("server_task completed unexpectedly.")
+            try:
+                server_task.result()
+            except Exception:
+                logger.exception("server_task failed.")
             db_monitor_task.cancel()
             await db_monitor_task
     except asyncio.CancelledError:
@@ -259,21 +263,19 @@ async def do_search(
             path_filter,
         )
     else:
-        await asyncio.ensure_future(
-            run_function_in_process(
-                create_and_monitor_job_in_db,
-                db_config,
-                results_cache,
-                wildcard_query,
-                tags,
-                begin_timestamp,
-                end_timestamp,
-                ignore_case,
-                path_filter,
-                None,
-                do_count_aggregation,
-                count_by_time_bucket_size,
-            )
+        await run_function_in_process(
+            create_and_monitor_job_in_db,
+            db_config,
+            results_cache,
+            wildcard_query,
+            tags,
+            begin_timestamp,
+            end_timestamp,
+            ignore_case,
+            path_filter,
+            None,
+            do_count_aggregation,
+            count_by_time_bucket_size,
         )
 
 

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -58,13 +58,6 @@ def main(argv):
         action="store_true",
         help="Ignore case distinctions between values in the query and the compressed data.",
     )
-    args_parser.add_argument(
-        "--max-num-results",
-        "-m",
-        type=int,
-        default=1000,
-        help="Maximum number of latest results to return.",
-    )
     args_parser.add_argument("--file-path", help="File to search.")
     args_parser.add_argument(
         "--count", action="store_true", help="Perform the query and count the number of results."
@@ -120,7 +113,6 @@ def main(argv):
         "-m", "clp_package_utils.scripts.native.search",
         "--config", str(container_clp_config.logs_directory / container_config_filename),
         parsed_args.wildcard_query,
-        "--max-num-results", str(parsed_args.max_num_results),
     ]
     # fmt: on
     if parsed_args.tags:

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -195,6 +195,7 @@ target_link_libraries(
         kql
         MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
+        msgpack-cxx
         simdjson
         spdlog::spdlog
         yaml-cpp::yaml-cpp

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -23,6 +23,26 @@ NetworkOutputHandler::NetworkOutputHandler(
     }
 }
 
+void NetworkOutputHandler::write(std::string const& message, epochtime_t timestamp) {
+    msgpack::type::tuple<std::string, epochtime_t, std::string> src("", timestamp, message);
+    msgpack::sbuffer m;
+    msgpack::pack(m, src);
+
+    if (-1 == send(m_socket_fd, m.data(), m.size(), 0)) {
+        throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
+    }
+}
+
+void NetworkOutputHandler::write(std::string const& message) {
+    msgpack::type::tuple<std::string, epochtime_t, std::string> src("", 0, message);
+    msgpack::sbuffer m;
+    msgpack::pack(m, src);
+
+    if (-1 == send(m_socket_fd, m.data(), m.size(), 0)) {
+        throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
+    }
+}
+
 ResultsCacheOutputHandler::ResultsCacheOutputHandler(
         std::string const& uri,
         std::string const& collection,

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -115,25 +115,9 @@ public:
     }
 
     // Methods inherited from OutputHandler
-    void write(std::string const& message, epochtime_t timestamp) override {
-        msgpack::type::tuple<std::string, epochtime_t, std::string> src("", timestamp, message);
-        msgpack::sbuffer m;
-        msgpack::pack(m, src);
+    void write(std::string const& message, epochtime_t timestamp) override;
 
-        if (-1 == send(m_socket_fd, m.data(), m.size(), 0)) {
-            throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
-        }
-    }
-
-    void write(std::string const& message) override {
-        msgpack::type::tuple<std::string, epochtime_t, std::string> src("", 0, message);
-        msgpack::sbuffer m;
-        msgpack::pack(m, src);
-
-        if (-1 == send(m_socket_fd, m.data(), m.size(), 0)) {
-            throw OperationFailed(ErrorCode::ErrorCodeFailureNetwork, __FILE__, __LINE__);
-        }
-    }
+    void write(std::string const& message) override;
 
 private:
     std::string m_host;

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -17,59 +17,8 @@ from job_orchestration.scheduler.scheduler_data import SearchTaskResult
 logger = get_task_logger(__name__)
 
 
-def make_clo_command(
-    clp_home: Path,
-    archive_path: Path,
-    search_config: SearchConfig,
-    results_cache_uri: str,
-    results_collection: str,
-):
-    # fmt: off
-    search_cmd = [
-        str(clp_home / "bin" / "clo"),
-        str(archive_path),
-        search_config.query_string,
-    ]
-    # fmt: on
-
-    if search_config.begin_timestamp is not None:
-        search_cmd.append("--tge")
-        search_cmd.append(str(search_config.begin_timestamp))
-    if search_config.end_timestamp is not None:
-        search_cmd.append("--tle")
-        search_cmd.append(str(search_config.end_timestamp))
-    if search_config.ignore_case:
-        search_cmd.append("--ignore-case")
-    if search_config.path_filter is not None:
-        search_cmd.append("--file-path")
-        search_cmd.append(search_config.path_filter)
-
-    if search_config.aggregation_config is not None:
-        aggregation_config = search_config.aggregation_config
-
-        if aggregation_config.do_count_aggregation is not None:
-            search_cmd.append("--count")
-
-        search_cmd.append("reducer")
-        search_cmd.append("--host")
-        search_cmd.append(aggregation_config.reducer_host)
-        search_cmd.append("--port")
-        search_cmd.append(str(aggregation_config.reducer_port))
-        search_cmd.append("--job-id")
-        search_cmd.append(str(aggregation_config.job_id))
-    else:
-        search_cmd.append("results-cache")
-        search_cmd.append("--uri")
-        search_cmd.append(results_cache_uri)
-        search_cmd.append("--collection")
-        search_cmd.append(results_collection)
-        search_cmd.append("--max-num-results")
-        search_cmd.append(str(search_config.max_num_results))
-
-    return search_cmd
-
-
-def make_clp_s_command(
+def make_command(
+    storage_engine: str,
     clp_home: Path,
     archives_dir: Path,
     archive_id: str,
@@ -77,48 +26,61 @@ def make_clp_s_command(
     results_cache_uri: str,
     results_collection: str,
 ):
-    # fmt: off
-    search_cmd = [
-        str(clp_home / "bin" / "clp-s"),
-        "s",
-        str(archives_dir),
-        "--archive-id", archive_id,
-        search_config.query_string,
-    ]
-    # fmt: on
+    if StorageEngine.CLP == storage_engine:
+        command = [str(clp_home / "bin" / "clo"), str(archives_dir / archive_id)]
+        if search_config.path_filter is not None:
+            command.append("--file-path")
+            command.append(search_config.path_filter)
+    elif StorageEngine.CLP_S == storage_engine:
+        command = [
+            str(clp_home / "bin" / "clp-s"),
+            "s",
+            str(archives_dir),
+            "--archive-id",
+            archive_id,
+        ]
+    else:
+        return []
 
+    command.append(search_config.query_string)
     if search_config.begin_timestamp is not None:
-        search_cmd.append("--tge")
-        search_cmd.append(str(search_config.begin_timestamp))
+        command.append("--tge")
+        command.append(str(search_config.begin_timestamp))
     if search_config.end_timestamp is not None:
-        search_cmd.append("--tle")
-        search_cmd.append(str(search_config.end_timestamp))
+        command.append("--tle")
+        command.append(str(search_config.end_timestamp))
     if search_config.ignore_case:
-        search_cmd.append("--ignore-case")
+        command.append("--ignore-case")
 
     if search_config.aggregation_config is not None:
         aggregation_config = search_config.aggregation_config
 
         if aggregation_config.do_count_aggregation is not None:
-            search_cmd.append("--count")
+            command.append("--count")
 
-        search_cmd.append("reducer")
-        search_cmd.append("--host")
-        search_cmd.append(aggregation_config.reducer_host)
-        search_cmd.append("--port")
-        search_cmd.append(str(aggregation_config.reducer_port))
-        search_cmd.append("--job-id")
-        search_cmd.append(str(aggregation_config.job_id))
+        command.append("reducer")
+        command.append("--host")
+        command.append(aggregation_config.reducer_host)
+        command.append("--port")
+        command.append(str(aggregation_config.reducer_port))
+        command.append("--job-id")
+        command.append(str(aggregation_config.job_id))
+    elif search_config.network_address is not None:
+        command.append("network")
+        command.append("--host")
+        command.append(search_config.network_address[0])
+        command.append("--port")
+        command.append(str(search_config.network_address[1]))
     else:
-        search_cmd.append("results-cache")
-        search_cmd.append("--uri")
-        search_cmd.append(results_cache_uri)
-        search_cmd.append("--collection")
-        search_cmd.append(results_collection)
-        search_cmd.append("--max-num-results")
-        search_cmd.append(str(search_config.max_num_results))
+        command.append("results-cache")
+        command.append("--uri")
+        command.append(results_cache_uri)
+        command.append("--collection")
+        command.append(results_collection)
+        command.append("--max-num-results")
+        command.append(str(search_config.max_num_results))
 
-    return search_cmd
+    return command
 
 
 @app.task(bind=True)
@@ -146,36 +108,28 @@ def search(
     logger.info(f"Started task for job {job_id}")
 
     search_config = SearchConfig.parse_obj(search_config_obj)
-    archive_path = archive_directory / archive_id
 
-    if StorageEngine.CLP == clp_storage_engine:
-        search_cmd = make_clo_command(
-            clp_home=clp_home,
-            archive_path=archive_path,
-            search_config=search_config,
-            results_cache_uri=results_cache_uri,
-            results_collection=job_id,
-        )
-    elif StorageEngine.CLP_S == clp_storage_engine:
-        search_cmd = make_clp_s_command(
-            clp_home=clp_home,
-            archives_dir=archive_directory,
-            archive_id=archive_id,
-            search_config=search_config,
-            results_cache_uri=results_cache_uri,
-            results_collection=job_id,
-        )
-    else:
+    search_command = make_command(
+        storage_engine=clp_storage_engine,
+        clp_home=clp_home,
+        archives_dir=archive_directory,
+        archive_id=archive_id,
+        search_config=search_config,
+        results_cache_uri=results_cache_uri,
+        results_collection=job_id,
+    )
+
+    if len(search_command) == 0:
         logger.error(f"Unsupported storage engine {clp_storage_engine}")
         return SearchTaskResult(
             success=False,
             task_id=task_id,
         ).dict()
 
-    logger.info(f'Running: {" ".join(search_cmd)}')
+    logger.info(f'Running: {" ".join(search_command)}')
     search_successful = False
     search_proc = subprocess.Popen(
-        search_cmd,
+        search_command,
         preexec_fn=os.setpgrp,
         close_fds=True,
         stdout=clo_log_file,

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -61,29 +61,29 @@ def make_command(
             command.append(str(aggregation_config.count_by_time_bucket_size))
 
         # fmt: off
-        command.extend([
+        command.extend((
              "reducer",
              "--host", aggregation_config.reducer_host,
              "--port", str(aggregation_config.reducer_port),
              "--job-id", str(aggregation_config.job_id)
-        ])
+        ))
         # fmt: on
     elif search_config.network_address is not None:
         # fmt: off
-        command.extend([
+        command.extend((
             "network",
             "--host", search_config.network_address[0],
             "--port", str(search_config.network_address[1])
-        ])
+        ))
         # fmt: on
     else:
         # fmt: off
-        command.extend([
+        command.extend((
             "results-cache",
             "--uri", results_cache_uri,
             "--collection", results_collection,
             "--max-num-results", str(search_config.max_num_results)
-        ])
+        ))
         # fmt: on
 
     return command

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -47,12 +47,13 @@ class SearchConfig(BaseModel):
     end_timestamp: typing.Optional[int] = None
     ignore_case: bool = False
     path_filter: typing.Optional[str] = None
+    # Tuple of (host, port)
     network_address: typing.Optional[typing.Tuple[str, int]] = None
     aggregation_config: typing.Optional[AggregationConfig] = None
 
     @validator("network_address")
     def validate_network_address(cls, field):
-        if field is not None and (field[1] < 0 or field[1] > 65535):
-            raise ValueError("Invalid port number")
+        if field is not None and (field[1] < 1 or field[1] > 65535):
+            raise ValueError("Port must be in the range [1, 65535]")
 
         return field

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -53,3 +53,5 @@ class SearchConfig(BaseModel):
     def validate_network_address(cls, field):
         if field is not None and (field[1] < 0 or field[1] > 65535):
             raise ValueError("Invalid port number")
+
+        return field

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -46,7 +46,7 @@ class SearchConfig(BaseModel):
     end_timestamp: typing.Optional[int] = None
     ignore_case: bool = False
     path_filter: typing.Optional[str] = None
-    network_address: typing.Optional[typing.Tuple[str, str]] = None
+    network_address: typing.Optional[typing.Tuple[str, int]] = None
     aggregation_config: typing.Optional[AggregationConfig] = None
 
     @validator("network_address")

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 
 class PathsToCompress(BaseModel):
@@ -46,4 +46,10 @@ class SearchConfig(BaseModel):
     end_timestamp: typing.Optional[int] = None
     ignore_case: bool = False
     path_filter: typing.Optional[str] = None
+    network_address: typing.Optional[typing.Tuple[str, str]] = None
     aggregation_config: typing.Optional[AggregationConfig] = None
+
+    @validator("network_address")
+    def validate_network_address(cls, field):
+        if field is not None and (field[1] < 0 or field[1] > 65535):
+            raise ValueError("Invalid port number")

--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -296,7 +296,10 @@ def handle_pending_search_jobs(
     for job in pending_jobs:
         job_id = job.id
 
-        if len(job.remaining_archives_for_search) > num_archives_to_search_per_sub_job:
+        if (
+            job.search_config.network_address is None
+            and len(job.remaining_archives_for_search) > num_archives_to_search_per_sub_job
+        ):
             archives_for_search = job.remaining_archives_for_search[
                 :num_archives_to_search_per_sub_job
             ]


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#299 and #324
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
#299 and #324 add support for sending query results to a network destination. This PR adds a network server to the package to receive query results. 

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Built the package and compressed [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) logs using clp
+ Executed `sbin/search.sh "org.apache.hadoop.metrics2.impl.MetricsSystemImpl: ReduceTask metrics system shutdown complete"`. Used WebUI to run the same query. Both returned results as expected.
+ Changed the storage engine to clp-s and compressed first 1,000,000 log messages of [mongodb](https://zenodo.org/records/10516285) dataset.
+ Executed `sbin/search.sh "id: 22419"`. Used WebUI to run the same query. Both returned results as expected.