### PR TITLE
webui: Update job status when the job is cancelled; parallelize meteor method handlers; Change `SEARCH_SIGNAL` enums to strings instead of numbers.

### DIFF
--- a/components/webui/imports/api/search/constants.js
+++ b/components/webui/imports/api/search/constants.js
@@ -1,33 +1,25 @@
-let enumSearchSignal;
 /**
  * Enum of search-related signals.
  *
  * This includes request and response signals for various search operations and their respective
  * states.
  *
- * @type {Object}
+ * @enum {string}
  */
 const SEARCH_SIGNAL = Object.freeze({
-    NONE: (enumSearchSignal = 0),
+    NONE: "none",
 
-    REQ_MASK: (enumSearchSignal = 0x10000000),
-    REQ_CLEARING: ++enumSearchSignal,
-    REQ_CANCELLING: ++enumSearchSignal,
-    REQ_QUERYING: ++enumSearchSignal,
+    REQ_CLEARING: "req-clearing",
+    REQ_CANCELLING: "req-cancelling",
+    REQ_QUERYING: "req-querying",
 
-    RESP_MASK: (enumSearchSignal = 0x20000000),
-    RESP_DONE: ++enumSearchSignal,
-    RESP_QUERYING: ++enumSearchSignal,
+    RESP_DONE: "resp-done",
+    RESP_QUERYING: "resp-querying",
 });
 
-const isSearchSignalReq = (s) => (0 !== (SEARCH_SIGNAL.REQ_MASK & s));
-const isSearchSignalResp = (s) => (0 !== (SEARCH_SIGNAL.RESP_MASK & s));
-const isSearchSignalQuerying = (s) => (
-    [
-        SEARCH_SIGNAL.REQ_QUERYING,
-        SEARCH_SIGNAL.RESP_QUERYING,
-    ].includes(s)
-);
+const isSearchSignalReq = (s) => s.startsWith("req-");
+const isSearchSignalResp = (s) => s.startsWith("resp-");
+const isSearchSignalQuerying = (s) => s.endsWith("-querying");
 
 /* eslint-disable sort-keys */
 let enumSearchJobStatus;


### PR DESCRIPTION
# References
Internally, it was discovered that:
1. When the job is cancelled by the user, the progress bar is still running. 
2. There are delays in UI updates after a search job is submitted.
3. It is hard to debug a job's `lastSignal`, which is a aggregated state from <u>the last request by user</u> and <u>the last response by server </u>, because the field appears as an base-10 integer in the MongoDB. Decimal to hex conversion is usually needed before developers can infer the status code. 

# Description
1. Update job status when the job is cancelled.
2. Parallelize meteor method handlers.
3. Change `SEARCH_SIGNAL` enums to strings instead of numbers.

# Validation performed
1. `cd <PROJECT_ROOT>; task`
2. `cd ./build/clp-package/sbin; ./start-clp.sh`
3. `./compress.sh ~/samples/hive-24hr/i-00c90a0f/`
4. Opened the WebUI address in a browser.
5. Started a query with string `123` and observed the job finished and the results are displayed in the results table.
6. Started another query with string `1234` and cancelled the job before the job finished. Observed the progress bar to disappear and an error message is displayed as "The search results are inconclusive because the user cancelled the job.". 
   ![image](https://github.com/y-scope/clp/assets/43196707/e3d2ee11-3bec-4057-ab83-cb55d8927fec)
7. Checked the `results-metadata` in MongoDB using MongoDB Compass and verified the job's last signal is a string of `resp-done` than an integer.

