### PR TITLE
webui: Fix a bug where collapsing the sidebar clears the search results.

### DIFF
--- a/components/webui/imports/ui/App.jsx
+++ b/components/webui/imports/ui/App.jsx
@@ -60,7 +60,7 @@ const App = () => {
         </div>
     </div>;
 
-    const Routes = () => <Switch>
+    const routeSwitch = <Switch>
         <Route exact path="/">
             <Redirect to="/ingest"/>
         </Route>
@@ -86,7 +86,7 @@ const App = () => {
             minWidth: 0,
         }}>
             <div style={{height: "100%"}}>
-                {!loggedIn ? <Spinner/> : <Routes/>}
+                {!loggedIn ? <Spinner/> : routeSwitch}
             </div>
         </div>
     </div>);


### PR DESCRIPTION
# References
Internally it was found that collapsing / expanding the sidebar would clear the search results. Further investigation found that the search page was re-rendered when the `isSidebarCollapsed` state variable got updated, causing unnecessary and undesired re-render of page contents. 

# Description
1. Change `Route` from a function component into a variable to avoid regeneration of the route switch.
 
# Validation performed
1. `cd <PROJECT_ROOT>; task`
2. `cd ./build/clp-package/sbin; ./start-clp.sh`
3. `./compress.sh ~/samples/hive-24hr/i-00c90a0f/`
4. Opened the WebUI address in a browser.
5. Started a query with string `123` and observed the job finished and the results are displayed in the results table.
6. Clicked the "Collapse" button to collapse the sidebar and observed the results still present within the search page.
7. Clicked the "Expand" button to expand the sidebar and observed the results still present within the search page.