### PR TITLE
webui: Replace MySQL connection with connection pool.

### DIFF
--- a/components/webui/imports/api/ingestion/server/StatsDbManager.js
+++ b/components/webui/imports/api/ingestion/server/StatsDbManager.js
@@ -19,7 +19,7 @@ class StatsDbManager {
     #clpFilesTableName;
 
     /**
-     * @param {mysql.Pool} sqlDbPool
+     * @param {import("mysql2/promise").Pool} sqlDbPool
      * @param {object} tableNames
      * @param {string} tableNames.clpArchivesTableName
      * @param {string} tableNames.clpFilesTableName

--- a/components/webui/imports/api/ingestion/server/StatsDbManager.js
+++ b/components/webui/imports/api/ingestion/server/StatsDbManager.js
@@ -14,21 +14,21 @@ const CLP_FILES_TABLE_COLUMN_NAMES = {
  * Class for retrieving compression stats from the database.
  */
 class StatsDbManager {
-    #sqlDbPool;
+    #sqlDbConnPool;
     #clpArchivesTableName;
     #clpFilesTableName;
 
     /**
-     * @param {import("mysql2/promise").Pool} sqlDbPool
+     * @param {import("mysql2/promise").Pool} sqlDbConnPool
      * @param {object} tableNames
      * @param {string} tableNames.clpArchivesTableName
      * @param {string} tableNames.clpFilesTableName
      */
-    constructor(sqlDbPool, {
+    constructor(sqlDbConnPool, {
         clpArchivesTableName,
         clpFilesTableName,
     }) {
-        this.#sqlDbPool = sqlDbPool;
+        this.#sqlDbConnPool = sqlDbConnPool;
 
         this.#clpArchivesTableName = clpArchivesTableName;
         this.#clpFilesTableName = clpFilesTableName;
@@ -50,7 +50,7 @@ class StatsDbManager {
      * @throws {Error} on error.
      */
     async getCompressionStats() {
-        const [queryStats] = await this.#sqlDbPool.query(
+        const [queryStats] = await this.#sqlDbConnPool.query(
             `SELECT a.begin_timestamp         AS begin_timestamp,
                     a.end_timestamp           AS end_timestamp,
                     a.total_uncompressed_size AS total_uncompressed_size,

--- a/components/webui/imports/api/ingestion/server/StatsDbManager.js
+++ b/components/webui/imports/api/ingestion/server/StatsDbManager.js
@@ -14,21 +14,21 @@ const CLP_FILES_TABLE_COLUMN_NAMES = {
  * Class for retrieving compression stats from the database.
  */
 class StatsDbManager {
-    #sqlDbConnection;
+    #sqlDbPool;
     #clpArchivesTableName;
     #clpFilesTableName;
 
     /**
-     * @param {mysql.Connection} sqlDbConnection
+     * @param {mysql.Pool} sqlDbPool
      * @param {object} tableNames
      * @param {string} tableNames.clpArchivesTableName
      * @param {string} tableNames.clpFilesTableName
      */
-    constructor(sqlDbConnection, {
+    constructor(sqlDbPool, {
         clpArchivesTableName,
         clpFilesTableName,
     }) {
-        this.#sqlDbConnection = sqlDbConnection;
+        this.#sqlDbPool = sqlDbPool;
 
         this.#clpArchivesTableName = clpArchivesTableName;
         this.#clpFilesTableName = clpFilesTableName;
@@ -50,7 +50,7 @@ class StatsDbManager {
      * @throws {Error} on error.
      */
     async getCompressionStats() {
-        const [queryStats] = await this.#sqlDbConnection.query(
+        const [queryStats] = await this.#sqlDbPool.query(
             `SELECT a.begin_timestamp         AS begin_timestamp,
                     a.end_timestamp           AS end_timestamp,
                     a.total_uncompressed_size AS total_uncompressed_size,

--- a/components/webui/imports/api/ingestion/server/publications.js
+++ b/components/webui/imports/api/ingestion/server/publications.js
@@ -45,17 +45,17 @@ const refreshCompressionStats = async () => {
 };
 
 /**
- * @param {import("mysql2/promise").Pool} sqlDbPool
+ * @param {import("mysql2/promise").Pool} sqlDbConnPool
  * @param {object} tableNames
  * @param {string} tableNames.clpArchivesTableName
  * @param {string} tableNames.clpFilesTableName
  * @throws {Error} on error.
  */
-const initStatsDbManager = (sqlDbPool, {
+const initStatsDbManager = (sqlDbConnPool, {
     clpArchivesTableName,
     clpFilesTableName,
 }) => {
-    statsDbManager = new StatsDbManager(sqlDbPool, {
+    statsDbManager = new StatsDbManager(sqlDbConnPool, {
         clpArchivesTableName,
         clpFilesTableName,
     });

--- a/components/webui/imports/api/ingestion/server/publications.js
+++ b/components/webui/imports/api/ingestion/server/publications.js
@@ -45,17 +45,17 @@ const refreshCompressionStats = async () => {
 };
 
 /**
- * @param {mysql.Connection} sqlDbConnection
+ * @param {mysql.Pool} sqlDbPool
  * @param {object} tableNames
  * @param {string} tableNames.clpArchivesTableName
  * @param {string} tableNames.clpFilesTableName
  * @throws {Error} on error.
  */
-const initStatsDbManager = (sqlDbConnection, {
+const initStatsDbManager = (sqlDbPool, {
     clpArchivesTableName,
     clpFilesTableName,
 }) => {
-    statsDbManager = new StatsDbManager(sqlDbConnection, {
+    statsDbManager = new StatsDbManager(sqlDbPool, {
         clpArchivesTableName,
         clpFilesTableName,
     });

--- a/components/webui/imports/api/ingestion/server/publications.js
+++ b/components/webui/imports/api/ingestion/server/publications.js
@@ -45,7 +45,7 @@ const refreshCompressionStats = async () => {
 };
 
 /**
- * @param {mysql.Pool} sqlDbPool
+ * @param {import("mysql2/promise").Pool} sqlDbPool
  * @param {object} tableNames
  * @param {string} tableNames.clpArchivesTableName
  * @param {string} tableNames.clpFilesTableName

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -17,16 +17,16 @@ const SEARCH_JOBS_TABLE_COLUMN_NAMES = {
  * Class for submitting and monitoring search jobs in the database.
  */
 class SearchJobsDbManager {
-    #sqlDbPool;
+    #sqlDbConnPool;
     #searchJobsTableName;
 
     /**
-     * @param {import("mysql2/promise").Pool} sqlDbPool
+     * @param {import("mysql2/promise").Pool} sqlDbConnPool
      * @param {object} tableNames
      * @param {string} tableNames.searchJobsTableName
      */
-    constructor(sqlDbPool, {searchJobsTableName}) {
-        this.#sqlDbPool = sqlDbPool;
+    constructor(sqlDbConnPool, {searchJobsTableName}) {
+        this.#sqlDbConnPool = sqlDbConnPool;
         this.#searchJobsTableName = searchJobsTableName;
     }
 
@@ -37,7 +37,7 @@ class SearchJobsDbManager {
      * @throws {Error} on error.
      */
     async submitQuery(searchConfig) {
-        const [queryInsertResults] = await this.#sqlDbPool.query(
+        const [queryInsertResults] = await this.#sqlDbConnPool.query(
             `INSERT INTO ${this.#searchJobsTableName}
                  (${SEARCH_JOBS_TABLE_COLUMN_NAMES.SEARCH_CONFIG})
              VALUES (?)`,
@@ -53,7 +53,7 @@ class SearchJobsDbManager {
      * @throws {Error} on error.
      */
     async submitQueryCancellation(jobId) {
-        await this.#sqlDbPool.query(
+        await this.#sqlDbConnPool.query(
             `UPDATE ${this.#searchJobsTableName}
              SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${SEARCH_JOB_STATUS.CANCELLING}
              WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?`,
@@ -72,7 +72,7 @@ class SearchJobsDbManager {
         while (true) {
             let rows;
             try {
-                const [queryRows, _] = await this.#sqlDbPool.query(
+                const [queryRows, _] = await this.#sqlDbConnPool.query(
                     `SELECT ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS}
                      FROM ${this.#searchJobsTableName}
                      WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?`,

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -17,16 +17,16 @@ const SEARCH_JOBS_TABLE_COLUMN_NAMES = {
  * Class for submitting and monitoring search jobs in the database.
  */
 class SearchJobsDbManager {
-    #sqlDbConnection;
+    #sqlDbPool;
     #searchJobsTableName;
 
     /**
-     * @param {mysql.Connection} sqlDbConnection
+     * @param {mysql.Pool} sqlDbPool
      * @param {object} tableNames
      * @param {string} tableNames.searchJobsTableName
      */
-    constructor(sqlDbConnection, {searchJobsTableName}) {
-        this.#sqlDbConnection = sqlDbConnection;
+    constructor(sqlDbPool, {searchJobsTableName}) {
+        this.#sqlDbPool = sqlDbPool;
         this.#searchJobsTableName = searchJobsTableName;
     }
 
@@ -37,7 +37,7 @@ class SearchJobsDbManager {
      * @throws {Error} on error.
      */
     async submitQuery(searchConfig) {
-        const [queryInsertResults] = await this.#sqlDbConnection.query(
+        const [queryInsertResults] = await this.#sqlDbPool.query(
             `INSERT INTO ${this.#searchJobsTableName}
                  (${SEARCH_JOBS_TABLE_COLUMN_NAMES.SEARCH_CONFIG})
              VALUES (?)`,
@@ -53,7 +53,7 @@ class SearchJobsDbManager {
      * @throws {Error} on error.
      */
     async submitQueryCancellation(jobId) {
-        await this.#sqlDbConnection.query(
+        await this.#sqlDbPool.query(
             `UPDATE ${this.#searchJobsTableName}
              SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${SEARCH_JOB_STATUS.CANCELLING}
              WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?`,
@@ -72,7 +72,7 @@ class SearchJobsDbManager {
         while (true) {
             let rows;
             try {
-                const [queryRows, _] = await this.#sqlDbConnection.query(
+                const [queryRows, _] = await this.#sqlDbPool.query(
                     `SELECT ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS}
                      FROM ${this.#searchJobsTableName}
                      WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?`,

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -21,7 +21,7 @@ class SearchJobsDbManager {
     #searchJobsTableName;
 
     /**
-     * @param {mysql.Pool} sqlDbPool
+     * @param {import("mysql2/promise").Pool} sqlDbPool
      * @param {object} tableNames
      * @param {string} tableNames.searchJobsTableName
      */

--- a/components/webui/imports/api/search/server/methods.js
+++ b/components/webui/imports/api/search/server/methods.js
@@ -15,13 +15,13 @@ import SearchJobsDbManager from "./SearchJobsDbManager";
 let searchJobsDbManager = null;
 
 /**
- * @param {mysql.Connection} sqlDbConnection
+ * @param {mysql.Pool} sqlDbPool
  * @param {object} tableNames
  * @param {string} tableNames.searchJobsTableName
  * @throws {Error} on error.
  */
-const initSearchJobsDbManager = (sqlDbConnection, {searchJobsTableName}) => {
-    searchJobsDbManager = new SearchJobsDbManager(sqlDbConnection, {searchJobsTableName});
+const initSearchJobsDbManager = (sqlDbPool, {searchJobsTableName}) => {
+    searchJobsDbManager = new SearchJobsDbManager(sqlDbPool, {searchJobsTableName});
 };
 
 /**

--- a/components/webui/imports/api/search/server/methods.js
+++ b/components/webui/imports/api/search/server/methods.js
@@ -15,13 +15,13 @@ import SearchJobsDbManager from "./SearchJobsDbManager";
 let searchJobsDbManager = null;
 
 /**
- * @param {import("mysql2/promise").Pool} sqlDbPool
+ * @param {import("mysql2/promise").Pool} sqlDbConnPool
  * @param {object} tableNames
  * @param {string} tableNames.searchJobsTableName
  * @throws {Error} on error.
  */
-const initSearchJobsDbManager = (sqlDbPool, {searchJobsTableName}) => {
-    searchJobsDbManager = new SearchJobsDbManager(sqlDbPool, {searchJobsTableName});
+const initSearchJobsDbManager = (sqlDbConnPool, {searchJobsTableName}) => {
+    searchJobsDbManager = new SearchJobsDbManager(sqlDbConnPool, {searchJobsTableName});
 };
 
 /**

--- a/components/webui/imports/api/search/server/methods.js
+++ b/components/webui/imports/api/search/server/methods.js
@@ -15,7 +15,7 @@ import SearchJobsDbManager from "./SearchJobsDbManager";
 let searchJobsDbManager = null;
 
 /**
- * @param {mysql.Pool} sqlDbPool
+ * @param {import("mysql2/promise").Pool} sqlDbPool
  * @param {object} tableNames
  * @param {string} tableNames.searchJobsTableName
  * @throws {Error} on error.

--- a/components/webui/imports/utils/DbManager.js
+++ b/components/webui/imports/utils/DbManager.js
@@ -10,7 +10,7 @@ const DB_MAX_IDLE = DB_CONNECTION_LIMIT;
 const DB_IDLE_TIMEOUT_IN_MS = 10000;
 
 /**
- * @type {mysql.Pool|null}
+ * @type {import("mysql2/promise").Pool|null}
  */
 let dbPool = null;
 

--- a/components/webui/imports/utils/DbManager.js
+++ b/components/webui/imports/utils/DbManager.js
@@ -12,7 +12,7 @@ const DB_IDLE_TIMEOUT_IN_MS = 10000;
 /**
  * @type {import("mysql2/promise").Pool|null}
  */
-let dbPool = null;
+let dbConnPool = null;
 
 /**
  * Creates a new database connection and initializes DB managers with it.
@@ -43,12 +43,12 @@ const initDbManagers = async ({
     clpArchivesTableName,
     clpFilesTableName,
 }) => {
-    if (null !== dbPool) {
+    if (null !== dbConnPool) {
         throw Error("This method should not be called twice.");
     }
 
     try {
-        dbPool = await mysql.createPool({
+        dbConnPool = await mysql.createPool({
             host: dbHost,
             port: dbPort,
             database: dbName,
@@ -62,10 +62,10 @@ const initDbManagers = async ({
             idleTimeout: DB_IDLE_TIMEOUT_IN_MS
         });
 
-        initSearchJobsDbManager(dbPool, {
+        initSearchJobsDbManager(dbConnPool, {
             searchJobsTableName,
         });
-        initStatsDbManager(dbPool, {
+        initStatsDbManager(dbConnPool, {
             clpArchivesTableName,
             clpFilesTableName,
         });
@@ -83,7 +83,7 @@ const initDbManagers = async ({
 const deinitDbManagers = async () => {
     deinitStatsDbManager();
 
-    await dbPool.end();
+    await dbConnPool.end();
 };
 
 export {initDbManagers, deinitDbManagers};

--- a/components/webui/imports/utils/DbManager.js
+++ b/components/webui/imports/utils/DbManager.js
@@ -5,10 +5,14 @@ import {deinitStatsDbManager, initStatsDbManager} from "../api/ingestion/server/
 import {initSearchJobsDbManager} from "../api/search/server/methods";
 
 
+const DB_CONNECTION_LIMIT = 2;
+const DB_MAX_IDLE = DB_CONNECTION_LIMIT;
+const DB_IDLE_TIMEOUT_IN_MS = 10000;
+
 /**
- * @type {mysql.Connection|null}
+ * @type {mysql.Pool|null}
  */
-let dbConnection = null;
+let dbPool = null;
 
 /**
  * Creates a new database connection and initializes DB managers with it.
@@ -39,13 +43,12 @@ const initDbManagers = async ({
     clpArchivesTableName,
     clpFilesTableName,
 }) => {
-    if (null !== dbConnection) {
-        logger.error("This method should not be called twice.");
-        return;
+    if (null !== dbPool) {
+        throw Error("This method should not be called twice.");
     }
 
     try {
-        dbConnection = await mysql.createConnection({
+        dbPool = await mysql.createPool({
             host: dbHost,
             port: dbPort,
             database: dbName,
@@ -53,18 +56,21 @@ const initDbManagers = async ({
             password: dbPassword,
             bigNumberStrings: true,
             supportBigNumbers: true,
+            enableKeepAlive: true,
+            connectionLimit: DB_CONNECTION_LIMIT,
+            maxIdle: DB_MAX_IDLE,
+            idleTimeout: DB_IDLE_TIMEOUT_IN_MS
         });
-        await dbConnection.connect();
 
-        initSearchJobsDbManager(dbConnection, {
+        initSearchJobsDbManager(dbPool, {
             searchJobsTableName,
         });
-        initStatsDbManager(dbConnection, {
+        initStatsDbManager(dbPool, {
             clpArchivesTableName,
             clpFilesTableName,
         });
     } catch (e) {
-        logger.error("Unable to create MySQL / mariadb connection.", e.toString());
+        logger.error("Unable to create MySQL / mariadb connection pool.", e.toString());
         throw e;
     }
 };
@@ -77,7 +83,7 @@ const initDbManagers = async ({
 const deinitDbManagers = async () => {
     deinitStatsDbManager();
 
-    await dbConnection.end();
+    await dbPool.end();
 };
 
 export {initDbManagers, deinitDbManagers};


### PR DESCRIPTION
# References
Internally, it was found that any clp-package instances running beyond some intermittent time would face connection error issues in the WebUI. The issue is believed to be related to the [`wait_timeout`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_wait_timeout) setting, which has a default of `28800 seconds = 8 hours`. By setting it to an even shorter interval of `2 seconds`, the issue was reproduced and the cause was confirmed.

Through a series of experiments and in-depth analysis, several strategies have been identified that may provide a solution to the observed `wait_timeout` problem.

1. **Ineffectiveness of the mysql2 `enableKeepAlive` option**
   It has been observed that enabling the `enableKeepAlive` option in `mysql2` connections does not mitigate the `wait_timeout` issue. Contrary to suggestions in various online discussions, setting `enableKeepAlive` to true, which is the default behavior, merely adjusts TCP socket options managed by Node.js without effectively maintaining the MySQL connection active. These options include:
    - `SO_KEEPALIVE=1`
    - `TCP_KEEPIDLE=initialDelay`
    - `TCP_KEEPCNT=10`
    - `TCP_KEEPINTVL=1`

   (Despite these settings, analysis with tools such as Wireshark revealed no significant keep-alive packet transmission to port 3306.) Further examination of the MariaDB source code indicates that `wait_timeout` serves as a read timeouts, rendering keep-alive packets ineffective due to their lack of actual data payload.

2. **Modifying the compression stats polling handler:**

   Running `show processlist;` reveals three connections (excluding the querying and WebUI connections) that typically display a "Sleep" command, indicating idle status. These are polling connections from schedulers. 

   The WebUI also queries compression stats every 5 seconds. However, this query is skipped if no active client connection is detected ([source code](https://github.com/y-scope/clp/blob/d6cf6e492863ec1de85da316c6d72742bea28329/components/webui/imports/api/ingestion/server/publications.js#L29)). By commenting out these checks, the idle time remains significantly lower than the default `wait_timeout` of 8 hours.

3. **Interval-based connection pinging:**

   Setting up an interval to periodically execute `connection.ping()` offers an efficient way to maintain connection vitality. `PING` packets are preferable to `STMT_EXECUTE` packets due to their lower overhead.

4. **Utilizing a Connection Pool:**

   As previously discussed, employing a connection pool can address connection management issues. The mysql2 documentation advises releasing connections back to the pool after use, which require some significant changes in the DB Managers arch. In fact, there is also a not well-documented `pool.execute()` metho,d where we can treat pool handles as connection handles. 
   Instead of adhering to the default connectionLimit of 10, we can adjust it to 2 (one for stats polling and up to two for searching, when polling job status and processing user cancellation requests). Also, given the stats polling interval of 5 seconds, the idleTimeout can be reduced to 10,000 milliseconds, compared to the default 60,000 milliseconds.

# Description
1. Implement Option 4 as discussed above. 

# Validation performed
1. `cd <PROJECT_ROOT>; task`
2. `cd ./build/clp-package/`
3. Modify MariaDB configs: `printf "[mysqld]\nwait_timeout=2\n" > ./etc/mysql/conf.d/wait_timeout.cnf`
4. `./sbin/start-clp.sh`
5. `./sbin/compress.sh ~/samples/hive-24hr/i-00c90a0f/`
6. Opened the WebUI address in a browser.
7. `./sbin/compress.sh ~/samples/hive-24hr/i-1ec90a11/` and observed the compression stats to be updated in 5 seconds after the compression job finished.
