### PR TITLE
webui: Don't run SearchResultsLoadSensor polling or increment visibleSearchResultsLimit when there are no more search results.

### DIFF
--- a/components/webui/imports/ui/SearchView/SearchResults.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResults.jsx
@@ -49,10 +49,15 @@ const SearchResults = ({
     const hasMoreResults = visibleSearchResultsLimit < numResultsOnServer;
 
     const handleLoadMoreResults = useCallback(() => {
-        setVisibleSearchResultsLimit(
-            (v) => (v + VISIBLE_RESULTS_LIMIT_INCREMENT)
-        );
-    }, []);
+        if (hasMoreResults) {
+            setVisibleSearchResultsLimit(
+                visibleSearchResultsLimit + VISIBLE_RESULTS_LIMIT_INCREMENT
+            );
+        }
+    }, [
+        hasMoreResults,
+        visibleSearchResultsLimit,
+    ]);
 
     return <>
         <div className={"flex-column"}>

--- a/components/webui/imports/ui/SearchView/SearchResults.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResults.jsx
@@ -50,13 +50,11 @@ const SearchResults = ({
 
     const handleLoadMoreResults = useCallback(() => {
         if (hasMoreResults) {
-            setVisibleSearchResultsLimit(
-                visibleSearchResultsLimit + VISIBLE_RESULTS_LIMIT_INCREMENT
-            );
+            setVisibleSearchResultsLimit((v) => v + VISIBLE_RESULTS_LIMIT_INCREMENT);
         }
     }, [
         hasMoreResults,
-        visibleSearchResultsLimit,
+        setVisibleSearchResultsLimit,
     ]);
 
     return <>

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -38,6 +38,7 @@ const SearchResultsLoadSensor = ({
 
         const observer = new IntersectionObserver((entries) => {
             if (entries[0].isIntersecting) {
+                onLoadMoreResults();
                 loadIntervalRef.current = setInterval(
                     onLoadMoreResults,
                     SEARCH_RESULTS_LOAD_SENSOR_POLL_INTERVAL_MS,

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -33,7 +33,7 @@ const SearchResultsLoadSensor = ({
 
     useEffect(() => {
         const observer = new IntersectionObserver((entries) => {
-            if (entries[0].isIntersecting) {
+            if (entries[0].isIntersecting && hasMoreResults) {
                 loadIntervalRef.current = setInterval(
                     onLoadMoreResults,
                     SEARCH_RESULTS_LOAD_SENSOR_POLL_INTERVAL_MS,
@@ -53,7 +53,10 @@ const SearchResultsLoadSensor = ({
             }
             observer.disconnect();
         };
-    }, [onLoadMoreResults]);
+    }, [
+        hasMoreResults,
+        onLoadMoreResults,
+    ]);
 
     return <div
         id={"search-results-load-sensor"}

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -33,7 +33,7 @@ const SearchResultsLoadSensor = ({
 
     useEffect(() => {
         const observer = new IntersectionObserver((entries) => {
-            if (entries[0].isIntersecting && hasMoreResults) {
+            if (entries[0].isIntersecting && false === hasMoreResults) {
                 loadIntervalRef.current = setInterval(
                     onLoadMoreResults,
                     SEARCH_RESULTS_LOAD_SENSOR_POLL_INTERVAL_MS,

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -33,7 +33,7 @@ const SearchResultsLoadSensor = ({
 
     useEffect(() => {
         const observer = new IntersectionObserver((entries) => {
-            if (entries[0].isIntersecting && false === hasMoreResults) {
+            if (entries[0].isIntersecting && true === hasMoreResults) {
                 loadIntervalRef.current = setInterval(
                     onLoadMoreResults,
                     SEARCH_RESULTS_LOAD_SENSOR_POLL_INTERVAL_MS,

--- a/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResultsTable.jsx
@@ -32,8 +32,12 @@ const SearchResultsLoadSensor = ({
     const loadIntervalRef = useRef(null);
 
     useEffect(() => {
+        if (false === hasMoreResults) {
+            return () => null;
+        }
+
         const observer = new IntersectionObserver((entries) => {
-            if (entries[0].isIntersecting && true === hasMoreResults) {
+            if (entries[0].isIntersecting) {
                 loadIntervalRef.current = setInterval(
                     onLoadMoreResults,
                     SEARCH_RESULTS_LOAD_SENSOR_POLL_INTERVAL_MS,


### PR DESCRIPTION
# References
Internally, it was found that in the WebUI, when there are too few search results in the table, "results" subscriptions were continuously getting subscribed by the client frequently. Further investigation found the visibility sensor polling interval handler did not get cancelled so long the sensor was visible, and therefore the `visibleSearchResultsLimit` was getting continuously incremented.

# Description
1. Check `hasMoreResults` before unnecessarily incrementing `visibleSearchResultsLimit`.

# Validation performed
1. `cd <PROJECT_ROOT>; task`
2. `cd ./build/clp-package/sbin; ./start-clp.sh`
3. `./compress.sh ~/samples/hive-24hr/i-00c90a0f/`
4. Opened the WebUI address in a browser.
5. Started a query with string `222` and observed the job finished without error. For the job, subscription `results` was only subscribed once, which was verified in the WebUI server logs:
   ```
   I20240329-07:47:33.613(-4)? {"timestamp":"2024-03-29T11:47:33.612Z","level":"debug","label":"Subscription._handler","message":"Subscription 'results-metadata' jobId=160"}
   ```