### PR TITLE
core: Add support to compile clp::ffi component using MSVC.

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/byteswap.hpp
+++ b/components/core/src/clp/ffi/ir_stream/byteswap.hpp
@@ -1,11 +1,16 @@
 #ifndef CLP_FFI_IR_STREAM_BYTESWAP_HPP
 #define CLP_FFI_IR_STREAM_BYTESWAP_HPP
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
     #include <libkern/OSByteOrder.h>
     #define bswap_16(x) OSSwapInt16(x)
     #define bswap_32(x) OSSwapInt32(x)
     #define bswap_64(x) OSSwapInt64(x)
+#elif defined(_MSC_VER)
+    #include <stdlib.h>
+    #define bswap_16(x) _byteswap_ushort(x)
+    #define bswap_32(x) _byteswap_ulong(x)
+    #define bswap_64(x) _byteswap_uint64(x)
 #else
     #include <byteswap.h>
 #endif

--- a/components/core/src/clp/string_utils/string_utils.hpp
+++ b/components/core/src/clp/string_utils/string_utils.hpp
@@ -127,8 +127,8 @@ bool convert_string_to_int(std::string_view raw, integer_t& converted);
 template <typename integer_t>
 bool convert_string_to_int(std::string_view raw, integer_t& converted) {
 #if defined(_MSC_VER)
-    auto raw_begin = raw.data();
-    auto raw_end = raw_begin + raw.size();
+    auto* raw_begin = raw.data();
+    auto* raw_end = raw_begin + raw.size();
 #else
     auto raw_begin = raw.cbegin();
     auto raw_end = raw.cend();

--- a/components/core/src/clp/string_utils/string_utils.hpp
+++ b/components/core/src/clp/string_utils/string_utils.hpp
@@ -126,8 +126,14 @@ bool convert_string_to_int(std::string_view raw, integer_t& converted);
 
 template <typename integer_t>
 bool convert_string_to_int(std::string_view raw, integer_t& converted) {
+#if defined(_MSC_VER)
+    auto raw_begin = raw.data();
+    auto raw_end = raw_begin + raw.size();
+#else
+    auto raw_begin = raw.cbegin();
     auto raw_end = raw.cend();
-    auto result = std::from_chars(raw.cbegin(), raw_end, converted);
+#endif
+    auto result = std::from_chars(raw_begin, raw_end, converted);
     if (raw_end != result.ptr) {
         return false;
     } else {


### PR DESCRIPTION
# References
Internally, it was found installing [`clp-ffi-py`](https://pypi.org/project/clp-ffi-py/) on Windows 11 gave errors. It was determined that the following needs to be added to support installation on Windows:
1. MSVC equivalent `Extension.extra_compile_args` in setup.py.
2. MSVC compatible `bswap` implementations.
3. MSVC compatible argument types to function `std::from_chars` in `<clp-repo-root>/components/core/src/string_utils.inc`:`convert_string_to_int`.

## Interdependent PR
https://github.com/y-scope/clp-ffi-py/pull/56

# Description
1. This PR implements Requirement 2 & 3 from above.
2. Requirement 1 are implemented in https://github.com/y-scope/clp-ffi-py/pull/56 .

# Validation performed
See https://github.com/y-scope/clp-ffi-py/pull/56 .
