### PR TITLE
clo: Fix a bug causing pure wildcard queries to return no results (fixes #342)

### DIFF
--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -148,7 +148,7 @@ void search_files(
 ) {
     if (query.contains_sub_queries()) {
         for (; file_metadata_ix.has_next(); file_metadata_ix.next()) {
-            if (segments_to_search.count(file_metadata_ix.get_segment_id()) > 0) {
+            if (segments_to_search.count(file_metadata_ix.get_segment_id()) == 0) {
                 continue;
             }
 

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -48,17 +48,30 @@ enum class SearchFilesResult {
 };
 
 /**
+ * Searches a file referenced by a given database cursor
+ * @param query
+ * @param archive
+ * @param file_metadata_ix
+ * @param output_handler
+ * @return SearchFilesResult::OpenFailure on failure to open a compressed file
+ * @return SearchFilesResult::ResultSendFailure on failure to send a result
+ * @return SearchFilesResult::Success otherwise
+ */
+static SearchFilesResult search_file(
+        Query& query,
+        Archive& archive,
+        MetadataDB::FileIterator& file_metadata_ix,
+        std::unique_ptr<OutputHandler>& output_handler
+);
+/**
  * Searches all files referenced by a given database cursor
  * @param query
  * @param archive
  * @param file_metadata_ix
  * @param output_handler
  * @param segments_to_search
- * @return SearchFilesResult::OpenFailure on failure to open a compressed file
- * @return SearchFilesResult::ResultSendFailure on failure to send a result
- * @return SearchFilesResult::Success otherwise
  */
-static SearchFilesResult search_files(
+static void search_files(
         Query& query,
         Archive& archive,
         MetadataDB::FileIterator& file_metadata_ix,
@@ -78,73 +91,94 @@ static bool search_archive(
         std::unique_ptr<OutputHandler> output_handler
 );
 
-static SearchFilesResult search_files(
+static SearchFilesResult search_file(
+        Query& query,
+        Archive& archive,
+        MetadataDB::FileIterator& file_metadata_ix,
+        std::unique_ptr<OutputHandler>& output_handler
+) {
+    File compressed_file;
+    Message compressed_message;
+    string decompressed_message;
+
+    ErrorCode error_code = archive.open_file(compressed_file, file_metadata_ix);
+    if (ErrorCode_Success != error_code) {
+        string orig_path;
+        file_metadata_ix.get_path(orig_path);
+        if (ErrorCode_errno == error_code) {
+            SPDLOG_ERROR("Failed to open {}, errno={}", orig_path.c_str(), errno);
+        } else {
+            SPDLOG_ERROR("Failed to open {}, error={}", orig_path.c_str(), error_code);
+        }
+        return SearchFilesResult::OpenFailure;
+    }
+
+    SearchFilesResult result = SearchFilesResult::Success;
+    query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
+    while (Grep::search_and_decompress(
+            query,
+            archive,
+            compressed_file,
+            compressed_message,
+            decompressed_message
+    ))
+    {
+        if (ErrorCode_Success
+            != output_handler->add_result(
+                    compressed_file.get_orig_path(),
+                    decompressed_message,
+                    compressed_message.get_ts_in_milli()
+            ))
+        {
+            result = SearchFilesResult::ResultSendFailure;
+            break;
+        }
+    }
+
+    archive.close_file(compressed_file);
+    return result;
+}
+
+void search_files(
         Query& query,
         Archive& archive,
         MetadataDB::FileIterator& file_metadata_ix,
         std::unique_ptr<OutputHandler>& output_handler,
         std::set<clp::segment_id_t> const& segments_to_search
 ) {
-    SearchFilesResult result = SearchFilesResult::Success;
-
-    File compressed_file;
-    Message compressed_message;
-    string decompressed_message;
-
-    // Run query on each file
-    for (; file_metadata_ix.has_next(); file_metadata_ix.next()) {
-        if (query.contains_sub_queries()
-            && segments_to_search.count(file_metadata_ix.get_segment_id()) == 0)
-        {
-            continue;
-        }
-
-        if (output_handler->can_skip_file(file_metadata_ix)) {
-            continue;
-        }
-
-        ErrorCode error_code = archive.open_file(compressed_file, file_metadata_ix);
-        if (ErrorCode_Success != error_code) {
-            string orig_path;
-            file_metadata_ix.get_path(orig_path);
-            if (ErrorCode_errno == error_code) {
-                SPDLOG_ERROR("Failed to open {}, errno={}", orig_path.c_str(), errno);
-            } else {
-                SPDLOG_ERROR("Failed to open {}, error={}", orig_path.c_str(), error_code);
+    if (query.contains_sub_queries()) {
+        for (; file_metadata_ix.has_next(); file_metadata_ix.next()) {
+            if (segments_to_search.count(file_metadata_ix.get_segment_id()) > 0) {
+                continue;
             }
-            result = SearchFilesResult::OpenFailure;
-            continue;
-        }
 
-        query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
-        while (Grep::search_and_decompress(
-                query,
-                archive,
-                compressed_file,
-                compressed_message,
-                decompressed_message
-        ))
-        {
-            if (ErrorCode_Success
-                != output_handler->add_result(
-                        compressed_file.get_orig_path(),
-                        decompressed_message,
-                        compressed_message.get_ts_in_milli()
-                ))
-            {
-                result = SearchFilesResult::ResultSendFailure;
+            if (output_handler->can_skip_file(file_metadata_ix)) {
+                continue;
+            }
+
+            auto result = search_file(query, archive, file_metadata_ix, output_handler);
+            if (SearchFilesResult::OpenFailure == result) {
+                continue;
+            }
+            if (SearchFilesResult::ResultSendFailure == result) {
                 break;
             }
         }
+    } else {
+        for (; file_metadata_ix.has_next(); file_metadata_ix.next()) {
+            if (output_handler->can_skip_file(file_metadata_ix)) {
+                continue;
+            }
 
-        archive.close_file(compressed_file);
-
-        if (SearchFilesResult::ResultSendFailure == result) {
-            break;
+            auto result = search_file(query, archive, file_metadata_ix, output_handler);
+            if (SearchFilesResult::OpenFailure == result) {
+                continue;
+            }
+            if (SearchFilesResult::ResultSendFailure == result) {
+                break;
+            }
         }
     }
-
-    return result;
 }
 
 static bool search_archive(

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -93,7 +93,9 @@ static SearchFilesResult search_files(
 
     // Run query on each file
     for (; file_metadata_ix.has_next(); file_metadata_ix.next()) {
-        if (segments_to_search.count(file_metadata_ix.get_segment_id()) == 0) {
+        if (query.contains_sub_queries()
+            && segments_to_search.count(file_metadata_ix.get_segment_id()) == 0)
+        {
             continue;
         }
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#342 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Previously clo didn't return any results for pure wildcard queries `*` because it skips searching each file. This PR resolves this issue.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Built clo and compressed [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) logs using clp.
+ Executed query `*` on one of the archives using clo and output results to MongoDB.
+ Checked the corresponding collection in MongoDB.
