### PR TITLE
clp: Fix missing corner case in LibarchiveFileReader::peek_buffered_data when the underlying buffer is empty (fixes: #241).

### DIFF
--- a/components/core/src/clp/LibarchiveFileReader.cpp
+++ b/components/core/src/clp/LibarchiveFileReader.cpp
@@ -227,8 +227,10 @@ void LibarchiveFileReader::peek_buffered_data(char const*& buf, size_t& buf_size
     if (nullptr == m_archive_entry) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
-
-    if (m_pos_in_file < m_data_block_pos_in_file) {
+    if (nullptr == m_data_block) {
+        buf_size = 0;
+        buf = nullptr;
+    } else if (m_pos_in_file < m_data_block_pos_in_file) {
         // Position in the file is before the current data block, so we return nulls corresponding
         // to the sparse bytes before the data block
         // NOTE: We don't return ALL sparse bytes before the data block since that might require
@@ -253,10 +255,9 @@ ErrorCode LibarchiveFileReader::read_next_data_block() {
             &m_data_block_pos_in_file
     );
     if (ARCHIVE_OK != return_value) {
-        m_pos_in_data_block = m_data_block_length;
+        m_data_block = nullptr;
         if (ARCHIVE_EOF == return_value) {
             m_reached_eof = true;
-            m_data_block = nullptr;
             return ErrorCode_EndOfFile;
         } else {
             SPDLOG_DEBUG(

--- a/components/core/src/clp/LibarchiveFileReader.cpp
+++ b/components/core/src/clp/LibarchiveFileReader.cpp
@@ -202,6 +202,7 @@ void LibarchiveFileReader::close() {
     m_data_block = nullptr;
     m_reached_eof = false;
 
+    m_data_block_pos_in_file = 0;
     m_pos_in_file = 0;
 }
 
@@ -252,6 +253,7 @@ ErrorCode LibarchiveFileReader::read_next_data_block() {
             &m_data_block_pos_in_file
     );
     if (ARCHIVE_OK != return_value) {
+        m_pos_in_data_block = m_data_block_length;
         if (ARCHIVE_EOF == return_value) {
             m_reached_eof = true;
             m_data_block = nullptr;

--- a/components/core/src/clp/LibarchiveFileReader.hpp
+++ b/components/core/src/clp/LibarchiveFileReader.hpp
@@ -35,6 +35,7 @@ public:
               m_archive_entry(nullptr),
               m_data_block(nullptr),
               m_reached_eof(false),
+              m_data_block_pos_in_file(0),
               m_pos_in_file(0) {}
 
     // Methods implementing the ReaderInterface


### PR DESCRIPTION
# References
https://github.com/y-scope/clp/issues/241

# Description
The previous LibarchiveFileReader implementation doesn't handle the corner case where an compressed file is empty. This fix adds a an extra nullptr check for m_data_block
Specificially, when a file is empty, [line 243](https://github.com/y-scope/clp/blob/df9e7819eb9ebc6c573f6e2cca715f90020c20d5/components/core/src/clp/LibarchiveFileReader.cpp#L243) will trigger a bug because m_data_block_length is set to 0 on eof, but m_pos_in_data_block has an uninitialized value, causing the function to return a negative buffer size.

This change properly initializes the m_pos variables and handles empty files.

# Validation performed

Compressed hadoop.tar.gz, openstack.tar.gz. Verified that CLP doesn't fail
Decompressed hadoop-24hrs and confirmed that empty logs are losslessly compressed and decompressed
