### PR TITLE
clp: Add maximum length for utf8 validation (fixes #242).

### DIFF
--- a/components/core/src/clp/clp/FileCompressor.cpp
+++ b/components/core/src/clp/clp/FileCompressor.cpp
@@ -145,7 +145,7 @@ bool FileCompressor::compress_file(
     size_t peek_size{0};
     m_file_reader.peek_buffered_data(utf8_validation_buf, peek_size);
     bool succeeded = true;
-    size_t utf8_validation_buf_len = std::min(peek_size, m_utf_max_validation_len);
+    auto utf8_validation_buf_len = std::min(peek_size, cUtfMaxValidationLen);
     if (is_utf8_sequence(utf8_validation_buf_len, utf8_validation_buf)) {
         if (use_heuristic) {
             parse_and_encode_with_heuristic(
@@ -359,7 +359,7 @@ bool FileCompressor::try_compressing_as_archive(
         size_t peek_size{0};
         m_libarchive_file_reader.peek_buffered_data(utf8_validation_buf, peek_size);
         string file_path{m_libarchive_reader.get_path()};
-        size_t utf8_validation_buf_len = std::min(peek_size, m_utf_max_validation_len);
+        auto utf8_validation_buf_len = std::min(peek_size, cUtfMaxValidationLen);
         if (is_utf8_sequence(utf8_validation_buf_len, utf8_validation_buf)) {
             auto boost_path_for_compression = parent_boost_path / file_path;
             if (use_heuristic) {

--- a/components/core/src/clp/clp/FileCompressor.hpp
+++ b/components/core/src/clp/clp/FileCompressor.hpp
@@ -50,6 +50,9 @@ public:
     );
 
 private:
+    // Constants
+    static constexpr size_t m_utf_max_validation_len = 4;
+
     // Methods
     /**
      * Parses and encodes content from the given reader into the given archive_writer
@@ -144,9 +147,7 @@ private:
             streaming_archive::writer::Archive& archive,
             ir::LogEventDeserializer<encoded_variable_t>& log_event_deserializer
     );
-
     // Variables
-    size_t const m_utf_max_validation_len = 4096;
     boost::uuids::random_generator& m_uuid_generator;
     BufferedFileReader m_file_reader;
     LibarchiveReader m_libarchive_reader;

--- a/components/core/src/clp/clp/FileCompressor.hpp
+++ b/components/core/src/clp/clp/FileCompressor.hpp
@@ -146,6 +146,7 @@ private:
     );
 
     // Variables
+    size_t const m_utf_max_validation_len = 4096;
     boost::uuids::random_generator& m_uuid_generator;
     BufferedFileReader m_file_reader;
     LibarchiveReader m_libarchive_reader;

--- a/components/core/src/clp/clp/FileCompressor.hpp
+++ b/components/core/src/clp/clp/FileCompressor.hpp
@@ -51,7 +51,7 @@ public:
 
 private:
     // Constants
-    static constexpr size_t m_utf_max_validation_len = 4;
+    static constexpr size_t cUtfMaxValidationLen = 4096;
 
     // Methods
     /**
@@ -147,6 +147,7 @@ private:
             streaming_archive::writer::Archive& archive,
             ir::LogEventDeserializer<encoded_variable_t>& log_event_deserializer
     );
+
     // Variables
     boost::uuids::random_generator& m_uuid_generator;
     BufferedFileReader m_file_reader;


### PR DESCRIPTION
# References
https://github.com/y-scope/clp/issues/242

# Description
The issue identified in https://github.com/y-scope/clp/issues/242 is not a real issue. It was caused by a size change in the validation buffer. so a non-utf8 char that was not detected by the previous 4k buffer size is revealed by 64k buffer. The decision is to let CLP only read the first 4096 bytes of a file for utf8 validation.

# Validation performed
Compressed the var-logs and verified that the error observed in issue 242 is gone.

