### PR TITLE
clp-package: Add connection pool option to SQL_Adapter; Make search scheduler resilient to database connection failures

### DIFF
--- a/components/clp-py-utils/clp_py_utils/decorators.py
+++ b/components/clp-py-utils/clp_py_utils/decorators.py
@@ -1,0 +1,20 @@
+import functools
+
+
+def exception_default_value(default):
+    """
+    A function decorator that returns the value specified by `default` when an uncaught exception
+    occurs in the decorated function. Otherwise, the decorated function's return value is returned.
+    """
+
+    def parametrized_decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception:
+                return default
+
+        return wrapper
+
+    return parametrized_decorator

--- a/components/clp-py-utils/clp_py_utils/decorators.py
+++ b/components/clp-py-utils/clp_py_utils/decorators.py
@@ -5,6 +5,8 @@ def exception_default_value(default):
     """
     A function decorator that returns the value specified by `default` when an uncaught exception
     occurs in the decorated function. Otherwise, the decorated function's return value is returned.
+    :param default: The value to return upon catching an uncaught exception.
+    :return: The decorator
     """
 
     def parametrized_decorator(func):

--- a/components/clp-py-utils/clp_py_utils/sql_adapter.py
+++ b/components/clp-py-utils/clp_py_utils/sql_adapter.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 import mariadb
@@ -7,6 +8,21 @@ from mysql.connector import errorcode
 from sqlalchemy.dialects.mysql import mariadbconnector, mysqlconnector
 
 from clp_py_utils.clp_config import Database
+
+
+def exception_default_value(default):
+    def _exception_default_value(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except:
+                logging.error("ERROR")
+                return default
+
+        return wrapper
+
+    return _exception_default_value
 
 
 class SQL_Adapter:
@@ -67,5 +83,9 @@ class SQL_Adapter:
         elif "mariadb" == self.database_config.type:
             dialect = mariadbconnector.dialect
         return pool.QueuePool(
-            create_connection, pool_size=pool_size, dialect=dialect, max_overflow=0, pre_ping=True
+            create_connection,
+            pool_size=pool_size,
+            dialect=dialect,
+            max_overflow=0,
+            pre_ping=True,
         )

--- a/components/clp-py-utils/clp_py_utils/sql_adapter.py
+++ b/components/clp-py-utils/clp_py_utils/sql_adapter.py
@@ -13,6 +13,12 @@ from clp_py_utils.clp_config import Database
 
 
 def exception_default_value(default):
+    """
+    This decorator wraps a function and returns the value specified by `default` whenever an
+    uncaught exception occurs in the function being wrapped. If no exception occurs this decorator
+    just forwards the return value of the function being wrapped.
+    """
+
     def _exception_default_value(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/components/clp-py-utils/pyproject.toml
+++ b/components/clp-py-utils/pyproject.toml
@@ -19,6 +19,7 @@ python-dotenv = "^1.0.1"
 python-Levenshtein = "~0.22"
 PyYAML = "^6.0.1"
 StrEnum = "^0.4.15"
+sqlalchemy = "~2.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/components/clp-py-utils/pyproject.toml
+++ b/components/clp-py-utils/pyproject.toml
@@ -17,9 +17,9 @@ mysql-connector-python = "^8.2.0"
 pydantic = "^1.10.13"
 python-dotenv = "^1.0.1"
 python-Levenshtein = "~0.22"
+sqlalchemy = "~2.0"
 PyYAML = "^6.0.1"
 StrEnum = "^0.4.15"
-sqlalchemy = "~2.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -1,4 +1,17 @@
-#!/usr/bin/env python3
+"""
+A scheduler for scheduling search jobs in the CLP package.
+
+NOTE: This scheduler currently only has partial handling for failures of the database. Specifically,
+in the event that the database is unreachable, the scheduler will continue running as if reads from
+the database return no records and writes to the database always fail. Failed writes are currently
+silently ignored, in which case the state of the database won't match the scheduler's internal
+state. If the database comes back up, the scheduler will eventually reconnect to it and reads/writes
+will function as normal again. However, the mismatched state may lead to unexpected behaviour like
+jobs seemingly being stuck in the "RUNNING" state or jobs being repeated, which in turn will create
+duplicated search results in the results cache, possibly long after the results had already been
+cleared from the cache. Unfortunately, these effects will require manual intervention to clean-up.
+TODO Address this limitation.
+"""
 
 import argparse
 import asyncio

--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -16,7 +16,8 @@ import pymongo
 from clp_py_utils.clp_config import CLP_METADATA_TABLE_PREFIX, CLPConfig, SEARCH_JOBS_TABLE_NAME
 from clp_py_utils.clp_logging import get_logger, get_logging_formatter, set_logging_level
 from clp_py_utils.core import read_yaml_config_file
-from clp_py_utils.sql_adapter import exception_default_value, SQL_Adapter
+from clp_py_utils.decorators import exception_default_value
+from clp_py_utils.sql_adapter import SQL_Adapter
 from job_orchestration.executor.search.fs_search_task import search
 from job_orchestration.scheduler.constants import SearchJobStatus
 from job_orchestration.scheduler.job_config import SearchConfig

--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -70,6 +70,10 @@ async def release_reducer_for_job(job: SearchJob):
 
 @exception_default_value(default=[])
 def fetch_new_search_jobs(db_conn) -> list:
+    """
+    Fetches and returns new PENDING jobs from the database. If an exception occurs while interacting
+    with the database this function will return an empty list.
+    """
     with contextlib.closing(db_conn.cursor(dictionary=True)) as db_cursor:
         db_cursor.execute(
             f"""
@@ -84,6 +88,10 @@ def fetch_new_search_jobs(db_conn) -> list:
 
 @exception_default_value(default=[])
 def fetch_cancelling_search_jobs(db_conn) -> list:
+    """
+    Fetches and returns jobs with CANCELLING status from the database. If an exception occurs while
+    interacting with the database this function will return an empty list.
+    """
     with contextlib.closing(db_conn.cursor(dictionary=True)) as db_cursor:
         db_cursor.execute(
             f"""
@@ -103,6 +111,14 @@ def set_job_status(
     prev_status: Optional[SearchJobStatus] = None,
     **kwargs,
 ) -> bool:
+    """
+    Sets the job status and any other fields specified by the kwargs for some job. Optionally, the
+    update can be made conditional on the current status of the job in the database matching
+    the value of `prev_status`.
+
+    This function returns True if the update is succesful, and False if the update fails or if an
+    exception occurs while interacting with the database.
+    """
     field_set_expressions = [f'{k}="{v}"' for k, v in kwargs.items()]
     field_set_expressions.append(f"status={status}")
     update = (
@@ -172,7 +188,6 @@ def get_archives_for_search(
         else:
             cursor.execute(query)
         archives_for_search = list(cursor.fetchall())
-        # db_conn.commit()
     return archives_for_search
 
 
@@ -520,6 +535,7 @@ async def main(argv: List[str]) -> int:
                 f"Failed to connect to archive database "
                 f"{clp_config.database.host}:{clp_config.database.port}."
             )
+            return -1
 
         logger.info(
             f"Connected to archive database"

--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -71,8 +71,10 @@ async def release_reducer_for_job(job: SearchJob):
 @exception_default_value(default=[])
 def fetch_new_search_jobs(db_conn) -> list:
     """
-    Fetches and returns new PENDING jobs from the database. If an exception occurs while interacting
-    with the database this function will return an empty list.
+    Fetches search jobs with status=PENDING from the database.
+    :param db_conn:
+    :return: The pending search jobs on success. An empty list if an exception occurs while
+    interacting with the database.
     """
     with contextlib.closing(db_conn.cursor(dictionary=True)) as db_cursor:
         db_cursor.execute(
@@ -89,8 +91,10 @@ def fetch_new_search_jobs(db_conn) -> list:
 @exception_default_value(default=[])
 def fetch_cancelling_search_jobs(db_conn) -> list:
     """
-    Fetches and returns jobs with CANCELLING status from the database. If an exception occurs while
-    interacting with the database this function will return an empty list.
+    Fetches search jobs with status=CANCELLING from the database.
+    :param db_conn:
+    :return: The cancelling search jobs on success. An empty list if an exception occurs while
+    interacting with the database.
     """
     with contextlib.closing(db_conn.cursor(dictionary=True)) as db_cursor:
         db_cursor.execute(
@@ -112,12 +116,16 @@ def set_job_status(
     **kwargs,
 ) -> bool:
     """
-    Sets the job status and any other fields specified by the kwargs for some job. Optionally, the
-    update can be made conditional on the current status of the job in the database matching
-    the value of `prev_status`.
-
-    This function returns True if the update is succesful, and False if the update fails or if an
-    exception occurs while interacting with the database.
+    Sets the status of the job identified by `job_id` to `status`. If `prev_status` is specified,
+    the update is conditional on the job's current status matching `prev_status`. If `kwargs` are
+    specified, the fields identified by the args are also updated.
+    :param db_conn:
+    :param job_id:
+    :param status:
+    :param prev_status:
+    :param kwargs:
+    :return: True on success, False if the update fails or an exception occurs while interacting
+    with the database.
     """
     field_set_expressions = [f'{k}="{v}"' for k, v in kwargs.items()]
     field_set_expressions.append(f"status={status}")

--- a/components/job-orchestration/pyproject.toml
+++ b/components/job-orchestration/pyproject.toml
@@ -22,6 +22,7 @@ pydantic = "^1.10.13"
 pymongo = "^4.6.1"
 PyYAML = "^6.0.1"
 redis = "^5.0.1"
+sqlalchemy = "~2.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/components/job-orchestration/pyproject.toml
+++ b/components/job-orchestration/pyproject.toml
@@ -22,7 +22,6 @@ pydantic = "^1.10.13"
 pymongo = "^4.6.1"
 PyYAML = "^6.0.1"
 redis = "^5.0.1"
-sqlalchemy = "~2.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# Description
This PR makes several changes in sql_adapter.py and search_scheduler.py to improve resilience with database connection issues.

In SQL_Adapter we introduce an option to create a connection pool using sqlalchemy to handle the details of maintaining a pool of living database connections. Since the connect() method can throw we wrap the sqlalchemy connection pool with a class that returns a dummy connection on error, and logs the connection errors (with a mechanism to ensure connection errors are only logged periodically to avoid log spew).

The dummy connection implements the close() method which means all of the code using the connection pool can be written like
```
with contextlib.closing(db_conn_pool.connect()) as db_conn:
...
```
without fear of throwing on the initial connect() call.

In the search scheduler we move all database operations into functions wrapped with a new decorator that catches database exceptions, and returns some default value on database failure. This means that code interacting with the database can be happily ignorant of database failures when there are errors on a real database connection, and when a dummy database connection has been provided by the connection pool.

# Validation performed
* Validated that the search scheduler continues functioning after bouncing mariadb database
* Validated that the search scheduler continues functioning after bouncing mysql database
* Validated that connection errors are only logged periodically to avoid log spew

