### PR TITLE
gh-actions: Preserve binary permissions with tar before artifact upload.

### DIFF
--- a/.github/actions/clp-core-build/action.yaml
+++ b/.github/actions/clp-core-build/action.yaml
@@ -63,7 +63,7 @@ runs:
 
         mkdir -p "${output_dir}"
         cd "$GITHUB_WORKSPACE/components/core/build"
-        tar cf "${output_dir}/clp.tar" clg clp clp-s glt make-dictionaries-readable
+        tar cfvv "${output_dir}/clp.tar" clg clp clp-s glt make-dictionaries-readable
       shell: "bash"
 
     - if: "inputs.upload_binaries == 'true'"

--- a/.github/actions/clp-core-build/action.yaml
+++ b/.github/actions/clp-core-build/action.yaml
@@ -63,10 +63,7 @@ runs:
 
         mkdir -p "${output_dir}"
         cd "$GITHUB_WORKSPACE/components/core/build"
-        cp clg clp clp-s glt make-dictionaries-readable "${output_dir}"
-        
-        # TODO Debug
-        ls -al "${output_dir}"
+        tar cf "${output_dir}/clp.tar" clg clp clp-s glt make-dictionaries-readable
       shell: "bash"
 
     - if: "inputs.upload_binaries == 'true'"

--- a/.github/actions/clp-core-build/action.yaml
+++ b/.github/actions/clp-core-build/action.yaml
@@ -64,6 +64,9 @@ runs:
         mkdir -p "${output_dir}"
         cd "$GITHUB_WORKSPACE/components/core/build"
         cp clg clp clp-s glt make-dictionaries-readable "${output_dir}"
+        
+        # TODO Debug
+        ls -al "${output_dir}"
       shell: "bash"
 
     - if: "inputs.upload_binaries == 'true'"

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -258,8 +258,8 @@ jobs:
     needs: "ubuntu-focal-binaries"
     runs-on: "ubuntu-latest"
     env:
-      BASE_OUTPUT_DIR: "/tmp"
       OS_NAME: "ubuntu-focal"
+      TMP_OUTPUT_DIR: "/tmp"
     steps:
       - uses: "actions/checkout@v3"
         with:
@@ -272,11 +272,11 @@ jobs:
       - uses: "actions/download-artifact@v4"
         with:
           name: "${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
-          path: "${{env.BASE_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
+          path: "${{env.TMP_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
 
       - name: "Untar binaries"
         working-directory: >-
-          ${{env.BASE_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}
+          ${{env.TMP_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}
         run: |-
           tar xf clp.tar
           rm clp.tar
@@ -305,7 +305,7 @@ jobs:
 
       - uses: "docker/build-push-action@v5"
         with:
-          context: "${{env.BASE_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
+          context: "${{env.TMP_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
           file: "components/core/tools/docker-images/clp-core-${{env.OS_NAME}}/Dockerfile"
           push: true
           tags: "${{steps.core_image_meta.outputs.tags}}"

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -258,6 +258,7 @@ jobs:
     needs: "ubuntu-focal-binaries"
     runs-on: "ubuntu-latest"
     env:
+      BASE_OUTPUT_DIR: "/tmp"
       OS_NAME: "ubuntu-focal"
     steps:
       - uses: "actions/checkout@v3"
@@ -271,7 +272,14 @@ jobs:
       - uses: "actions/download-artifact@v4"
         with:
           name: "${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
-          path: "/tmp/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
+          path: "${{env.BASE_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
+
+      - name: "Untar binaries"
+        working-directory: >-
+          ${{env.BASE_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}
+        run: |-
+          tar xf clp.tar
+          rm clp.tar
 
       - uses: "docker/login-action@v3"
         with:
@@ -297,7 +305,7 @@ jobs:
 
       - uses: "docker/build-push-action@v5"
         with:
-          context: "/tmp/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
+          context: "${{env.BASE_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
           file: "components/core/tools/docker-images/clp-core-${{env.OS_NAME}}/Dockerfile"
           push: true
           tags: "${{steps.core_image_meta.outputs.tags}}"


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The binaries in the latest ghcr.io/y-scope/clp/clp-core-x86-ubuntu-focal:main are not executable. This is because the [upload-artifacts](https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss) action used to transfer the binaries between GH workflows doesn't retain file permissions.

This PR tars the binaries (retaining the file permissions) before uploading them and untars them after downloading them.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated workflows were successful.
* Merged the change to the `main` branch of my fork and verified that the binaries in the published ghcr.io/kirkrodrigues/clp/clp-core-x86-ubuntu-focal:main image were executable.

