### PR TITLE
clp-s: Avoid unnecessary string allocation and string copying while marshalling json

### DIFF
--- a/components/core/src/clp_s/ColumnReader.hpp
+++ b/components/core/src/clp_s/ColumnReader.hpp
@@ -47,6 +47,13 @@ public:
     virtual std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message)
             = 0;
 
+    /**
+     * Extracts a value from the column and serializes it into a provided buffer as a string.
+     * @param cur_message
+     * @param buffer
+     */
+    virtual void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) = 0;
+
 private:
     std::string m_name;
     int32_t m_id;
@@ -69,6 +76,8 @@ public:
     std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message
     ) override;
 
+    void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
+
 private:
     std::unique_ptr<int64_t[]> m_values;
 };
@@ -90,6 +99,8 @@ public:
     std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message
     ) override;
 
+    void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
+
 private:
     std::unique_ptr<double[]> m_values;
 };
@@ -110,6 +121,8 @@ public:
 
     std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message
     ) override;
+
+    void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
 
 private:
     std::unique_ptr<uint8_t[]> m_values;
@@ -140,6 +153,8 @@ public:
 
     std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message
     ) override;
+
+    void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
 
     /**
      * Gets the encoded id of the variable
@@ -188,6 +203,8 @@ public:
     std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message
     ) override;
 
+    void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
+
     /**
      * Gets the encoded id of the variable
      * @param cur_message
@@ -222,6 +239,8 @@ public:
 
     std::variant<int64_t, double, std::string, uint8_t> extract_value(uint64_t cur_message
     ) override;
+
+    void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
 
     /**
      * @param cur_message

--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -63,12 +63,21 @@ public:
 
     void append_key() { append_key(m_special_keys[m_special_keys_index++]); }
 
-    void append_key(std::string const& key) { m_json_string += "\"" + key + "\":"; }
+    void append_key(std::string const& key) {
+        m_json_string += "\"";
+        m_json_string += key;
+        m_json_string += "\":";
+    }
 
-    void append_value(std::string const& value) { m_json_string += value + ","; }
+    void append_value(std::string const& value) {
+        m_json_string += value;
+        m_json_string += ",";
+    }
 
     void append_value_with_quotes(std::string const& value) {
-        m_json_string += "\"" + value + "\",";
+        m_json_string += "\"";
+        m_json_string += value;
+        m_json_string += "\",";
     }
 
 private:

--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "ColumnReader.hpp"
+
 class JsonSerializer {
 public:
     enum Op : uint8_t {
@@ -74,9 +76,10 @@ public:
         m_json_string += ",";
     }
 
-    void append_value_with_quotes(std::string const& value) {
+    void
+    append_value_from_column_with_quotes(clp_s::BaseColumnReader* column, uint64_t cur_message) {
         m_json_string += "\"";
-        m_json_string += value;
+        column->extract_string_value_into_buffer(cur_message, m_json_string);
         m_json_string += "\",";
     }
 

--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -76,6 +76,10 @@ public:
         m_json_string += ",";
     }
 
+    void append_value_from_column(clp_s::BaseColumnReader* column, uint64_t cur_message) {
+        column->extract_string_value_into_buffer(cur_message, m_json_string);
+    }
+
     void
     append_value_from_column_with_quotes(clp_s::BaseColumnReader* column, uint64_t cur_message) {
         m_json_string += "\"";

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -93,9 +93,7 @@ void SchemaReader::generate_json_string() {
             case JsonSerializer::Op::AddStringField: {
                 column = m_reordered_columns[column_id_index++];
                 m_json_serializer.append_key(column->get_name());
-                m_json_serializer.append_value_with_quotes(
-                        std::get<std::string>(column->extract_value(m_cur_message))
-                );
+                m_json_serializer.append_value_from_column_with_quotes(column, m_cur_message);
                 break;
             }
             case JsonSerializer::Op::AddArrayField: {

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -99,9 +99,7 @@ void SchemaReader::generate_json_string() {
             case JsonSerializer::Op::AddArrayField: {
                 column = m_reordered_columns[column_id_index++];
                 m_json_serializer.append_key(column->get_name());
-                m_json_serializer.append_value(
-                        std::get<std::string>(column->extract_value(m_cur_message))
-                );
+                m_json_serializer.append_value_from_column(column, m_cur_message);
                 break;
             }
             case JsonSerializer::Op::AddNullField: {


### PR DESCRIPTION
# Description
This PR makes a few small changes to avoid unnecessary string copies/string allocations during decompression.

This consists of some small changes inside of JsonSerializer to avoid creating temporary strings unnecessarily, and changes to BaseColumnReader to add an api that will append the value from a column directly to a string buffer instead of the old method where we allocate a new string each time extract_value is called.

# Validation performed
* Validated that mongodb dataset decompresses exactly the same after this change
* Validated that mongodb dataset gets 1.5x speedup during decompression

