### PR TITLE
Linting: Add support for always using latest `eslint-config-yscope` package.

### DIFF
--- a/components/webui/README.md
+++ b/components/webui/README.md
@@ -106,7 +106,7 @@ To integrate ESLint into IDEs like WebStorm and VSCode, follow these steps:
       much older version of `npm` than the one used below.
 
     ```shell
-    npm install --package-lock=false
+    npm --package-lock=false install eslint-config-yscope@latest
     ```
 
 [eslint]: https://eslint.org/

--- a/components/webui/README.md
+++ b/components/webui/README.md
@@ -87,11 +87,9 @@ To integrate ESLint into IDEs like WebStorm and VSCode, follow these steps:
     nvm use node
     ```
 
-2. Re-install the project's dependencies.
-    * `--package-lock=false` is used to make `npm` *actually* install the dependencies; otherwise
-      the first invocation will only update `package-lock.json`, and installing the dependencies
-      requires a second invocation. This is likely because the initial `package-lock.json` is from a
-      much older version of `npm` than the one used below.
+2. Install the latest ESLint shared config package.
+    We use `--package-lock=false` and `--no-save` to avoid adding the package to the
+`package-lock.json` and the `package.json`.
 
     ```shell
     npm --package-lock=false install --no-save eslint-config-yscope@latest

--- a/components/webui/README.md
+++ b/components/webui/README.md
@@ -88,8 +88,8 @@ To integrate ESLint into IDEs like WebStorm and VSCode, follow these steps:
     ```
 
 2. Install the latest ESLint shared config package.
-    We use `--package-lock=false` and `--no-save` to avoid adding the package to the
-`package-lock.json` and the `package.json`.
+    * We use `--package-lock=false` and `--no-save` to avoid adding the package to
+      `package-lock.json` and `package.json`.
 
     ```shell
     npm --package-lock=false install --no-save eslint-config-yscope@latest

--- a/components/webui/README.md
+++ b/components/webui/README.md
@@ -18,18 +18,6 @@ meteor npm install
 If you ever add a package manually to `package.json` or `package.json` changes
 for some other reason, you should rerun this command.
 
-> [!NOTE]
-> When running this command, you might see warnings related to uninstalled `eslint-config-yscope`
-> peer dependencies, like the ones below:
-> ```
-> npm WARN eslint-config-yscope@0.0.20 requires a peer of eslint@^8.57.0 but
->  none is installed. You must install peer dependencies yourself.
-> ```
-> **These `eslint-config-yscope` warnings can be safely ignored.** They occur because the default
-> npm version in Node.js v14 does not automatically install peer dependencies. If needed, peer
-> dependencies are automatically installed when switching to Node.js v18 or higher for linting
-> purposes, as outlined in the [Linting](#linting) section.
-
 ## Running in development
 
 The full functionality of the webui depends on other components in the CLP
@@ -106,7 +94,7 @@ To integrate ESLint into IDEs like WebStorm and VSCode, follow these steps:
       much older version of `npm` than the one used below.
 
     ```shell
-    npm --package-lock=false install eslint-config-yscope@latest
+    npm --package-lock=false install --no-save eslint-config-yscope@latest
     ```
 
 [eslint]: https://eslint.org/

--- a/components/webui/package-lock.json
+++ b/components/webui/package-lock.json
@@ -658,11 +658,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
-    "eslint-config-yscope": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/eslint-config-yscope/-/eslint-config-yscope-0.0.25.tgz",
-      "integrity": "sha512-tAWpaWg83wkqqVFwCaX03u5vwP+VjimejunRxeK3XJp3pK7OiqjHx4jdXRYCSt70T6wl7urs0hJWGbc8+eXRBg=="
-    },
     "fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",

--- a/components/webui/package-lock.json
+++ b/components/webui/package-lock.json
@@ -633,9 +633,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.745",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.745.tgz",
-      "integrity": "sha512-tRbzkaRI5gbUn5DEvF0dV4TQbMZ5CLkWeTAXmpC9IrYT+GE+x76i9p+o3RJ5l9XmdQlI1pPhVtE9uNcJJ0G0EA=="
+      "version": "1.4.747",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.747.tgz",
+      "integrity": "sha512-+FnSWZIAvFHbsNVmUxhEqWiaOiPMcfum1GQzlWCg/wLigVtshOsjXHyEFfmt6cFK6+HkS3QOJBv6/3OPumbBfw=="
     },
     "enabled": {
       "version": "2.0.0",
@@ -659,10 +659,9 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint-config-yscope": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/eslint-config-yscope/-/eslint-config-yscope-0.0.23.tgz",
-      "integrity": "sha512-YALjlnaN6XiLvdD6BVj3AZx1aQE9kfR2I+HHJ+txaGrt4wyrExTmg0iKtkJi8KrzoS+N7IcrcJAqbz941apaAg==",
-      "dev": true
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/eslint-config-yscope/-/eslint-config-yscope-0.0.25.tgz",
+      "integrity": "sha512-tAWpaWg83wkqqVFwCaX03u5vwP+VjimejunRxeK3XJp3pK7OiqjHx4jdXRYCSt70T6wl7urs0hJWGbc8+eXRBg=="
     },
     "fecha": {
       "version": "4.2.3",

--- a/components/webui/package.json
+++ b/components/webui/package.json
@@ -39,8 +39,7 @@
     "winston-daily-rotate-file": "^4.7.1"
   },
   "devDependencies": {
-    "jsdoc": "^4.0.2",
-    "eslint-config-yscope": "latest"
+    "jsdoc": "^4.0.2"
   },
   "eslintConfig": {
     "extends": [

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -174,7 +174,7 @@ tasks:
       CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "PATH='{{.LINTER_NODEJS_BIN_DIR}}':$PATH npm install"
+      - "PATH='{{.LINTER_NODEJS_BIN_DIR}}':$PATH npm update"
       # Checksum the generated files (this command must be last)
       - >-
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .


### PR DESCRIPTION
# References
https://github.com/y-scope/clp/pull/351 integrated eslint-config-yscope into the repository.
#356 Added js-check and js-fix lint tasks and also specified `eslint-config-yscope` dependency in both `component/webui/packages.json` and `component/webui/linter/packages.json` to use the `latest` version. However, after there were version upgrades to the `eslint-config-yscope` npm package, the version of the package in this repo is not getting upgraded accordingly in the lint tasks. 
Without manually installing the new version, the IDE ESLint integration is also using the old version. 

# Description
1. Replace 'npm install' with 'npm update' in lint tasks configuration.
2. Update webui ESLint IDE integration instructions.
3. Remove dependency "eslint-config-yscope" from webui's package.json.

# Validation performed
1. `cd component/webui/linter; npm i eslint-config-yscope@0.0.23`.
2. Note that `eslint-config-yscope@0.0.25` turned off rule ["no-continue"](https://eslint.org/docs/latest/rules/no-continue). Made a violation of that and another rule (for sanity).
   e.g. in `components/webui/imports/utils/misc.js`, modify `computeHumanSize` as follows:
    ```
    const computeHumanSize = (num) => {
        // eslint-disable-next-line @stylistic/js/array-element-newline
        const siPrefixes = ["", "K", "M", "G", "T", "P", "E", "Z"];
        for (let i = 0; i < siPrefixes.length; ++i) {
            if (num === 0) { // violates rule "yoda"
                continue;    // violates rule "no-continue"
            }
            if (BYTES_PER_KIBIBYTE > Math.abs(num)) {
                return `${Math.round(num)} ${siPrefixes[i]}B`;
            }
            num /= BYTES_PER_KIBIBYTE;
        }
    
        return `${Math.round(num)} B`;
    };
    ```
4. Ran `task lint:js-check` and observed violation of "yoda" getting reported but not "no-continue". e.g.,
    ```
    /home/junhao/workspace/clp/components/webui/imports/utils/misc.js
      24:13  error  Expected literal to be on the left side of ===  yoda
    
    ✖ 1 problem (1 error, 0 warnings)
      1 error and 0 warnings potentially fixable with the `--fix` option.
    ```
5. Followed the updated ESLint "IDE Integration" instructions in README.md.
6. Enabled ESLint integration in PyCharm: File -> Settings -> Languages & Frameworks > JavaScript > Code Quality Tools > ESLint: "Automatic ESLint configuration". Observed the same violation getting reported in the IDE editor.