### PR TITLE
webui: Improve responsiveness of compression job table; Use placeholders for null statistics.

### DIFF
--- a/components/webui/imports/api/ingestion/server/publications.js
+++ b/components/webui/imports/api/ingestion/server/publications.js
@@ -203,6 +203,8 @@ Meteor.publish(Meteor.settings.public.CompressionJobsCollectionName, async () =>
     await refreshCompressionJobs();
 
     const findOptions = {
+        disableOplog: true,
+        pollingIntervalMs: COMPRESSION_JOBS_REFRESH_INTERVAL_MILLIS,
         sort: [MONGO_SORT_BY_ID],
     };
 

--- a/components/webui/imports/api/ingestion/types.js
+++ b/components/webui/imports/api/ingestion/types.js
@@ -5,8 +5,8 @@
  * @property {string} status_msg
  * @property {Date} start_time
  * @property {number} duration
- * @property {number} uncompressed_size
- * @property {number} compressed_size
+ * @property {string} uncompressed_size
+ * @property {string} compressed_size
  */
 
 /**

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
@@ -1,4 +1,5 @@
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Placeholder from "react-bootstrap/Placeholder";
 import Spinner from "react-bootstrap/Spinner";
 import Tooltip from "react-bootstrap/Tooltip";
 
@@ -16,6 +17,8 @@ import {
     COMPRESSION_JOB_STATUS_NAMES,
 } from "/imports/api/ingestion/constants";
 import {computeHumanSize} from "/imports/utils/misc";
+
+import PlaceholderText from "./PlaceholderText";
 
 
 /**
@@ -37,20 +40,31 @@ const COMPRESSION_JOB_STATUS_ICONS = Object.freeze({
  * @return {React.ReactElement}
  */
 const IngestionJobRow = ({job}) => {
-    let speedText = "";
-    let uncompressedSizeText = "";
-    let compressedSizeText = "";
-
     if (null === job.duration && null !== job.start_time) {
         job.duration = dayjs.duration(
             dayjs() - dayjs(job.start_time)
         ).asSeconds();
     }
-    if (0 < job.duration) {
-        speedText = `${computeHumanSize(job.uncompressed_size / job.duration)}/s`;
-        uncompressedSizeText = computeHumanSize(job.uncompressed_size);
-        compressedSizeText = computeHumanSize(job.compressed_size);
-    }
+
+    const uncompressedSize = Number(job.uncompressed_size);
+    const uncompressedSizeText =
+        (false === isNaN(uncompressedSize) && 0 !== uncompressedSize) ?
+            computeHumanSize(uncompressedSize) :
+            "";
+
+    const speedText = (
+        0 < job.duration &&
+        false === isNaN(uncompressedSize) &&
+        0 !== uncompressedSize
+    ) ?
+        `${computeHumanSize(job.uncompressed_size / job.duration)}/s` :
+        "";
+
+    const compressedSize = Number(job.compressed_size);
+    const compressedSizeText =
+        (false === isNaN(compressedSize) && 0 !== compressedSize) ?
+            computeHumanSize(compressedSize) :
+            "";
 
     return (
         <tr>
@@ -75,13 +89,13 @@ const IngestionJobRow = ({job}) => {
                 {job._id}
             </td>
             <td className={"text-end"}>
-                {speedText}
+                <PlaceholderText text={speedText}/>
             </td>
             <td className={"text-end"}>
-                {uncompressedSizeText}
+                <PlaceholderText text={uncompressedSizeText}/>
             </td>
             <td className={"text-end"}>
-                {compressedSizeText}
+                <PlaceholderText text={compressedSizeText}/>
             </td>
         </tr>
     );

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
@@ -40,6 +40,10 @@ const COMPRESSION_JOB_STATUS_ICONS = Object.freeze({
  * @return {React.ReactElement}
  */
 const IngestionJobRow = ({job}) => {
+    let uncompressedSizeText = "";
+    let speedText = "";
+    let compressedSizeText = "";
+
     if (null === job.duration && null !== job.start_time) {
         job.duration = dayjs.duration(
             dayjs() - dayjs(job.start_time)
@@ -47,24 +51,22 @@ const IngestionJobRow = ({job}) => {
     }
 
     const uncompressedSize = Number(job.uncompressed_size);
-    const uncompressedSizeText =
-        (false === isNaN(uncompressedSize) && 0 !== uncompressedSize) ?
-            computeHumanSize(uncompressedSize) :
-            "";
+    if (false === isNaN(uncompressedSize) && 0 !== uncompressedSize) {
+        uncompressedSizeText = computeHumanSize(uncompressedSize);
+    }
 
-    const speedText = (
-        0 < job.duration &&
+    if (
         false === isNaN(uncompressedSize) &&
-        0 !== uncompressedSize
-    ) ?
-        `${computeHumanSize(job.uncompressed_size / job.duration)}/s` :
-        "";
+        0 !== uncompressedSize &&
+        0 < job.duration
+    ) {
+        speedText = `${computeHumanSize(job.uncompressed_size / job.duration)}/s`;
+    }
 
     const compressedSize = Number(job.compressed_size);
-    const compressedSizeText =
-        (false === isNaN(compressedSize) && 0 !== compressedSize) ?
-            computeHumanSize(compressedSize) :
-            "";
+    if (false === isNaN(compressedSize) && 0 !== compressedSize) {
+        compressedSizeText = computeHumanSize(compressedSize);
+    }
 
     return (
         <tr>

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
@@ -41,8 +41,8 @@ const COMPRESSION_JOB_STATUS_ICONS = Object.freeze({
  */
 const IngestionJobRow = ({job}) => {
     let uncompressedSizeText = "";
-    let speedText = "";
     let compressedSizeText = "";
+    let speedText = "";
 
     if (null === job.duration && null !== job.start_time) {
         job.duration = dayjs.duration(
@@ -55,17 +55,17 @@ const IngestionJobRow = ({job}) => {
         uncompressedSizeText = computeHumanSize(uncompressedSize);
     }
 
+    const compressedSize = Number(job.compressed_size);
+    if (false === isNaN(compressedSize) && 0 !== compressedSize) {
+        compressedSizeText = computeHumanSize(compressedSize);
+    }
+
     if (
         false === isNaN(uncompressedSize) &&
         0 !== uncompressedSize &&
         0 < job.duration
     ) {
         speedText = `${computeHumanSize(job.uncompressed_size / job.duration)}/s`;
-    }
-
-    const compressedSize = Number(job.compressed_size);
-    if (false === isNaN(compressedSize) && 0 !== compressedSize) {
-        compressedSizeText = computeHumanSize(compressedSize);
     }
 
     return (

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
@@ -1,5 +1,4 @@
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
-import Placeholder from "react-bootstrap/Placeholder";
 import Spinner from "react-bootstrap/Spinner";
 import Tooltip from "react-bootstrap/Tooltip";
 
@@ -68,6 +67,8 @@ const IngestionJobRow = ({job}) => {
         speedText = `${computeHumanSize(job.uncompressed_size / job.duration)}/s`;
     }
 
+    const isPlaceholderVisible = job.status !== COMPRESSION_JOB_STATUS.FAILED;
+
     return (
         <tr>
             <td className={"text-center"}>
@@ -92,17 +93,17 @@ const IngestionJobRow = ({job}) => {
             </td>
             <td className={"text-end"}>
                 <PlaceholderText
-                    isAlwaysVisible={job.status !== COMPRESSION_JOB_STATUS.FAILED}
+                    isAlwaysVisible={isPlaceholderVisible}
                     text={speedText}/>
             </td>
             <td className={"text-end"}>
                 <PlaceholderText
-                    isAlwaysVisible={job.status !== COMPRESSION_JOB_STATUS.FAILED}
+                    isAlwaysVisible={isPlaceholderVisible}
                     text={uncompressedSizeText}/>
             </td>
             <td className={"text-end"}>
                 <PlaceholderText
-                    isAlwaysVisible={job.status !== COMPRESSION_JOB_STATUS.FAILED}
+                    isAlwaysVisible={isPlaceholderVisible}
                     text={compressedSizeText}/>
             </td>
         </tr>

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobRow.jsx
@@ -89,13 +89,19 @@ const IngestionJobRow = ({job}) => {
                 {job._id}
             </td>
             <td className={"text-end"}>
-                <PlaceholderText text={speedText}/>
+                <PlaceholderText
+                    isAlwaysVisible={job.status !== COMPRESSION_JOB_STATUS.FAILED}
+                    text={speedText}/>
             </td>
             <td className={"text-end"}>
-                <PlaceholderText text={uncompressedSizeText}/>
+                <PlaceholderText
+                    isAlwaysVisible={job.status !== COMPRESSION_JOB_STATUS.FAILED}
+                    text={uncompressedSizeText}/>
             </td>
             <td className={"text-end"}>
-                <PlaceholderText text={compressedSizeText}/>
+                <PlaceholderText
+                    isAlwaysVisible={job.status !== COMPRESSION_JOB_STATUS.FAILED}
+                    text={compressedSizeText}/>
             </td>
         </tr>
     );

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobs.scss
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/IngestionJobs.scss
@@ -1,0 +1,3 @@
+.ingestion-jobs-table {
+  table-layout: fixed;
+}

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
@@ -20,7 +20,7 @@ const PlaceholderText = ({
         {(0 !== text.length) ?
             text :
             (
-                (true === isAlwaysVisible) &&
+                (isAlwaysVisible) &&
                 <Placeholder
                     size={"sm"}
                     xs={4}/>

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
@@ -1,5 +1,7 @@
 import Placeholder from "react-bootstrap/Placeholder";
 
+import "./PlaceholderText.scss";
+
 
 /**
  * Renders an animated text placeholder when the text is an empty string.
@@ -22,6 +24,7 @@ const PlaceholderText = ({
             (
                 (isAlwaysVisible) &&
                 <Placeholder
+                    className={"placeholder-element"}
                     size={"sm"}
                     xs={4}/>
             )}

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
@@ -1,0 +1,24 @@
+import Placeholder from "react-bootstrap/Placeholder";
+
+
+/**
+ * Renders an animated text placeholder when the text is an empty string.
+ *
+ * @param {object} props
+ * @param {string} props.text
+ * @return {React.ReactElement}
+ */
+const PlaceholderText = ({text}) => (
+    <Placeholder
+        animation={"glow"}
+        as={"span"}
+    >
+        {text ?
+            text :
+            <Placeholder
+                size={"sm"}
+                xs={4}/>}
+    </Placeholder>
+);
+
+export default PlaceholderText;

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.jsx
@@ -6,18 +6,25 @@ import Placeholder from "react-bootstrap/Placeholder";
  *
  * @param {object} props
  * @param {string} props.text
+ * @param {boolean} props.isAlwaysVisible
  * @return {React.ReactElement}
  */
-const PlaceholderText = ({text}) => (
+const PlaceholderText = ({
+    text,
+    isAlwaysVisible = true,
+}) => (
     <Placeholder
         animation={"glow"}
         as={"span"}
     >
-        {text ?
+        {(0 !== text.length) ?
             text :
-            <Placeholder
-                size={"sm"}
-                xs={4}/>}
+            (
+                (true === isAlwaysVisible) &&
+                <Placeholder
+                    size={"sm"}
+                    xs={4}/>
+            )}
     </Placeholder>
 );
 

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.scss
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/PlaceholderText.scss
@@ -1,0 +1,3 @@
+.placeholder-element {
+  border-radius: 3px;
+}

--- a/components/webui/imports/ui/IngestView/panels/IngestionJobs/index.jsx
+++ b/components/webui/imports/ui/IngestView/panels/IngestionJobs/index.jsx
@@ -9,6 +9,8 @@ import {MONGO_SORT_BY_ID} from "/imports/utils/mongo";
 import Panel from "../../Panel";
 import IngestionJobRow from "./IngestionJobRow";
 
+import "./IngestionJobs.scss";
+
 
 /**
  * Displays a table of ingestion jobs.
@@ -37,10 +39,10 @@ const IngestionJobs = () => {
             xl={6}
             xs={12}
         >
-            <Table>
+            <Table className={"ingestion-jobs-table"}>
                 <thead>
                     <tr>
-                        <th className={"text-center"}>Status</th>
+                        <th className={"text-center col-1"}>Status</th>
                         <th className={"text-end"}>Job ID</th>
                         <th className={"text-end"}>Speed</th>
                         <th className={"text-end"}>Data Ingested</th>


### PR DESCRIPTION
# References
#350 added a table to display the status of recent ingestion jobs.

It was found the table does not immediately get updated after a job is submitted. Also, some newlly added and pending jobs might contain empty / zero values for the ingestion speed and sizes, which can be confusing to users at times.

# Description
1. [Use polling instead of oplog finding in CompressionJobsCollection.](https://github.com/y-scope/clp/commit/c0b520abfa9e4c634002c2ffb7177bbaed798261)
2. [Show loading animation for non-numeric and empty values in IngestionJobRow.](https://github.com/y-scope/clp/commit/4704b190c685d5368bf75bb3b7f5ccb5687f2fef)
3. [Set fixed width of columns except "Status" in compression job table.](https://github.com/y-scope/clp/commit/1b4c65d61e1f65a99394e0d8d6b4e14f3e381edd)

# Validation performed
1. Followed same validation steps in #350.
2. Observed any non-"Status" table columns have equal widths.
3. Observed jobs appearing in the table within approximately 1 seconds of submission.
4. Observed loading animations shown for the "Speed", "Data Ingested" & "Compressed Size" columns when the newly submitted job is pending.