### PR TITLE
clp-s: Fix performance bug involving unnecessary reallocations of stack object during scan

### DIFF
--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -48,6 +48,12 @@ public:
     bool filter();
 
 private:
+    enum class ExpressionType {
+        And,
+        Or,
+        Filter
+    };
+
     std::shared_ptr<ArchiveReader> m_archive_reader;
     std::shared_ptr<Expression> m_expr;
     SchemaMatch& m_match;
@@ -85,6 +91,11 @@ private:
     std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_varstrings;
     std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_datestrings;
     std::map<ColumnDescriptor*, std::vector<int32_t>> m_wildcard_to_searched_columns;
+
+    std::stack<
+            std::pair<ExpressionType, OpList::iterator>,
+            std::vector<std::pair<ExpressionType, OpList::iterator>>>
+            m_expression_state;
 
     simdjson::ondemand::parser m_array_parser;
     std::string m_array_search_string;

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <set>
+#include <stack>
 #include <string>
 #include <unordered_set>
 #include <utility>


### PR DESCRIPTION
# Description
This PR fixes a performance bug related to churning reallocations on a stack object during scan time. This performance bug mostly affects queries with at least a few filters. There are some other easy-to-fix issues that reduce scan performance (unnecessary use of shared_ptr, etc.) but they require a much larger diff to fix, so they will be left to another PR.

# Validation performed
* Validated that queries containing several conditions on mongodb dataset experience significant speedup

