### PR TITLE
Taskfile: Clean up and apply new conventions; Deduplicate checksum handling into reusable tasks.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,22 +4,27 @@ includes:
   lint: "lint-tasks.yml"
 
 vars:
-  BUILD_DIR: "{{.TASKFILE_DIR}}/build"
+  # Paths
+  BUILD_DIR: "{{.ROOT_DIR}}/build"
+  CORE_COMPONENT_BUILD_DIR: "{{.BUILD_DIR}}/core"
+  PACKAGE_BUILD_DIR: "{{.BUILD_DIR}}/clp-package"
+  PACKAGE_VENV_DIR: "{{.BUILD_DIR}}/package-venv"
+  WEBUI_BUILD_DIR: "{{.BUILD_DIR}}/webui"
+  WEBUI_NODEJS_BUILD_DIR: "{{.BUILD_DIR}}/webui-nodejs"
+  WEBUI_NODEJS_BIN_DIR: "{{.WEBUI_NODEJS_BUILD_DIR}}/node/bin"
+
+  # Versions
+  PACKAGE_VERSION: "0.0.3-dev"
+  PYTHON_VERSION:
+    sh: "python3 -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\""
+
+  # Utils
   CHECKSUM_TAR_BASE_ARGS: >-
     --group=0
     --mtime='UTC 1970-01-01'
     --numeric-owner
     --owner=0
     --sort=name
-  CORE_COMPONENT_BUILD_DIR: "{{.TASKFILE_DIR}}/build/core"
-  PACKAGE_BUILD_DIR: "{{.TASKFILE_DIR}}/build/clp-package"
-  PACKAGE_VENV_DIR: "{{.TASKFILE_DIR}}/build/package-venv"
-  PACKAGE_VERSION: "0.0.3-dev"
-  PYTHON_VERSION:
-    sh: "python3 -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\""
-  WEBUI_BUILD_DIR: "{{.TASKFILE_DIR}}/build/webui"
-  WEBUI_NODEJS_BUILD_DIR: "{{.TASKFILE_DIR}}/build/webui-nodejs"
-  WEBUI_NODEJS_BIN_DIR: "{{.WEBUI_NODEJS_BUILD_DIR}}/node/bin"
 
 tasks:
   default:
@@ -57,7 +62,7 @@ tasks:
       - "tar czf '{{.VERSIONED_PACKAGE_NAME}}.tar.gz' --dereference '{{.VERSIONED_PACKAGE_NAME}}'"
     sources:
       - "{{.BUILD_DIR}}/package.md5"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
     generates:
       - "{{.VERSIONED_PACKAGE_NAME}}.tar.gz"
 
@@ -118,7 +123,7 @@ tasks:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
       - "{{.CORE_COMPONENT_BUILD_DIR}}/reducer-server"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
       - "/etc/os-release"
       - "components/clp-package-utils/dist/*.whl"
       - "components/clp-py-utils/dist/*.whl"
@@ -148,7 +153,7 @@ tasks:
       - "{{.SRC_DIR}}/cmake/**/*"
       - "{{.SRC_DIR}}/CMakeLists.txt"
       - "{{.SRC_DIR}}/src/**/*"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
       - "/etc/os-release"
     generates:
       - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
@@ -195,7 +200,7 @@ tasks:
         cd "{{.OUTPUT_DIR}}"
         tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
       - "*"
       - ".meteor/*"
       - "client/**/*"
@@ -223,7 +228,7 @@ tasks:
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
         | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
     status:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
@@ -244,7 +249,7 @@ tasks:
         cd "{{.OUTPUT_DIR}}"
         tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
       - ".gitmodules"
       - "tools/scripts/deps-download/**/*"
     status:
@@ -294,14 +299,14 @@ tasks:
       - "python3 -m venv '{{.OUTPUT_DIR}}'"
       - |-
         . "{{.OUTPUT_DIR}}/bin/activate"
-        pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
+        pip3 install --upgrade -r "{{.ROOT_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
       - |-
         cd "{{.OUTPUT_DIR}}"
         tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.TASKFILE_DIR}}/requirements.txt"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.ROOT_DIR}}/requirements.txt"
+      - "{{.TASKFILE}}"
       - "/etc/os-release"
     status:
       - "test -f '{{.CHECKSUM_FILE}}'"
@@ -335,8 +340,8 @@ tasks:
     sources:
       - "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.md5"
       - "{{.PACKAGE}}/**/*"
-      - "{{.TASKFILE_DIR}}/requirements.txt"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.ROOT_DIR}}/requirements.txt"
+      - "{{.TASKFILE}}"
       - "/etc/os-release"
       - "pyproject.toml"
     generates:
@@ -346,7 +351,7 @@ tasks:
     internal: true
     vars:
       CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
-      WEBUI_SRC_DIR: "{{.TASKFILE_DIR}}/components/webui"
+      WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
       OUTPUT_DIR: "{{.WEBUI_SRC_DIR}}/node_modules"
     dir: "{{.WEBUI_SRC_DIR}}"
     cmds:
@@ -358,7 +363,7 @@ tasks:
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
         | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
       - ".meteor/packages"
       - "package.json"
     status:
@@ -381,14 +386,14 @@ tasks:
       - "python3 -m venv '{{.OUTPUT_DIR}}'"
       - |-
         . "{{.OUTPUT_DIR}}/bin/activate"
-        pip3 install --upgrade -r "{{.TASKFILE_DIR}}/requirements.txt"
+        pip3 install --upgrade -r "{{.ROOT_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
       - |-
         cd "{{.OUTPUT_DIR}}"
         tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.TASKFILE_DIR}}/requirements.txt"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.ROOT_DIR}}/requirements.txt"
+      - "{{.TASKFILE}}"
       - "/etc/os-release"
       - "pyproject.toml"
     status:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,13 +5,13 @@ includes:
 
 vars:
   # Paths
-  BUILD_DIR: "{{.ROOT_DIR}}/build"
-  CORE_COMPONENT_BUILD_DIR: "{{.BUILD_DIR}}/core"
-  PACKAGE_BUILD_DIR: "{{.BUILD_DIR}}/clp-package"
-  PACKAGE_VENV_DIR: "{{.BUILD_DIR}}/package-venv"
-  WEBUI_BUILD_DIR: "{{.BUILD_DIR}}/webui"
-  WEBUI_NODEJS_BUILD_DIR: "{{.BUILD_DIR}}/webui-nodejs"
-  WEBUI_NODEJS_BIN_DIR: "{{.WEBUI_NODEJS_BUILD_DIR}}/node/bin"
+  G_BUILD_DIR: "{{.ROOT_DIR}}/build"
+  G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
+  G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
+  G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
+  G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"
+  G_WEBUI_NODEJS_BUILD_DIR: "{{.G_BUILD_DIR}}/webui-nodejs"
+  G_WEBUI_NODEJS_BIN_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}/node/bin"
 
   # Versions
   PACKAGE_VERSION: "0.0.3-dev"
@@ -32,7 +32,7 @@ tasks:
 
   clean:
     cmds:
-      - "rm -rf '{{.BUILD_DIR}}'"
+      - "rm -rf '{{.G_BUILD_DIR}}'"
       - task: "clean-python-component"
         vars:
           COMPONENT: "clp-package-utils"
@@ -45,7 +45,7 @@ tasks:
 
   clean-package:
     cmds:
-      - "rm -rf '{{.PACKAGE_BUILD_DIR}}'"
+      - "rm -rf '{{.G_PACKAGE_BUILD_DIR}}'"
 
   package-tar:
     deps:
@@ -55,22 +55,22 @@ tasks:
         sh: |
           source /etc/os-release
           echo "clp-package-${ID}-${VERSION_CODENAME}-$(arch)-v{{.PACKAGE_VERSION}}"
-    dir: "{{.BUILD_DIR}}"
+    dir: "{{.G_BUILD_DIR}}"
     cmds:
       - "rm -rf '{{.VERSIONED_PACKAGE_NAME}}' '{{.VERSIONED_PACKAGE_NAME}}.tar.gz'"
-      - "ln -s '{{.PACKAGE_BUILD_DIR}}' '{{.VERSIONED_PACKAGE_NAME}}'"
+      - "ln -s '{{.G_PACKAGE_BUILD_DIR}}' '{{.VERSIONED_PACKAGE_NAME}}'"
       - "tar czf '{{.VERSIONED_PACKAGE_NAME}}.tar.gz' --dereference '{{.VERSIONED_PACKAGE_NAME}}'"
     sources:
-      - "{{.BUILD_DIR}}/package.md5"
+      - "{{.G_BUILD_DIR}}/package.md5"
       - "{{.TASKFILE}}"
     generates:
       - "{{.VERSIONED_PACKAGE_NAME}}.tar.gz"
 
   package:
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.PACKAGE_BUILD_DIR}}"
-      PACKAGE_VERSION_FILE: "{{.PACKAGE_BUILD_DIR}}/VERSION"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "{{.G_PACKAGE_BUILD_DIR}}"
+      PACKAGE_VERSION_FILE: "{{.G_PACKAGE_BUILD_DIR}}/VERSION"
     deps:
       - "core"
       - "clp-package-utils"
@@ -86,7 +86,7 @@ tasks:
       - "rsync --copy-links /etc/os-release '{{.OUTPUT_DIR}}/etc/os-release'"
       - "mkdir -p '{{.OUTPUT_DIR}}/lib/python3/site-packages'"
       - |-
-        . "{{.PACKAGE_VENV_DIR}}/bin/activate"
+        . "{{.G_PACKAGE_VENV_DIR}}/bin/activate"
         pip3 install --upgrade \
           components/clp-package-utils/dist/*.whl \
           components/clp-py-utils/dist/*.whl \
@@ -95,34 +95,34 @@ tasks:
       - "mkdir -p '{{.OUTPUT_DIR}}/bin'"
       - >-
         rsync -a
-        "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
-        "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
-        "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
-        "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
-        "{{.CORE_COMPONENT_BUILD_DIR}}/reducer-server"
-        "{{.WEBUI_NODEJS_BIN_DIR}}/node"
+        "{{.G_CORE_COMPONENT_BUILD_DIR}}/clg"
+        "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"
+        "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp"
+        "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+        "{{.G_CORE_COMPONENT_BUILD_DIR}}/reducer-server"
+        "{{.G_WEBUI_NODEJS_BIN_DIR}}/node"
         "{{.OUTPUT_DIR}}/bin/"
       - "mkdir -p '{{.OUTPUT_DIR}}/var/www/'"
       - >-
         rsync -a
-        "{{.WEBUI_BUILD_DIR}}/"
+        "{{.G_WEBUI_BUILD_DIR}}/"
         "{{.OUTPUT_DIR}}/var/www/"
       - |-
         cd "{{.OUTPUT_DIR}}/var/www/programs/server"
-        PATH="{{.WEBUI_NODEJS_BIN_DIR}}":$PATH npm install
+        PATH="{{.G_WEBUI_NODEJS_BIN_DIR}}":$PATH npm install
       # Checksum the generated files (this command must be last)
       - >-
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
         | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.BUILD_DIR}}/package-venv.md5"
-      - "{{.BUILD_DIR}}/webui.md5"
-      - "{{.BUILD_DIR}}/webui-nodejs.md5"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/reducer-server"
+      - "{{.G_BUILD_DIR}}/package-venv.md5"
+      - "{{.G_BUILD_DIR}}/webui.md5"
+      - "{{.G_BUILD_DIR}}/webui-nodejs.md5"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clg"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/reducer-server"
       - "{{.TASKFILE}}"
       - "/etc/os-release"
       - "components/clp-package-utils/dist/*.whl"
@@ -141,26 +141,26 @@ tasks:
     vars:
       SRC_DIR: "components/core"
     cmds:
-      - "mkdir -p '{{.CORE_COMPONENT_BUILD_DIR}}'"
-      - "cmake -S '{{.SRC_DIR}}' -B '{{.CORE_COMPONENT_BUILD_DIR}}'"
+      - "mkdir -p '{{.G_CORE_COMPONENT_BUILD_DIR}}'"
+      - "cmake -S '{{.SRC_DIR}}' -B '{{.G_CORE_COMPONENT_BUILD_DIR}}'"
       - >-
         cmake
-        --build "{{.CORE_COMPONENT_BUILD_DIR}}"
+        --build "{{.G_CORE_COMPONENT_BUILD_DIR}}"
         --parallel
         --target clg clo clp clp-s reducer-server
     sources:
-      - "{{.BUILD_DIR}}/core-submodules.md5"
+      - "{{.G_BUILD_DIR}}/core-submodules.md5"
       - "{{.SRC_DIR}}/cmake/**/*"
       - "{{.SRC_DIR}}/CMakeLists.txt"
       - "{{.SRC_DIR}}/src/**/*"
       - "{{.TASKFILE}}"
       - "/etc/os-release"
     generates:
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clg"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clo"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clp"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/clp-s"
-      - "{{.CORE_COMPONENT_BUILD_DIR}}/reducer-server"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clg"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/reducer-server"
 
   clp-package-utils:
     - task: "python-component"
@@ -182,8 +182,8 @@ tasks:
     dir: "components/webui"
     platforms: ["386", "amd64"]
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.WEBUI_BUILD_DIR}}"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "{{.G_WEBUI_BUILD_DIR}}"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "mkdir -p '{{.OUTPUT_DIR}}'"
@@ -216,8 +216,8 @@ tasks:
 
   webui-nodejs:
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.WEBUI_NODEJS_BUILD_DIR}}"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}"
     cmds:
       - task: "nodejs"
         vars:
@@ -240,7 +240,7 @@ tasks:
     internal: true
     dir: "components/core"
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "submodules"
     cmds:
       - "tools/scripts/deps-download/download-all.sh"
@@ -292,8 +292,8 @@ tasks:
   package-venv:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.PACKAGE_VENV_DIR}}"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "{{.G_PACKAGE_VENV_DIR}}"
     cmds:
       - task: "create-venv"
         vars:
@@ -328,7 +328,7 @@ tasks:
     vars:
       PACKAGE:
         sh: "echo {{.COMPONENT}} | tr - _"
-      VENV_DIR: "{{.BUILD_DIR}}/{{.COMPONENT}}/venv"
+      VENV_DIR: "{{.G_BUILD_DIR}}/{{.COMPONENT}}/venv"
     dir: "components/{{.COMPONENT}}"
     cmds:
       - task: "clean-python-component"
@@ -338,7 +338,7 @@ tasks:
         . "{{.VENV_DIR}}/bin/activate"
         poetry build --format wheel
     sources:
-      - "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.md5"
+      - "{{.G_BUILD_DIR}}/{{.COMPONENT}}_venv.md5"
       - "{{.PACKAGE}}/**/*"
       - "{{.ROOT_DIR}}/requirements.txt"
       - "{{.TASKFILE}}"
@@ -350,12 +350,12 @@ tasks:
   webui-node-modules:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
       OUTPUT_DIR: "{{.WEBUI_SRC_DIR}}/node_modules"
     dir: "{{.WEBUI_SRC_DIR}}"
     cmds:
-      - "mkdir -p '{{.BUILD_DIR}}'"
+      - "mkdir -p '{{.G_BUILD_DIR}}'"
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "meteor npm install --production"
       # Checksum the generated files (this command must be last)
@@ -380,7 +380,7 @@ tasks:
     label: "{{.COMPONENT}}-venv"
     dir: "components/{{.COMPONENT}}"
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}-venv.md5"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.COMPONENT}}-venv.md5"
     cmds:
       - task: "create-venv"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -111,9 +111,9 @@ tasks:
         cd "{{.OUTPUT_DIR}}/var/www/programs/server"
         PATH="{{.WEBUI_NODEJS_BIN_DIR}}":$PATH npm install
       # Checksum the generated files (this command must be last)
-      - |-
-        cd "{{.OUTPUT_DIR}}"
-        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
+      - >-
+        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
+        | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.BUILD_DIR}}/package-venv.md5"
       - "{{.BUILD_DIR}}/webui.md5"
@@ -133,7 +133,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
+        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   core:
@@ -196,9 +196,9 @@ tasks:
         "{{.OUTPUT_DIR}}/"
       - "rm -rf '{{.OUTPUT_DIR}}/bundle/'"
       # Checksum the generated files (this command must be last)
-      - |-
-        cd "{{.OUTPUT_DIR}}"
-        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
+      - >-
+        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
+        | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE}}"
       - "*"
@@ -211,7 +211,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
+        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   webui-nodejs:
@@ -245,9 +245,9 @@ tasks:
     cmds:
       - "tools/scripts/deps-download/download-all.sh"
       # Checksum the generated files (this command must be last)
-      - |-
-        cd "{{.OUTPUT_DIR}}"
-        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
+      - >-
+        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
+        | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE}}"
       - ".gitmodules"
@@ -256,7 +256,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
+        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   nodejs:
@@ -301,9 +301,9 @@ tasks:
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.ROOT_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
-      - |-
-        cd "{{.OUTPUT_DIR}}"
-        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
+      - >-
+        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
+        | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.ROOT_DIR}}/requirements.txt"
       - "{{.TASKFILE}}"
@@ -312,7 +312,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
+        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   python-component:
@@ -388,9 +388,9 @@ tasks:
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r "{{.ROOT_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
-      - |-
-        cd "{{.OUTPUT_DIR}}"
-        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
+      - >-
+        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
+        | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.ROOT_DIR}}/requirements.txt"
       - "{{.TASKFILE}}"
@@ -400,7 +400,7 @@ tasks:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
         diff
-        <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
+        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
   clean-python-component:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,9 +14,7 @@ vars:
   G_WEBUI_NODEJS_BIN_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}/node/bin"
 
   # Versions
-  PACKAGE_VERSION: "0.0.3-dev"
-  PYTHON_VERSION:
-    sh: "python3 -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\""
+  G_PACKAGE_VERSION: "0.0.3-dev"
 
   # Utils
   CHECKSUM_TAR_BASE_ARGS: >-
@@ -54,7 +52,7 @@ tasks:
       VERSIONED_PACKAGE_NAME:
         sh: |
           source /etc/os-release
-          echo "clp-package-${ID}-${VERSION_CODENAME}-$(arch)-v{{.PACKAGE_VERSION}}"
+          echo "clp-package-${ID}-${VERSION_CODENAME}-$(arch)-v{{.G_PACKAGE_VERSION}}"
     dir: "{{.G_BUILD_DIR}}"
     cmds:
       - "rm -rf '{{.VERSIONED_PACKAGE_NAME}}' '{{.VERSIONED_PACKAGE_NAME}}.tar.gz'"
@@ -70,7 +68,6 @@ tasks:
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_PACKAGE_BUILD_DIR}}"
-      PACKAGE_VERSION_FILE: "{{.G_PACKAGE_BUILD_DIR}}/VERSION"
     deps:
       - "core"
       - "clp-package-utils"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,20 +16,9 @@ vars:
   # Versions
   G_PACKAGE_VERSION: "0.0.3-dev"
 
-  # Utils
-  CHECKSUM_TAR_BASE_ARGS: >-
-    --group=0
-    --mtime='UTC 1970-01-01'
-    --numeric-owner
-    --owner=0
-    --sort=name
-
 tasks:
   default:
     deps: ["package"]
-
-  init:
-    cmds: ["mkdir -p '{{.G_BUILD_DIR}}'"]
 
   clean:
     cmds:
@@ -78,6 +67,10 @@ tasks:
       - "init"
       - "job-orchestration"
       - "package-venv"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
       - "webui"
       - "webui-nodejs"
     cmds:
@@ -110,10 +103,11 @@ tasks:
       - |-
         cd "{{.OUTPUT_DIR}}/var/www/programs/server"
         PATH="{{.G_WEBUI_NODEJS_BIN_DIR}}":$PATH npm install
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.G_BUILD_DIR}}/package-venv.md5"
       - "{{.G_BUILD_DIR}}/webui.md5"
@@ -129,12 +123,7 @@ tasks:
       - "components/clp-py-utils/dist/*.whl"
       - "components/job-orchestration/dist/*.whl"
       - "components/package-template/src/**/*"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   core:
     deps: ["core-submodules", "init"]
@@ -178,7 +167,13 @@ tasks:
         COMPONENT: "{{.TASK}}"
 
   webui:
-    deps: ["init", "webui-node-modules"]
+    deps:
+      - "init"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+      - "webui-node-modules"
     dir: "components/webui"
     platforms: ["386", "amd64"]
     vars:
@@ -195,10 +190,11 @@ tasks:
         settings.json
         "{{.OUTPUT_DIR}}/"
       - "rm -rf '{{.OUTPUT_DIR}}/bundle/'"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE}}"
       - "*"
@@ -207,59 +203,56 @@ tasks:
       - "imports/**/*"
       - "server/**/*"
       - "tests/**/*"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   webui-nodejs:
-    deps: ["init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}"
+    deps:
+      - "init"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - task: "nodejs"
         vars:
           NODEJS_VERSION: "v14.21.3"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE}}"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   core-submodules:
     internal: true
-    deps: ["init"]
     dir: "components/core"
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "submodules"
+    deps:
+      - "init"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - "tools/scripts/deps-download/download-all.sh"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE}}"
       - ".gitmodules"
       - "tools/scripts/deps-download/**/*"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   nodejs:
     internal: true
@@ -294,30 +287,31 @@ tasks:
 
   package-venv:
     internal: true
-    deps: ["init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_PACKAGE_VENV_DIR}}"
+    deps:
+      - "init"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - task: "create-venv"
         vars:
           LABEL: "package"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
           REQUIREMENTS_FILE: "requirements.txt"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.ROOT_DIR}}/requirements.txt"
       - "{{.TASKFILE}}"
       - "/etc/os-release"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   python-component:
     internal: true
@@ -352,61 +346,63 @@ tasks:
       - "dist/*.whl"
 
   webui-node-modules:
-    deps: ["init"]
     internal: true
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
       OUTPUT_DIR: "{{.WEBUI_SRC_DIR}}/node_modules"
     dir: "{{.WEBUI_SRC_DIR}}"
+    deps:
+      - "init"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "meteor npm install --production"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.TASKFILE}}"
       - ".meteor/packages"
       - "package.json"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   component-venv:
     internal: true
-    deps: ["init"]
     requires:
       vars: ["COMPONENT", "OUTPUT_DIR"]
     label: "{{.COMPONENT}}-venv"
     dir: "components/{{.COMPONENT}}"
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.COMPONENT}}-venv.md5"
+    deps:
+      - "init"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - task: "create-venv"
         vars:
           LABEL: "{{.COMPONENT}}"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
           REQUIREMENTS_FILE: "{{.ROOT_DIR}}/requirements.txt"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.ROOT_DIR}}/requirements.txt"
       - "{{.TASKFILE}}"
       - "/etc/os-release"
       - "pyproject.toml"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   clean-python-component:
     internal: true
@@ -439,3 +435,48 @@ tasks:
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade pip
         pip3 install --upgrade -r "{{.REQUIREMENTS_FILE}}"
+
+  init:
+    internal: true
+    run: "once"
+    silent: true
+    cmd: "mkdir -p '{{.G_BUILD_DIR}}'"
+
+  compute-checksum:
+    desc: "Tries to compute a checksum for the given directory and output it to a file."
+    internal: true
+    # Ignore errors so that dependent tasks don't fail
+    ignore_error: true
+    silent: true
+    requires:
+      vars: ["DATA_DIR", "OUTPUT_FILE"]
+    cmds:
+      - >-
+        tar cf -
+        --directory "{{.DATA_DIR}}"
+        --group=0
+        --mtime='UTC 1970-01-01'
+        --numeric-owner
+        --owner=0
+        --sort=name
+        {{.CHECKSUM_TAR_BASE_ARGS}} . 2> /dev/null
+        | md5sum > {{.OUTPUT_FILE}}
+
+  validate-checksum:
+    desc: "Validates the checksum of the given directory matches the checksum in the given file, or
+    deletes the checksum file otherwise."
+    internal: true
+    silent: true
+    requires:
+      vars: ["CHECKSUM_FILE", "DATA_DIR"]
+    vars:
+      TMP_CHECKSUM_FILE: "{{.CHECKSUM_FILE}}.tmp"
+    cmds:
+      - task: "compute-checksum"
+        vars:
+          DATA_DIR: "{{.DATA_DIR}}"
+          OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
+      - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
+      - >-
+        diff -q '{{.TMP_CHECKSUM_FILE}}' '{{.CHECKSUM_FILE}}' 2> /dev/null
+        || rm -f '{{.CHECKSUM_FILE}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -295,11 +295,11 @@ tasks:
       CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.PACKAGE_VENV_DIR}}"
     cmds:
-      - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "python3 -m venv '{{.OUTPUT_DIR}}'"
-      - |-
-        . "{{.OUTPUT_DIR}}/bin/activate"
-        pip3 install --upgrade -r "{{.ROOT_DIR}}/requirements.txt"
+      - task: "create-venv"
+        vars:
+          LABEL: "package"
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
+          REQUIREMENTS_FILE: "{{.ROOT_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
       - >-
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
@@ -377,16 +377,16 @@ tasks:
     internal: true
     requires:
       vars: ["COMPONENT", "OUTPUT_DIR"]
-    label: "{{.COMPONENT}}_venv"
+    label: "{{.COMPONENT}}-venv"
     dir: "components/{{.COMPONENT}}"
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}_venv.md5"
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.COMPONENT}}-venv.md5"
     cmds:
-      - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "python3 -m venv '{{.OUTPUT_DIR}}'"
-      - |-
-        . "{{.OUTPUT_DIR}}/bin/activate"
-        pip3 install --upgrade -r "{{.ROOT_DIR}}/requirements.txt"
+      - task: "create-venv"
+        vars:
+          LABEL: "{{.COMPONENT}}"
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
+          REQUIREMENTS_FILE: "{{.ROOT_DIR}}/requirements.txt"
       # Checksum the generated files (this command must be last)
       - >-
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
@@ -411,3 +411,26 @@ tasks:
     dir: "components/{{.COMPONENT}}"
     cmds:
       - "rm -rf dist"
+
+  create-venv:
+    internal: true
+    requires:
+      vars: ["LABEL", "OUTPUT_DIR", "REQUIREMENTS_FILE"]
+    label: "create-venv-{{.LABEL}}"
+    cmds:
+      - "rm -rf '{{.OUTPUT_DIR}}'"
+      - "python3 -m venv '{{.OUTPUT_DIR}}'"
+      # Remove calls to `hash` from the venv activation script since Task uses `gosh` rather than
+      # `bash`.
+      # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
+      # shell was one that had the command, but that's not the case in newer versions.
+      - |-
+        # NOTE: We can't use `sed -i` since `-i` has different syntax on Linux and macOS
+        old="{{.OUTPUT_DIR}}/bin/activate"
+        new="{{.OUTPUT_DIR}}/bin/activate.tmp"
+        sed -E 's/^([[:space:]]*)hash[[:space:]]+.*/\1true/g' "${old}" > "${new}"
+        mv "${new}" "${old}"
+      - |-
+        . "{{.OUTPUT_DIR}}/bin/activate"
+        pip3 install --upgrade pip
+        pip3 install --upgrade -r "{{.REQUIREMENTS_FILE}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -296,7 +296,7 @@ tasks:
         vars:
           LABEL: "package"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
-          REQUIREMENTS_FILE: "{{.ROOT_DIR}}/requirements.txt"
+          REQUIREMENTS_FILE: "requirements.txt"
       # Checksum the generated files (this command must be last)
       - >-
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,6 +28,9 @@ tasks:
   default:
     deps: ["package"]
 
+  init:
+    cmds: ["mkdir -p '{{.G_BUILD_DIR}}'"]
+
   clean:
     cmds:
       - "rm -rf '{{.G_BUILD_DIR}}'"
@@ -72,13 +75,13 @@ tasks:
       - "core"
       - "clp-package-utils"
       - "clp-py-utils"
+      - "init"
       - "job-orchestration"
       - "package-venv"
       - "webui"
       - "webui-nodejs"
     cmds:
       - task: "clean-package"
-      - "mkdir -p '{{.OUTPUT_DIR}}'"
       - "rsync -a components/package-template/src/ '{{.OUTPUT_DIR}}'"
       - "rsync --copy-links /etc/os-release '{{.OUTPUT_DIR}}/etc/os-release'"
       - "mkdir -p '{{.OUTPUT_DIR}}/lib/python3/site-packages'"
@@ -134,7 +137,7 @@ tasks:
         "{{.CHECKSUM_FILE}}"
 
   core:
-    deps: ["core-submodules"]
+    deps: ["core-submodules", "init"]
     vars:
       SRC_DIR: "components/core"
     cmds:
@@ -175,7 +178,7 @@ tasks:
         COMPONENT: "{{.TASK}}"
 
   webui:
-    deps: ["webui-node-modules"]
+    deps: ["init", "webui-node-modules"]
     dir: "components/webui"
     platforms: ["386", "amd64"]
     vars:
@@ -212,6 +215,7 @@ tasks:
         "{{.CHECKSUM_FILE}}"
 
   webui-nodejs:
+    deps: ["init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}"
@@ -235,6 +239,7 @@ tasks:
 
   core-submodules:
     internal: true
+    deps: ["init"]
     dir: "components/core"
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
@@ -258,6 +263,7 @@ tasks:
 
   nodejs:
     internal: true
+    deps: ["init"]
     requires:
       vars: ["NODEJS_VERSION", "OUTPUT_DIR"]
     vars:
@@ -288,6 +294,7 @@ tasks:
 
   package-venv:
     internal: true
+    deps: ["init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_PACKAGE_VENV_DIR}}"
@@ -345,6 +352,7 @@ tasks:
       - "dist/*.whl"
 
   webui-node-modules:
+    deps: ["init"]
     internal: true
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
@@ -352,7 +360,6 @@ tasks:
       OUTPUT_DIR: "{{.WEBUI_SRC_DIR}}/node_modules"
     dir: "{{.WEBUI_SRC_DIR}}"
     cmds:
-      - "mkdir -p '{{.G_BUILD_DIR}}'"
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "meteor npm install --production"
       # Checksum the generated files (this command must be last)
@@ -372,6 +379,7 @@ tasks:
 
   component-venv:
     internal: true
+    deps: ["init"]
     requires:
       vars: ["COMPONENT", "OUTPUT_DIR"]
     label: "{{.COMPONENT}}-venv"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,9 +1,9 @@
 version: "3"
 
 vars:
-  LINTER_NODEJS_BUILD_DIR: "{{.TASKFILE_DIR}}/build/linter-nodejs"
+  LINTER_NODEJS_BUILD_DIR: "{{.BUILD_DIR}}/linter-nodejs"
   LINTER_NODEJS_BIN_DIR: "{{.LINTER_NODEJS_BUILD_DIR}}/node/bin"
-  VENV_DIR: "{{.TASKFILE_DIR}}/.lint-venv"
+  LINT_VENV_DIR: "{{.BUILD_DIR}}/lint-venv"
 
 tasks:
   check:
@@ -21,13 +21,13 @@ tasks:
       - task: "yml-fix"
 
   cpp-check:
-    dir: "{{.TASKFILE_DIR}}/components/core"
+    dir: "{{.ROOT_DIR}}/components/core"
     cmds:
       - task: "cpp"
         vars:
           FLAGS: "--dry-run"
     sources: &cpp_source_files
-      - "{{.TASKFILE_DIR}}/lint-tasks.yml"
+      - "{{.TASKFILE}}"
       - ".clang-format"
       - "src/**/*.cpp"
       - "src/**/*.h"
@@ -39,7 +39,7 @@ tasks:
       - "tests/**/*.inc"
 
   cpp-fix:
-    dir: "{{.TASKFILE_DIR}}/components/core"
+    dir: "{{.ROOT_DIR}}/components/core"
     cmds:
       - task: "cpp"
         vars:
@@ -47,7 +47,7 @@ tasks:
     sources: *cpp_source_files
 
   js-check:
-    dir: "{{.TASKFILE_DIR}}/components/webui"
+    dir: "{{.ROOT_DIR}}/components/webui"
     cmds:
       - task: "js"
         vars:
@@ -55,8 +55,8 @@ tasks:
     sources: &js_source_files
       - "{{.BUILD_DIR}}/lint#linter-node-modules.md5"
       - "{{.BUILD_DIR}}/webui-node-modules.md5"
-      - "{{.TASKFILE_DIR}}/lint-tasks.yml"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.ROOT_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
       - "client/**/*.js"
       - "client/**/*.jsx"
       - "imports/**/*.js"
@@ -69,7 +69,7 @@ tasks:
       - "tests/**/*.jsx"
 
   js-fix:
-    dir: "{{.TASKFILE_DIR}}/components/webui"
+    dir: "{{.ROOT_DIR}}/components/webui"
     cmds:
       - task: "js"
         vars:
@@ -97,7 +97,7 @@ tasks:
     deps: ["venv"]
     cmds:
       - |-
-        . "{{.VENV_DIR}}/bin/activate"
+        . "{{.LINT_VENV_DIR}}/bin/activate"
         yamllint .
 
   cpp:
@@ -105,10 +105,10 @@ tasks:
     requires:
       vars: ["FLAGS"]
     deps: ["venv"]
-    dir: "{{.TASKFILE_DIR}}/components/core"
+    dir: "{{.ROOT_DIR}}/components/core"
     cmds:
       - |-
-        . "{{.VENV_DIR}}/bin/activate"
+        . "{{.LINT_VENV_DIR}}/bin/activate"
         find src tests \
           -type f \
           \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
@@ -120,7 +120,7 @@ tasks:
     requires:
       vars: ["LINT_CMD"]
     deps: ["linter-node-modules"]
-    dir: "{{.TASKFILE_DIR}}/components/webui"
+    dir: "{{.ROOT_DIR}}/components/webui"
     cmds:
       - "PATH='{{.LINTER_NODEJS_BIN_DIR}}':$PATH npm run 'lint:{{.LINT_CMD}}'"
 
@@ -135,7 +135,7 @@ tasks:
           - "components/clp-py-utils/clp_py_utils"
           - "components/job-orchestration/job_orchestration"
         cmd: |-
-          . "{{.VENV_DIR}}/bin/activate"
+          . "{{.LINT_VENV_DIR}}/bin/activate"
           cd "{{.ITEM}}"
           black --color --line-length 100 {{.BLACK_FLAGS}} .
           ruff check {{.RUFF_FLAGS}} .
@@ -155,8 +155,8 @@ tasks:
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
         | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.TASKFILE_DIR}}/lint-tasks.yml"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.ROOT_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
     status:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-
@@ -169,7 +169,7 @@ tasks:
     deps: [":webui-node-modules", "linter-nodejs"]
     dir: "{{.WEBUI_LINTER_DIR}}"
     vars:
-      WEBUI_LINTER_DIR: "{{.TASKFILE_DIR}}/components/webui/linter"
+      WEBUI_LINTER_DIR: "{{.ROOT_DIR}}/components/webui/linter"
       OUTPUT_DIR: "{{.WEBUI_LINTER_DIR}}/node_modules"
       CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
     cmds:
@@ -182,8 +182,8 @@ tasks:
     sources:
       - "{{.BUILD_DIR}}/lint#linter-nodejs.md5"
       - "{{.BUILD_DIR}}/webui-node-modules.md5"
-      - "{{.TASKFILE_DIR}}/lint-tasks.yml"
-      - "{{.TASKFILE_DIR}}/Taskfile.yml"
+      - "{{.ROOT_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
       - "../package.json"
     status:
       - "test -f '{{.CHECKSUM_FILE}}'"
@@ -194,20 +194,19 @@ tasks:
 
   venv:
     internal: true
-    dir: "{{.TASKFILE_DIR}}"
     cmds:
-      - "rm -rf '{{.VENV_DIR}}'"
-      - "python3 -m venv '{{.VENV_DIR}}'"
+      - "rm -rf '{{.LINT_VENV_DIR}}'"
+      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
       # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.
-      - "sed -i 's/^\\s*hash\\s\\+.*/true/g' \"{{.VENV_DIR}}/bin/activate\""
+      - "sed -i 's/^\\s*hash\\s\\+.*/true/g' \"{{.LINT_VENV_DIR}}/bin/activate\""
       - |-
-        . "{{.VENV_DIR}}/bin/activate"
+        . "{{.LINT_VENV_DIR}}/bin/activate"
         pip3 install --upgrade pip
         pip3 install --upgrade -r lint-requirements.txt
     sources:
+      - "{{.TASKFILE}}"
       - "lint-requirements.txt"
-      - "lint-tasks.yml"
     generates:
-      - "{{.VENV_DIR}}/**/*"
+      - "{{.LINT_VENV_DIR}}/**/*"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,9 +1,9 @@
 version: "3"
 
 vars:
-  LINTER_NODEJS_BUILD_DIR: "{{.BUILD_DIR}}/linter-nodejs"
-  LINTER_NODEJS_BIN_DIR: "{{.LINTER_NODEJS_BUILD_DIR}}/node/bin"
-  LINT_VENV_DIR: "{{.BUILD_DIR}}/lint-venv"
+  G_LINTER_NODEJS_BUILD_DIR: "{{.G_BUILD_DIR}}/linter-nodejs"
+  G_LINTER_NODEJS_BIN_DIR: "{{.G_LINTER_NODEJS_BUILD_DIR}}/node/bin"
+  G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
 
 tasks:
   check:
@@ -53,8 +53,8 @@ tasks:
         vars:
           LINT_CMD: "check"
     sources: &js_source_files
-      - "{{.BUILD_DIR}}/lint#linter-node-modules.md5"
-      - "{{.BUILD_DIR}}/webui-node-modules.md5"
+      - "{{.G_BUILD_DIR}}/lint#linter-node-modules.md5"
+      - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
       - "client/**/*.js"
@@ -97,7 +97,7 @@ tasks:
     deps: ["venv"]
     cmds:
       - |-
-        . "{{.LINT_VENV_DIR}}/bin/activate"
+        . "{{.G_LINT_VENV_DIR}}/bin/activate"
         yamllint .
 
   cpp:
@@ -108,7 +108,7 @@ tasks:
     dir: "{{.ROOT_DIR}}/components/core"
     cmds:
       - |-
-        . "{{.LINT_VENV_DIR}}/bin/activate"
+        . "{{.G_LINT_VENV_DIR}}/bin/activate"
         find src tests \
           -type f \
           \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inc" \) \
@@ -122,7 +122,7 @@ tasks:
     deps: ["linter-node-modules"]
     dir: "{{.ROOT_DIR}}/components/webui"
     cmds:
-      - "PATH='{{.LINTER_NODEJS_BIN_DIR}}':$PATH npm run 'lint:{{.LINT_CMD}}'"
+      - "PATH='{{.G_LINTER_NODEJS_BIN_DIR}}':$PATH npm run 'lint:{{.LINT_CMD}}'"
 
   py:
     internal: true
@@ -135,7 +135,7 @@ tasks:
           - "components/clp-py-utils/clp_py_utils"
           - "components/job-orchestration/job_orchestration"
         cmd: |-
-          . "{{.LINT_VENV_DIR}}/bin/activate"
+          . "{{.G_LINT_VENV_DIR}}/bin/activate"
           cd "{{.ITEM}}"
           black --color --line-length 100 {{.BLACK_FLAGS}} .
           ruff check {{.RUFF_FLAGS}} .
@@ -143,8 +143,8 @@ tasks:
   linter-nodejs:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
-      OUTPUT_DIR: "{{.LINTER_NODEJS_BUILD_DIR}}"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
+      OUTPUT_DIR: "{{.G_LINTER_NODEJS_BUILD_DIR}}"
     cmds:
       - task: ":nodejs"
         vars:
@@ -171,17 +171,17 @@ tasks:
     vars:
       WEBUI_LINTER_DIR: "{{.ROOT_DIR}}/components/webui/linter"
       OUTPUT_DIR: "{{.WEBUI_LINTER_DIR}}/node_modules"
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "PATH='{{.LINTER_NODEJS_BIN_DIR}}':$PATH npm update"
+      - "PATH='{{.G_LINTER_NODEJS_BIN_DIR}}':$PATH npm update"
       # Checksum the generated files (this command must be last)
       - >-
         tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
         | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.BUILD_DIR}}/lint#linter-nodejs.md5"
-      - "{{.BUILD_DIR}}/webui-node-modules.md5"
+      - "{{.G_BUILD_DIR}}/lint#linter-nodejs.md5"
+      - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
       - "../package.json"
@@ -195,8 +195,8 @@ tasks:
   venv:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
-      OUTPUT_DIR: "{{.LINT_VENV_DIR}}"
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
+      OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"
     cmds:
       - task: ":create-venv"
         vars:

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -142,32 +142,40 @@ tasks:
 
   linter-nodejs:
     internal: true
-    deps: [":init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
       OUTPUT_DIR: "{{.G_LINTER_NODEJS_BUILD_DIR}}"
+    deps:
+      - ":init"
+      - task: ":validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - task: ":nodejs"
         vars:
           NODEJS_VERSION: "latest"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: ":compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   linter-node-modules:
     internal: true
-    deps: [":init", ":webui-node-modules", "linter-nodejs"]
+    deps:
+      - ":init"
+      - ":webui-node-modules"
+      - task: ":validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+      - "linter-nodejs"
     dir: "{{.WEBUI_LINTER_DIR}}"
     vars:
       WEBUI_LINTER_DIR: "{{.ROOT_DIR}}/components/webui/linter"
@@ -176,46 +184,43 @@ tasks:
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "PATH='{{.G_LINTER_NODEJS_BIN_DIR}}':$PATH npm update"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: ":compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.G_BUILD_DIR}}/lint#linter-nodejs.md5"
       - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
       - "../package.json"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   venv:
     internal: true
-    deps: [":init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
       OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"
+    deps:
+      - ":init"
+      - task: ":validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - task: ":create-venv"
         vars:
           LABEL: "lint"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
           REQUIREMENTS_FILE: "lint-requirements.txt"
-      # Checksum the generated files (this command must be last)
-      - >-
-        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
-        | md5sum > "{{.CHECKSUM_FILE}}"
+      # This command must be last
+      - task: ":compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
-    status:
-      - "test -f '{{.CHECKSUM_FILE}}'"
-      - >-
-        diff
-        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
-        "{{.CHECKSUM_FILE}}"
+    generates: ["{{.CHECKSUM_FILE}}"]

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -194,19 +194,26 @@ tasks:
 
   venv:
     internal: true
+    vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
+      OUTPUT_DIR: "{{.LINT_VENV_DIR}}"
     cmds:
-      - "rm -rf '{{.LINT_VENV_DIR}}'"
-      - "python3 -m venv '{{.LINT_VENV_DIR}}'"
-      # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
-      # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
-      # shell was one that had the command, but that's not the case in newer versions.
-      - "sed -i 's/^\\s*hash\\s\\+.*/true/g' \"{{.LINT_VENV_DIR}}/bin/activate\""
-      - |-
-        . "{{.LINT_VENV_DIR}}/bin/activate"
-        pip3 install --upgrade pip
-        pip3 install --upgrade -r lint-requirements.txt
+      - task: ":create-venv"
+        vars:
+          LABEL: "lint"
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
+          REQUIREMENTS_FILE: "lint-requirements.txt"
+      # Checksum the generated files (this command must be last)
+      - >-
+        tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} .
+        | md5sum > "{{.CHECKSUM_FILE}}"
     sources:
+      - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
-    generates:
-      - "{{.LINT_VENV_DIR}}/**/*"
+    status:
+      - "test -f '{{.CHECKSUM_FILE}}'"
+      - >-
+        diff
+        <(tar cf - --directory "{{.OUTPUT_DIR}}" {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
+        "{{.CHECKSUM_FILE}}"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -142,6 +142,7 @@ tasks:
 
   linter-nodejs:
     internal: true
+    deps: [":init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
       OUTPUT_DIR: "{{.G_LINTER_NODEJS_BUILD_DIR}}"
@@ -166,7 +167,7 @@ tasks:
 
   linter-node-modules:
     internal: true
-    deps: [":webui-node-modules", "linter-nodejs"]
+    deps: [":init", ":webui-node-modules", "linter-nodejs"]
     dir: "{{.WEBUI_LINTER_DIR}}"
     vars:
       WEBUI_LINTER_DIR: "{{.ROOT_DIR}}/components/webui/linter"
@@ -194,6 +195,7 @@ tasks:
 
   venv:
     internal: true
+    deps: [":init"]
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
       OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -21,7 +21,7 @@ tasks:
       - task: "yml-fix"
 
   cpp-check:
-    dir: "{{.ROOT_DIR}}/components/core"
+    dir: "components/core"
     cmds:
       - task: "cpp"
         vars:
@@ -39,7 +39,7 @@ tasks:
       - "tests/**/*.inc"
 
   cpp-fix:
-    dir: "{{.ROOT_DIR}}/components/core"
+    dir: "components/core"
     cmds:
       - task: "cpp"
         vars:
@@ -47,7 +47,7 @@ tasks:
     sources: *cpp_source_files
 
   js-check:
-    dir: "{{.ROOT_DIR}}/components/webui"
+    dir: "components/webui"
     cmds:
       - task: "js"
         vars:
@@ -69,7 +69,7 @@ tasks:
       - "tests/**/*.jsx"
 
   js-fix:
-    dir: "{{.ROOT_DIR}}/components/webui"
+    dir: "components/webui"
     cmds:
       - task: "js"
         vars:
@@ -105,7 +105,7 @@ tasks:
     requires:
       vars: ["FLAGS"]
     deps: ["venv"]
-    dir: "{{.ROOT_DIR}}/components/core"
+    dir: "components/core"
     cmds:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
@@ -120,7 +120,7 @@ tasks:
     requires:
       vars: ["LINT_CMD"]
     deps: ["linter-node-modules"]
-    dir: "{{.ROOT_DIR}}/components/webui"
+    dir: "components/webui"
     cmds:
       - "PATH='{{.G_LINTER_NODEJS_BIN_DIR}}':$PATH npm run 'lint:{{.LINT_CMD}}'"
 


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR cleans up the Taskfiles in this repo and applies a new naming convention for global variables. A future PR will further reorder the tasks to be more logical.

Itemized changes:

* Replaces the `cd` + `tar` sequence with tar's `--directory` argument.
* Moves the lint-venv directory into the build directory, so that it's removed on `task clean` and doesn't pollute the source.
* Deduplicates the venv tasks with a single venv creation task.
  * This task now also works on macOS by replicating the functionality of `sed -i` (to avoid differences between `-i` on Linux versus macOS).
* Deduplicates the checksum computation and validation into tasks.
  * Since `task` can't call a task as a `status` check, we use a new mechanism for determining when to rerun the task:
    * We list the checksum as a generated file so that in its absence, the task will rerun.
    * We make the checksum validation a dependency of the task, where the validation will remove the checksum file if it doesn't match.
* Creates the build directory as an init task for tasks that need it.
* Reuses the `{{.BUILD_DIR}}` variable in other variables rather than repeating it (since task [respects](https://taskfile.dev/api/#variable) variable declaration order).
* Replaces `{{.TASKFILE_DIR}}` with `{{.ROOT_DIR}}` where appropriate.
* Uses `{{.TASKFILE}}` to replace instances of `{{.TASKFILE_DIR}}/Taskfile.yml` and `{{.TASKFILE_DIR}}/lint-tasks.yml`.
* Renames some task labels and output directories to replace `_` with `-`.
* Prefixes global variables with `G_` to avoid conflicts with local variables.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated the lint workflow.
* Built the package with `task`.
* Called `task` again to ensure incremental builds still work (`webui-node-modules` was still rebuilt due to a known issue).
* Cleaned the package with `task`.
* Built the package again with `task`.
* Tested compression and search with the package is still functional.