### PR TITLE
Taskfile: Bypass cache when querying for latest node version.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -263,7 +263,7 @@ tasks:
       NODEJS_VERSION_BASE_URL: "https://nodejs.org/dist/{{.NODEJS_VERSION}}/"
       NODEJS_FILE_BASE_NAME:
         sh: >-
-          curl --silent "{{.NODEJS_VERSION_BASE_URL}}"
+          curl --header "Cache-Control: no-cache, no-store" --silent "{{.NODEJS_VERSION_BASE_URL}}"
           | grep
           --only-matching
           --perl-regexp


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Recent runs of the lint workflow are [failing](https://github.com/y-scope/clp/actions/runs/8823559590/job/24224479242) because when fetching the page of available Node.js downloads, the page is a cached version pointing to a version of node.js that's no longer available.

Thus, this PR adds no-cache headers to the request in an attempt to bypass the cache.

Thanks to @junhaoliao for the investigation and validating the solution.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated the lint workflow succeeds now.
