### PR TITLE
webui: Make query input placeholder specific to the current storage engine.

### DIFF
--- a/components/webui/imports/ui/SearchView/SearchControls/index.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls/index.jsx
@@ -15,6 +15,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
+import {CLP_STORAGE_ENGINES} from "/imports/api/constants";
 import {
     isOperationInProgress,
     isSearchSignalReq,
@@ -85,6 +86,10 @@ const SearchControls = ({
         onSubmitQuery();
     };
 
+    const queryPlaceholderText =
+        CLP_STORAGE_ENGINES.CLP === Meteor.settings.public.ClpStorageEngine ?
+            "Enter a wildcard query..." :
+            "Enter a KQL query...";
     return (
         <>
             <Form onSubmit={handleQuerySubmission}>
@@ -102,7 +107,7 @@ const SearchControls = ({
                             autoFocus={true}
                             className={"border-top-0 border-bottom-0"}
                             disabled={isInputDisabled}
-                            placeholder={"Enter your query..."}
+                            placeholder={queryPlaceholderText}
                             ref={inputRef}
                             type={"text"}
                             value={queryString}


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The current placeholder for the query input is `Enter your query...`. Since `clp` and `clp-s` use different query syntaxes, it's a good idea to remind the user in the UI.

This PR uses different placeholders per storage engine:
* clp: `Enter a wildcard query`
* clp-s: `Enter a KQL query`

In a future PR, we should add a help icon somewhere which links to our upcoming docs about the precise syntax for each.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that the placeholder that shows up changes depending on the configured storage engine.

