### PR TITLE
Refactor Ubuntu Focal gcc-10 setup and update related usage instructions.

### DIFF
--- a/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile
@@ -9,15 +9,10 @@ ADD ./tools/scripts/lib_install ./tools/scripts/lib_install
 # `install-prebuilt-packages.sh` and `install-packages-from-source.sh`.
 RUN ./tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
 
-# Set gcc/g++ 10 as the default compiler
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
-RUN update-alternatives --set gcc /usr/bin/gcc-10
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 20
+# Set cpp, cc, and c++ to v10
 RUN update-alternatives --set cc /usr/bin/gcc-10
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
-RUN update-alternatives --set g++ /usr/bin/g++-10
-RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 20
 RUN update-alternatives --set c++ /usr/bin/g++-10
+RUN update-alternatives --set cpp /usr/bin/cpp-10
 
 RUN ./tools/scripts/lib_install/ubuntu-focal/install-packages-from-source.sh
 

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -26,3 +26,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   python3 \
   python3-pip \
   zlib1g-dev
+
+# Add alternatives for cpp-10, gcc-10, and g++-10
+# NOTE: We use a low priority to avoid affecting the prioritization of any existing alternatives
+# on the user's system.
+update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 0 \
+  --slave /usr/share/mna/man1/cc.1.gz cc.1.gz /usr/share/man/man1/gcc.1.gz
+update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 0 \
+  --slave /usr/share/mna/man1/c++.1.gz c++.1.gz /usr/share/man/man1/g++.1.gz
+update-alternatives --install /lib/cpp cpp /usr/bin/cpp-10 0

--- a/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
+++ b/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
@@ -21,15 +21,7 @@ components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
 Enable GCC 10 as the default compiler by running:
 
 ```shell
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
-update-alternatives --set gcc /usr/bin/gcc-10
-
-update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 20
 update-alternatives --set cc /usr/bin/gcc-10
-
-update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
-update-alternatives --set g++ /usr/bin/g++-10
-
-update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 20
 update-alternatives --set c++ /usr/bin/g++-10
+update-alternatives --set cpp /usr/bin/cpp-10
 ```


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

In #131, we made GCC v10+ a requirement. Since the default version of GCC on Ubuntu Focal is v9, #131 also added set up steps to configure v10 as the compiler on Focal. However, these steps were flawed:

* They were configuring `gcc` and `g++` as the names for the [alternatives](https://linux.die.net/man/8/update-alternatives) whereas Ubuntu usually sets `cc` and `c++` as the names.
  * This is why we had to add `cc` and `c++` in #288.
* Adding the alternatives was done as a configuration step rather than as part of the installation.
* The priority of the added alternatives was set to 10/20 rather than something low that wouldn't affect any alternatives the user already had installed and prioritized.
* They were not configuring slave links for the man pages (something the Ubuntu GCC package maintainers usually do).
  * To investigate the alternatives created by the package maintainers, you can use `update-alternatives --query <program>` where `<program>` is one of `cc`, `c++`, or `cpp`.

This PR addresses these limitations:
* We create low-priority alternatives for `cc`, `c++`, and `cpp` (the same alternatives created by the Ubuntu GCC package maintainers, except for GCC v10) as part of the dependency install scripts.
  * We no longer create alternatives for `gcc` and `g++`.
* The configuration setup steps only switch to the alternative.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated that workflow for building and testing the Ubuntu core deps container [image](https://github.com/kirkrodrigues/clp/blob/main/components/core/tools/docker-images/clp-env-base-ubuntu-focal/Dockerfile) succeeded.
* Built and ran the container image locally.
* Validated that `cc --version`, `c++ --version` and `/lib/cpp --version` all print a v10 version string.
  * We use `/lib/cpp` based on the alternative that the Ubuntu gcc package usually creates (see `ls /etc/alternatives`).
* Validated that building clp showed that it was using v10.
