### PR TITLE
Fix path typo in Ubuntu Focal dependency install script.

### DIFF
--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -31,7 +31,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
 # NOTE: We use a low priority to avoid affecting the prioritization of any existing alternatives
 # on the user's system.
 update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 0 \
-  --slave /usr/share/mna/man1/cc.1.gz cc.1.gz /usr/share/man/man1/gcc.1.gz
+  --slave /usr/share/man/man1/cc.1.gz cc.1.gz /usr/share/man/man1/gcc.1.gz
 update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 0 \
-  --slave /usr/share/mna/man1/c++.1.gz c++.1.gz /usr/share/man/man1/g++.1.gz
+  --slave /usr/share/man/man1/c++.1.gz c++.1.gz /usr/share/man/man1/g++.1.gz
 update-alternatives --install /lib/cpp cpp /usr/bin/cpp-10 0


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

#371 had a typo in it which causes this error when trying to run `components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh` on an Ubuntu Focal host (not a container):

```text
update-alternatives: renaming cc.1.gz slave link from /usr/share/man/man1/cc.1.gz to /usr/share/mna/man1/cc.1.gz
update-alternatives: error: unable to install '/usr/share/man/man1/cc.1.gz' as '/usr/share/mna/man1/cc.1.gz': No such file or directory
```

This error is not triggered when the script is used inside the container images since there are no man pages installed in the first place.

# Validation performed
<!-- What tests and validation you performed on the change -->

Ran `components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh` on an Ubuntu host and verified the error no longer occurs.
