### PR TITLE
core: Remove invalid methods for getting a column's value from a SQLitePreparedStatement.

### DIFF
--- a/components/core/src/clp/SQLitePreparedStatement.cpp
+++ b/components/core/src/clp/SQLitePreparedStatement.cpp
@@ -3,6 +3,8 @@
 #include "Defs.h"
 #include "spdlog_with_specializations.hpp"
 
+#include <iostream>
+
 using std::string;
 
 namespace clp {
@@ -169,36 +171,12 @@ int SQLitePreparedStatement::column_int(int parameter_index) const {
     return sqlite3_column_int(m_statement_handle, parameter_index);
 }
 
-int SQLitePreparedStatement::column_int(string const& parameter_name) const {
-    if (false == m_row_ready) {
-        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-    }
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    return column_int(parameter_index);
-}
-
 int64_t SQLitePreparedStatement::column_int64(int parameter_index) const {
     if (false == m_row_ready) {
         throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
     }
 
     return sqlite3_column_int64(m_statement_handle, parameter_index);
-}
-
-int64_t SQLitePreparedStatement::column_int64(string const& parameter_name) const {
-    if (false == m_row_ready) {
-        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-    }
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    return column_int64(parameter_index);
 }
 
 void SQLitePreparedStatement::column_string(int parameter_index, std::string& value) const {
@@ -210,20 +188,5 @@ void SQLitePreparedStatement::column_string(int parameter_index, std::string& va
             reinterpret_cast<char const*>(sqlite3_column_text(m_statement_handle, parameter_index)),
             sqlite3_column_bytes(m_statement_handle, parameter_index)
     );
-}
-
-void SQLitePreparedStatement::column_string(
-        std::string const& parameter_name,
-        std::string& value
-) const {
-    if (false == m_row_ready) {
-        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-    }
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    column_string(parameter_index, value);
 }
 }  // namespace clp

--- a/components/core/src/clp/SQLitePreparedStatement.cpp
+++ b/components/core/src/clp/SQLitePreparedStatement.cpp
@@ -3,8 +3,6 @@
 #include "Defs.h"
 #include "spdlog_with_specializations.hpp"
 
-#include <iostream>
-
 using std::string;
 
 namespace clp {

--- a/components/core/src/clp/SQLitePreparedStatement.hpp
+++ b/components/core/src/clp/SQLitePreparedStatement.hpp
@@ -48,11 +48,8 @@ public:
 
     bool step();
     int column_int(int parameter_index) const;
-    int column_int(std::string const& parameter_name) const;
     int64_t column_int64(int parameter_index) const;
-    int64_t column_int64(std::string const& parameter_name) const;
     void column_string(int parameter_index, std::string& value) const;
-    void column_string(std::string const& parameter_name, std::string& value) const;
 
     bool is_row_ready() const { return m_row_ready; }
 

--- a/components/core/src/glt/SQLitePreparedStatement.cpp
+++ b/components/core/src/glt/SQLitePreparedStatement.cpp
@@ -169,36 +169,12 @@ int SQLitePreparedStatement::column_int(int parameter_index) const {
     return sqlite3_column_int(m_statement_handle, parameter_index);
 }
 
-int SQLitePreparedStatement::column_int(string const& parameter_name) const {
-    if (false == m_row_ready) {
-        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-    }
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    return column_int(parameter_index);
-}
-
 int64_t SQLitePreparedStatement::column_int64(int parameter_index) const {
     if (false == m_row_ready) {
         throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
     }
 
     return sqlite3_column_int64(m_statement_handle, parameter_index);
-}
-
-int64_t SQLitePreparedStatement::column_int64(string const& parameter_name) const {
-    if (false == m_row_ready) {
-        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-    }
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    return column_int64(parameter_index);
 }
 
 void SQLitePreparedStatement::column_string(int parameter_index, std::string& value) const {
@@ -210,20 +186,5 @@ void SQLitePreparedStatement::column_string(int parameter_index, std::string& va
             reinterpret_cast<char const*>(sqlite3_column_text(m_statement_handle, parameter_index)),
             sqlite3_column_bytes(m_statement_handle, parameter_index)
     );
-}
-
-void SQLitePreparedStatement::column_string(
-        std::string const& parameter_name,
-        std::string& value
-) const {
-    if (false == m_row_ready) {
-        throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
-    }
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    column_string(parameter_index, value);
 }
 }  // namespace glt

--- a/components/core/src/glt/SQLitePreparedStatement.hpp
+++ b/components/core/src/glt/SQLitePreparedStatement.hpp
@@ -48,11 +48,8 @@ public:
 
     bool step();
     int column_int(int parameter_index) const;
-    int column_int(std::string const& parameter_name) const;
     int64_t column_int64(int parameter_index) const;
-    int64_t column_int64(std::string const& parameter_name) const;
     void column_string(int parameter_index, std::string& value) const;
-    void column_string(std::string const& parameter_name, std::string& value) const;
 
     bool is_row_ready() const { return m_row_ready; }
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
In the current `SQLitePreparedStatement` implementations, we provide methods to get the column data with the column string names. However, it is functionally incorrect since the underlying `sqlite3_bind_parameter_index` does not return the correct index in the prepared statement. This PR removes these incorrect methods.

# Validation performed
<!-- What tests and validation you performed on the change -->
- These methods are not used so they should not break any functionalities in theory.
- Ensure the build flow is unaffected.
