### PR TITLE
core: Remove unsed bind methods from SQLitePreparedStatement.

### DIFF
--- a/components/core/src/clp/SQLitePreparedStatement.cpp
+++ b/components/core/src/clp/SQLitePreparedStatement.cpp
@@ -77,15 +77,6 @@ void SQLitePreparedStatement::bind_int(int parameter_index, int value) {
     }
 }
 
-void SQLitePreparedStatement::bind_int(string const& parameter_name, int value) {
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    bind_int(parameter_index, value);
-}
-
 void SQLitePreparedStatement::bind_int64(int parameter_index, int64_t value) {
     auto return_value = sqlite3_bind_int64(m_statement_handle, parameter_index, value);
     if (SQLITE_OK != return_value) {
@@ -95,15 +86,6 @@ void SQLitePreparedStatement::bind_int64(int parameter_index, int64_t value) {
         );
         throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
     }
-}
-
-void SQLitePreparedStatement::bind_int64(string const& parameter_name, int64_t value) {
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    bind_int64(parameter_index, value);
 }
 
 void SQLitePreparedStatement::bind_text(
@@ -125,19 +107,6 @@ void SQLitePreparedStatement::bind_text(
         );
         throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
     }
-}
-
-void SQLitePreparedStatement::bind_text(
-        string const& parameter_name,
-        string const& value,
-        bool copy_parameter
-) {
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    bind_text(parameter_index, value, copy_parameter);
 }
 
 void SQLitePreparedStatement::reset() {

--- a/components/core/src/clp/SQLitePreparedStatement.hpp
+++ b/components/core/src/clp/SQLitePreparedStatement.hpp
@@ -38,12 +38,8 @@ public:
 
     // Methods
     void bind_int(int parameter_index, int value);
-    void bind_int(std::string const& parameter_name, int value);
     void bind_int64(int parameter_index, int64_t value);
-    void bind_int64(std::string const& parameter_name, int64_t value);
     void bind_text(int parameter_index, std::string const& value, bool copy_parameter);
-    void
-    bind_text(std::string const& parameter_name, std::string const& value, bool copy_parameter);
     void reset();
 
     bool step();

--- a/components/core/src/glt/SQLitePreparedStatement.cpp
+++ b/components/core/src/glt/SQLitePreparedStatement.cpp
@@ -77,15 +77,6 @@ void SQLitePreparedStatement::bind_int(int parameter_index, int value) {
     }
 }
 
-void SQLitePreparedStatement::bind_int(string const& parameter_name, int value) {
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    bind_int(parameter_index, value);
-}
-
 void SQLitePreparedStatement::bind_int64(int parameter_index, int64_t value) {
     auto return_value = sqlite3_bind_int64(m_statement_handle, parameter_index, value);
     if (SQLITE_OK != return_value) {
@@ -95,15 +86,6 @@ void SQLitePreparedStatement::bind_int64(int parameter_index, int64_t value) {
         );
         throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
     }
-}
-
-void SQLitePreparedStatement::bind_int64(string const& parameter_name, int64_t value) {
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    bind_int64(parameter_index, value);
 }
 
 void SQLitePreparedStatement::bind_text(
@@ -125,19 +107,6 @@ void SQLitePreparedStatement::bind_text(
         );
         throw OperationFailed(ErrorCode_Failure, __FILENAME__, __LINE__);
     }
-}
-
-void SQLitePreparedStatement::bind_text(
-        string const& parameter_name,
-        string const& value,
-        bool copy_parameter
-) {
-    int parameter_index = sqlite3_bind_parameter_index(m_statement_handle, parameter_name.c_str());
-    if (0 == parameter_index) {
-        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
-    }
-
-    bind_text(parameter_index, value, copy_parameter);
 }
 
 void SQLitePreparedStatement::reset() {

--- a/components/core/src/glt/SQLitePreparedStatement.hpp
+++ b/components/core/src/glt/SQLitePreparedStatement.hpp
@@ -38,12 +38,8 @@ public:
 
     // Methods
     void bind_int(int parameter_index, int value);
-    void bind_int(std::string const& parameter_name, int value);
     void bind_int64(int parameter_index, int64_t value);
-    void bind_int64(std::string const& parameter_name, int64_t value);
     void bind_text(int parameter_index, std::string const& value, bool copy_parameter);
-    void
-    bind_text(std::string const& parameter_name, std::string const& value, bool copy_parameter);
     void reset();
 
     bool step();


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The current `SQLitePreparedStatement` implementation provides interfaces to `bind` a value with a string name parameter as the column name. However, this operation is ambiguous. For example, in a select statement, the column must appear in the selected list. After discussion, we decided to remove these methods from the implementations. Suppose a statement needs to bind values to a column specified by a string name. In that case, it should be implemented by a derived class rather than a generic `SQLitePreparedStatement`, which has a more clear specification on what the passed-in column name means.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure all the workflow passed. The methods removed are not used in the current codebase. Removing them should not influence the core functionalities.