### PR TITLE
core: Add unit test to cover basic SQLite functionalities.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -389,6 +389,7 @@ set(SOURCE_FILES_unitTest
         tests/test-ParserWithUserSchema.cpp
         tests/test-query_methods.cpp
         tests/test-Segment.cpp
+        tests/test-SQLiteDB.cpp
         tests/test-Stopwatch.cpp
         tests/test-StreamingCompression.cpp
         tests/test-string_utils.cpp

--- a/components/core/src/clp/SQLiteDB.cpp
+++ b/components/core/src/clp/SQLiteDB.cpp
@@ -19,6 +19,15 @@ void SQLiteDB::open(string const& path) {
     }
 }
 
+SQLiteDB::~SQLiteDB() {
+    if (nullptr == m_db_handle) {
+        return;
+    }
+    if (false == close()) {
+        SPDLOG_WARN("Memory leak due to failure of closing sqlite database.");
+    }
+}
+
 bool SQLiteDB::close() {
     auto return_value = sqlite3_close(m_db_handle);
     if (SQLITE_BUSY == return_value) {

--- a/components/core/src/clp/SQLiteDB.cpp
+++ b/components/core/src/clp/SQLiteDB.cpp
@@ -24,7 +24,7 @@ SQLiteDB::~SQLiteDB() {
         return;
     }
     if (false == close()) {
-        SPDLOG_WARN("Memory leak due to failure of closing sqlite database.");
+        SPDLOG_WARN("Failed to close underlying SQLite database - this may cause a memory leak.");
     }
 }
 

--- a/components/core/src/clp/SQLiteDB.hpp
+++ b/components/core/src/clp/SQLiteDB.hpp
@@ -26,11 +26,7 @@ public:
     SQLiteDB() : m_db_handle(nullptr) {}
 
     // Destructor
-    ~SQLiteDB() {
-        if (nullptr != m_db_handle) {
-            close();
-        }
-    }
+    ~SQLiteDB();
 
     // Methods
     void open(std::string const& path);

--- a/components/core/src/clp/SQLiteDB.hpp
+++ b/components/core/src/clp/SQLiteDB.hpp
@@ -25,6 +25,13 @@ public:
     // Constructors
     SQLiteDB() : m_db_handle(nullptr) {}
 
+    // Destructor
+    ~SQLiteDB() {
+        if (nullptr != m_db_handle) {
+            close();
+        }
+    }
+
     // Methods
     void open(std::string const& path);
     bool close();

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -1,0 +1,243 @@
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <Catch2/single_include/catch2/catch.hpp>
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include "../src/clp/database_utils.hpp"
+#include "../src/clp/Defs.h"
+#include "../src/clp/SQLiteDB.hpp"
+#include "../src/clp/SQLitePreparedStatement.hpp"
+#include "../src/clp/streaming_archive/Constants.hpp"
+
+using clp::epochtime_t;
+using clp::SQLiteDB;
+using clp::SQLitePreparedStatement;
+
+namespace {
+class TestTable {
+public:
+    TestTable() {
+        auto add_column = [&](std::string_view column_name, std::string type) -> void {
+            m_columns.emplace_back(column_name);
+            m_column_types.emplace_back(column_name, type);
+            m_column_idx_map.emplace(column_name, static_cast<int>(m_column_idx_map.size() + 1));
+        };
+
+        add_column(clp::streaming_archive::cMetadataDB::File::Path, "TEXT PRIMARY KEY");
+        add_column(clp::streaming_archive::cMetadataDB::File::BeginTimestamp, "INTEGER");
+        add_column(clp::streaming_archive::cMetadataDB::File::EndTimestamp, "INTEGER");
+        add_column(clp::streaming_archive::cMetadataDB::File::SegmentId, "INTEGER");
+        add_column(clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition, "INTEGER");
+    }
+
+    [[nodiscard]] auto get_column_idx(std::string const& column_name) const -> int {
+        auto const it{m_column_idx_map.find(column_name)};
+        REQUIRE(m_column_idx_map.cend() != it);
+        return it->second;
+    }
+
+    [[nodiscard]] auto get_columns() const -> std::vector<std::string> const& { return m_columns; }
+
+    [[nodiscard]] auto get_column_types(
+    ) const -> std::vector<std::pair<std::string, std::string>> const& {
+        return m_column_types;
+    }
+
+    [[nodiscard]] auto get_column_idx_map() const -> std::unordered_map<std::string, int> const& {
+        return m_column_idx_map;
+    }
+
+    [[nodiscard]] auto get_name() const -> std::string_view { return m_name; }
+
+private:
+    std::string m_name{"CLP_TEST_TABLE"};
+    std::vector<std::string> m_columns;
+    std::vector<std::pair<std::string, std::string>> m_column_types;
+    std::unordered_map<std::string, int> m_column_idx_map;
+};
+
+class TestRow {
+public:
+    TestRow(std::string path,
+            epochtime_t begin_ts,
+            epochtime_t end_ts,
+            size_t segment_id,
+            size_t segment_ts_pos)
+            : m_path{std::move(path)},
+              m_begin_ts{begin_ts},
+              m_end_ts{end_ts},
+              m_segment_id{segment_id},
+              m_segment_ts_pos{segment_ts_pos} {}
+
+    [[nodiscard]] auto get_path() const -> std::string_view { return m_path; }
+
+    [[nodiscard]] auto get_begin_ts() const -> epochtime_t { return m_begin_ts; }
+
+    [[nodiscard]] auto get_end_ts() const -> epochtime_t { return m_end_ts; }
+
+    [[nodiscard]] auto get_segment_id() const -> size_t { return m_segment_id; }
+
+    [[nodiscard]] auto get_segment_ts_pos() const -> size_t { return m_segment_ts_pos; }
+
+    auto
+    insert_to_table(SQLitePreparedStatement& insert_stmt, TestTable const& table) const -> void {
+        insert_stmt.bind_text(
+                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::Path),
+                m_path,
+                false
+        );
+        insert_stmt.bind_int64(
+                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::BeginTimestamp),
+                m_begin_ts
+        );
+        insert_stmt.bind_int64(
+                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::EndTimestamp),
+                m_end_ts
+        );
+        insert_stmt.bind_int64(
+                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::SegmentId),
+                m_segment_id
+        );
+        insert_stmt.bind_int64(
+                table.get_column_idx(
+                        clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition
+                ),
+                m_segment_ts_pos
+        );
+        insert_stmt.step();
+        insert_stmt.reset();
+    }
+
+private:
+    std::string m_path;
+    epochtime_t m_begin_ts;
+    epochtime_t m_end_ts;
+    size_t m_segment_id;
+    size_t m_segment_ts_pos;
+};
+
+[[nodiscard]] auto get_test_table() -> TestTable const& {
+    static std::unique_ptr<TestTable> table_ptr{nullptr};
+    if (nullptr == table_ptr) {
+        table_ptr = std::make_unique<TestTable>();
+    }
+    return *table_ptr;
+}
+
+auto create_table_and_indices(SQLiteDB& db) -> void {
+    fmt::memory_buffer statement_buffer;
+    auto statement_buffer_ix{std::back_inserter(statement_buffer)};
+    auto const& test_table{get_test_table()};
+
+    fmt::format_to(
+            statement_buffer_ix,
+            "CREATE TABLE IF NOT EXISTS {} ({}) WITHOUT ROWID",
+            test_table.get_name(),
+            clp::get_field_names_and_types_sql(test_table.get_column_types())
+    );
+    auto create_table_stmt{db.prepare_statement(statement_buffer.data(), statement_buffer.size())};
+    create_table_stmt.step();
+    statement_buffer.clear();
+
+    fmt::format_to(
+            statement_buffer_ix,
+            "CREATE INDEX IF NOT EXISTS files_begin_timestamp ON {} ({})",
+            test_table.get_name(),
+            clp::streaming_archive::cMetadataDB::File::BeginTimestamp
+    );
+    auto create_begin_ts_idx_stmt{
+            db.prepare_statement(statement_buffer.data(), statement_buffer.size())
+    };
+    create_begin_ts_idx_stmt.step();
+    statement_buffer.clear();
+
+    fmt::format_to(
+            statement_buffer_ix,
+            "CREATE INDEX IF NOT EXISTS files_begin_timestamp ON {} ({})",
+            test_table.get_name(),
+            clp::streaming_archive::cMetadataDB::File::BeginTimestamp
+    );
+    auto create_end_ts_idx_stmt{
+            db.prepare_statement(statement_buffer.data(), statement_buffer.size())
+    };
+    create_end_ts_idx_stmt.step();
+    statement_buffer.clear();
+
+    fmt::format_to(
+            statement_buffer_ix,
+            "CREATE INDEX IF NOT EXISTS files_segment_order ON {} ({},{})",
+            test_table.get_name(),
+            clp::streaming_archive::cMetadataDB::File::SegmentId,
+            clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition
+    );
+    auto create_segment_order_idx_stmt{
+            db.prepare_statement(statement_buffer.data(), statement_buffer.size())
+    };
+    create_segment_order_idx_stmt.step();
+    statement_buffer.clear();
+}
+
+[[nodiscard]] auto get_test_sqlite_db_abs_path() -> std::filesystem::path {
+    std::filesystem::path const file_path{__FILE__};
+    auto const test_root_path{file_path.parent_path()};
+    return test_root_path / "test_sqlite_db/test.db";
+}
+
+auto sqlite_db_create(std::vector<TestRow> const& rows) -> void {
+    auto const db_path{get_test_sqlite_db_abs_path()};
+    if (std::filesystem::exists(db_path)) {
+        REQUIRE(std::filesystem::remove(db_path));
+    }
+
+    SQLiteDB sqlite_db;
+    sqlite_db.open(db_path.string());
+
+    // Create a new table and indices.
+    create_table_and_indices(sqlite_db);
+
+    // Insert rows to the table.
+    auto const& test_table{get_test_table()};
+    auto transaction_begin_stmt{sqlite_db.prepare_statement("BEGIN TRANSACTION")};
+    auto transaction_end_stmt{sqlite_db.prepare_statement("END TRANSACTION")};
+    fmt::memory_buffer stmt_buf;
+    auto statement_buffer_ix{std::back_inserter(stmt_buf)};
+    fmt::format_to(
+            statement_buffer_ix,
+            "INSERT INTO {} ({}) VALUES ({})",
+            test_table.get_name(),
+            clp::get_field_names_sql(test_table.get_columns()),
+            clp::get_numbered_placeholders_sql(test_table.get_columns().size())
+    );
+    auto insert_stmt{sqlite_db.prepare_statement(stmt_buf.data(), stmt_buf.size())};
+    stmt_buf.clear();
+
+    auto insert_row = [&](TestRow const& row) -> void {
+        transaction_begin_stmt.step();
+        row.insert_to_table(insert_stmt, test_table);
+        transaction_end_stmt.step();
+        transaction_begin_stmt.reset();
+        transaction_end_stmt.reset();
+    };
+    std::for_each(rows.cbegin(), rows.cend(), insert_row);
+
+    sqlite_db.close();
+}
+}  // namespace
+
+TEST_CASE("sqlite_db_create", "[SQLiteDB]") {
+    std::vector<TestRow> rows{
+            {"0.log", 1000, 2000, 0, 0},
+            {"1.log", 1200, 1800, 0, 30},
+            {"2.log", 800, 3800, 1, 0}
+    };
+    sqlite_db_create(rows);
+}

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -88,8 +88,8 @@ public:
 
     [[nodiscard]] auto get_columns() const -> std::vector<std::string> const& { return m_columns; }
 
-    [[nodiscard]] auto get_column_types(
-    ) const -> std::vector<std::pair<std::string, std::string>> const& {
+    [[nodiscard]] auto get_column_types() const
+            -> std::vector<std::pair<std::string, std::string>> const& {
         return m_column_types;
     }
 

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -2,7 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
-#include <memory>
+#include <iterator>
 #include <random>
 #include <string>
 #include <string_view>
@@ -16,7 +16,6 @@
 
 #include "../src/clp/database_utils.hpp"
 #include "../src/clp/SQLiteDB.hpp"
-#include "../src/clp/SQLitePreparedStatement.hpp"
 
 using epochtime_t = int64_t;
 using clp::SQLiteDB;

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -264,9 +264,8 @@ auto create_db(TestTableSchema const& table_schema, vector<Row> const& rows) -> 
     stmt_buf.clear();
 
     // Insert rows into the table
+    transaction_begin_stmt.step();
     for (auto const& row : rows) {
-        transaction_begin_stmt.step();
-
         // Bind a value to each column using its corresponding parameter ID
         auto const path_param_id_it{column_name_to_param_id.find(TestTableSchema::cPath)};
         REQUIRE((column_name_to_param_id.cend() != path_param_id_it));
@@ -307,11 +306,10 @@ auto create_db(TestTableSchema const& table_schema, vector<Row> const& rows) -> 
 
         insert_stmt.step();
         insert_stmt.reset();
-
-        transaction_end_stmt.step();
-        transaction_begin_stmt.reset();
-        transaction_end_stmt.reset();
     }
+    transaction_end_stmt.step();
+    transaction_begin_stmt.reset();
+    transaction_end_stmt.reset();
 
     sqlite_db.close();
 }

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -13,116 +14,67 @@
 #include <fmt/format.h>
 
 #include "../src/clp/database_utils.hpp"
-#include "../src/clp/Defs.h"
 #include "../src/clp/SQLiteDB.hpp"
 #include "../src/clp/SQLitePreparedStatement.hpp"
-#include "../src/clp/streaming_archive/Constants.hpp"
 
-using clp::epochtime_t;
+using epochtime_t = int64_t;
 using clp::SQLiteDB;
-using clp::SQLitePreparedStatement;
 
 namespace {
 /**
- * This class defines a SQlite table schema for testing purpose, It includes the data column name
- * and types.
+ * A class for inserting and retrieving rows from the test table.
+ */
+class Row {
+public:
+    Row(std::string path,
+        epochtime_t begin_ts,
+        epochtime_t end_ts,
+        size_t segment_id,
+        size_t segment_ts_pos)
+            : m_path{std::move(path)},
+              m_begin_ts{begin_ts},
+              m_end_ts{end_ts},
+              m_segment_id{segment_id},
+              m_segment_ts_pos{segment_ts_pos} {}
+
+    [[nodiscard]] auto get_path() const -> std::string const& { return m_path; }
+
+    [[nodiscard]] auto get_begin_ts() const -> epochtime_t { return m_begin_ts; }
+
+    [[nodiscard]] auto get_end_ts() const -> epochtime_t { return m_end_ts; }
+
+    [[nodiscard]] auto get_segment_id() const -> size_t { return m_segment_id; }
+
+    [[nodiscard]] auto get_segment_ts_pos() const -> size_t { return m_segment_ts_pos; }
+
+    [[nodiscard]] auto operator==(Row const& rhs) const -> bool {
+        return rhs.m_path == m_path && rhs.m_begin_ts == m_begin_ts && rhs.m_end_ts == m_end_ts
+               && rhs.m_segment_id == m_segment_id && rhs.m_segment_ts_pos == m_segment_ts_pos;
+    }
+
+private:
+    std::string m_path;
+    epochtime_t m_begin_ts;
+    epochtime_t m_end_ts;
+    size_t m_segment_id;
+    size_t m_segment_ts_pos;
+};
+
+/**
+ * A class that defines a sqlite table schema (column names and types) for testing purposes.
  */
 class TestTableSchema {
 public:
-    static constexpr auto* cPath{
-            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::Path)
-    };
-    static constexpr auto* cBeginTs{
-            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::BeginTimestamp)
-    };
-    static constexpr auto* cEndTs{
-            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::EndTimestamp)
-    };
-    static constexpr auto* cSegmentId{
-            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::SegmentId)
-    };
-    static constexpr auto* cSegmentTsPos{static_cast<char const*>(
-            clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition
-    )};
-
-    /**
-     * This class represents a data row of the test table.
-     */
-    class Row {
-    public:
-        Row(std::string path,
-            epochtime_t begin_ts,
-            epochtime_t end_ts,
-            size_t segment_id,
-            size_t segment_ts_pos)
-                : m_path{std::move(path)},
-                  m_begin_ts{begin_ts},
-                  m_end_ts{end_ts},
-                  m_segment_id{segment_id},
-                  m_segment_ts_pos{segment_ts_pos} {}
-
-        [[nodiscard]] auto get_path() const -> std::string_view { return m_path; }
-
-        [[nodiscard]] auto get_begin_ts() const -> epochtime_t { return m_begin_ts; }
-
-        [[nodiscard]] auto get_end_ts() const -> epochtime_t { return m_end_ts; }
-
-        [[nodiscard]] auto get_segment_id() const -> size_t { return m_segment_id; }
-
-        [[nodiscard]] auto get_segment_ts_pos() const -> size_t { return m_segment_ts_pos; }
-
-        /**
-         * Inserts a row into the table, using a prepared insert statement.
-         * @param insert_stmt
-         * @param table_schema
-         */
-        auto insert_to_table(
-                SQLitePreparedStatement& insert_stmt,
-                TestTableSchema const& table_schema
-        ) const -> void {
-            insert_stmt.bind_text(
-                    table_schema.get_column_idx(TestTableSchema::cPath) + 1,
-                    m_path,
-                    false
-            );
-            insert_stmt.bind_int64(
-                    table_schema.get_column_idx(TestTableSchema::cBeginTs) + 1,
-                    m_begin_ts
-            );
-            insert_stmt.bind_int64(
-                    table_schema.get_column_idx(TestTableSchema::cEndTs) + 1,
-                    m_end_ts
-            );
-            insert_stmt.bind_int64(
-                    table_schema.get_column_idx(TestTableSchema::cSegmentId) + 1,
-                    static_cast<int64_t>(m_segment_id)
-            );
-            insert_stmt.bind_int64(
-                    table_schema.get_column_idx(TestTableSchema::cSegmentTsPos) + 1,
-                    static_cast<int64_t>(m_segment_ts_pos)
-            );
-            insert_stmt.step();
-            insert_stmt.reset();
-        }
-
-        [[nodiscard]] auto operator==(Row const& rhs) const -> bool {
-            return rhs.m_path == m_path && rhs.m_begin_ts == m_begin_ts && rhs.m_end_ts == m_end_ts
-                   && rhs.m_segment_id == m_segment_id && rhs.m_segment_ts_pos == m_segment_ts_pos;
-        }
-
-    private:
-        std::string m_path;
-        epochtime_t m_begin_ts;
-        epochtime_t m_end_ts;
-        size_t m_segment_id;
-        size_t m_segment_ts_pos;
-    };
+    static constexpr char const* cPath{"path"};
+    static constexpr char const* cBeginTs{"begin_timestamp"};
+    static constexpr char const* cEndTs{"end_timestamp"};
+    static constexpr char const* cSegmentId{"segment_id"};
+    static constexpr char const* cSegmentTsPos{"segment_timestamp_position"};
 
     TestTableSchema() {
         auto add_column = [&](std::string_view column_name, std::string_view type) -> void {
             m_columns.emplace_back(column_name);
             m_column_types.emplace_back(column_name, type);
-            m_column_idx_map.emplace(column_name, static_cast<int>(m_column_idx_map.size()));
         };
 
         add_column(cPath, "TEXT PRIMARY KEY");
@@ -132,64 +84,35 @@ public:
         add_column(cSegmentTsPos, "INTEGER");
     }
 
-    /**
-     * Gets the index of a given column in the table. If the given column doesn't exist, this method
-     * will fail the test infrastructure insertion.
-     * @param column_name
-     * @return The index of the column.
-     */
-    [[nodiscard]] auto get_column_idx(std::string const& column_name) const -> int {
-        auto const it{m_column_idx_map.find(column_name)};
-        REQUIRE((m_column_idx_map.cend() != it));
-        return it->second;
-    }
-
     [[nodiscard]] auto get_name() const -> std::string_view { return m_name; }
 
     [[nodiscard]] auto get_columns() const -> std::vector<std::string> const& { return m_columns; }
 
-    [[nodiscard]] auto get_column_types() const
-            -> std::vector<std::pair<std::string, std::string>> const& {
+    [[nodiscard]] auto get_column_types(
+    ) const -> std::vector<std::pair<std::string, std::string>> const& {
         return m_column_types;
-    }
-
-    [[nodiscard]] auto get_column_idx_map() const -> std::unordered_map<std::string, int> const& {
-        return m_column_idx_map;
     }
 
 private:
     std::string m_name{"CLP_TEST_TABLE"};
     std::vector<std::string> m_columns;
     std::vector<std::pair<std::string, std::string>> m_column_types;
-    std::unordered_map<std::string, int> m_column_idx_map;
 };
-
-/**
- * Gets the test table schema which has a global storage. It will be initialized only once.
- * @return A const reference to the test table schema.
- */
-[[nodiscard]] auto get_test_table_schema() -> TestTableSchema const& {
-    static std::unique_ptr<TestTableSchema> table_ptr{nullptr};
-    if (nullptr == table_ptr) {
-        table_ptr = std::make_unique<TestTableSchema>();
-    }
-    return *table_ptr;
-}
 
 /**
  * Creates the table using the test table schemas.
  * @param db A SQLite database.
+ * @param table_schema
  */
-auto create_table(SQLiteDB& db) -> void {
+auto create_table(SQLiteDB& db, TestTableSchema const& table_schema) -> void {
     fmt::memory_buffer statement_buffer;
-    auto stmt_buf_ix{std::back_inserter(statement_buffer)};
-    auto const& test_table_schema{get_test_table_schema()};
+    auto stmt_buf_it{std::back_inserter(statement_buffer)};
 
     fmt::format_to(
-            stmt_buf_ix,
+            stmt_buf_it,
             "CREATE TABLE IF NOT EXISTS {} ({}) WITHOUT ROWID",
-            test_table_schema.get_name(),
-            clp::get_field_names_and_types_sql(test_table_schema.get_column_types())
+            table_schema.get_name(),
+            clp::get_field_names_and_types_sql(table_schema.get_column_types())
     );
     auto create_table_stmt{db.prepare_statement(statement_buffer.data(), statement_buffer.size())};
     create_table_stmt.step();
@@ -199,17 +122,17 @@ auto create_table(SQLiteDB& db) -> void {
 /**
  * Creates indices in the table.
  * @param db A SQLite database.
+ * @param table_schema
  */
-auto create_indices(SQLiteDB& db) -> void {
+auto create_indices(SQLiteDB& db, TestTableSchema const& table_schema) -> void {
     fmt::memory_buffer statement_buffer;
-    auto stmt_buf_ix{std::back_inserter(statement_buffer)};
-    auto const& test_table_schema{get_test_table_schema()};
+    auto stmt_buf_it{std::back_inserter(statement_buffer)};
 
     fmt::format_to(
-            stmt_buf_ix,
+            stmt_buf_it,
             "CREATE INDEX IF NOT EXISTS files_begin_timestamp ON {} ({})",
-            test_table_schema.get_name(),
-            clp::streaming_archive::cMetadataDB::File::BeginTimestamp
+            table_schema.get_name(),
+            TestTableSchema::cBeginTs
     );
     auto create_begin_ts_idx_stmt{
             db.prepare_statement(statement_buffer.data(), statement_buffer.size())
@@ -218,10 +141,10 @@ auto create_indices(SQLiteDB& db) -> void {
     statement_buffer.clear();
 
     fmt::format_to(
-            stmt_buf_ix,
+            stmt_buf_it,
             "CREATE INDEX IF NOT EXISTS files_end_timestamp ON {} ({})",
-            test_table_schema.get_name(),
-            clp::streaming_archive::cMetadataDB::File::EndTimestamp
+            table_schema.get_name(),
+            TestTableSchema::cEndTs
     );
     auto create_end_ts_idx_stmt{
             db.prepare_statement(statement_buffer.data(), statement_buffer.size())
@@ -230,11 +153,11 @@ auto create_indices(SQLiteDB& db) -> void {
     statement_buffer.clear();
 
     fmt::format_to(
-            stmt_buf_ix,
+            stmt_buf_it,
             "CREATE INDEX IF NOT EXISTS files_segment_order ON {} ({},{})",
-            test_table_schema.get_name(),
-            clp::streaming_archive::cMetadataDB::File::SegmentId,
-            clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition
+            table_schema.get_name(),
+            TestTableSchema::cSegmentId,
+            TestTableSchema::cSegmentTsPos
     );
     auto create_segment_order_idx_stmt{
             db.prepare_statement(statement_buffer.data(), statement_buffer.size())
@@ -246,16 +169,17 @@ auto create_indices(SQLiteDB& db) -> void {
 /**
  * @return The absolute path of the generated test sqlite database.
  */
-[[nodiscard]] auto get_test_sqlite_db_abs_path() -> std::filesystem::path {
+[[nodiscard]] auto get_test_db_abs_path() -> std::filesystem::path {
     return std::filesystem::current_path() / "sqlite-test.db";
 }
 
 /**
- * Creates a SQLite database using `TestTableSchema`, and inserts the given rows into the table.
+ * Creates a SQLite database using the given table schema, and inserts the rows into the table.
+ * @param table_schema
  * @param rows
  */
-auto sqlite_db_create(std::vector<TestTableSchema::Row> const& rows) -> void {
-    auto const db_path{get_test_sqlite_db_abs_path()};
+auto create_db(TestTableSchema const& table_schema, std::vector<Row> const& rows) -> void {
+    auto const db_path{get_test_db_abs_path()};
     if (std::filesystem::exists(db_path)) {
         REQUIRE((std::filesystem::remove(db_path)));
     }
@@ -263,99 +187,154 @@ auto sqlite_db_create(std::vector<TestTableSchema::Row> const& rows) -> void {
     SQLiteDB sqlite_db;
     sqlite_db.open(db_path.string());
 
-    create_table(sqlite_db);
+    create_table(sqlite_db, table_schema);
+    create_indices(sqlite_db, table_schema);
 
     // Insert rows into the table
-    auto const& test_table_schema{get_test_table_schema()};
     auto transaction_begin_stmt{sqlite_db.prepare_statement("BEGIN TRANSACTION")};
     auto transaction_end_stmt{sqlite_db.prepare_statement("END TRANSACTION")};
     fmt::memory_buffer stmt_buf;
-    auto stmt_buf_ix{std::back_inserter(stmt_buf)};
+    auto stmt_buf_it{std::back_inserter(stmt_buf)};
+    auto const& table_columns{table_schema.get_columns()};
     fmt::format_to(
-            stmt_buf_ix,
+            stmt_buf_it,
             "INSERT INTO {} ({}) VALUES ({})",
-            test_table_schema.get_name(),
-            clp::get_field_names_sql(test_table_schema.get_columns()),
-            clp::get_numbered_placeholders_sql(test_table_schema.get_columns().size())
+            table_schema.get_name(),
+            clp::get_field_names_sql(table_columns),
+            clp::get_numbered_placeholders_sql(table_columns.size())
     );
     auto insert_stmt{sqlite_db.prepare_statement(stmt_buf.data(), stmt_buf.size())};
     stmt_buf.clear();
 
-    auto insert_row = [&](TestTableSchema::Row const& row) -> void {
+    // Create indicies for each column in the order they are defined in the insert statement,
+    // counting from 1.
+    std::unordered_map<std::string, int> placeholder_idx_map;
+    int idx{1};
+    for (auto const& column : table_columns) {
+        placeholder_idx_map.emplace(column, idx++);
+    }
+
+    for (auto const& row : rows) {
         transaction_begin_stmt.step();
-        row.insert_to_table(insert_stmt, test_table_schema);
+
+        // Bind values to the columns with the corresponded placeholder index.
+        auto const path_placeholder_idx_it{placeholder_idx_map.find(TestTableSchema::cPath)};
+        REQUIRE((placeholder_idx_map.cend() != path_placeholder_idx_it));
+        insert_stmt.bind_text(path_placeholder_idx_it->second, row.get_path(), false);
+
+        auto const begin_ts_placeholder_idx_it{placeholder_idx_map.find(TestTableSchema::cBeginTs)};
+        REQUIRE((placeholder_idx_map.cend() != begin_ts_placeholder_idx_it));
+        insert_stmt.bind_int64(begin_ts_placeholder_idx_it->second, row.get_begin_ts());
+
+        auto const end_ts_placeholder_idx_it{placeholder_idx_map.find(TestTableSchema::cEndTs)};
+        REQUIRE((placeholder_idx_map.cend() != end_ts_placeholder_idx_it));
+        insert_stmt.bind_int64(end_ts_placeholder_idx_it->second, row.get_end_ts());
+
+        auto const seg_id_placeholder_idx_it{placeholder_idx_map.find(TestTableSchema::cSegmentId)};
+        REQUIRE((placeholder_idx_map.cend() != seg_id_placeholder_idx_it));
+        insert_stmt.bind_int64(
+                seg_id_placeholder_idx_it->second,
+                static_cast<int64_t>(row.get_segment_id())
+        );
+
+        auto const seg_ts_pos_placeholder_idx_it{
+                placeholder_idx_map.find(TestTableSchema::cSegmentTsPos)
+        };
+        REQUIRE((placeholder_idx_map.cend() != seg_ts_pos_placeholder_idx_it));
+        insert_stmt.bind_int64(
+                seg_ts_pos_placeholder_idx_it->second,
+                static_cast<int64_t>(row.get_segment_ts_pos())
+        );
+
+        insert_stmt.step();
+        insert_stmt.reset();
+
         transaction_end_stmt.step();
         transaction_begin_stmt.reset();
         transaction_end_stmt.reset();
-    };
-    std::for_each(rows.cbegin(), rows.cend(), insert_row);
+    }
 
     sqlite_db.close();
 }
 }  // namespace
 
 TEST_CASE("sqlite_db_basic", "[SQLiteDB]") {
-    std::vector<TestTableSchema::Row> ref_rows{
+    std::vector<Row> ref_rows{
             // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
             {"0.log", 1000, 2000, 0, 0},
             {"1.log", 1200, 1800, 0, 30},
             {"2.log", 800, 3800, 1, 0}
             // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
     };
-    sqlite_db_create(ref_rows);
+    TestTableSchema const table_schema;
+    create_db(table_schema, ref_rows);
 
-    auto const test_db_path{get_test_sqlite_db_abs_path()};
+    auto test_db_path{get_test_db_abs_path()};
     SQLiteDB sqlite_db;
     sqlite_db.open(test_db_path.string());
-    create_indices(sqlite_db);
 
     // Read all the columns from db, sorted by the begin ts
-    auto const& test_table_schema{get_test_table_schema()};
     fmt::memory_buffer stmt_buf;
-    auto stmt_buf_ix{std::back_inserter(stmt_buf)};
+    auto stmt_buf_it{std::back_inserter(stmt_buf)};
+    auto const& table_columns{table_schema.get_columns()};
     fmt::format_to(
-            stmt_buf_ix,
+            stmt_buf_it,
             "SELECT {} FROM {} ORDER BY {} ASC",
-            clp::get_field_names_sql(test_table_schema.get_columns()),
-            test_table_schema.get_name(),
+            clp::get_field_names_sql(table_columns),
+            table_schema.get_name(),
             TestTableSchema::cBeginTs
     );
     auto select_stmt{sqlite_db.prepare_statement(stmt_buf.data(), stmt_buf.size())};
     stmt_buf.clear();
 
-    std::vector<TestTableSchema::Row> rows;
+    // Create indicies for each column in the order they are defined in the insert statement,
+    // counting from 0.
+    std::unordered_map<std::string, int> selected_column_idx;
+    size_t idx{0};
+    for (auto const& column : table_columns) {
+        selected_column_idx.emplace(column, idx++);
+    }
+
+    std::vector<Row> rows;
     while (true) {
         select_stmt.step();
         if (false == select_stmt.is_row_ready()) {
             break;
         }
+
         std::string path;
-        select_stmt.column_string(test_table_schema.get_column_idx(TestTableSchema::cPath), path);
-        rows.emplace_back(
-                path,
-                select_stmt.column_int64(test_table_schema.get_column_idx(TestTableSchema::cBeginTs)
-                ),
-                select_stmt.column_int64(test_table_schema.get_column_idx(TestTableSchema::cEndTs)),
-                select_stmt.column_int64(
-                        test_table_schema.get_column_idx(TestTableSchema::cSegmentId)
-                ),
-                select_stmt.column_int64(
-                        test_table_schema.get_column_idx(TestTableSchema::cSegmentTsPos)
-                )
-        );
+        auto const path_idx_it{selected_column_idx.find(TestTableSchema::cPath)};
+        REQUIRE((selected_column_idx.cend() != path_idx_it));
+        select_stmt.column_string(path_idx_it->second, path);
+
+        auto const begin_ts_idx_it{selected_column_idx.find(TestTableSchema::cBeginTs)};
+        REQUIRE((selected_column_idx.cend() != begin_ts_idx_it));
+        epochtime_t const begin_ts{select_stmt.column_int64(begin_ts_idx_it->second)};
+
+        auto const end_ts_idx_it{selected_column_idx.find(TestTableSchema::cEndTs)};
+        REQUIRE((selected_column_idx.cend() != end_ts_idx_it));
+        epochtime_t const end_ts{select_stmt.column_int64(end_ts_idx_it->second)};
+
+        auto const seg_id_idx_it{selected_column_idx.find(TestTableSchema::cSegmentId)};
+        REQUIRE((selected_column_idx.cend() != seg_id_idx_it));
+        size_t const seg_id{static_cast<size_t>(select_stmt.column_int64(seg_id_idx_it->second))};
+
+        auto const seg_ts_pos_idx_it{selected_column_idx.find(TestTableSchema::cSegmentTsPos)};
+        REQUIRE((selected_column_idx.cend() != seg_ts_pos_idx_it));
+        size_t const seg_ts_pos{
+                static_cast<size_t>(select_stmt.column_int64(seg_ts_pos_idx_it->second))
+        };
+
+        rows.emplace_back(path, begin_ts, end_ts, seg_id, seg_ts_pos);
     }
 
     // Sort the reference rows by the begin ts
-    std::sort(
-            ref_rows.begin(),
-            ref_rows.end(),
-            [](TestTableSchema::Row const& lhs, TestTableSchema::Row const& rhs) -> bool {
-                if (lhs.get_begin_ts() == rhs.get_begin_ts()) {
-                    return lhs.get_path() < rhs.get_path();
-                }
-                return lhs.get_begin_ts() < rhs.get_begin_ts();
-            }
-    );
+    std::sort(ref_rows.begin(), ref_rows.end(), [](Row const& lhs, Row const& rhs) -> bool {
+        if (lhs.get_begin_ts() == rhs.get_begin_ts()) {
+            return lhs.get_path() < rhs.get_path();
+        }
+        return lhs.get_begin_ts() < rhs.get_begin_ts();
+    });
 
     REQUIRE((ref_rows == rows));
     sqlite_db.close();

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -258,7 +258,7 @@ auto create_db(TestTableSchema const& table_schema, vector<Row> const& rows) -> 
             "INSERT INTO {} ({}) VALUES ({})",
             table_schema.get_name(),
             clp::get_field_names_sql(table_columns),
-            string{param_id_buf.begin(), param_id_buf.end()}
+            fmt::to_string(param_id_buf)
     );
     auto insert_stmt{sqlite_db.prepare_statement(stmt_buf.data(), stmt_buf.size())};
     stmt_buf.clear();

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -27,7 +27,7 @@ using std::vector;
 
 namespace {
 /**
- * A class for inserting and retrieving rows from the test table.
+ * A row in the test table.
  */
 class Row {
 public:
@@ -79,7 +79,7 @@ private:
 };
 
 /**
- * A class that defines a sqlite table schema (column names and types) for testing purposes.
+ * A class that defines a SQLite table schema (column names and types) for testing purposes.
  */
 class TestTableSchema {
 public:
@@ -186,14 +186,15 @@ auto create_indices(SQLiteDB& db, TestTableSchema const& table_schema) -> void {
 }
 
 /**
- * @return The absolute path of the generated test sqlite database.
+ * @return The absolute path of the generated test SQLite database.
  */
 [[nodiscard]] auto get_test_db_abs_path() -> std::filesystem::path {
     return std::filesystem::current_path() / "sqlite-test.db";
 }
 
 /**
- * Creates a SQLite database using the given table schema, and inserts the rows into the table.
+ * Creates a SQLite database using the given table schema, and inserts the given rows into the
+ * table.
  * @param table_schema
  * @param rows
  */

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -247,12 +247,11 @@ auto create_indices(SQLiteDB& db) -> void {
  * @return The absolute path of the generated test sqlite database.
  */
 [[nodiscard]] auto get_test_sqlite_db_abs_path() -> std::filesystem::path {
-    return std::filesystem::current_path() / "sqlite_test.db";
+    return std::filesystem::current_path() / "sqlite-test.db";
 }
 
 /**
- * Creates a SQLite database with a table specified in `TestTableSchema`, and insert all the rows
- * to the table.
+ * Creates a SQLite database using `TestTableSchema`, and inserts the given rows into the table.
  * @param rows
  */
 auto sqlite_db_create(std::vector<TestTableSchema::Row> const& rows) -> void {
@@ -264,10 +263,9 @@ auto sqlite_db_create(std::vector<TestTableSchema::Row> const& rows) -> void {
     SQLiteDB sqlite_db;
     sqlite_db.open(db_path.string());
 
-    // Create a new table and indices.
     create_table(sqlite_db);
 
-    // Insert rows to the table.
+    // Insert rows into the table
     auto const& test_table_schema{get_test_table_schema()};
     auto transaction_begin_stmt{sqlite_db.prepare_statement("BEGIN TRANSACTION")};
     auto transaction_end_stmt{sqlite_db.prepare_statement("END TRANSACTION")};
@@ -363,5 +361,5 @@ TEST_CASE("sqlite_db_basic", "[SQLiteDB]") {
     sqlite_db.close();
 
     // Cleanup
-    REQUIRE((std::filesystem::remove(test_db_path)));
+    REQUIRE(std::filesystem::remove(test_db_path));
 }

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -23,40 +23,139 @@ using clp::SQLiteDB;
 using clp::SQLitePreparedStatement;
 
 namespace {
-class TestTable {
+/**
+ * This class defines a SQlite table schema for testing purpose, It includes the data column name
+ * and types.
+ */
+class TestTableSchema {
 public:
-    TestTable() {
-        auto add_column = [&](std::string_view column_name, std::string type) -> void {
+    static constexpr auto* cPath{
+            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::Path)
+    };
+    static constexpr auto* cBeginTs{
+            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::BeginTimestamp)
+    };
+    static constexpr auto* cEndTs{
+            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::EndTimestamp)
+    };
+    static constexpr auto* cSegmentId{
+            static_cast<char const*>(clp::streaming_archive::cMetadataDB::File::SegmentId)
+    };
+    static constexpr auto* cSegmentTsPos{static_cast<char const*>(
+            clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition
+    )};
+
+    /**
+     * This class represents a data row of the test table.
+     */
+    class Row {
+    public:
+        Row(std::string path,
+            epochtime_t begin_ts,
+            epochtime_t end_ts,
+            size_t segment_id,
+            size_t segment_ts_pos)
+                : m_path{std::move(path)},
+                  m_begin_ts{begin_ts},
+                  m_end_ts{end_ts},
+                  m_segment_id{segment_id},
+                  m_segment_ts_pos{segment_ts_pos} {}
+
+        [[nodiscard]] auto get_path() const -> std::string_view { return m_path; }
+
+        [[nodiscard]] auto get_begin_ts() const -> epochtime_t { return m_begin_ts; }
+
+        [[nodiscard]] auto get_end_ts() const -> epochtime_t { return m_end_ts; }
+
+        [[nodiscard]] auto get_segment_id() const -> size_t { return m_segment_id; }
+
+        [[nodiscard]] auto get_segment_ts_pos() const -> size_t { return m_segment_ts_pos; }
+
+        /**
+         * Inserts a row into the table, using a prepared insert statement.
+         * @param insert_stmt
+         * @param table_schema
+         */
+        auto insert_to_table(
+                SQLitePreparedStatement& insert_stmt,
+                TestTableSchema const& table_schema
+        ) const -> void {
+            insert_stmt.bind_text(
+                    table_schema.get_column_idx(TestTableSchema::cPath) + 1,
+                    m_path,
+                    false
+            );
+            insert_stmt.bind_int64(
+                    table_schema.get_column_idx(TestTableSchema::cBeginTs) + 1,
+                    m_begin_ts
+            );
+            insert_stmt.bind_int64(
+                    table_schema.get_column_idx(TestTableSchema::cEndTs) + 1,
+                    m_end_ts
+            );
+            insert_stmt.bind_int64(
+                    table_schema.get_column_idx(TestTableSchema::cSegmentId) + 1,
+                    static_cast<int64_t>(m_segment_id)
+            );
+            insert_stmt.bind_int64(
+                    table_schema.get_column_idx(TestTableSchema::cSegmentTsPos) + 1,
+                    static_cast<int64_t>(m_segment_ts_pos)
+            );
+            insert_stmt.step();
+            insert_stmt.reset();
+        }
+
+        [[nodiscard]] auto operator==(Row const& rhs) const -> bool {
+            return rhs.m_path == m_path && rhs.m_begin_ts == m_begin_ts && rhs.m_end_ts == m_end_ts
+                   && rhs.m_segment_id == m_segment_id && rhs.m_segment_ts_pos == m_segment_ts_pos;
+        }
+
+    private:
+        std::string m_path;
+        epochtime_t m_begin_ts;
+        epochtime_t m_end_ts;
+        size_t m_segment_id;
+        size_t m_segment_ts_pos;
+    };
+
+    TestTableSchema() {
+        auto add_column = [&](std::string_view column_name, std::string_view type) -> void {
             m_columns.emplace_back(column_name);
             m_column_types.emplace_back(column_name, type);
-            m_column_idx_map.emplace(column_name, static_cast<int>(m_column_idx_map.size() + 1));
+            m_column_idx_map.emplace(column_name, static_cast<int>(m_column_idx_map.size()));
         };
 
-        add_column(clp::streaming_archive::cMetadataDB::File::Path, "TEXT PRIMARY KEY");
-        add_column(clp::streaming_archive::cMetadataDB::File::BeginTimestamp, "INTEGER");
-        add_column(clp::streaming_archive::cMetadataDB::File::EndTimestamp, "INTEGER");
-        add_column(clp::streaming_archive::cMetadataDB::File::SegmentId, "INTEGER");
-        add_column(clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition, "INTEGER");
+        add_column(cPath, "TEXT PRIMARY KEY");
+        add_column(cBeginTs, "INTEGER");
+        add_column(cEndTs, "INTEGER");
+        add_column(cSegmentId, "INTEGER");
+        add_column(cSegmentTsPos, "INTEGER");
     }
 
+    /**
+     * Gets the index of a given column in the table. If the given column doesn't exist, this method
+     * will fail the test infrastructure insertion.
+     * @param column_name
+     * @return The index of the column.
+     */
     [[nodiscard]] auto get_column_idx(std::string const& column_name) const -> int {
         auto const it{m_column_idx_map.find(column_name)};
-        REQUIRE(m_column_idx_map.cend() != it);
+        REQUIRE((m_column_idx_map.cend() != it));
         return it->second;
     }
 
+    [[nodiscard]] auto get_name() const -> std::string_view { return m_name; }
+
     [[nodiscard]] auto get_columns() const -> std::vector<std::string> const& { return m_columns; }
 
-    [[nodiscard]] auto get_column_types(
-    ) const -> std::vector<std::pair<std::string, std::string>> const& {
+    [[nodiscard]] auto get_column_types() const
+            -> std::vector<std::pair<std::string, std::string>> const& {
         return m_column_types;
     }
 
     [[nodiscard]] auto get_column_idx_map() const -> std::unordered_map<std::string, int> const& {
         return m_column_idx_map;
     }
-
-    [[nodiscard]] auto get_name() const -> std::string_view { return m_name; }
 
 private:
     std::string m_name{"CLP_TEST_TABLE"};
@@ -65,93 +164,51 @@ private:
     std::unordered_map<std::string, int> m_column_idx_map;
 };
 
-class TestRow {
-public:
-    TestRow(std::string path,
-            epochtime_t begin_ts,
-            epochtime_t end_ts,
-            size_t segment_id,
-            size_t segment_ts_pos)
-            : m_path{std::move(path)},
-              m_begin_ts{begin_ts},
-              m_end_ts{end_ts},
-              m_segment_id{segment_id},
-              m_segment_ts_pos{segment_ts_pos} {}
-
-    [[nodiscard]] auto get_path() const -> std::string_view { return m_path; }
-
-    [[nodiscard]] auto get_begin_ts() const -> epochtime_t { return m_begin_ts; }
-
-    [[nodiscard]] auto get_end_ts() const -> epochtime_t { return m_end_ts; }
-
-    [[nodiscard]] auto get_segment_id() const -> size_t { return m_segment_id; }
-
-    [[nodiscard]] auto get_segment_ts_pos() const -> size_t { return m_segment_ts_pos; }
-
-    auto
-    insert_to_table(SQLitePreparedStatement& insert_stmt, TestTable const& table) const -> void {
-        insert_stmt.bind_text(
-                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::Path),
-                m_path,
-                false
-        );
-        insert_stmt.bind_int64(
-                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::BeginTimestamp),
-                m_begin_ts
-        );
-        insert_stmt.bind_int64(
-                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::EndTimestamp),
-                m_end_ts
-        );
-        insert_stmt.bind_int64(
-                table.get_column_idx(clp::streaming_archive::cMetadataDB::File::SegmentId),
-                m_segment_id
-        );
-        insert_stmt.bind_int64(
-                table.get_column_idx(
-                        clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition
-                ),
-                m_segment_ts_pos
-        );
-        insert_stmt.step();
-        insert_stmt.reset();
-    }
-
-private:
-    std::string m_path;
-    epochtime_t m_begin_ts;
-    epochtime_t m_end_ts;
-    size_t m_segment_id;
-    size_t m_segment_ts_pos;
-};
-
-[[nodiscard]] auto get_test_table() -> TestTable const& {
-    static std::unique_ptr<TestTable> table_ptr{nullptr};
+/**
+ * Gets the test table schema which has a global storage. It will be initialized only once.
+ * @return A const reference to the test table schema.
+ */
+[[nodiscard]] auto get_test_table_schema() -> TestTableSchema const& {
+    static std::unique_ptr<TestTableSchema> table_ptr{nullptr};
     if (nullptr == table_ptr) {
-        table_ptr = std::make_unique<TestTable>();
+        table_ptr = std::make_unique<TestTableSchema>();
     }
     return *table_ptr;
 }
 
-auto create_table_and_indices(SQLiteDB& db) -> void {
+/**
+ * Creates the table using the test table schemas.
+ * @param db A SQLite database.
+ */
+auto create_table(SQLiteDB& db) -> void {
     fmt::memory_buffer statement_buffer;
-    auto statement_buffer_ix{std::back_inserter(statement_buffer)};
-    auto const& test_table{get_test_table()};
+    auto stmt_buf_ix{std::back_inserter(statement_buffer)};
+    auto const& test_table_schema{get_test_table_schema()};
 
     fmt::format_to(
-            statement_buffer_ix,
+            stmt_buf_ix,
             "CREATE TABLE IF NOT EXISTS {} ({}) WITHOUT ROWID",
-            test_table.get_name(),
-            clp::get_field_names_and_types_sql(test_table.get_column_types())
+            test_table_schema.get_name(),
+            clp::get_field_names_and_types_sql(test_table_schema.get_column_types())
     );
     auto create_table_stmt{db.prepare_statement(statement_buffer.data(), statement_buffer.size())};
     create_table_stmt.step();
     statement_buffer.clear();
+}
+
+/**
+ * Creates indices in the table.
+ * @param db A SQLite database.
+ */
+auto create_indices(SQLiteDB& db) -> void {
+    fmt::memory_buffer statement_buffer;
+    auto stmt_buf_ix{std::back_inserter(statement_buffer)};
+    auto const& test_table_schema{get_test_table_schema()};
 
     fmt::format_to(
-            statement_buffer_ix,
+            stmt_buf_ix,
             "CREATE INDEX IF NOT EXISTS files_begin_timestamp ON {} ({})",
-            test_table.get_name(),
+            test_table_schema.get_name(),
             clp::streaming_archive::cMetadataDB::File::BeginTimestamp
     );
     auto create_begin_ts_idx_stmt{
@@ -161,10 +218,10 @@ auto create_table_and_indices(SQLiteDB& db) -> void {
     statement_buffer.clear();
 
     fmt::format_to(
-            statement_buffer_ix,
-            "CREATE INDEX IF NOT EXISTS files_begin_timestamp ON {} ({})",
-            test_table.get_name(),
-            clp::streaming_archive::cMetadataDB::File::BeginTimestamp
+            stmt_buf_ix,
+            "CREATE INDEX IF NOT EXISTS files_end_timestamp ON {} ({})",
+            test_table_schema.get_name(),
+            clp::streaming_archive::cMetadataDB::File::EndTimestamp
     );
     auto create_end_ts_idx_stmt{
             db.prepare_statement(statement_buffer.data(), statement_buffer.size())
@@ -173,9 +230,9 @@ auto create_table_and_indices(SQLiteDB& db) -> void {
     statement_buffer.clear();
 
     fmt::format_to(
-            statement_buffer_ix,
+            stmt_buf_ix,
             "CREATE INDEX IF NOT EXISTS files_segment_order ON {} ({},{})",
-            test_table.get_name(),
+            test_table_schema.get_name(),
             clp::streaming_archive::cMetadataDB::File::SegmentId,
             clp::streaming_archive::cMetadataDB::File::SegmentTimestampsPosition
     );
@@ -186,43 +243,49 @@ auto create_table_and_indices(SQLiteDB& db) -> void {
     statement_buffer.clear();
 }
 
+/**
+ * @return The absolute path of the generated test sqlite database.
+ */
 [[nodiscard]] auto get_test_sqlite_db_abs_path() -> std::filesystem::path {
-    std::filesystem::path const file_path{__FILE__};
-    auto const test_root_path{file_path.parent_path()};
-    return test_root_path / "test_sqlite_db/test.db";
+    return std::filesystem::current_path() / "sqlite_test.db";
 }
 
-auto sqlite_db_create(std::vector<TestRow> const& rows) -> void {
+/**
+ * Creates a SQLite database with a table specified in `TestTableSchema`, and insert all the rows
+ * to the table.
+ * @param rows
+ */
+auto sqlite_db_create(std::vector<TestTableSchema::Row> const& rows) -> void {
     auto const db_path{get_test_sqlite_db_abs_path()};
     if (std::filesystem::exists(db_path)) {
-        REQUIRE(std::filesystem::remove(db_path));
+        REQUIRE((std::filesystem::remove(db_path)));
     }
 
     SQLiteDB sqlite_db;
     sqlite_db.open(db_path.string());
 
     // Create a new table and indices.
-    create_table_and_indices(sqlite_db);
+    create_table(sqlite_db);
 
     // Insert rows to the table.
-    auto const& test_table{get_test_table()};
+    auto const& test_table_schema{get_test_table_schema()};
     auto transaction_begin_stmt{sqlite_db.prepare_statement("BEGIN TRANSACTION")};
     auto transaction_end_stmt{sqlite_db.prepare_statement("END TRANSACTION")};
     fmt::memory_buffer stmt_buf;
-    auto statement_buffer_ix{std::back_inserter(stmt_buf)};
+    auto stmt_buf_ix{std::back_inserter(stmt_buf)};
     fmt::format_to(
-            statement_buffer_ix,
+            stmt_buf_ix,
             "INSERT INTO {} ({}) VALUES ({})",
-            test_table.get_name(),
-            clp::get_field_names_sql(test_table.get_columns()),
-            clp::get_numbered_placeholders_sql(test_table.get_columns().size())
+            test_table_schema.get_name(),
+            clp::get_field_names_sql(test_table_schema.get_columns()),
+            clp::get_numbered_placeholders_sql(test_table_schema.get_columns().size())
     );
     auto insert_stmt{sqlite_db.prepare_statement(stmt_buf.data(), stmt_buf.size())};
     stmt_buf.clear();
 
-    auto insert_row = [&](TestRow const& row) -> void {
+    auto insert_row = [&](TestTableSchema::Row const& row) -> void {
         transaction_begin_stmt.step();
-        row.insert_to_table(insert_stmt, test_table);
+        row.insert_to_table(insert_stmt, test_table_schema);
         transaction_end_stmt.step();
         transaction_begin_stmt.reset();
         transaction_end_stmt.reset();
@@ -233,11 +296,72 @@ auto sqlite_db_create(std::vector<TestRow> const& rows) -> void {
 }
 }  // namespace
 
-TEST_CASE("sqlite_db_create", "[SQLiteDB]") {
-    std::vector<TestRow> rows{
+TEST_CASE("sqlite_db_basic", "[SQLiteDB]") {
+    std::vector<TestTableSchema::Row> ref_rows{
+            // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
             {"0.log", 1000, 2000, 0, 0},
             {"1.log", 1200, 1800, 0, 30},
             {"2.log", 800, 3800, 1, 0}
+            // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
     };
-    sqlite_db_create(rows);
+    sqlite_db_create(ref_rows);
+
+    auto const test_db_path{get_test_sqlite_db_abs_path()};
+    SQLiteDB sqlite_db;
+    sqlite_db.open(test_db_path.string());
+    create_indices(sqlite_db);
+
+    // Read all the columns from db, sorted by the begin ts
+    auto const& test_table_schema{get_test_table_schema()};
+    fmt::memory_buffer stmt_buf;
+    auto stmt_buf_ix{std::back_inserter(stmt_buf)};
+    fmt::format_to(
+            stmt_buf_ix,
+            "SELECT {} FROM {} ORDER BY {} ASC",
+            clp::get_field_names_sql(test_table_schema.get_columns()),
+            test_table_schema.get_name(),
+            TestTableSchema::cBeginTs
+    );
+    auto select_stmt{sqlite_db.prepare_statement(stmt_buf.data(), stmt_buf.size())};
+    stmt_buf.clear();
+
+    std::vector<TestTableSchema::Row> rows;
+    while (true) {
+        select_stmt.step();
+        if (false == select_stmt.is_row_ready()) {
+            break;
+        }
+        std::string path;
+        select_stmt.column_string(test_table_schema.get_column_idx(TestTableSchema::cPath), path);
+        rows.emplace_back(
+                path,
+                select_stmt.column_int64(test_table_schema.get_column_idx(TestTableSchema::cBeginTs)
+                ),
+                select_stmt.column_int64(test_table_schema.get_column_idx(TestTableSchema::cEndTs)),
+                select_stmt.column_int64(
+                        test_table_schema.get_column_idx(TestTableSchema::cSegmentId)
+                ),
+                select_stmt.column_int64(
+                        test_table_schema.get_column_idx(TestTableSchema::cSegmentTsPos)
+                )
+        );
+    }
+
+    // Sort the reference rows by the begin ts
+    std::sort(
+            ref_rows.begin(),
+            ref_rows.end(),
+            [](TestTableSchema::Row const& lhs, TestTableSchema::Row const& rhs) -> bool {
+                if (lhs.get_begin_ts() == rhs.get_begin_ts()) {
+                    return lhs.get_path() < rhs.get_path();
+                }
+                return lhs.get_begin_ts() < rhs.get_begin_ts();
+            }
+    );
+
+    REQUIRE((ref_rows == rows));
+    sqlite_db.close();
+
+    // Cleanup
+    REQUIRE((std::filesystem::remove(test_db_path)));
 }


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Before this PR, we don't have unit test coverage for SQLite Database functionalities. This PR implements a simple SQLite DB unit test, which includes the following testing flow:
1. The test case will create a new database with a fixed testing table schema.
2. Insert data rows into the database.
3. Persist the database to the disk.
4. Open the created database and create indices.
5. Iterate data rows from the database with a certain ordering (with select statement).
6. Ensure the read results are the same as the input data in step 2, with the expected ordering.
Notice that this PR only provides a skeleton for SQLite functionality testing. It doesn't cover all the SQLite db usage we have in the current `clp` implementation. We will add more tests later when we push new SQLite abstracted features, such as `SQLitePreparedSelectStatement`.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Passed `clang-tidy` linting check.
2. Ensure unit tests are passed locally in Linux.
3. GH Workflow passed.

