### PR TITLE
clp-s: Add basic unit tests for parsing KQL queries.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -211,11 +211,6 @@ add_subdirectory(src/clp_s)
 add_subdirectory(src/reducer)
 
 set(SOURCE_FILES_clp_s_unitTest
-    src/clp_s/SchemaTree.hpp
-    src/clp_s/TimestampPattern.cpp
-    src/clp_s/TimestampPattern.hpp
-    src/clp_s/Utils.cpp
-    src/clp_s/Utils.hpp
     src/clp_s/search/AndExpr.cpp
     src/clp_s/search/AndExpr.hpp
     src/clp_s/search/BooleanLiteral.cpp
@@ -248,6 +243,11 @@ set(SOURCE_FILES_clp_s_unitTest
     src/clp_s/search/StringLiteral.hpp
     src/clp_s/search/Transformation.hpp
     src/clp_s/search/Value.hpp
+    src/clp_s/SchemaTree.hpp
+    src/clp_s/TimestampPattern.cpp
+    src/clp_s/TimestampPattern.hpp
+    src/clp_s/Utils.cpp
+    src/clp_s/Utils.hpp
 )
 
 set(SOURCE_FILES_unitTest
@@ -418,13 +418,13 @@ set(SOURCE_FILES_unitTest
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
-        tests/test-kql.cpp
         tests/test-BufferedFileReader.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp
         tests/test-Grep.cpp
         tests/test-ir_encoding_methods.cpp
         tests/test-ir_parsing.cpp
+        tests/test-kql.cpp
         tests/test-main.cpp
         tests/test-math_utils.cpp
         tests/test-ParserWithUserSchema.cpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -418,6 +418,7 @@ set(SOURCE_FILES_unitTest
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
+	tests/LogSuppressor.hpp
         tests/test-BufferedFileReader.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -418,7 +418,7 @@ set(SOURCE_FILES_unitTest
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
-	tests/LogSuppressor.hpp
+        tests/LogSuppressor.hpp
         tests/test-BufferedFileReader.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -210,6 +210,46 @@ add_subdirectory(src/clp/make_dictionaries_readable)
 add_subdirectory(src/clp_s)
 add_subdirectory(src/reducer)
 
+set(SOURCE_FILES_clp_s_unitTest
+    src/clp_s/SchemaTree.hpp
+    src/clp_s/TimestampPattern.cpp
+    src/clp_s/TimestampPattern.hpp
+    src/clp_s/Utils.cpp
+    src/clp_s/Utils.hpp
+    src/clp_s/search/AndExpr.cpp
+    src/clp_s/search/AndExpr.hpp
+    src/clp_s/search/BooleanLiteral.cpp
+    src/clp_s/search/BooleanLiteral.hpp
+    src/clp_s/search/clp_search/Query.cpp
+    src/clp_s/search/clp_search/Query.hpp
+    src/clp_s/search/ColumnDescriptor.cpp
+    src/clp_s/search/ColumnDescriptor.hpp
+    src/clp_s/search/DateLiteral.cpp
+    src/clp_s/search/DateLiteral.hpp
+    src/clp_s/search/EmptyExpr.cpp
+    src/clp_s/search/EmptyExpr.hpp
+    src/clp_s/search/Expression.cpp
+    src/clp_s/search/Expression.hpp
+    src/clp_s/search/FilterExpr.cpp
+    src/clp_s/search/FilterExpr.hpp
+    src/clp_s/search/FilterOperation.hpp
+    src/clp_s/search/Integral.cpp
+    src/clp_s/search/Integral.hpp
+    src/clp_s/search/Literal.hpp
+    src/clp_s/search/NullLiteral.cpp
+    src/clp_s/search/NullLiteral.hpp
+    src/clp_s/search/OrExpr.cpp
+    src/clp_s/search/OrExpr.hpp
+    src/clp_s/search/OrOfAndForm.cpp
+    src/clp_s/search/OrOfAndForm.hpp
+    src/clp_s/search/SearchUtils.cpp
+    src/clp_s/search/SearchUtils.hpp
+    src/clp_s/search/StringLiteral.cpp
+    src/clp_s/search/StringLiteral.hpp
+    src/clp_s/search/Transformation.hpp
+    src/clp_s/search/Value.hpp
+)
+
 set(SOURCE_FILES_unitTest
         src/clp/BufferedFileReader.cpp
         src/clp/BufferedFileReader.hpp
@@ -378,6 +418,7 @@ set(SOURCE_FILES_unitTest
         submodules/sqlite3/sqlite3.c
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
+        tests/test-kql.cpp
         tests/test-BufferedFileReader.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp
@@ -395,7 +436,7 @@ set(SOURCE_FILES_unitTest
         tests/test-TimestampPattern.cpp
         tests/test-Utils.cpp
         )
-add_executable(unitTest ${SOURCE_FILES_unitTest})
+add_executable(unitTest ${SOURCE_FILES_unitTest} ${SOURCE_FILES_clp_s_unitTest})
 target_include_directories(unitTest
         PRIVATE
         ${CMAKE_SOURCE_DIR}/submodules
@@ -403,7 +444,9 @@ target_include_directories(unitTest
 target_link_libraries(unitTest
         PRIVATE
         Boost::filesystem Boost::iostreams Boost::program_options
+        absl::flat_hash_map
         fmt::fmt
+        kql
         log_surgeon::log_surgeon
         LibArchive::LibArchive
         MariaDBClient::MariaDBClient

--- a/components/core/tests/LogSuppressor.hpp
+++ b/components/core/tests/LogSuppressor.hpp
@@ -1,0 +1,21 @@
+/**
+ * A class that suppresses logs so long as it instantiated.
+ */
+class LogSuppressor {
+public:
+    LogSuppressor() {
+        m_previous_logging_level = spdlog::default_logger()->level();
+        spdlog::default_logger()->set_level(spdlog::level::off);
+    }
+
+    LogSuppressor(LogSuppressor const& other) = default;
+    LogSuppressor(LogSuppressor&& other) noexcept = default;
+
+    LogSuppressor& operator=(LogSuppressor const& other) = default;
+    LogSuppressor& operator=(LogSuppressor&& other) noexcept = default;
+
+    ~LogSuppressor() { spdlog::default_logger()->set_level(m_previous_logging_level); }
+
+private:
+    spdlog::level::level_enum m_previous_logging_level;
+};

--- a/components/core/tests/LogSuppressor.hpp
+++ b/components/core/tests/LogSuppressor.hpp
@@ -1,5 +1,5 @@
 /**
- * A class that suppresses logs so long as it instantiated.
+ * A class that suppresses logs so long as it's instantiated.
  */
 class LogSuppressor {
 public:

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -1,0 +1,114 @@
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <Catch2/single_include/catch2/catch.hpp>
+
+#include "../src/clp_s/search/AndExpr.hpp"
+#include "../src/clp_s/search/FilterExpr.hpp"
+#include "../src/clp_s/search/kql/kql.hpp"
+#include "../src/clp_s/search/OrExpr.hpp"
+
+using clp_s::search::AndExpr;
+using clp_s::search::DescriptorToken;
+using clp_s::search::FilterExpr;
+using clp_s::search::FilterOperation;
+using clp_s::search::kql::parse_kql_expression;
+using clp_s::search::OrExpr;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+TEST_CASE("Test parsing KQL", "[KQL]") {
+    // Initialize data for testing
+    vector<string> const basic_equivalent_wildcard_queries{
+            "value",
+            "\"value\"",
+            "*:value",
+            "*:\"value\"",
+            "\"*\":value"
+    };
+
+    SECTION("Parsing basic wildcard column queries") {
+        for (auto const& query : basic_equivalent_wildcard_queries) {
+            stringstream wildcard_filter{query};
+            std::string extracted_value;
+            auto filter
+                    = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(wildcard_filter));
+            REQUIRE(nullptr != filter);
+            REQUIRE(false == filter->is_inverted());
+            REQUIRE(filter->get_column()->is_pure_wildcard());
+            REQUIRE(FilterOperation::EQ == filter->get_operation());
+            REQUIRE(filter->get_operand()->as_var_string(extracted_value, filter->get_operation()));
+            REQUIRE("value" == extracted_value);
+        }
+    }
+
+    SECTION("Parsing basic filter") {
+        stringstream basic_filter{"key:value"};
+        auto filter = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(basic_filter));
+        REQUIRE(nullptr != filter);
+        REQUIRE(false == filter->is_inverted());
+        REQUIRE(FilterOperation::EQ == filter->get_operation());
+        REQUIRE(1 == filter->get_column()->get_descriptor_list().size());
+        REQUIRE(DescriptorToken{"key"} == *filter->get_column()->descriptor_begin());
+    }
+
+    SECTION("Parsing basic NOT filter") {
+        stringstream basic_not{"not key : value"};
+        auto not_filter = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(basic_not));
+        REQUIRE(nullptr != not_filter);
+        REQUIRE(true == not_filter->is_inverted());
+        REQUIRE(FilterOperation::EQ == not_filter->get_operation());
+        REQUIRE(1 == not_filter->get_column()->get_descriptor_list().size());
+        REQUIRE(DescriptorToken{"key"} == *not_filter->get_column()->descriptor_begin());
+    }
+
+    SECTION("Parsing basic AND expression") {
+        stringstream basic_and{"a:a and b:b"};
+        auto and_expr = std::dynamic_pointer_cast<AndExpr>(parse_kql_expression(basic_and));
+        REQUIRE(nullptr != and_expr);
+        REQUIRE(false == and_expr->is_inverted());
+        REQUIRE(true == and_expr->has_only_expression_operands());
+        REQUIRE(2 == and_expr->get_num_operands());
+        char c = 'a';
+        for (auto operand : and_expr->get_op_list()) {
+            std::string const str(1, c);
+            auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
+            std::string extracted_value;
+            REQUIRE(nullptr != filter);
+            REQUIRE(false == filter->is_inverted());
+            REQUIRE(FilterOperation::EQ == filter->get_operation());
+            REQUIRE(true
+                    == filter->get_operand()
+                               ->as_var_string(extracted_value, filter->get_operation()));
+            REQUIRE(str == extracted_value);
+            REQUIRE(DescriptorToken{str} == *filter->get_column()->descriptor_begin());
+            ++c;
+        }
+    }
+
+    SECTION("Parsing basic OR expression") {
+        stringstream basic_or{"a:a or b:b"};
+        auto or_expr = std::dynamic_pointer_cast<OrExpr>(parse_kql_expression(basic_or));
+        REQUIRE(nullptr != or_expr);
+        REQUIRE(false == or_expr->is_inverted());
+        REQUIRE(true == or_expr->has_only_expression_operands());
+        REQUIRE(2 == or_expr->get_num_operands());
+        char c = 'a';
+        for (auto operand : or_expr->get_op_list()) {
+            std::string const str(1, c);
+            auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
+            std::string extracted_value;
+            REQUIRE(nullptr != filter);
+            REQUIRE(false == filter->is_inverted());
+            REQUIRE(FilterOperation::EQ == filter->get_operation());
+            REQUIRE(true
+                    == filter->get_operand()
+                               ->as_var_string(extracted_value, filter->get_operation()));
+            REQUIRE(str == extracted_value);
+            REQUIRE(DescriptorToken{str} == *filter->get_column()->descriptor_begin());
+            ++c;
+        }
+    }
+}

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -9,6 +9,7 @@
 #include "../src/clp_s/search/FilterExpr.hpp"
 #include "../src/clp_s/search/kql/kql.hpp"
 #include "../src/clp_s/search/OrExpr.hpp"
+#include "LogSuppressor.hpp"
 
 using clp_s::search::AndExpr;
 using clp_s::search::DescriptorToken;
@@ -22,8 +23,7 @@ using std::vector;
 
 TEST_CASE("Test parsing KQL", "[KQL]") {
     // Suppress logging
-    auto previous_logging_level = spdlog::default_logger()->level();
-    spdlog::default_logger()->set_level(spdlog::level::off);
+    LogSuppressor suppressor{};
 
     SECTION("Pure wildcard key queries") {
         auto query = GENERATE(
@@ -187,7 +187,4 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         auto failure = parse_kql_expression(incorrect_query);
         REQUIRE(nullptr == failure);
     }
-
-    // Re-enable logging
-    spdlog::default_logger()->set_level(previous_logging_level);
 }

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -20,51 +20,59 @@ using std::stringstream;
 using std::vector;
 
 TEST_CASE("Test parsing KQL", "[KQL]") {
-    // Initialize data for testing
-    vector<string> const basic_equivalent_wildcard_queries{
-            "value",
-            "\"value\"",
-            "*:value",
-            "*:\"value\"",
-            "\"*\":value"
-    };
-
-    SECTION("Parsing basic wildcard column queries") {
+    SECTION("Pure wildcard key queries") {
+        vector<string> const basic_equivalent_wildcard_queries{
+                "value",
+                "\"value\"",
+                "*:value",
+                "*:\"value\"",
+                "\"*\":value",
+                "\"*\":\"value\""
+        };
         for (auto const& query : basic_equivalent_wildcard_queries) {
             stringstream wildcard_filter{query};
-            std::string extracted_value;
             auto filter
                     = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(wildcard_filter));
             REQUIRE(nullptr != filter);
+            REQUIRE(nullptr != filter->get_operand());
+            REQUIRE(nullptr != filter->get_column());
+            REQUIRE(false == filter->has_only_expression_operands());
             REQUIRE(false == filter->is_inverted());
             REQUIRE(filter->get_column()->is_pure_wildcard());
             REQUIRE(FilterOperation::EQ == filter->get_operation());
+            std::string extracted_value;
             REQUIRE(filter->get_operand()->as_var_string(extracted_value, filter->get_operation()));
             REQUIRE("value" == extracted_value);
         }
     }
 
-    SECTION("Parsing basic filter") {
+    SECTION("Basic filter") {
         stringstream basic_filter{"key:value"};
         auto filter = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(basic_filter));
         REQUIRE(nullptr != filter);
+        REQUIRE(nullptr != filter->get_operand());
+        REQUIRE(nullptr != filter->get_column());
+        REQUIRE(false == filter->has_only_expression_operands());
         REQUIRE(false == filter->is_inverted());
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         REQUIRE(1 == filter->get_column()->get_descriptor_list().size());
         REQUIRE(DescriptorToken{"key"} == *filter->get_column()->descriptor_begin());
     }
 
-    SECTION("Parsing basic NOT filter") {
+    SECTION("Basic NOT filter") {
         stringstream basic_not{"not key : value"};
         auto not_filter = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(basic_not));
         REQUIRE(nullptr != not_filter);
+        REQUIRE(nullptr != not_filter->get_operand());
+        REQUIRE(nullptr != not_filter->get_column());
+        REQUIRE(false == not_filter->has_only_expression_operands());
         REQUIRE(true == not_filter->is_inverted());
         REQUIRE(FilterOperation::EQ == not_filter->get_operation());
         REQUIRE(1 == not_filter->get_column()->get_descriptor_list().size());
         REQUIRE(DescriptorToken{"key"} == *not_filter->get_column()->descriptor_begin());
     }
 
-    SECTION("Parsing basic AND expression") {
+    SECTION("Basic AND expression") {
         stringstream basic_and{"a:a and b:b"};
         auto and_expr = std::dynamic_pointer_cast<AndExpr>(parse_kql_expression(basic_and));
         REQUIRE(nullptr != and_expr);
@@ -72,13 +80,16 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(true == and_expr->has_only_expression_operands());
         REQUIRE(2 == and_expr->get_num_operands());
         char c = 'a';
-        for (const auto& operand : and_expr->get_op_list()) {
+        for (auto const& operand : and_expr->get_op_list()) {
             std::string const str(1, c);
             auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
-            std::string extracted_value;
             REQUIRE(nullptr != filter);
+            REQUIRE(nullptr != filter->get_operand());
+            REQUIRE(nullptr != filter->get_column());
+            REQUIRE(false == filter->has_only_expression_operands());
             REQUIRE(false == filter->is_inverted());
             REQUIRE(FilterOperation::EQ == filter->get_operation());
+            std::string extracted_value;
             REQUIRE(true
                     == filter->get_operand()
                                ->as_var_string(extracted_value, filter->get_operation()));
@@ -88,7 +99,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         }
     }
 
-    SECTION("Parsing basic OR expression") {
+    SECTION("Basic OR expression") {
         stringstream basic_or{"a:a or b:b"};
         auto or_expr = std::dynamic_pointer_cast<OrExpr>(parse_kql_expression(basic_or));
         REQUIRE(nullptr != or_expr);
@@ -96,13 +107,16 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(true == or_expr->has_only_expression_operands());
         REQUIRE(2 == or_expr->get_num_operands());
         char c = 'a';
-        for (const auto& operand : or_expr->get_op_list()) {
+        for (auto const& operand : or_expr->get_op_list()) {
             std::string const str(1, c);
             auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
-            std::string extracted_value;
             REQUIRE(nullptr != filter);
+            REQUIRE(nullptr != filter->get_operand());
+            REQUIRE(nullptr != filter->get_column());
+            REQUIRE(false == filter->has_only_expression_operands());
             REQUIRE(false == filter->is_inverted());
             REQUIRE(FilterOperation::EQ == filter->get_operation());
+            std::string extracted_value;
             REQUIRE(true
                     == filter->get_operand()
                                ->as_var_string(extracted_value, filter->get_operation()));

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -72,7 +72,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(true == and_expr->has_only_expression_operands());
         REQUIRE(2 == and_expr->get_num_operands());
         char c = 'a';
-        for (auto operand : and_expr->get_op_list()) {
+        for (const auto& operand : and_expr->get_op_list()) {
             std::string const str(1, c);
             auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
             std::string extracted_value;
@@ -96,7 +96,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(true == or_expr->has_only_expression_operands());
         REQUIRE(2 == or_expr->get_num_operands());
         char c = 'a';
-        for (auto operand : or_expr->get_op_list()) {
+        for (const auto& operand : or_expr->get_op_list()) {
             std::string const str(1, c);
             auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
             std::string extracted_value;

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -66,6 +66,9 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         REQUIRE(1 == filter->get_column()->get_descriptor_list().size());
         REQUIRE(DescriptorToken{"key"} == *filter->get_column()->descriptor_begin());
+        std::string extracted_value;
+        REQUIRE(filter->get_operand()->as_var_string(extracted_value, filter->get_operation()));
+        REQUIRE("value" == extracted_value);
     }
 
     SECTION("Basic NOT filter") {
@@ -80,6 +83,10 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(FilterOperation::EQ == not_filter->get_operation());
         REQUIRE(1 == not_filter->get_column()->get_descriptor_list().size());
         REQUIRE(DescriptorToken{"key"} == *not_filter->get_column()->descriptor_begin());
+        std::string extracted_value;
+        REQUIRE(not_filter->get_operand()
+                        ->as_var_string(extracted_value, not_filter->get_operation()));
+        REQUIRE("value" == extracted_value);
     }
 
     SECTION("Incorrect NOT filter") {
@@ -91,12 +98,12 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
 
     SECTION("Basic AND expression") {
         auto query = GENERATE(
-                "a:a and b:b",
-                "a  : a and  b  : b",
-                "a:a AND b:b",
-                "a  : a AND  b  : b",
-                "a:a aND b:b",
-                "a  : a aND  b  : b"
+                "key1:value1 and key2:value2",
+                "key1  : value1 and  key2  : value2",
+                "key1:value1 AND key2:value2",
+                "key1  : value1 AND  key2  : value2",
+                "key1:value1 aND key2:value2",
+                "key1  : value1 aND  key2  : value2"
         );
         stringstream basic_and{query};
         auto and_expr = std::dynamic_pointer_cast<AndExpr>(parse_kql_expression(basic_and));
@@ -104,9 +111,8 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(false == and_expr->is_inverted());
         REQUIRE(true == and_expr->has_only_expression_operands());
         REQUIRE(2 == and_expr->get_num_operands());
-        char c = 'a';
+        int suffix_number = 1;
         for (auto const& operand : and_expr->get_op_list()) {
-            std::string const str(1, c);
             auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
             REQUIRE(nullptr != filter);
             REQUIRE(nullptr != filter->get_operand());
@@ -118,9 +124,11 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
             REQUIRE(true
                     == filter->get_operand()
                                ->as_var_string(extracted_value, filter->get_operation()));
-            REQUIRE(str == extracted_value);
-            REQUIRE(DescriptorToken{str} == *filter->get_column()->descriptor_begin());
-            ++c;
+            std::string key = "key" + std::to_string(suffix_number);
+            std::string value = "value" + std::to_string(suffix_number);
+            REQUIRE(value == extracted_value);
+            REQUIRE(DescriptorToken{key} == *filter->get_column()->descriptor_begin());
+            ++suffix_number;
         }
     }
 
@@ -139,12 +147,12 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
 
     SECTION("Basic OR expression") {
         auto query = GENERATE(
-                "a:a or b:b",
-                "a  : a or  b  : b",
-                "a:a OR b:b",
-                "a  : a OR  b  : b",
-                "a:a oR b:b",
-                "a  : a oR  b  : b"
+                "key1:value1 or key2:value2",
+                "key1  : value1 or  key2  : value2",
+                "key1:value1 OR key2:value2",
+                "key1  : value1 OR  key2  : value2",
+                "key1:value1 oR key2:value2",
+                "key1  : value1 oR  key2  : value2"
         );
         stringstream basic_or{query};
         auto or_expr = std::dynamic_pointer_cast<OrExpr>(parse_kql_expression(basic_or));
@@ -152,9 +160,8 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(false == or_expr->is_inverted());
         REQUIRE(true == or_expr->has_only_expression_operands());
         REQUIRE(2 == or_expr->get_num_operands());
-        char c = 'a';
+        int suffix_number = 1;
         for (auto const& operand : or_expr->get_op_list()) {
-            std::string const str(1, c);
             auto filter = std::dynamic_pointer_cast<FilterExpr>(operand);
             REQUIRE(nullptr != filter);
             REQUIRE(nullptr != filter->get_operand());
@@ -166,9 +173,11 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
             REQUIRE(true
                     == filter->get_operand()
                                ->as_var_string(extracted_value, filter->get_operation()));
-            REQUIRE(str == extracted_value);
-            REQUIRE(DescriptorToken{str} == *filter->get_column()->descriptor_begin());
-            ++c;
+            std::string key = "key" + std::to_string(suffix_number);
+            std::string value = "value" + std::to_string(suffix_number);
+            REQUIRE(value == extracted_value);
+            REQUIRE(DescriptorToken{key} == *filter->get_column()->descriptor_begin());
+            ++suffix_number;
         }
     }
 


### PR DESCRIPTION
# Description
This PR adds new unit tests that cover very basic KQL functionality. Over time we will add to these tests so that we can have more confidence when making changes to our KQL grammar and search AST.

# Validation performed
* Built unitTest target
* Validated that new unit tests pass

