### PR TITLE
Add support for linting on macOS and enable GH workflow for macOS.

### DIFF
--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -11,7 +11,7 @@ jobs:
   lint-check:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
     runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -9,7 +9,10 @@ concurrency:
 
 jobs:
   lint-check:
-    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@v3"
         with:

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -26,6 +26,10 @@ jobs:
         shell: "bash"
         run: "npm install -g @go-task/cli"
 
+      - if: "matrix.os == 'macos-latest'"
+        name: "Install coreutils (for md5sum)"
+        run: "brew install coreutils"
+
       - name: "Run lint task"
         shell: "bash"
         run: "task lint:check"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -308,7 +308,7 @@ tasks:
           --only-matching
           --perl-regexp
           --max-count 1
-          "node-v\\d+\\.\\d+\\.\\d+-{{.OS}}-{{.NODEJS_ARCH}}"
+          "node-v\\d+\\.\\d+\\.\\d+-{{OS}}-{{.NODEJS_ARCH}}"
           | head --lines 1
     cmds:
       - task: "download-and-extract-tar"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -308,7 +308,7 @@ tasks:
           --only-matching
           --perl-regexp
           --max-count 1
-          "node-v\\d+\\.\\d+\\.\\d+-linux-{{.NODEJS_ARCH}}"
+          "node-v\\d+\\.\\d+\\.\\d+-{{.OS}}-{{.NODEJS_ARCH}}"
           | head --lines 1
     cmds:
       - task: "download-and-extract-tar"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -306,9 +306,8 @@ tasks:
           curl --header "Cache-Control: no-cache, no-store" --silent "{{.NODEJS_VERSION_BASE_URL}}"
           | grep
           --only-matching
-          --perl-regexp
           --max-count 1
-          "node-v\\d+\\.\\d+\\.\\d+-{{OS}}-{{.NODEJS_ARCH}}"
+          "node-v[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+-{{OS}}-{{.NODEJS_ARCH}}"
           | head --lines 1
     cmds:
       - task: "download-and-extract-tar"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -565,8 +565,10 @@ tasks:
       vars: ["FILE_PATH", "SED_EXP"]
     cmds:
       - |-
-        # NOTE: We can't use `sed -i` since `-i` has different syntax on Linux and macOS
+        # NOTE:
+        # 1. We can't use `sed -i` since `-i` has different syntax on Linux and macOS
+        # 2. We can't use `--regexp` instead of `-E` since `--regexp` is not supported on macOS
         src="{{.FILE_PATH}}"
         dst="{{.FILE_PATH}}.tmp"
-        sed --regexp-extended '{{.SED_EXP}}' "${src}" > "${dst}"
+        sed -E '{{.SED_EXP}}' "${src}" > "${dst}"
         mv "${dst}" "${src}"

--- a/docs/src/dev-guide/contributing-linting.md
+++ b/docs/src/dev-guide/contributing-linting.md
@@ -1,8 +1,23 @@
 # Linting
 
 Before submitting a PR, ensure you've run our linting tools and either fixed any violations or
-suppressed the warning. To run our linting workflows locally, you'll need [Task]. Alternatively,
-you can run the [clp-lint] workflow in your fork.
+suppressed the warning. If you can't run the linting workflows locally, you can enable and run the
+[clp-lint] workflow in your fork.
+
+## Requirements
+
+We currently support running our linting tools on Linux and macOS. If you're developing on another
+OS, you can submit a [feature request][feature-req], or use our [clp-lint] workflow in your fork.
+
+To run the linting tools, besides commonly installed tools like `tar`, you'll need:
+
+* `curl`
+* `md5sum`
+* Python 3.8 or newer
+* python3-venv
+* [Task]
+
+## Running the linters
 
 To perform the linting checks:
 
@@ -17,4 +32,5 @@ task lint:fix
 ```
 
 [clp-lint]: https://github.com/y-scope/clp/blob/main/.github/workflows/clp-lint.yaml
+[feature-req]: https://github.com/y-scope/clp/issues/new?assignees=&labels=enhancement&projects=&template=feature-request.yml
 [Task]: https://taskfile.dev/


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The `lint` tasks are currently failing on macOS because of some Linux-specific command syntax that we're using. This PR switches to Linux/macOS-agnostic command syntax and enables the [clp-lint](https://github.com/y-scope/clp/blob/main/.github/workflows/clp-lint.yaml) workflow for macOS (so we have automated testing for linting on macOS).

Itemized changes:

* Replace `sed --regexp-extended` with `sed -E`.
* Remove `--perl-regexp` from the `grep` call and use the equivalent grep-compatible syntax.
* Make the node version selection Linux/macOS-agnostic.
* Document the requirements for running the linting tools.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Validated `task lint:check` and `task lint:fix` pass locally on a Linux host.
* Validated the `clp-lint` workflow succeeds.
* Sanity-checked that `task package` still works.
