### PR TITLE
linting: Always use latest versions of linting tools; Upgrade clang-format config.

### DIFF
--- a/components/core/.clang-format
+++ b/components/core/.clang-format
@@ -18,8 +18,10 @@ AlignTrailingComments:
   Kind: "Never"
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
+AllowBreakBeforeNoexceptSpecifier: "OnlyWithParen"
 AllowShortBlocksOnASingleLine: "Always"
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: "Inline"
 AllowShortIfStatementsOnASingleLine: "Never"
@@ -146,16 +148,18 @@ SpaceBeforeParens: "ControlStatements"
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
-SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
 SpacesInLineCommentPrefix:
   Minimum: 1
   Maximum: -1
-SpacesInParentheses: false
+SpacesInParens: "Custom"
+SpacesInParensOptions:
+  InConditionalStatements: false
+  InCStyleCasts: false
+  InEmptyParentheses: false
+  Other: false
 SpacesInSquareBrackets: false
 Standard: "Latest"
 TabWidth: 4

--- a/components/core/src/clp/BufferReader.hpp
+++ b/components/core/src/clp/BufferReader.hpp
@@ -63,8 +63,8 @@ public:
      * @return ErrorCode_EndOfFile if the buffer doesn't contain any more data
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
-            -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
 
     /**
      * Tries to seek to the given position, relative to the beginning of the buffer
@@ -88,9 +88,12 @@ public:
      * @param str Returns the content read from the buffer
      * @return Same as BufferReader::try_read_to_delimiter(char, bool, std::string&, bool&, size_t&)
      */
-    [[nodiscard]] auto
-    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
-            -> ErrorCode override;
+    [[nodiscard]] auto try_read_to_delimiter(
+            char delim,
+            bool keep_delimiter,
+            bool append,
+            std::string& str
+    ) -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/clp/BufferedFileReader.hpp
+++ b/components/core/src/clp/BufferedFileReader.hpp
@@ -41,11 +41,11 @@ public:
         // Constructors
         OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
                 : OperationFailed(
-                        error_code,
-                        filename,
-                        line_number,
-                        "BufferedFileReader operation failed"
-                ) {}
+                          error_code,
+                          filename,
+                          line_number,
+                          "BufferedFileReader operation failed"
+                  ) {}
 
         OperationFailed(
                 ErrorCode error_code,
@@ -127,8 +127,8 @@ public:
      * @return ErrorCode_NotInit if the file is not opened
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_peek_buffered_data(char const*& buf, size_t& peek_size) const
-            -> ErrorCode;
+    [[nodiscard]] auto
+    try_peek_buffered_data(char const*& buf, size_t& peek_size) const -> ErrorCode;
 
     /**
      * Peeks the remaining buffered content without advancing the read head.
@@ -191,8 +191,8 @@ public:
      * @return ErrorCode_EndOfFile on EOF
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
-            -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
 
     /**
      * Tries to read up to an occurrence of the given delimiter
@@ -206,9 +206,12 @@ public:
      * @return Same as BufferReader::try_read_to_delimiter if it fails
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
-            -> ErrorCode override;
+    [[nodiscard]] auto try_read_to_delimiter(
+            char delim,
+            bool keep_delimiter,
+            bool append,
+            std::string& str
+    ) -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/clp/Thread.hpp
+++ b/components/core/src/clp/Thread.hpp
@@ -28,7 +28,7 @@ public:
     };
 
     // Constructors
-    Thread() : m_thread_running(false){};
+    Thread() : m_thread_running(false) {};
 
     // Destructor
     virtual ~Thread();

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -249,24 +249,24 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             cerr << R"(  # Search ARCHIVE_PATH for " ERROR " and send results to )"
                     "a network destination"
                  << endl;
-            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")" << " "
-                 << static_cast<char const*>(cNetworkOutputHandlerName)
+            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")"
+                 << " " << static_cast<char const*>(cNetworkOutputHandlerName)
                  << " --host localhost --port 18000" << endl;
             cerr << endl;
 
             cerr << R"(  # Search ARCHIVE_PATH for " ERROR " and output the results )"
                     "by performing a count aggregation"
                  << endl;
-            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")" << " "
-                 << static_cast<char const*>(cReducerOutputHandlerName) << " --count"
+            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")"
+                 << " " << static_cast<char const*>(cReducerOutputHandlerName) << " --count"
                  << " --host localhost --port 14009 --job-id 1" << endl;
             cerr << endl;
 
             cerr << R"(  # Search ARCHIVE_PATH for " ERROR " and send results to)"
                     R"( mongodb://127.0.0.1:27017/test "result" collection )"
                  << endl;
-            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")" << " "
-                 << static_cast<char const*>(cResultsCacheOutputHandlerName)
+            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")"
+                 << " " << static_cast<char const*>(cResultsCacheOutputHandlerName)
                  << R"( --uri mongodb://127.0.0.1:27017/test --collection result)" << endl;
             cerr << endl;
 

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -249,24 +249,24 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
             cerr << R"(  # Search ARCHIVE_PATH for " ERROR " and send results to )"
                     "a network destination"
                  << endl;
-            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")"
-                 << " " << static_cast<char const*>(cNetworkOutputHandlerName)
+            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")" << " "
+                 << static_cast<char const*>(cNetworkOutputHandlerName)
                  << " --host localhost --port 18000" << endl;
             cerr << endl;
 
             cerr << R"(  # Search ARCHIVE_PATH for " ERROR " and output the results )"
                     "by performing a count aggregation"
                  << endl;
-            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")"
-                 << " " << static_cast<char const*>(cReducerOutputHandlerName) << " --count"
+            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")" << " "
+                 << static_cast<char const*>(cReducerOutputHandlerName) << " --count"
                  << " --host localhost --port 14009 --job-id 1" << endl;
             cerr << endl;
 
             cerr << R"(  # Search ARCHIVE_PATH for " ERROR " and send results to)"
                     R"( mongodb://127.0.0.1:27017/test "result" collection )"
                  << endl;
-            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")"
-                 << " " << static_cast<char const*>(cResultsCacheOutputHandlerName)
+            cerr << "  " << get_program_name() << R"( ARCHIVE_PATH " ERROR ")" << " "
+                 << static_cast<char const*>(cResultsCacheOutputHandlerName)
                  << R"( --uri mongodb://127.0.0.1:27017/test --collection result)" << endl;
             cerr << endl;
 

--- a/components/core/src/clp/ir/LogEventDeserializer.cpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.cpp
@@ -10,8 +10,8 @@
 
 namespace clp::ir {
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader)
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
     ffi::ir_stream::encoded_tag_t metadata_type{0};
     std::vector<int8_t> metadata;
     auto ir_error_code = ffi::ir_stream::deserialize_preamble(reader, metadata_type, metadata);
@@ -66,8 +66,8 @@ auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader)
 }
 
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event()
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
     epoch_time_ms_t timestamp_or_timestamp_delta{};
     std::string logtype;
     std::vector<std::string> dict_vars;
@@ -109,8 +109,8 @@ template auto LogEventDeserializer<eight_byte_encoded_variable_t>::create(Reader
 ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<eight_byte_encoded_variable_t>>;
 template auto LogEventDeserializer<four_byte_encoded_variable_t>::create(ReaderInterface& reader
 ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<four_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event()
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event()
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
 }  // namespace clp::ir

--- a/components/core/src/clp/ir/LogEventDeserializer.hpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.hpp
@@ -33,8 +33,8 @@ public:
      * - std::errc::protocol_not_supported if the IR stream contains an unsupported metadata format
      *   or uses an unsupported version
      */
-    static auto create(ReaderInterface& reader)
-            -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
+    static auto create(ReaderInterface& reader
+    ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
 
     // Delete copy constructor and assignment
     LogEventDeserializer(LogEventDeserializer const&) = delete;
@@ -58,8 +58,8 @@ public:
      * - std::errc::result_out_of_range if the IR stream is truncated
      * - std::errc::result_out_of_range if the IR stream is corrupted
      */
-    [[nodiscard]] auto deserialize_log_event()
-            -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
+    [[nodiscard]] auto deserialize_log_event(
+    ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
 
 private:
     // Constructors
@@ -74,8 +74,7 @@ private:
     [[no_unique_address]] std::conditional_t<
             std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
             epoch_time_ms_t,
-            EmptyType>
-            m_prev_msg_timestamp{};
+            EmptyType> m_prev_msg_timestamp{};
     ReaderInterface& m_reader;
 };
 }  // namespace clp::ir

--- a/components/core/src/clp/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/clp/streaming_archive/MetadataDB.cpp
@@ -303,14 +303,14 @@ MetadataDB::FileIterator::FileIterator(
         bool order_by_segment_end_ts
 )
         : Iterator(get_files_select_statement(
-                db,
-                begin_timestamp,
-                end_timestamp,
-                file_path,
-                in_specific_segment,
-                segment_id,
-                order_by_segment_end_ts
-        )) {}
+                  db,
+                  begin_timestamp,
+                  end_timestamp,
+                  file_path,
+                  in_specific_segment,
+                  segment_id,
+                  order_by_segment_end_ts
+          )) {}
 
 MetadataDB::EmptyDirectoryIterator::EmptyDirectoryIterator(SQLiteDB& db)
         : Iterator(get_empty_directories_select_statement(db)) {}

--- a/components/core/src/clp/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Segment.hpp
@@ -20,7 +20,7 @@ namespace clp::streaming_archive::reader {
 class Segment {
 public:
     // Constructor
-    Segment() : m_segment_path({}){};
+    Segment() : m_segment_path({}) {};
 
     // Destructor
     ~Segment();

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -107,9 +107,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  x - decompress" << std::endl;
                 std::cerr << "  s - search" << std::endl;
                 std::cerr << std::endl;
-                std::cerr << "Try "
-                          << " c --help OR"
-                          << " x --help OR"
+                std::cerr << "Try " << " c --help OR" << " x --help OR"
                           << " s --help for command-specific details." << std::endl;
 
                 po::options_description visible_options;
@@ -484,8 +482,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output to the results cache)"
                           << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
-                          << " " << cResultsCacheOutputHandlerName
+                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")" << " "
+                          << cResultsCacheOutputHandlerName
                           << " --uri mongodb://127.0.0.1:27017/test"
                              " --collection test"
                           << std::endl;
@@ -494,8 +492,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output to a network destination)"
                           << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
-                          << " " << cNetworkOutputHandlerName
+                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")" << " "
+                          << cNetworkOutputHandlerName
                           << " --host localhost"
                              " --port 18000"
                           << std::endl;
@@ -504,11 +502,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output perform a count aggregation)"
                           << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
-                          << " " << cReducerOutputHandlerName << " --count"
-                          << " --host localhost"
-                          << " --port 14009"
-                          << " --job-id 1" << std::endl;
+                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")" << " "
+                          << cReducerOutputHandlerName << " --count" << " --host localhost"
+                          << " --port 14009" << " --job-id 1" << std::endl;
 
                 po::options_description visible_options;
                 visible_options.add(general_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -107,7 +107,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  x - decompress" << std::endl;
                 std::cerr << "  s - search" << std::endl;
                 std::cerr << std::endl;
-                std::cerr << "Try " << " c --help OR" << " x --help OR"
+                std::cerr << "Try "
+                          << " c --help OR"
+                          << " x --help OR"
                           << " s --help for command-specific details." << std::endl;
 
                 po::options_description visible_options;
@@ -482,8 +484,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output to the results cache)"
                           << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")" << " "
-                          << cResultsCacheOutputHandlerName
+                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
+                          << " " << cResultsCacheOutputHandlerName
                           << " --uri mongodb://127.0.0.1:27017/test"
                              " --collection test"
                           << std::endl;
@@ -492,8 +494,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output to a network destination)"
                           << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")" << " "
-                          << cNetworkOutputHandlerName
+                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
+                          << " " << cNetworkOutputHandlerName
                           << " --host localhost"
                              " --port 18000"
                           << std::endl;
@@ -502,9 +504,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output perform a count aggregation)"
                           << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")" << " "
-                          << cReducerOutputHandlerName << " --count" << " --host localhost"
-                          << " --port 14009" << " --job-id 1" << std::endl;
+                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
+                          << " " << cReducerOutputHandlerName << " --count"
+                          << " --host localhost"
+                          << " --port 14009"
+                          << " --job-id 1" << std::endl;
 
                 po::options_description visible_options;
                 visible_options.add(general_options);

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -254,7 +254,7 @@ template <typename T>
 class Span {
 public:
     Span() = default;
-    Span(T* begin, size_t size) : m_begin(begin), m_size(size){};
+    Span(T* begin, size_t size) : m_begin(begin), m_size(size) {};
 
     T* begin() { return m_begin; }
 

--- a/components/core/src/clp_s/search/BooleanLiteral.hpp
+++ b/components/core/src/clp_s/search/BooleanLiteral.hpp
@@ -51,7 +51,7 @@ private:
     // Constructors
     BooleanLiteral() = default;
 
-    explicit BooleanLiteral(bool v) : m_v(v){};
+    explicit BooleanLiteral(bool v) : m_v(v) {};
 };
 }  // namespace clp_s::search
 

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -146,7 +146,8 @@ void Output::init(
             } else if (var_reader != nullptr && var_reader->get_type() == NodeType::VARSTRING) {
                 m_var_string_readers[column.first] = var_reader;
                 m_other_columns.push_back(column.second);
-            } else if (auto date_column_reader = dynamic_cast<DateStringColumnReader*>(column.second))
+            } else if (auto date_column_reader
+                       = dynamic_cast<DateStringColumnReader*>(column.second))
             {
                 m_datestring_readers[column.first] = date_column_reader;
                 m_other_columns.push_back(column.second);
@@ -1091,7 +1092,10 @@ Output::constant_propagate(std::shared_ptr<Expression> const& expr, int32_t sche
             // trivially matching
             // FIXME: have an edgecase to handle with NEXISTS on pure wildcard columns
             return EvaluatedValue::True;
-        } else if (filter->get_column()->is_pure_wildcard() && filter->get_column()->matches_any(LiteralType::ClpStringT | LiteralType::VarStringT))
+        } else if (filter->get_column()->is_pure_wildcard()
+                   && filter->get_column()->matches_any(
+                           LiteralType::ClpStringT | LiteralType::VarStringT
+                   ))
         {
             auto wildcard = filter->get_column().get();
             bool has_var_string = false;

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -30,7 +30,7 @@ public:
     // Constructors
     explicit OutputHandler(bool should_output_timestamp, bool should_marshal_records)
             : m_should_output_timestamp(should_output_timestamp),
-              m_should_marshal_records(should_marshal_records){};
+              m_should_marshal_records(should_marshal_records) {};
 
     // Destructor
     virtual ~OutputHandler() = default;

--- a/components/core/src/clp_s/search/clp_search/Grep.cpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.cpp
@@ -366,7 +366,8 @@ SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
         } else {
             if (false == query_token.is_var()) {
                 logtype += query_token.get_value();
-            } else if (false == process_var_token(query_token, var_dict, ignore_case, sub_query, logtype))
+            } else if (false
+                       == process_var_token(query_token, var_dict, ignore_case, sub_query, logtype))
             {
                 return SubQueryMatchabilityResult::WontMatch;
             }

--- a/components/core/src/glt/BufferReader.hpp
+++ b/components/core/src/glt/BufferReader.hpp
@@ -63,8 +63,8 @@ public:
      * @return ErrorCode_EndOfFile if the buffer doesn't contain any more data
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
-            -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
 
     /**
      * Tries to seek to the given position, relative to the beginning of the buffer
@@ -88,9 +88,12 @@ public:
      * @param str Returns the content read from the buffer
      * @return Same as BufferReader::try_read_to_delimiter(char, bool, std::string&, bool&, size_t&)
      */
-    [[nodiscard]] auto
-    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
-            -> ErrorCode override;
+    [[nodiscard]] auto try_read_to_delimiter(
+            char delim,
+            bool keep_delimiter,
+            bool append,
+            std::string& str
+    ) -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/glt/BufferedFileReader.hpp
+++ b/components/core/src/glt/BufferedFileReader.hpp
@@ -41,11 +41,11 @@ public:
         // Constructors
         OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
                 : OperationFailed(
-                        error_code,
-                        filename,
-                        line_number,
-                        "BufferedFileReader operation failed"
-                ) {}
+                          error_code,
+                          filename,
+                          line_number,
+                          "BufferedFileReader operation failed"
+                  ) {}
 
         OperationFailed(
                 ErrorCode error_code,
@@ -127,8 +127,8 @@ public:
      * @return ErrorCode_NotInit if the file is not opened
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_peek_buffered_data(char const*& buf, size_t& peek_size) const
-            -> ErrorCode;
+    [[nodiscard]] auto
+    try_peek_buffered_data(char const*& buf, size_t& peek_size) const -> ErrorCode;
 
     /**
      * Peeks the remaining buffered content without advancing the read head.
@@ -191,8 +191,8 @@ public:
      * @return ErrorCode_EndOfFile on EOF
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
-            -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
 
     /**
      * Tries to read up to an occurrence of the given delimiter
@@ -206,9 +206,12 @@ public:
      * @return Same as BufferReader::try_read_to_delimiter if it fails
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
-            -> ErrorCode override;
+    [[nodiscard]] auto try_read_to_delimiter(
+            char delim,
+            bool keep_delimiter,
+            bool append,
+            std::string& str
+    ) -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/glt/ir/LogEventDeserializer.cpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.cpp
@@ -10,8 +10,8 @@
 
 namespace glt::ir {
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader)
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
     ffi::ir_stream::encoded_tag_t metadata_type{0};
     std::vector<int8_t> metadata;
     auto ir_error_code = ffi::ir_stream::deserialize_preamble(reader, metadata_type, metadata);
@@ -66,8 +66,8 @@ auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader)
 }
 
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event()
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
     epoch_time_ms_t timestamp_or_timestamp_delta{};
     std::string logtype;
     std::vector<std::string> dict_vars;
@@ -109,8 +109,8 @@ template auto LogEventDeserializer<eight_byte_encoded_variable_t>::create(Reader
 ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<eight_byte_encoded_variable_t>>;
 template auto LogEventDeserializer<four_byte_encoded_variable_t>::create(ReaderInterface& reader
 ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<four_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event()
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event()
-        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
 }  // namespace glt::ir

--- a/components/core/src/glt/ir/LogEventDeserializer.hpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.hpp
@@ -33,8 +33,8 @@ public:
      * - std::errc::protocol_not_supported if the IR stream contains an unsupported metadata format
      *   or uses an unsupported version
      */
-    static auto create(ReaderInterface& reader)
-            -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
+    static auto create(ReaderInterface& reader
+    ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
 
     // Delete copy constructor and assignment
     LogEventDeserializer(LogEventDeserializer const&) = delete;
@@ -58,8 +58,8 @@ public:
      * - std::errc::result_out_of_range if the IR stream is truncated
      * - std::errc::result_out_of_range if the IR stream is corrupted
      */
-    [[nodiscard]] auto deserialize_log_event()
-            -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
+    [[nodiscard]] auto deserialize_log_event(
+    ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
 
 private:
     // Constructors
@@ -74,8 +74,7 @@ private:
     [[no_unique_address]] std::conditional_t<
             std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>,
             epoch_time_ms_t,
-            EmptyType>
-            m_prev_msg_timestamp{};
+            EmptyType> m_prev_msg_timestamp{};
     ReaderInterface& m_reader;
 };
 }  // namespace glt::ir

--- a/components/core/src/glt/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/glt/streaming_archive/MetadataDB.cpp
@@ -288,13 +288,13 @@ MetadataDB::FileIterator::FileIterator(
         segment_id_t segment_id
 )
         : Iterator(get_files_select_statement(
-                db,
-                begin_timestamp,
-                end_timestamp,
-                file_path,
-                in_specific_segment,
-                segment_id
-        )) {}
+                  db,
+                  begin_timestamp,
+                  end_timestamp,
+                  file_path,
+                  in_specific_segment,
+                  segment_id
+          )) {}
 
 MetadataDB::EmptyDirectoryIterator::EmptyDirectoryIterator(SQLiteDB& db)
         : Iterator(get_empty_directories_select_statement(db)) {}

--- a/components/core/src/glt/streaming_archive/reader/LogtypeTableManager.hpp
+++ b/components/core/src/glt/streaming_archive/reader/LogtypeTableManager.hpp
@@ -25,7 +25,7 @@ public:
         }
     };
 
-    LogtypeTableManager() : m_is_open(false){};
+    LogtypeTableManager() : m_is_open(false) {};
 
     /**
      * Open the concated variable segment file and metadata associated with the segment

--- a/components/core/src/glt/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/glt/streaming_archive/reader/Segment.hpp
@@ -20,7 +20,7 @@ namespace glt::streaming_archive::reader {
 class Segment {
 public:
     // Constructor
-    Segment() : m_segment_path({}){};
+    Segment() : m_segment_path({}) {};
 
     // Destructor
     ~Segment();

--- a/components/core/src/glt/streaming_archive/reader/SingleLogtypeTableManager.hpp
+++ b/components/core/src/glt/streaming_archive/reader/SingleLogtypeTableManager.hpp
@@ -11,7 +11,7 @@
 namespace glt::streaming_archive::reader {
 class SingleLogtypeTableManager : public streaming_archive::reader::LogtypeTableManager {
 public:
-    SingleLogtypeTableManager() : m_logtype_table_loaded(false){};
+    SingleLogtypeTableManager() : m_logtype_table_loaded(false) {};
     void open_logtype_table(logtype_dictionary_id_t logtype_id);
     void close_logtype_table();
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,4 @@
-black>=*
-clang-format>=*
-ruff>=*
-yamllint>=*
+black>=24.4.2
+clang-format>=18.1.5
+ruff>=0.4.4
+yamllint>=1.35.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,4 @@
-black~=24.1
-clang-format~=17.0
-ruff~=0.1
-yamllint~=1.33
+black>=*
+clang-format>=*
+ruff>=*
+yamllint>=*


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The current listing tools are set to specific versions in our local linting tasks and GitHub linting workflow. However, these versions are getting outdated. For example, clang has released `clang-format` version 18.1. Linting tool version updating normally includes more formatting standards and bug fixes. We should set the linting tool versions to the latest to apply these updates. Therefore, this PR updates the following things:
- Ensure `lint-requirements.txt`  to install tools with the latest available versions
- Update src files with the latest linting tools and formatting

In the future PR, we should set the workflow to run periodically for health-checking purposes.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Linting tools worked well using `task` locally in Linux.
- Workflow passed, manually checked the tools installed are the latest versions.

