### PR TITLE
gh-actions: Run linting workflow daily to validate latest linting tool versions.

### DIFF
--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: "*0 0 * * *"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -1,6 +1,11 @@
 name: "clp-lint"
 
-on: ["pull_request", "push", "workflow_dispatch"]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/10 * * * *'
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
+    # Scheduled to run every midnight in UTC.
     - cron: "*0 0 * * *"
 
 concurrency:

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: "*/10 * * * *"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -1,12 +1,12 @@
 name: "clp-lint"
 
 on:
-  push:
   pull_request:
-  workflow_dispatch:
+  push:
   schedule:
-    # Scheduled to run every midnight in UTC.
-    - cron: "0 0 * * *"
+    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    - cron: "0 15 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   schedule:
     # Scheduled to run every midnight in UTC.
-    - cron: "*0 0 * * *"
+    - cron: "0 0 * * *"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Note: this PR should not be merged before PR #384
This PR schedules our linting workflow to run every midnight in UTC. It shall help us catch linting tool version updates.
The schedule period reference can be found here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule.

# Validation performed
<!-- What tests and validation you performed on the change -->
- In a forked repo, configure the period to be every 10 minutes and ensure it runs as scheduled.

