### PR TITLE
WIP - Replace boost memory-mapped files with own implementation.

### DIFF
--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
@@ -1,7 +1,8 @@
 #include "Decompressor.hpp"
 
-#include <algorithm>
 #include <sys/mman.h>
+
+#include <algorithm>
 
 #include "../../Defs.h"
 #include "../../spdlog_with_specializations.hpp"
@@ -210,11 +211,11 @@ ErrorCode Decompressor::open(std::string const& compressed_file_path) {
     m_compressed_file_fd = ::open(compressed_file_path.c_str(), O_RDONLY);
     if (-1 == m_compressed_file_fd) {
         SPDLOG_ERROR(
-            "streaming_compression::zstd::Decompressor: Unable to open the compressed file with "
-            "path: {}, error: {}-{}",
-            compressed_file_path.c_str(),
-            errno,
-            strerror(errno)
+                "streaming_compression::zstd::Decompressor: Unable to open the compressed file "
+                "with path: {}, error: {}-{}",
+                compressed_file_path.c_str(),
+                errno,
+                strerror(errno)
         );
         return ErrorCode_errno;
     }
@@ -231,15 +232,8 @@ ErrorCode Decompressor::open(std::string const& compressed_file_path) {
         return ErrorCode_errno;
     }
 
-    m_mem_mapped_compressed_file_buffer = static_cast<char *>(
-        mmap(
-            nullptr,
-            m_compressed_file_size,
-            PROT_READ,
-            MAP_PRIVATE,
-            m_compressed_file_fd,
-            0
-        )
+    m_mem_mapped_compressed_file_buffer = static_cast<char*>(
+            mmap(nullptr, m_compressed_file_size, PROT_READ, MAP_PRIVATE, m_compressed_file_fd, 0)
     );
     if (MAP_FAILED == m_mem_mapped_compressed_file_buffer) {
         SPDLOG_ERROR(

--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 
-#include <boost/iostreams/device/mapped_file.hpp>
 #include <zstd.h>
 
 #include "../../FileReader.hpp"
@@ -125,7 +124,9 @@ private:
     // Compressed stream variables
     ZSTD_DStream* m_decompression_stream;
 
-    boost::iostreams::mapped_file_source m_memory_mapped_compressed_file;
+    int m_compressed_file_fd;
+    size_t m_compressed_file_size;
+    char* m_mem_mapped_compressed_file_buffer;
     FileReader* m_file_reader;
     size_t m_file_reader_initial_pos;
     std::unique_ptr<char[]> m_file_read_buffer;

--- a/components/core/tests/test-StreamingCompression.cpp
+++ b/components/core/tests/test-StreamingCompression.cpp
@@ -1,6 +1,7 @@
 #include <string>
 
 #include <boost/filesystem.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
 #include <Catch2/single_include/catch2/catch.hpp>
 #include <zstd.h>
 


### PR DESCRIPTION
# References
When compiling the Zstd decompressor code with Emscripten for use in Log Viewer WebUI, it was identified that the code has dependency on Boost's memory-mapped files. That requires setting up extra compiling procedures - downloading Boost and also making modifications in Boost to avoid `emcc` complaining on missing some std::atomic implementations. However, the Boost dependencies can be replace with POSIX system calls.

In Emscripten compiled example code, with the replacement the speedup is > 30 ms.
 
# Description
This is WIP. Criticism is welcomed:
1. Shall we abstract the changes into a class to avoid bloating the Decoder class with 3 extra members?
2. Shall we replace other Boost memory-mapped file usages in CLP core?

---
1. Replace boost memory-mapped files with own implementation.


# Validation performed
1. Built and ran `unitTest` target and passed all:
   ```
   ...
   All tests passed (95962 assertions in 51 test cases)
   ```
