### PR TITLE
yamllint: Treat warnings as errors.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -98,7 +98,7 @@ tasks:
     cmds:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
-        yamllint .
+        yamllint --strict .
 
   cpp:
     internal: true


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

`task lint:yml` doesn't currently treat warnings as errors meaning that an improperly indented comment wouldn't get caught in the lint workflow. Thus, this PR enables `yamllint`'s strict mode.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Added a comment with way too much indentation to `.yamllint.yml`
* Validated that `task lint:yml` failed even though the violation was just a warning.
