### PR TITLE
gh-actions: Run scheduled lint workflow at 00:15 rather than 15:00.

### DIFF
--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -5,7 +5,7 @@ on:
   push:
   schedule:
     # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
-    - cron: "0 15 * * *"
+    - cron: "15 0 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

#385 scheduled the `clp-lint` workflow to run daily at 15:00 UTC instead of the intended 00:15 UTC. This PR fixes the typo.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that a crontab generator generates the same crontab.
