### PR TITLE
clp-package: Fix errors and warnings in search scheduler (fixes #393).

### DIFF
--- a/components/clp-py-utils/clp_py_utils/sql_adapter.py
+++ b/components/clp-py-utils/clp_py_utils/sql_adapter.py
@@ -114,9 +114,9 @@ class SQL_Adapter:
             return self.create_connection(disable_localhost_socket_connection)
 
         if "mysql" == self.database_config.type:
-            dialect = mysqlconnector.dialect
+            dialect = mysqlconnector.dialect()
         elif "mariadb" == self.database_config.type:
-            dialect = mariadbconnector.dialect
+            dialect = mariadbconnector.dialect()
         else:
             raise NotImplementedError
         return ConnectionPoolWrapper(

--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -492,7 +492,7 @@ async def handle_jobs(
             db_conn_pool, results_cache_uri, num_archives_to_search_per_sub_job
         )
         if 0 == len(reducer_acquisition_tasks):
-            tasks.append(asyncio.sleep(jobs_poll_delay))
+            tasks.append(asyncio.create_task(asyncio.sleep(jobs_poll_delay)))
         else:
             tasks.extend(reducer_acquisition_tasks)
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#393 
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Currently, when starting the search scheduler, two types of warning and error logs are printed
```
/opt/clp/lib/python3/site-packages/job_orchestration/scheduler/search/search_scheduler.py:499: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
```
```
Traceback (most recent call last):
  File "/opt/clp/lib/python3/site-packages/sqlalchemy/pool/base.py", line 374, in _close_connection
    self._dialect.do_terminate(connection)
TypeError: DefaultDialect.do_terminate() missing 1 required positional argument: 'dbapi_connection'
Exception during reset or similar
Traceback (most recent call last):
  File "/opt/clp/lib/python3/site-packages/sqlalchemy/pool/base.py", line 986, in _finalize_fairy
    fairy._reset(
  File "/opt/clp/lib/python3/site-packages/sqlalchemy/pool/base.py", line 1432, in _reset
    pool._dialect.do_rollback(self)
TypeError: DefaultDialect.do_rollback() missing 1 required positional argument: 'dbapi_connection'
Exception terminating connection <mariadb.connection connected to '127.0.0.1' at 0x7f69a6f25fe0>
Traceback (most recent call last):
  File "/opt/clp/lib/python3/site-packages/sqlalchemy/pool/base.py", line 986, in _finalize_fairy
    fairy._reset(
  File "/opt/clp/lib/python3/site-packages/sqlalchemy/pool/base.py", line 1432, in _reset
    pool._dialect.do_rollback(self)
TypeError: DefaultDialect.do_rollback() missing 1 required positional argument: 'dbapi_connection
```
This PR resolves the aforementioned warnings and errors by ensuring the correct usage of parameters.
# Validation performed
<!-- What tests and validation you performed on the change -->
+ Started the package, compressed [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset, and searched `org.apache.hadoop.metrics2.impl.MetricsConfig: loaded properties from hadoop-metrics2.properties`
+ Executed `docker logs clp-search_scheduler-{suffix}`, the warning and error logs were no longer printed.