### PR TITLE
package: Add redis.compression_backend_database to template config file.

### DIFF
--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -35,6 +35,7 @@
 #  host: "localhost"
 #  port: 6379
 #  search_backend_database: 0
+#  compression_backend_database: 1
 #
 #reducer:
 #  host: "localhost"


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

We missed adding `redis.compression_backend_database` to the template config file in #238. This PR adds it.

# Validation performed
<!-- What tests and validation you performed on the change -->

* `task`
* `cd build/clp-package`
* Uncommented `etc/clp-config.yml`
* Changed `redis.search_backend_database` from 0 to 1
* Changed `redis.compression_backend_database` from 1 to 0
* Compressed a dataset
* Validated that the keyspace in redis showed db0.
  * `docker exec -it clp-redis-<instance-id> redis-cli -h localhost -p 6379`
  * `AUTH <redis-password>` (see `etc/credentials.yml`)
  * `INFO keyspace`
* Searched for a log
* Validated that the keyspace in redis showed both db0 and db1.