### PR TITLE
clp-s: Add a parser to structurize arrays.

### DIFF
--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -130,6 +130,7 @@ BaseColumnReader* ArchiveReader::append_reader_column(SchemaReader& reader, int3
         // No need to push columns without associated object readers into the SchemaReader.
         case NodeType::Object:
         case NodeType::NullValue:
+        case NodeType::StructuredArray:
         case NodeType::Unknown:
             break;
     }
@@ -182,6 +183,7 @@ void ArchiveReader::append_unordered_reader_columns(
             case NodeType::UnstructuredArray:
             case NodeType::DateString:
             // No need to push columns without associated object readers into the SchemaReader.
+            case NodeType::StructuredArray:
             case NodeType::Object:
             case NodeType::NullValue:
             case NodeType::Unknown:

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -118,6 +118,7 @@ void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const&
             case NodeType::DateString:
                 writer->append_column(new DateStringColumnWriter(id));
                 break;
+            case NodeType::StructuredArray:
             case NodeType::Object:
             case NodeType::NullValue:
             case NodeType::Unknown:

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -185,6 +185,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "print-archive-stats",
                     po::bool_switch(&m_print_archive_stats),
                     "Print statistics (json) about the archive after it's compressed."
+            )(
+                    "structurize-arrays",
+                    po::bool_switch(&m_structurize_arrays),
+                    "Structurize arrays instead of compressing them as clp strings."
             );
             // clang-format on
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -102,6 +102,8 @@ public:
 
     OutputHandlerType get_output_handler_type() const { return m_output_handler_type; }
 
+    bool get_structurize_arrays() const { return m_structurize_arrays; }
+
 private:
     // Methods
     /**
@@ -164,6 +166,7 @@ private:
     size_t m_target_encoded_size{8ULL * 1024 * 1024 * 1024};  // 8 GiB
     bool m_print_archive_stats{false};
     size_t m_max_document_size{512ULL * 1024 * 1024};  // 512 MB
+    bool m_structurize_arrays{false};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -16,7 +16,8 @@ JsonParser::JsonParser(JsonParserOption const& option)
           m_compression_level(option.compression_level),
           m_target_encoded_size(option.target_encoded_size),
           m_max_document_size(option.max_document_size),
-          m_timestamp_key(option.timestamp_key) {
+          m_timestamp_key(option.timestamp_key),
+          m_structurize_arrays(option.structurize_arrays) {
     if (false == FileUtils::validate_path(option.file_paths)) {
         exit(1);
     }
@@ -37,6 +38,199 @@ JsonParser::JsonParser(JsonParserOption const& option)
 
     m_archive_writer = std::make_unique<ArchiveWriter>(option.metadata_db);
     m_archive_writer->open(archive_writer_option);
+}
+
+void JsonParser::parse_obj_in_array(ondemand::object line, int32_t parent_node_id) {
+    ondemand::object_iterator it = line.begin();
+    if (it == line.end()) {
+        m_current_schema.insert_unordered(parent_node_id);
+        return;
+    }
+
+    std::stack<ondemand::object> object_stack;
+    std::stack<ondemand::object_iterator> object_it_stack;
+
+    std::stack<int32_t> node_id_stack;
+    node_id_stack.push(parent_node_id);
+    object_stack.push(std::move(line));
+    object_it_stack.push(std::move(it));
+
+    size_t object_start = m_current_schema.start_unordered_object(NodeType::Object);
+    ondemand::field cur_field;
+    ondemand::value cur_value;
+    std::string cur_key;
+    int32_t node_id;
+    while (true) {
+        while (false == object_stack.empty() && object_it_stack.top() == object_stack.top().end()) {
+            object_stack.pop();
+            node_id_stack.pop();
+            object_it_stack.pop();
+            if (false == object_it_stack.empty()) {
+                ++object_it_stack.top();
+            }
+        }
+
+        if (object_stack.empty()) {
+            m_current_schema.end_unordered_object(object_start);
+            return;
+        }
+
+        cur_field = *object_it_stack.top();
+        cur_key = std::string_view(cur_field.unescaped_key(true));
+        cur_value = cur_field.value();
+
+        switch (cur_value.type()) {
+            case ondemand::json_type::object: {
+                node_id = m_archive_writer
+                                  ->add_node(node_id_stack.top(), NodeType::Object, cur_key);
+                object_stack.push(std::move(cur_value.get_object()));
+                object_it_stack.push(std::move(object_stack.top().begin()));
+                if (object_it_stack.top() == object_stack.top().end()) {
+                    m_current_schema.insert_unordered(node_id);
+                    object_stack.pop();
+                    object_it_stack.pop();
+                } else {
+                    node_id_stack.push(node_id);
+                    continue;
+                }
+                break;
+            }
+            case ondemand::json_type::array: {
+                node_id = m_archive_writer->add_node(
+                        node_id_stack.top(),
+                        NodeType::StructuredArray,
+                        cur_key
+                );
+                parse_array_obj(cur_value.get_array(), node_id);
+                break;
+            }
+            case ondemand::json_type::number: {
+                ondemand::number number_value = cur_value.get_number();
+                if (true == number_value.is_double()) {
+                    double double_value = number_value.get_double();
+                    m_current_parsed_message.add_unordered_value(double_value);
+                    node_id = m_archive_writer
+                                      ->add_node(node_id_stack.top(), NodeType::Float, cur_key);
+                } else {
+                    int64_t i64_value;
+                    if (number_value.is_uint64()) {
+                        i64_value = static_cast<int64_t>(number_value.get_uint64());
+                    } else {
+                        i64_value = number_value.get_int64();
+                    }
+                    m_current_parsed_message.add_unordered_value(i64_value);
+                    node_id = m_archive_writer
+                                      ->add_node(node_id_stack.top(), NodeType::Integer, cur_key);
+                }
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+            case ondemand::json_type::string: {
+                std::string value = std::string(
+                        cur_value.raw_json_token().substr(1, cur_value.raw_json_token().size() - 2)
+                );
+                if (value.find(' ') != std::string::npos) {
+                    node_id = m_archive_writer
+                                      ->add_node(node_id_stack.top(), NodeType::ClpString, cur_key);
+                } else {
+                    node_id = m_archive_writer
+                                      ->add_node(node_id_stack.top(), NodeType::VarString, cur_key);
+                }
+                m_current_parsed_message.add_unordered_value(value);
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+            case ondemand::json_type::boolean: {
+                bool bval = cur_value.get_bool();
+                m_current_parsed_message.add_unordered_value(bval);
+                node_id = m_archive_writer
+                                  ->add_node(node_id_stack.top(), NodeType::Boolean, cur_key);
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+            case ondemand::json_type::null: {
+                node_id = m_archive_writer
+                                  ->add_node(node_id_stack.top(), NodeType::NullValue, cur_key);
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+        }
+
+        ++object_it_stack.top();
+    }
+}
+
+void JsonParser::parse_array_obj(ondemand::array array, int32_t parent_node_id) {
+    ondemand::array_iterator it = array.begin();
+    if (it == array.end()) {
+        m_current_schema.insert_unordered(parent_node_id);
+        return;
+    }
+
+    size_t array_start = m_current_schema.start_unordered_object(NodeType::StructuredArray);
+    ondemand::value cur_value;
+    int32_t node_id;
+    for (; it != array.end(); ++it) {
+        cur_value = *it;
+
+        switch (cur_value.type()) {
+            case ondemand::json_type::object: {
+                node_id = m_archive_writer->add_node(parent_node_id, NodeType::Object, "");
+                parse_obj_in_array(std::move(cur_value.get_object()), node_id);
+                break;
+            }
+            case ondemand::json_type::array: {
+                node_id = m_archive_writer->add_node(parent_node_id, NodeType::StructuredArray, "");
+                parse_array_obj(std::move(cur_value.get_array()), node_id);
+                break;
+            }
+            case ondemand::json_type::number: {
+                ondemand::number number_value = cur_value.get_number();
+                if (true == number_value.is_double()) {
+                    double double_value = number_value.get_double();
+                    m_current_parsed_message.add_unordered_value(double_value);
+                    node_id = m_archive_writer->add_node(parent_node_id, NodeType::Float, "");
+                } else {
+                    int64_t i64_value;
+                    if (number_value.is_uint64()) {
+                        i64_value = static_cast<int64_t>(number_value.get_uint64());
+                    } else {
+                        i64_value = number_value.get_int64();
+                    }
+                    m_current_parsed_message.add_unordered_value(i64_value);
+                    node_id = m_archive_writer->add_node(parent_node_id, NodeType::Integer, "");
+                }
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+            case ondemand::json_type::string: {
+                std::string value = std::string(
+                        cur_value.raw_json_token().substr(1, cur_value.raw_json_token().size() - 2)
+                );
+                if (value.find(' ') != std::string::npos) {
+                    node_id = m_archive_writer->add_node(parent_node_id, NodeType::ClpString, "");
+                } else {
+                    node_id = m_archive_writer->add_node(parent_node_id, NodeType::VarString, "");
+                }
+                m_current_parsed_message.add_unordered_value(value);
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+            case ondemand::json_type::boolean: {
+                bool bval = cur_value.get_bool();
+                m_current_parsed_message.add_unordered_value(bval);
+                node_id = m_archive_writer->add_node(parent_node_id, NodeType::Boolean, "");
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+            case ondemand::json_type::null: {
+                node_id = m_archive_writer->add_node(parent_node_id, NodeType::NullValue, "");
+                m_current_schema.insert_unordered(node_id);
+                break;
+            }
+        }
+    }
+    m_current_schema.end_unordered_object(array_start);
 }
 
 void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::string const& key) {
@@ -95,14 +289,24 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
                 }
             }
             case ondemand::json_type::array: {
-                std::string value = std::string(std::string_view(simdjson::to_json_string(line)));
-                node_id = m_archive_writer->add_node(
-                        node_id_stack.top(),
-                        NodeType::UnstructuredArray,
-                        cur_key
-                );
-                m_current_parsed_message.add_value(node_id, value);
-                m_current_schema.insert_ordered(node_id);
+                if (m_structurize_arrays) {
+                    node_id = m_archive_writer->add_node(
+                            node_id_stack.top(),
+                            NodeType::StructuredArray,
+                            cur_key
+                    );
+                    parse_array_obj(std::move(line.get_array()), node_id);
+                } else {
+                    std::string value
+                            = std::string(std::string_view(simdjson::to_json_string(line)));
+                    node_id = m_archive_writer->add_node(
+                            node_id_stack.top(),
+                            NodeType::UnstructuredArray,
+                            cur_key
+                    );
+                    m_current_parsed_message.add_value(node_id, value);
+                    m_current_schema.insert_ordered(node_id);
+                }
                 break;
             }
             case ondemand::json_type::number: {

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -34,6 +34,7 @@ struct JsonParserOption {
     size_t max_document_size;
     int compression_level;
     bool print_archive_stats;
+    bool structurize_arrays;
     std::shared_ptr<clp::GlobalMySQLMetadataDB> metadata_db;
 };
 
@@ -73,6 +74,20 @@ private:
     void parse_line(ondemand::value line, int32_t parent_node_id, std::string const& key);
 
     /**
+     * Parses an array within a JSON line
+     * @param line the JSON array
+     * @param parent_node_id the parent node id
+     */
+    void parse_array_obj(ondemand::array line, int32_t parent_node_id);
+
+    /**
+     * Parses an object within an array in a JSON line
+     * @param line the JSON object
+     * @param parent_node_id the parent node id
+     */
+    void parse_obj_in_array(ondemand::object line, int32_t parent_node_id);
+
+    /**
      * Splits the archive if the size of the archive exceeds the maximum size
      */
     void split_archive();
@@ -93,6 +108,7 @@ private:
     std::unique_ptr<ArchiveWriter> m_archive_writer;
     size_t m_target_encoded_size;
     size_t m_max_document_size;
+    bool m_structurize_arrays{false};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -23,9 +23,7 @@ public:
         AddStringValue,
         AddNullValue,
         BeginArray,
-        EndArray,
-        BeginDocument,
-        BeginArrayDocument,
+        EndArray
     };
 
     static int64_t const cReservedLength = 4096;
@@ -78,15 +76,11 @@ public:
     void end_document() { m_json_string[m_json_string.size() - 1] = '}'; }
 
     void end_object() {
-        if (m_op_list[m_op_list_index - 2] != BeginObject
-            && m_op_list[m_op_list_index - 2] != BeginDocument)
-        {
+        if (m_op_list[m_op_list_index - 2] != BeginObject) {
             m_json_string.pop_back();
         }
         m_json_string += "},";
     }
-
-    void begin_array_document() { m_json_string += "["; }
 
     void begin_array() {
         append_key();
@@ -94,9 +88,7 @@ public:
     }
 
     void end_array() {
-        if (m_op_list[m_op_list_index - 2] != BeginArray
-            && m_op_list[m_op_list_index - 2] != BeginArrayDocument)
-        {
+        if (m_op_list[m_op_list_index - 2] != BeginArray) {
             m_json_string.pop_back();
         }
         m_json_string += "],";

--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -21,7 +21,11 @@ public:
         AddFloatValue,
         AddBoolValue,
         AddStringValue,
-        AddNullValue
+        AddNullValue,
+        BeginArray,
+        EndArray,
+        BeginDocument,
+        BeginArrayDocument,
     };
 
     static int64_t const cReservedLength = 4096;
@@ -74,10 +78,28 @@ public:
     void end_document() { m_json_string[m_json_string.size() - 1] = '}'; }
 
     void end_object() {
-        if (m_op_list[m_op_list_index - 2] != BeginObject) {
+        if (m_op_list[m_op_list_index - 2] != BeginObject
+            && m_op_list[m_op_list_index - 2] != BeginDocument)
+        {
             m_json_string.pop_back();
         }
         m_json_string += "},";
+    }
+
+    void begin_array_document() { m_json_string += "["; }
+
+    void begin_array() {
+        append_key();
+        m_json_string += "[";
+    }
+
+    void end_array() {
+        if (m_op_list[m_op_list_index - 2] != BeginArray
+            && m_op_list[m_op_list_index - 2] != BeginArrayDocument)
+        {
+            m_json_string.pop_back();
+        }
+        m_json_string += "],";
     }
 
     void append_key() { append_key(m_special_keys[m_special_keys_index++]); }

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -72,6 +72,22 @@ void SchemaReader::generate_json_string() {
                 m_json_serializer.end_object();
                 break;
             }
+            case JsonSerializer::Op::BeginDocument: {
+                m_json_serializer.begin_document();
+                break;
+            }
+            case JsonSerializer::Op::BeginArray: {
+                m_json_serializer.begin_array();
+                break;
+            }
+            case JsonSerializer::Op::EndArray: {
+                m_json_serializer.end_array();
+                break;
+            }
+            case JsonSerializer::Op::BeginArrayDocument: {
+                m_json_serializer.begin_array_document();
+                break;
+            }
             case JsonSerializer::Op::AddIntField: {
                 column = m_reordered_columns[column_id_index++];
                 auto const& name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
@@ -286,6 +302,236 @@ int32_t SchemaReader::get_first_column_in_span(std::span<int32_t> schema) {
     return -1;
 }
 
+void SchemaReader::find_intersection_and_fix_brackets(
+        int32_t cur_root,
+        int32_t next_root,
+        std::vector<int32_t>& path_to_intersection
+) {
+    auto const* cur_node = &m_global_schema_tree->get_node(cur_root);
+    auto const* next_node = &m_global_schema_tree->get_node(next_root);
+    while (cur_node->get_parent_id() != next_node->get_parent_id()) {
+        if (cur_node->get_depth() > next_node->get_depth()) {
+            cur_root = cur_node->get_parent_id();
+            cur_node = &m_global_schema_tree->get_node(cur_root);
+            m_json_serializer.add_op(JsonSerializer::Op::EndObject);
+        } else if (cur_node->get_depth() < next_node->get_depth()) {
+            path_to_intersection.push_back(next_root);
+            next_root = next_node->get_parent_id();
+            next_node = &m_global_schema_tree->get_node(next_root);
+        } else {
+            cur_root = cur_node->get_parent_id();
+            cur_node = &m_global_schema_tree->get_node(cur_root);
+            m_json_serializer.add_op(JsonSerializer::Op::EndObject);
+            path_to_intersection.push_back(next_root);
+            next_root = next_node->get_parent_id();
+            next_node = &m_global_schema_tree->get_node(next_root);
+        }
+    }
+
+    for (auto it = path_to_intersection.rbegin(); it != path_to_intersection.rend(); ++it) {
+        auto const& node = m_global_schema_tree->get_node(*it);
+        bool no_name = true;
+        if (false == node.get_key_name().empty()) {
+            m_json_serializer.add_special_key(node.get_key_name());
+            no_name = false;
+        }
+        if (NodeType::Object == node.get_type()) {
+            m_json_serializer.add_op(
+                    no_name ? JsonSerializer::Op::BeginDocument : JsonSerializer::Op::BeginObject
+            );
+        } else if (NodeType::StructuredArray == node.get_type()) {
+            m_json_serializer.add_op(
+                    no_name ? JsonSerializer::Op::BeginArrayDocument
+                            : JsonSerializer::Op::BeginArray
+            );
+        }
+    }
+    path_to_intersection.clear();
+}
+
+size_t SchemaReader::generate_structured_array_template(
+        int32_t array_root,
+        size_t column_start,
+        std::span<int32_t> schema
+) {
+    size_t column_idx = column_start;
+    std::vector<int32_t> path_to_intersection;
+    int32_t depth = m_global_schema_tree->get_node(array_root).get_depth();
+
+    for (size_t i = 0; i < schema.size(); ++i) {
+        int32_t global_column_id = schema[i];
+        if (Schema::schema_entry_is_unordered_object(global_column_id)) {
+            auto type = Schema::get_unordered_object_type(global_column_id);
+            size_t length = Schema::get_unordered_object_length(global_column_id);
+            auto sub_object_schema = schema.subspan(i + 1, length);
+            if (NodeType::StructuredArray == type) {
+                int32_t sub_array_root
+                        = m_global_schema_tree->find_matching_subtree_root_in_subtree(
+                                array_root,
+                                get_first_column_in_span(sub_object_schema),
+                                NodeType::StructuredArray
+                        );
+                m_json_serializer.add_op(JsonSerializer::Op::BeginArrayDocument);
+                column_idx = generate_structured_array_template(
+                        sub_array_root,
+                        column_idx,
+                        sub_object_schema
+                );
+                m_json_serializer.add_op(JsonSerializer::Op::EndArray);
+            } else if (NodeType::Object == type) {
+                int32_t object_root = m_global_schema_tree->find_matching_subtree_root_in_subtree(
+                        array_root,
+                        get_first_column_in_span(sub_object_schema),
+                        NodeType::Object
+                );
+                m_json_serializer.add_op(JsonSerializer::Op::BeginDocument);
+                column_idx = generate_structured_object_template(
+                        object_root,
+                        column_idx,
+                        sub_object_schema
+                );
+                m_json_serializer.add_op(JsonSerializer::Op::EndObject);
+            }
+            i += length;
+        } else {
+            auto const& node = m_global_schema_tree->get_node(global_column_id);
+            switch (node.get_type()) {
+                case NodeType::Object: {
+                    find_intersection_and_fix_brackets(
+                            array_root,
+                            node.get_id(),
+                            path_to_intersection
+                    );
+                    for (int j = 0; j < (node.get_depth() - depth); ++j) {
+                        m_json_serializer.add_op(JsonSerializer::Op::EndObject);
+                    }
+                    break;
+                }
+                case NodeType::StructuredArray: {
+                    m_json_serializer.add_op(JsonSerializer::Op::BeginArrayDocument);
+                    m_json_serializer.add_op(JsonSerializer::Op::EndArray);
+                    break;
+                }
+                case NodeType::Integer: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddIntValue);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::Float: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddFloatValue);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::Boolean: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddBoolValue);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::ClpString:
+                case NodeType::VarString: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddStringValue);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::NullValue: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddNullValue);
+                    break;
+                }
+                case NodeType::DateString:
+                case NodeType::UnstructuredArray:
+                case NodeType::Unknown:
+                    break;
+            }
+        }
+    }
+    return column_idx;
+}
+
+size_t SchemaReader::generate_structured_object_template(
+        int32_t object_root,
+        size_t column_start,
+        std::span<int32_t> schema
+) {
+    int32_t root = object_root;
+    size_t column_idx = column_start;
+    std::vector<int32_t> path_to_intersection;
+
+    for (size_t i = 0; i < schema.size(); ++i) {
+        int32_t global_column_id = schema[i];
+        if (Schema::schema_entry_is_unordered_object(global_column_id)) {
+            // It should only be possible to encounter arrays inside of structured objects
+            size_t array_length = Schema::get_unordered_object_length(global_column_id);
+            auto array_schema = schema.subspan(i + 1, array_length);
+            // we can guarantee that the last array we hit on the path to object root must be the
+            // right one because otherwise we'd be inside the structured array generator
+            int32_t array_root = m_global_schema_tree->find_matching_subtree_root_in_subtree(
+                    object_root,
+                    get_first_column_in_span(array_schema),
+                    NodeType::StructuredArray
+            );
+
+            find_intersection_and_fix_brackets(root, array_root, path_to_intersection);
+            column_idx = generate_structured_array_template(array_root, column_idx, array_schema);
+            m_json_serializer.add_op(JsonSerializer::Op::EndArray);
+            i += array_length;
+            // root is parent of the array object since we close the array bracket above
+            auto const& node = m_global_schema_tree->get_node(array_root);
+            root = node.get_parent_id();
+        } else {
+            auto const& node = m_global_schema_tree->get_node(global_column_id);
+            int32_t next_root = node.get_parent_id();
+            find_intersection_and_fix_brackets(root, next_root, path_to_intersection);
+            root = next_root;
+            switch (node.get_type()) {
+                case NodeType::Object: {
+                    m_json_serializer.add_op(JsonSerializer::Op::BeginObject);
+                    m_json_serializer.add_special_key(node.get_key_name());
+                    m_json_serializer.add_op(JsonSerializer::Op::EndObject);
+                    break;
+                }
+                case NodeType::StructuredArray: {
+                    m_json_serializer.add_op(JsonSerializer::Op::BeginArray);
+                    m_json_serializer.add_special_key(node.get_key_name());
+                    m_json_serializer.add_op(JsonSerializer::Op::EndArray);
+                    break;
+                }
+                case NodeType::Integer: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddIntField);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::Float: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddFloatField);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::Boolean: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddBoolField);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::ClpString:
+                case NodeType::VarString: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddStringField);
+                    m_reordered_columns.push_back(m_columns[column_idx++]);
+                    break;
+                }
+                case NodeType::NullValue: {
+                    m_json_serializer.add_op(JsonSerializer::Op::AddNullField);
+                    m_json_serializer.add_special_key(node.get_key_name());
+                    break;
+                }
+                case NodeType::DateString:
+                case NodeType::UnstructuredArray:
+                case NodeType::Unknown:
+                    break;
+            }
+        }
+    }
+    find_intersection_and_fix_brackets(root, object_root, path_to_intersection);
+    return column_idx;
+}
+
 void SchemaReader::initialize_serializer() {
     if (m_serializer_initialized) {
         return;
@@ -328,6 +574,23 @@ void SchemaReader::generate_json_template(int32_t id) {
             case NodeType::UnstructuredArray: {
                 m_json_serializer.add_op(JsonSerializer::Op::AddArrayField);
                 m_reordered_columns.push_back(m_column_map[child_global_id]);
+                break;
+            }
+            case NodeType::StructuredArray: {
+                m_json_serializer.add_op(JsonSerializer::Op::BeginArray);
+                m_json_serializer.add_special_key(child_node.get_key_name());
+                int32_t global_child_id = m_local_id_to_global_id[child_id];
+                auto structured_it = m_global_id_to_unordered_object.find(global_child_id);
+                if (m_global_id_to_unordered_object.end() != structured_it) {
+                    size_t column_start = structured_it->second.first;
+                    std::span<int32_t> structured_schema = structured_it->second.second;
+                    generate_structured_array_template(
+                            global_child_id,
+                            column_start,
+                            structured_schema
+                    );
+                }
+                m_json_serializer.add_op(JsonSerializer::Op::EndArray);
                 break;
             }
             case NodeType::Integer: {

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -72,20 +72,12 @@ void SchemaReader::generate_json_string() {
                 m_json_serializer.end_object();
                 break;
             }
-            case JsonSerializer::Op::BeginDocument: {
-                m_json_serializer.begin_document();
-                break;
-            }
             case JsonSerializer::Op::BeginArray: {
                 m_json_serializer.begin_array();
                 break;
             }
             case JsonSerializer::Op::EndArray: {
                 m_json_serializer.end_array();
-                break;
-            }
-            case JsonSerializer::Op::BeginArrayDocument: {
-                m_json_serializer.begin_array_document();
                 break;
             }
             case JsonSerializer::Op::AddIntField: {
@@ -302,236 +294,6 @@ int32_t SchemaReader::get_first_column_in_span(std::span<int32_t> schema) {
     return -1;
 }
 
-void SchemaReader::find_intersection_and_fix_brackets(
-        int32_t cur_root,
-        int32_t next_root,
-        std::vector<int32_t>& path_to_intersection
-) {
-    auto const* cur_node = &m_global_schema_tree->get_node(cur_root);
-    auto const* next_node = &m_global_schema_tree->get_node(next_root);
-    while (cur_node->get_parent_id() != next_node->get_parent_id()) {
-        if (cur_node->get_depth() > next_node->get_depth()) {
-            cur_root = cur_node->get_parent_id();
-            cur_node = &m_global_schema_tree->get_node(cur_root);
-            m_json_serializer.add_op(JsonSerializer::Op::EndObject);
-        } else if (cur_node->get_depth() < next_node->get_depth()) {
-            path_to_intersection.push_back(next_root);
-            next_root = next_node->get_parent_id();
-            next_node = &m_global_schema_tree->get_node(next_root);
-        } else {
-            cur_root = cur_node->get_parent_id();
-            cur_node = &m_global_schema_tree->get_node(cur_root);
-            m_json_serializer.add_op(JsonSerializer::Op::EndObject);
-            path_to_intersection.push_back(next_root);
-            next_root = next_node->get_parent_id();
-            next_node = &m_global_schema_tree->get_node(next_root);
-        }
-    }
-
-    for (auto it = path_to_intersection.rbegin(); it != path_to_intersection.rend(); ++it) {
-        auto const& node = m_global_schema_tree->get_node(*it);
-        bool no_name = true;
-        if (false == node.get_key_name().empty()) {
-            m_json_serializer.add_special_key(node.get_key_name());
-            no_name = false;
-        }
-        if (NodeType::Object == node.get_type()) {
-            m_json_serializer.add_op(
-                    no_name ? JsonSerializer::Op::BeginDocument : JsonSerializer::Op::BeginObject
-            );
-        } else if (NodeType::StructuredArray == node.get_type()) {
-            m_json_serializer.add_op(
-                    no_name ? JsonSerializer::Op::BeginArrayDocument
-                            : JsonSerializer::Op::BeginArray
-            );
-        }
-    }
-    path_to_intersection.clear();
-}
-
-size_t SchemaReader::generate_structured_array_template(
-        int32_t array_root,
-        size_t column_start,
-        std::span<int32_t> schema
-) {
-    size_t column_idx = column_start;
-    std::vector<int32_t> path_to_intersection;
-    int32_t depth = m_global_schema_tree->get_node(array_root).get_depth();
-
-    for (size_t i = 0; i < schema.size(); ++i) {
-        int32_t global_column_id = schema[i];
-        if (Schema::schema_entry_is_unordered_object(global_column_id)) {
-            auto type = Schema::get_unordered_object_type(global_column_id);
-            size_t length = Schema::get_unordered_object_length(global_column_id);
-            auto sub_object_schema = schema.subspan(i + 1, length);
-            if (NodeType::StructuredArray == type) {
-                int32_t sub_array_root
-                        = m_global_schema_tree->find_matching_subtree_root_in_subtree(
-                                array_root,
-                                get_first_column_in_span(sub_object_schema),
-                                NodeType::StructuredArray
-                        );
-                m_json_serializer.add_op(JsonSerializer::Op::BeginArrayDocument);
-                column_idx = generate_structured_array_template(
-                        sub_array_root,
-                        column_idx,
-                        sub_object_schema
-                );
-                m_json_serializer.add_op(JsonSerializer::Op::EndArray);
-            } else if (NodeType::Object == type) {
-                int32_t object_root = m_global_schema_tree->find_matching_subtree_root_in_subtree(
-                        array_root,
-                        get_first_column_in_span(sub_object_schema),
-                        NodeType::Object
-                );
-                m_json_serializer.add_op(JsonSerializer::Op::BeginDocument);
-                column_idx = generate_structured_object_template(
-                        object_root,
-                        column_idx,
-                        sub_object_schema
-                );
-                m_json_serializer.add_op(JsonSerializer::Op::EndObject);
-            }
-            i += length;
-        } else {
-            auto const& node = m_global_schema_tree->get_node(global_column_id);
-            switch (node.get_type()) {
-                case NodeType::Object: {
-                    find_intersection_and_fix_brackets(
-                            array_root,
-                            node.get_id(),
-                            path_to_intersection
-                    );
-                    for (int j = 0; j < (node.get_depth() - depth); ++j) {
-                        m_json_serializer.add_op(JsonSerializer::Op::EndObject);
-                    }
-                    break;
-                }
-                case NodeType::StructuredArray: {
-                    m_json_serializer.add_op(JsonSerializer::Op::BeginArrayDocument);
-                    m_json_serializer.add_op(JsonSerializer::Op::EndArray);
-                    break;
-                }
-                case NodeType::Integer: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddIntValue);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::Float: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddFloatValue);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::Boolean: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddBoolValue);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::ClpString:
-                case NodeType::VarString: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddStringValue);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::NullValue: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddNullValue);
-                    break;
-                }
-                case NodeType::DateString:
-                case NodeType::UnstructuredArray:
-                case NodeType::Unknown:
-                    break;
-            }
-        }
-    }
-    return column_idx;
-}
-
-size_t SchemaReader::generate_structured_object_template(
-        int32_t object_root,
-        size_t column_start,
-        std::span<int32_t> schema
-) {
-    int32_t root = object_root;
-    size_t column_idx = column_start;
-    std::vector<int32_t> path_to_intersection;
-
-    for (size_t i = 0; i < schema.size(); ++i) {
-        int32_t global_column_id = schema[i];
-        if (Schema::schema_entry_is_unordered_object(global_column_id)) {
-            // It should only be possible to encounter arrays inside of structured objects
-            size_t array_length = Schema::get_unordered_object_length(global_column_id);
-            auto array_schema = schema.subspan(i + 1, array_length);
-            // we can guarantee that the last array we hit on the path to object root must be the
-            // right one because otherwise we'd be inside the structured array generator
-            int32_t array_root = m_global_schema_tree->find_matching_subtree_root_in_subtree(
-                    object_root,
-                    get_first_column_in_span(array_schema),
-                    NodeType::StructuredArray
-            );
-
-            find_intersection_and_fix_brackets(root, array_root, path_to_intersection);
-            column_idx = generate_structured_array_template(array_root, column_idx, array_schema);
-            m_json_serializer.add_op(JsonSerializer::Op::EndArray);
-            i += array_length;
-            // root is parent of the array object since we close the array bracket above
-            auto const& node = m_global_schema_tree->get_node(array_root);
-            root = node.get_parent_id();
-        } else {
-            auto const& node = m_global_schema_tree->get_node(global_column_id);
-            int32_t next_root = node.get_parent_id();
-            find_intersection_and_fix_brackets(root, next_root, path_to_intersection);
-            root = next_root;
-            switch (node.get_type()) {
-                case NodeType::Object: {
-                    m_json_serializer.add_op(JsonSerializer::Op::BeginObject);
-                    m_json_serializer.add_special_key(node.get_key_name());
-                    m_json_serializer.add_op(JsonSerializer::Op::EndObject);
-                    break;
-                }
-                case NodeType::StructuredArray: {
-                    m_json_serializer.add_op(JsonSerializer::Op::BeginArray);
-                    m_json_serializer.add_special_key(node.get_key_name());
-                    m_json_serializer.add_op(JsonSerializer::Op::EndArray);
-                    break;
-                }
-                case NodeType::Integer: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddIntField);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::Float: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddFloatField);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::Boolean: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddBoolField);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::ClpString:
-                case NodeType::VarString: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddStringField);
-                    m_reordered_columns.push_back(m_columns[column_idx++]);
-                    break;
-                }
-                case NodeType::NullValue: {
-                    m_json_serializer.add_op(JsonSerializer::Op::AddNullField);
-                    m_json_serializer.add_special_key(node.get_key_name());
-                    break;
-                }
-                case NodeType::DateString:
-                case NodeType::UnstructuredArray:
-                case NodeType::Unknown:
-                    break;
-            }
-        }
-    }
-    find_intersection_and_fix_brackets(root, object_root, path_to_intersection);
-    return column_idx;
-}
-
 void SchemaReader::initialize_serializer() {
     if (m_serializer_initialized) {
         return;
@@ -577,19 +339,10 @@ void SchemaReader::generate_json_template(int32_t id) {
                 break;
             }
             case NodeType::StructuredArray: {
+                // Note: Marshalling structured arrays is left intentionally stubbed out so that we
+                // can split up the PR for supporting structurized arrays.
                 m_json_serializer.add_op(JsonSerializer::Op::BeginArray);
                 m_json_serializer.add_special_key(child_node.get_key_name());
-                int32_t global_child_id = m_local_id_to_global_id[child_id];
-                auto structured_it = m_global_id_to_unordered_object.find(global_child_id);
-                if (m_global_id_to_unordered_object.end() != structured_it) {
-                    size_t column_start = structured_it->second.first;
-                    std::span<int32_t> structured_schema = structured_it->second.second;
-                    generate_structured_array_template(
-                            global_child_id,
-                            column_start,
-                            structured_schema
-                    );
-                }
                 m_json_serializer.add_op(JsonSerializer::Op::EndArray);
                 break;
             }

--- a/components/core/src/clp_s/SchemaReader.hpp
+++ b/components/core/src/clp_s/SchemaReader.hpp
@@ -194,11 +194,35 @@ private:
     void generate_json_template(int32_t id);
 
     /**
+     * Generates a json template for a structured array
+     * @param id
+     * @param column_start
+     * @param schema
+     */
+    size_t
+    generate_structured_array_template(int32_t id, size_t column_start, std::span<int32_t> schema);
+
+    /**
+     * Generates a json template for a structured object
+     * @param id
+     * @param column_start
+     * @param schema
+     */
+    size_t
+    generate_structured_object_template(int32_t id, size_t column_start, std::span<int32_t> schema);
+
+    /**
      * @param schema
      * @return the first column ID found in the given schema, or -1 if the schema contains no
      * columns
      */
     static inline int32_t get_first_column_in_span(std::span<int32_t> schema);
+
+    void find_intersection_and_fix_brackets(
+            int32_t cur_root,
+            int32_t next_root,
+            std::vector<int32_t>& path_to_intersection
+    );
 
     /**
      * Generates a json string from the extracted values

--- a/components/core/src/clp_s/SchemaReader.hpp
+++ b/components/core/src/clp_s/SchemaReader.hpp
@@ -194,35 +194,11 @@ private:
     void generate_json_template(int32_t id);
 
     /**
-     * Generates a json template for a structured array
-     * @param id
-     * @param column_start
-     * @param schema
-     */
-    size_t
-    generate_structured_array_template(int32_t id, size_t column_start, std::span<int32_t> schema);
-
-    /**
-     * Generates a json template for a structured object
-     * @param id
-     * @param column_start
-     * @param schema
-     */
-    size_t
-    generate_structured_object_template(int32_t id, size_t column_start, std::span<int32_t> schema);
-
-    /**
      * @param schema
      * @return the first column ID found in the given schema, or -1 if the schema contains no
      * columns
      */
     static inline int32_t get_first_column_in_span(std::span<int32_t> schema);
-
-    void find_intersection_and_fix_brackets(
-            int32_t cur_root,
-            int32_t next_root,
-            std::vector<int32_t>& path_to_intersection
-    );
 
     /**
      * Generates a json string from the extracted values

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -20,6 +20,7 @@ enum class NodeType : uint8_t {
     UnstructuredArray,
     NullValue,
     DateString,
+    StructuredArray,
     Unknown = std::underlying_type<NodeType>::type(~0ULL)
 };
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -92,6 +92,7 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     option.compression_level = command_line_arguments.get_compression_level();
     option.timestamp_key = command_line_arguments.get_timestamp_key();
     option.print_archive_stats = command_line_arguments.print_archive_stats();
+    option.structurize_arrays = command_line_arguments.get_structurize_arrays();
 
     auto const& db_config_container = command_line_arguments.get_metadata_db_config();
     if (db_config_container.has_value()) {


### PR DESCRIPTION
# Description
This PR implements the compression. Most of the code change can be found in JsonParser.cpp where parse_array_obj parses an array to structurize it, and parse_obj_in_array parses objects inside of structured arrays. Both of these parsers preserve the order of fields from the original log message. The decompression side of this feature has been stubbed out to keep the PR smaller -- as a result, structured arrays always decompress to `[]` in this PR.

Array structurization can be triggered by passing the --structurize-arrays flag at compression time.

# Validation performed
* Validated that compression works correctly when array structurization is turned on
* Validated with code from the follow-up PR that order inside of arrays is preserved

