### PR TITLE
clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).

### DIFF
--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -888,23 +888,7 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
 
             // search on log type dictionary
             Query& q = m_string_query_map[query_string];
-            if (query_string.find("*") != std::string::npos
-                || filter->get_column()->matches_type(LiteralType::VarStringT))
-            {
-                // if it matches VarStringT then it contains no space, so we
-                // don't't add more wildcards. Likewise if it already contains some wildcards
-                // we do not add more
-                Grep::process_raw_query(
-                        m_log_dict,
-                        m_var_dict,
-                        query_string,
-                        m_ignore_case,
-                        q,
-                        false
-                );
-            } else {
-                Grep::process_raw_query(m_log_dict, m_var_dict, query_string, m_ignore_case, q);
-            }
+            Grep::process_raw_query(m_log_dict, m_var_dict, query_string, m_ignore_case, q, false);
         }
         SubQuery sub_query;
         if (filter->get_column()->matches_type(LiteralType::VarStringT)) {


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#390

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR fixes #390, which makes wildcard match consistent for both log-text and variable values. It simply sets `add_wildcards` to `false` for all log-text cases.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Used clp-s to compress the first 1,000,000 log messages of [mongodb](https://zenodo.org/records/10516285) dataset.
+ Without the code change, query `msg: "wire "` returned four results. Now it returns nothing. And `*wire *` works fine as before.
