### PR TITLE
clp-s: Handle cases where clp-string query-parsing falls back to decompress + match (fixes #403).

### DIFF
--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -1,10 +1,9 @@
 #include "Output.hpp"
 
-#include <string>
+#include <memory>
 #include <vector>
 
 #include "../../clp/type_utils.hpp"
-#include "../Utils.hpp"
 #include "AndExpr.hpp"
 #include "clp_search/EncodedVariableInterpreter.hpp"
 #include "clp_search/Grep.hpp"
@@ -317,7 +316,7 @@ bool Output::evaluate_wildcard_filter(FilterExpr* expr, int32_t schema) {
 }
 
 bool Output::evaluate_filter(FilterExpr* expr, int32_t schema) {
-    auto column = expr->get_column().get();
+    auto* column = expr->get_column().get();
     int32_t column_id = column->get_column_id();
     auto literal = expr->get_operand();
     Query* q = nullptr;

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -259,12 +259,12 @@ bool Output::evaluate(Expression* expr, int32_t schema) {
 bool Output::evaluate_wildcard_filter(FilterExpr* expr, int32_t schema) {
     auto literal = expr->get_operand();
     auto* column = expr->get_column().get();
-    Query* q = m_expr_clp_query[expr];
     std::unordered_set<int64_t>* matching_vars = m_expr_var_match_map[expr];
     auto op = expr->get_operation();
     if (column->matches_type(LiteralType::ClpStringT)) {
+        Query* q = m_expr_clp_query[expr];
         for (auto entry : m_clp_string_readers) {
-            if (evaluate_clp_string_filter(op, q, entry.second, literal)) {
+            if (evaluate_clp_string_filter(op, q, entry.second)) {
                 return true;
             }
         }
@@ -272,7 +272,7 @@ bool Output::evaluate_wildcard_filter(FilterExpr* expr, int32_t schema) {
 
     if (column->matches_type(LiteralType::VarStringT)) {
         for (auto entry : m_var_string_readers) {
-            if (evaluate_var_string_filter(op, entry.second, matching_vars, literal)) {
+            if (evaluate_var_string_filter(op, entry.second, matching_vars)) {
                 return true;
             }
         }
@@ -334,16 +334,14 @@ bool Output::evaluate_filter(FilterExpr* expr, int32_t schema) {
             return evaluate_clp_string_filter(
                     expr->get_operation(),
                     q,
-                    m_clp_string_readers[column_id],
-                    literal
+                    m_clp_string_readers[column_id]
             );
         case LiteralType::VarStringT:
             matching_vars = m_expr_var_match_map.at(expr);
             return evaluate_var_string_filter(
                     expr->get_operation(),
                     m_var_string_readers[column_id],
-                    matching_vars,
-                    literal
+                    matching_vars
             );
         case LiteralType::BooleanT:
             return evaluate_bool_filter(expr->get_operation(), column_id, literal);
@@ -455,9 +453,8 @@ bool Output::evaluate_float_filter_core(FilterOperation op, double value, double
 bool Output::evaluate_clp_string_filter(
         FilterOperation op,
         Query* q,
-        std::vector<ClpStringColumnReader*> const& readers,
-        std::shared_ptr<Literal> const& operand
-) {
+        std::vector<ClpStringColumnReader*> const& readers
+) const {
     if (FilterOperation::EXISTS == op || FilterOperation::NEXISTS == op) {
         return true;
     }
@@ -466,29 +463,43 @@ bool Output::evaluate_clp_string_filter(
         return false;
     }
 
+    if (nullptr == q) {
+        return op == FilterOperation::NEQ;
+    }
+
     if (q->search_string_matches_all()) {
         return op == FilterOperation::EQ;
     }
 
     bool matched = false;
     for (ClpStringColumnReader* reader : readers) {
-        int64_t id = reader->get_encoded_id(m_cur_message);
+        int64_t const id = reader->get_encoded_id(m_cur_message);
         auto vars = reader->get_encoded_vars(m_cur_message);
-        for (auto const& subquery : q->get_sub_queries()) {
-            if (subquery.matches_logtype(id) && subquery.matches_vars(vars)) {
-                if (subquery.wildcard_match_required()) {
-                    std::string decompressed_message
-                            = std::get<std::string>(reader->extract_value(m_cur_message));
-                    matched = StringUtils::wildcard_match_unsafe(
-                            decompressed_message,
-                            q->get_search_string(),
-                            !q->get_ignore_case()
-                    );
-                } else {
-                    matched = true;
+        if (q->contains_sub_queries()) {
+            for (auto const& subquery : q->get_sub_queries()) {
+                if (subquery.matches_logtype(id) && subquery.matches_vars(vars)) {
+                    if (subquery.wildcard_match_required()) {
+                        std::string const decompressed_message
+                                = std::get<std::string>(reader->extract_value(m_cur_message));
+                        matched = StringUtils::wildcard_match_unsafe(
+                                decompressed_message,
+                                q->get_search_string(),
+                                !q->get_ignore_case()
+                        );
+                    } else {
+                        matched = true;
+                    }
+                    break;
                 }
-                break;
             }
+        } else {
+            std::string const decompressed_message
+                    = std::get<std::string>(reader->extract_value(m_cur_message));
+            matched = StringUtils::wildcard_match_unsafe(
+                    decompressed_message,
+                    q->get_search_string(),
+                    !q->get_ignore_case()
+            );
         }
 
         if ((op == FilterOperation::EQ) == matched) {
@@ -501,8 +512,7 @@ bool Output::evaluate_clp_string_filter(
 bool Output::evaluate_var_string_filter(
         FilterOperation op,
         std::vector<VariableStringColumnReader*> const& readers,
-        std::unordered_set<int64_t>* matching_vars,
-        std::shared_ptr<Literal> const& operand
+        std::unordered_set<int64_t>* matching_vars
 ) const {
     if (FilterOperation::EXISTS == op || FilterOperation::NEXISTS == op) {
         return true;
@@ -887,23 +897,26 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
             }
 
             // search on log type dictionary
-            Query& q = m_string_query_map[query_string];
             if (query_string.find("*") != std::string::npos
                 || filter->get_column()->matches_type(LiteralType::VarStringT))
             {
                 // if it matches VarStringT then it contains no space, so we
                 // don't't add more wildcards. Likewise if it already contains some wildcards
                 // we do not add more
-                Grep::process_raw_query(
+                m_string_query_map[query_string] = std::move(Grep::process_raw_query(
                         m_log_dict,
                         m_var_dict,
                         query_string,
                         m_ignore_case,
-                        q,
                         false
-                );
+                ));
             } else {
-                Grep::process_raw_query(m_log_dict, m_var_dict, query_string, m_ignore_case, q);
+                m_string_query_map[query_string] = Grep::process_raw_query(
+                        m_log_dict,
+                        m_var_dict,
+                        query_string,
+                        m_ignore_case
+                );
             }
         }
         SubQuery sub_query;
@@ -1084,11 +1097,14 @@ Output::constant_propagate(std::shared_ptr<Expression> const& expr, int32_t sche
                 return EvaluatedValue::False;
             }
             if (filter->get_column()->matches_type(LiteralType::ClpStringT)) {
-                m_expr_clp_query[expr.get()] = &m_string_query_map.at(filter_string);
+                auto& query_processing_result = m_string_query_map.at(filter_string);
+                if (query_processing_result.has_value()) {
+                    m_expr_clp_query[expr.get()] = &(query_processing_result.value());
+                    matches_clp_string = true;
+                } else {
+                    m_expr_clp_query[expr.get()] = nullptr;
+                }
                 has_clp_string = wildcard->matches_type(LiteralType::ClpStringT);
-                matches_clp_string
-                        = !m_expr_clp_query.at(expr.get())->get_sub_queries().empty()
-                          || m_expr_clp_query.at(expr.get())->search_string_matches_all();
             }
             if (filter->get_column()->matches_type(LiteralType::VarStringT)) {
                 m_expr_var_match_map[expr.get()] = &m_string_var_match_map.at(filter_string);
@@ -1132,12 +1148,12 @@ Output::constant_propagate(std::shared_ptr<Expression> const& expr, int32_t sche
             filter->get_operand()->as_clp_string(filter_string, filter->get_operation());
 
             // set up string query for this filter
-            m_expr_clp_query[expr.get()] = &m_string_query_map.at(filter_string);
-
-            // use string queries to potentially propagate known result
-            if (m_expr_clp_query.at(expr.get())->get_sub_queries().empty()
-                && !m_expr_clp_query.at(expr.get())->search_string_matches_all())
-            {
+            auto& query_processing_result = m_string_query_map.at(filter_string);
+            if (query_processing_result.has_value()) {
+                m_expr_clp_query[expr.get()] = &(query_processing_result.value());
+                return EvaluatedValue::Unknown;
+            } else {
+                m_expr_clp_query[expr.get()] = nullptr;
                 // If filter can not match then return it's guaranteed value based on
                 // whether the filter is inverted and whether the operation was == or !=
                 if (filter->get_operation() == FilterOperation::EQ) {
@@ -1147,8 +1163,6 @@ Output::constant_propagate(std::shared_ptr<Expression> const& expr, int32_t sche
                 }
                 // FIXME: throw
                 return EvaluatedValue::False;
-            } else {
-                return EvaluatedValue::Unknown;
             }
         } else if (filter->get_column()->matches_type(LiteralType::VarStringT)) {
             std::string filter_string;

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -891,13 +891,16 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
             }
 
             // search on log type dictionary
-            m_string_query_map.emplace(query_string, Grep::process_raw_query(
-                    m_log_dict,
-                    m_var_dict,
+            m_string_query_map.emplace(
                     query_string,
-                    m_ignore_case,
-                    false
-            ));
+                    Grep::process_raw_query(
+                            m_log_dict,
+                            m_var_dict,
+                            query_string,
+                            m_ignore_case,
+                            false
+                    )
+            );
         }
         SubQuery sub_query;
         if (filter->get_column()->matches_type(LiteralType::VarStringT)) {

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -74,7 +74,7 @@ private:
 
     std::shared_ptr<ReaderUtils::SchemaMap> m_schemas;
 
-    std::map<std::string, Query> m_string_query_map;
+    std::map<std::string, std::optional<Query>> m_string_query_map;
     std::map<std::string, std::unordered_set<int64_t>> m_string_var_match_map;
     std::unordered_map<Expression*, Query*> m_expr_clp_query;
     std::unordered_map<Expression*, std::unordered_set<int64_t>*> m_expr_var_match_map;
@@ -185,29 +185,25 @@ private:
      * @param op
      * @param q
      * @param readers
-     * @param operand
      * @return true if the expression evaluates to true, false otherwise
      */
     bool evaluate_clp_string_filter(
             FilterOperation op,
             Query* q,
-            std::vector<ClpStringColumnReader*> const& readers,
-            std::shared_ptr<Literal> const& operand
-    );
+            std::vector<ClpStringColumnReader*> const& readers
+    ) const;
 
     /**
      * Evaluates a var string filter expression
      * @param op
      * @param reader
      * @param matching_vars
-     * @param operand
      * @return true if the expression evaluates to true, false otherwise
      */
     bool evaluate_var_string_filter(
             FilterOperation op,
             std::vector<VariableStringColumnReader*> const& readers,
-            std::unordered_set<int64_t>* matching_vars,
-            std::shared_ptr<Literal> const& operand
+            std::unordered_set<int64_t>* matching_vars
     ) const;
 
     /**

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -15,7 +15,6 @@
 #include "../Utils.hpp"
 #include "clp_search/Query.hpp"
 #include "Expression.hpp"
-#include "Integral.hpp"
 #include "OutputHandler.hpp"
 #include "SchemaMatch.hpp"
 #include "StringLiteral.hpp"

--- a/components/core/src/clp_s/search/clp_search/Grep.cpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.cpp
@@ -498,6 +498,10 @@ std::optional<Query> Grep::process_raw_query(
         }
     }
 
+    if (sub_queries.empty()) {
+        return std::nullopt;
+    }
+
     return Query{ignore_case, processed_search_string, std::move(sub_queries)};
 }
 

--- a/components/core/src/clp_s/search/clp_search/Grep.cpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.cpp
@@ -434,7 +434,7 @@ std::optional<Query> Grep::process_raw_query(
     vector<QueryToken> query_tokens;
     size_t begin_pos = 0;
     size_t end_pos = 0;
-    bool is_var
+    bool is_var;
     while (get_bounds_of_next_potential_var(processed_search_string, begin_pos, end_pos, is_var)) {
         query_tokens.emplace_back(processed_search_string, begin_pos, end_pos, is_var);
     }

--- a/components/core/src/clp_s/search/clp_search/Grep.cpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.cpp
@@ -3,8 +3,11 @@
 #include "Grep.hpp"
 
 #include <algorithm>
+#include <string>
+#include <utility>
 
 #include "../../VariableEncoder.hpp"
+#include "../../Utils.hpp"
 #include "EncodedVariableInterpreter.hpp"
 
 using std::string;
@@ -401,21 +404,13 @@ SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
     return SubQueryMatchabilityResult::MayMatch;
 }
 
-bool Grep::process_raw_query(
+std::optional<Query> Grep::process_raw_query(
         std::shared_ptr<LogTypeDictionaryReader> log_dict,
-        std::shared_ptr<VariableDictionaryReader> var_dict, /*const Archive& archive,*/
-        string const& search_string, /*epochtime_t search_begin_ts, epochtime_t search_end_ts,*/
+        std::shared_ptr<VariableDictionaryReader> var_dict,
+        string const& search_string,
         bool ignore_case,
-        Query& query, /* compressor_frontend::lexers::ByteLexer& forward_lexer,
-                         compressor_frontend::lexers::ByteLexer& reverse_lexer,*/
-        bool add_wildcards,
-        bool use_heuristic
+        bool add_wildcards
 ) {
-    // Set properties which require no processing
-    // query.set_search_begin_timestamp(search_begin_ts);
-    // query.set_search_end_timestamp(search_end_ts);
-    query.set_ignore_case(ignore_case);
-
     // Add prefix and suffix '*' to make the search a sub-string match
     string processed_search_string;
     if (add_wildcards) {
@@ -428,7 +423,6 @@ bool Grep::process_raw_query(
 
     // Clean-up search string
     processed_search_string = StringUtils::clean_up_wildcard_search_string(processed_search_string);
-    query.set_search_string(processed_search_string);
 
     // Replace non-greedy wildcards with greedy wildcards since we currently have no support for
     // searching compressed files with non-greedy wildcards
@@ -446,12 +440,6 @@ bool Grep::process_raw_query(
     while (get_bounds_of_next_potential_var(processed_search_string, begin_pos, end_pos, is_var)) {
         query_tokens.emplace_back(processed_search_string, begin_pos, end_pos, is_var);
     }
-    /*} else {
-        while (get_bounds_of_next_potential_var(processed_search_string, begin_pos, end_pos,
-    is_var, forward_lexer, reverse_lexer)) { query_tokens.emplace_back(processed_search_string,
-    begin_pos, end_pos, is_var);
-        }
-    }*/
 
     // Get pointers to all ambiguous tokens. Exclude tokens with wildcards in the middle since
     // we fall-back to decompression + wildcard matching for those.
@@ -471,31 +459,28 @@ bool Grep::process_raw_query(
     // - (token1 as logtype) (token2 as var)
     // - (token1 as var) (token2 as logtype)
     // - (token1 as var) (token2 as var)
-    SubQuery sub_query;
+
+    vector<SubQuery> sub_queries;
     string logtype;
     bool type_of_one_token_changed = true;
     while (type_of_one_token_changed) {
-        sub_query.clear();
-
+        SubQuery sub_query;
         // Compute logtypes and variables for query
         auto matchability = generate_logtypes_and_vars_for_subquery(
                 log_dict,
                 var_dict,
                 processed_search_string,
                 query_tokens,
-                query.get_ignore_case(),
+                ignore_case,
                 sub_query
         );
         switch (matchability) {
             case SubQueryMatchabilityResult::SupercedesAllSubQueries:
-                // Clear all sub-queries since they will be superceded by this sub-query
-                query.clear_sub_queries();
-
                 // Since other sub-queries will be superceded by this one, we can stop
                 // processing now
-                return true;
+                return Query{ignore_case, processed_search_string, {}};
             case SubQueryMatchabilityResult::MayMatch:
-                query.add_sub_query(sub_query);
+                sub_queries.push_back(std::move(sub_query));
                 break;
             case SubQueryMatchabilityResult::WontMatch:
             default:
@@ -513,7 +498,7 @@ bool Grep::process_raw_query(
         }
     }
 
-    return query.contains_sub_queries();
+    return Query{ignore_case, processed_search_string, std::move(sub_queries)};
 }
 
 bool Grep::get_bounds_of_next_potential_var(

--- a/components/core/src/clp_s/search/clp_search/Grep.cpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.cpp
@@ -434,8 +434,7 @@ std::optional<Query> Grep::process_raw_query(
     vector<QueryToken> query_tokens;
     size_t begin_pos = 0;
     size_t end_pos = 0;
-    bool is_var;
-
+    bool is_var
     while (get_bounds_of_next_potential_var(processed_search_string, begin_pos, end_pos, is_var)) {
         query_tokens.emplace_back(processed_search_string, begin_pos, end_pos, is_var);
     }

--- a/components/core/src/clp_s/search/clp_search/Grep.cpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.cpp
@@ -435,8 +435,7 @@ std::optional<Query> Grep::process_raw_query(
     size_t begin_pos = 0;
     size_t end_pos = 0;
     bool is_var;
-    // FIXME: may want to use non-heuristic method of tokenizing query
-    // if (use_heuristic) {
+
     while (get_bounds_of_next_potential_var(processed_search_string, begin_pos, end_pos, is_var)) {
         query_tokens.emplace_back(processed_search_string, begin_pos, end_pos, is_var);
     }
@@ -459,12 +458,12 @@ std::optional<Query> Grep::process_raw_query(
     // - (token1 as logtype) (token2 as var)
     // - (token1 as var) (token2 as logtype)
     // - (token1 as var) (token2 as var)
-
     vector<SubQuery> sub_queries;
     string logtype;
     bool type_of_one_token_changed = true;
     while (type_of_one_token_changed) {
         SubQuery sub_query;
+
         // Compute logtypes and variables for query
         auto matchability = generate_logtypes_and_vars_for_subquery(
                 log_dict,

--- a/components/core/src/clp_s/search/clp_search/Grep.cpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.cpp
@@ -6,8 +6,8 @@
 #include <string>
 #include <utility>
 
-#include "../../VariableEncoder.hpp"
 #include "../../Utils.hpp"
+#include "../../VariableEncoder.hpp"
 #include "EncodedVariableInterpreter.hpp"
 
 using std::string;

--- a/components/core/src/clp_s/search/clp_search/Grep.hpp
+++ b/components/core/src/clp_s/search/clp_search/Grep.hpp
@@ -3,6 +3,8 @@
 #ifndef CLP_S_SEARCH_CLP_SEARCH_GREP_HPP
 #define CLP_S_SEARCH_CLP_SEARCH_GREP_HPP
 
+#include <memory>
+#include <optional>
 #include <string>
 
 #include "../../Defs.hpp"
@@ -15,22 +17,19 @@ public:
     // Methods
     /**
      * Processes a raw user query into a Query
-     * @param archive
+     * @param log_dict
+     * @param var_dict
      * @param search_string
-     * @param search_begin_ts
-     * @param search_end_ts
      * @param ignore_case
-     * @param query
-     * @return true if query may match messages, false otherwise
+     * @param add_wildcards
+     * @return Query if it may match a message, std::nullopt otherwise
      */
-    static bool process_raw_query(
+    static std::optional<Query> process_raw_query(
             std::shared_ptr<LogTypeDictionaryReader> log_dict,
             std::shared_ptr<VariableDictionaryReader> var_dict,
             std::string const& search_string,
             bool ignore_case,
-            Query& query,
-            bool add_wildcards = true,
-            bool use_heuristic = true
+            bool add_wildcards = true
     );
 
     /**

--- a/components/core/src/clp_s/search/clp_search/Query.hpp
+++ b/components/core/src/clp_s/search/clp_search/Query.hpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "../../Defs.hpp"
@@ -154,7 +155,11 @@ private:
 class Query {
 public:
     // Constructors
-    Query() : m_ignore_case(false), m_search_string_matches_all(true) {}
+    Query(bool ignore_case, std::string const& search_string, std::vector<SubQuery> sub_queries)
+            : m_ignore_case(ignore_case),
+              m_sub_queries(std::move(sub_queries)) {
+        set_search_string(search_string);
+    }
 
     void set_ignore_case(bool ignore_case) { m_ignore_case = ignore_case; }
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#403

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Previously, when a query did not contain a subquery, it was not evaluated in clp-s. However, in cases where `matchability = SubQueryMatchabilityResult::SupercedesAllSubQueries`, this caused an issue. This PR fixes the bug, which indirectly resolves issue #403. The primary code change aligns clp-s with the behavior of clp in `Grep::process_raw_query`. The relevant code in `clp_s/search/Output.cpp` has also been updated.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Validated the example in #403, the query returned all matching results.
+ Compressed first 1,000,000 log messages of [mongodb](https://zenodo.org/records/10516285) dataset. Executed queries below that targets a log-text field:
  ```
  msg: "*wire *"
  attr.message.msg: log_remove*
  attr.message.msg: "*id 1*"
  attr.message.msg: "*journal/WiredTigerLog*LSN*3456*"
  ```
  The query results remain unchanged after the code change.
