### PR TITLE
clp-s: Add a comma after unstructured array fields during JSON serialization (fixes #410).

### DIFF
--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -95,6 +95,7 @@ public:
 
     void append_value_from_column(clp_s::BaseColumnReader* column, uint64_t cur_message) {
         column->extract_string_value_into_buffer(cur_message, m_json_string);
+        m_json_string += ",";
     }
 
     void


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#410 
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The JSON serializer does not add a comma after an unstructured array field during decompression, which makes the decompressed log not in a valid JSON format. This PR fixes the bug.

# Validation performed
<!-- What tests and validation you performed on the change -->
Compressed the logs below and decompressed the archive
```
{"array":[1,2,3],"object":{"key":"value"}}
{"array":[4,5,6]}
```
Without the code change, the decompressed logs are 
```
{"array":[1,2,3]"object":{"key":"value"}}
{"array":[4,5,6}
```
Now they are 
```
{"array":[1,2,3],"object":{"key":"value"}}
{"array":[4,5,6]}
```

