### PR TITLE
clp-s: Add support for wildcard queries using "?" on a variable field.

### DIFF
--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -172,6 +172,18 @@ bool StringUtils::is_wildcard(char c) {
     return false;
 }
 
+bool StringUtils::has_unescaped_wildcards(std::string const& str) {
+    for (size_t i = 0; i < str.size(); ++i) {
+        if ('*' == str[i] || '?' == str[i]) {
+            return true;
+        }
+        if ('\\' == str[i]) {
+            ++i;
+        }
+    }
+    return false;
+}
+
 string StringUtils::clean_up_wildcard_search_string(string_view str) {
     string cleaned_str;
 

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -149,6 +149,13 @@ public:
     static bool is_wildcard(char c);
 
     /**
+     * Checks if the given string has unescaped wildcards
+     * @param str
+     * @return true if the string has unescaped wildcards, false otherwise
+     */
+    static bool has_unescaped_wildcards(std::string const& str);
+
+    /**
      * Same as ``wildcard_match_unsafe_case_sensitive`` except this method
      * allows the caller to specify whether the match should be case sensitive.
      *

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -915,7 +915,9 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
             }
 
             std::unordered_set<int64_t>& matching_vars = m_string_var_match_map[query_string];
-            if (query_string.find('*') == std::string::npos) {
+            if (query_string.find('*') == std::string::npos
+                && query_string.find('?') == std::string::npos)
+            {
                 auto entry = m_var_dict->get_entry_matching_value(query_string, m_ignore_case);
 
                 if (entry != nullptr) {

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -932,7 +932,7 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
                     }
                 }
 
-                const auto *entry = m_var_dict->get_entry_matching_value(
+                auto const* entry = m_var_dict->get_entry_matching_value(
                         unescaped_query_string,
                         m_ignore_case
                 );
@@ -948,14 +948,14 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
                                        sub_query
                                ))
             {
-                for (const auto& var : sub_query.get_vars()) {
+                for (auto const& var : sub_query.get_vars()) {
                     if (var.is_precise_var()) {
-                        const auto *entry = var.get_var_dict_entry();
+                        auto const* entry = var.get_var_dict_entry();
                         if (entry != nullptr) {
                             matching_vars.insert(entry->get_id());
                         }
                     } else {
-                        for (const auto *entry : var.get_possible_var_dict_entries()) {
+                        for (auto const* entry : var.get_possible_var_dict_entries()) {
                             matching_vars.insert(entry->get_id());
                         }
                     }

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -915,10 +915,7 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
             }
 
             std::unordered_set<int64_t>& matching_vars = m_string_var_match_map[query_string];
-            if (query_string.find('*') == std::string::npos
-                && query_string.find('?') == std::string::npos)
-            {
-                // Unescape '\' before matching
+            if (false == StringUtils::has_unescaped_wildcards(query_string)) {
                 std::string unescaped_query_string;
                 bool escape = false;
                 for (char const c : query_string) {

--- a/components/core/src/clp_s/search/StringLiteral.hpp
+++ b/components/core/src/clp_s/search/StringLiteral.hpp
@@ -68,8 +68,19 @@ private:
             m_string_type = LiteralType::VarStringT;
         }
 
-        if (m_v.find('*') != std::string::npos || m_v.find('?') != std::string::npos) {
-            m_string_type |= LiteralType::ClpStringT;
+        // If '?' and '*' are not escaped, we add LiteralType::ClpStringT to m_string_type
+        bool escape = false;
+        for (char const c : m_v) {
+            if ('\\' == c) {
+                escape = !escape;
+            } else if ('?' == c || '*' == c) {
+                if (!escape) {
+                    m_string_type |= LiteralType::ClpStringT;
+                    break;
+                }
+            } else {
+                escape = false;
+            }
         }
     }
 };

--- a/components/core/src/clp_s/search/StringLiteral.hpp
+++ b/components/core/src/clp_s/search/StringLiteral.hpp
@@ -68,7 +68,7 @@ private:
             m_string_type = LiteralType::VarStringT;
         }
 
-        if (m_v.find('*') != std::string::npos) {
+        if (m_v.find('*') != std::string::npos || m_v.find('?') != std::string::npos) {
             m_string_type |= LiteralType::ClpStringT;
         }
     }

--- a/components/core/src/clp_s/search/StringLiteral.hpp
+++ b/components/core/src/clp_s/search/StringLiteral.hpp
@@ -74,7 +74,7 @@ private:
             if ('\\' == c) {
                 escape = !escape;
             } else if ('?' == c || '*' == c) {
-                if (!escape) {
+                if (false == escape) {
                     m_string_type |= LiteralType::ClpStringT;
                     break;
                 }

--- a/components/core/src/clp_s/search/kql/Kql.g4
+++ b/components/core/src/clp_s/search/kql/Kql.g4
@@ -64,7 +64,7 @@ fragment UNQUOTED_CHARACTER
     |  ~[\\():<>"{} \r\n\t]
     ;
 
-fragment WILDCARD:   '*';
+fragment WILDCARD:   '*' | '?';
 
 // TODO: unescape keywords
 fragment ESCAPED_KEYWORD
@@ -96,7 +96,7 @@ fragment ESCAPED_SPACE
     ;
 
 fragment SPECIAL_CHARACTER
-    : [\\():<>"*{}]
+    : [\\():<>"*?{}]
     ;
 
 

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -78,11 +78,6 @@ Although you can use a single `*` to search for a kv-pair with *any* value, the 
 syntax above only works for values that are strings.
 :::
 
-:::{caution}
-CLP doesn't currently support the `?` wildcard (which matches any single character) _except_ in
-values containing multiple words. This limitation will be addressed in a future version of CLP.
-:::
-
 ### Wildcards in keys
 
 To search for a kv-pair with *any* key, you can specify the query in one of two ways:


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#392 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR adds the feature requested in #392. Now we can use `?` to match an arbitrary single character on a variable field. However, there are still two limitations.
+ Queries with a `?` in the middle return empty results. This should be fixes by #407.
+ Queries combined with `?`(`*`) and `\?`(`\*`) cannot work well. This will be fixed later.

# Validation performed
<!-- What tests and validation you performed on the change -->
Compressed the logs below
```
{"a": "Hello world?", "b": "wwoorr\lldd", "c":"*world"}
{"a": "Hello *", "b": "?world"}
```
The queries below all returned correct results
```
b: \?world
b: ?world
b: ?wo?ld
b: wwoorr\\lldd
c: ?world
c: \*world
```

