### PR TITLE
ffi: Add SchemaTree implementation to support the next IR stream format.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -424,8 +424,8 @@ set(SOURCE_FILES_unitTest
         tests/LogSuppressor.hpp
         tests/test-BufferedFileReader.cpp
         tests/test-EncodedVariableInterpreter.cpp
-        tests/test-ffi_SchemaTree.cpp
         tests/test-encoding_methods.cpp
+        tests/test-ffi_SchemaTree.cpp
         tests/test-Grep.cpp
         tests/test-ir_encoding_methods.cpp
         tests/test-ir_parsing.cpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -291,6 +291,9 @@ set(SOURCE_FILES_unitTest
         src/clp/ffi/ir_stream/encoding_methods.cpp
         src/clp/ffi/ir_stream/encoding_methods.hpp
         src/clp/ffi/ir_stream/protocol_constants.hpp
+        src/clp/ffi/SchemaTree.cpp
+        src/clp/ffi/SchemaTree.hpp
+        src/clp/ffi/SchemaTreeNode.hpp
         src/clp/ffi/search/CompositeWildcardToken.cpp
         src/clp/ffi/search/CompositeWildcardToken.hpp
         src/clp/ffi/search/ExactVariableToken.cpp
@@ -421,6 +424,7 @@ set(SOURCE_FILES_unitTest
         tests/LogSuppressor.hpp
         tests/test-BufferedFileReader.cpp
         tests/test-EncodedVariableInterpreter.cpp
+        tests/test-ffi_SchemaTree.cpp
         tests/test-encoding_methods.cpp
         tests/test-Grep.cpp
         tests/test-ir_encoding_methods.cpp

--- a/components/core/src/clp/ffi/SchemaTree.cpp
+++ b/components/core/src/clp/ffi/SchemaTree.cpp
@@ -1,0 +1,71 @@
+#include "SchemaTree.hpp"
+
+#include <string>
+
+#include "../ErrorCode.hpp"
+
+namespace clp::ffi {
+auto SchemaTree::get_node(SchemaTreeNode::id_t id) const -> SchemaTreeNode const& {
+    if (m_tree_nodes.size() <= static_cast<size_t>(id)) {
+        throw OperationFailed(
+                ErrorCode_OutOfBounds,
+                __FILE__,
+                __LINE__,
+                "The given tree node id is invalid: " + std::to_string(id)
+        );
+    }
+    return m_tree_nodes[id];
+}
+
+auto SchemaTree::try_get_node_id(
+        TreeNodeLocator const& locator,
+        SchemaTreeNode::id_t& node_id
+) const -> bool {
+    auto const parent_id{static_cast<size_t>(locator.get_parent_id())};
+    if (m_tree_nodes.size() <= parent_id) {
+        return false;
+    }
+    for (auto const child_id : m_tree_nodes[parent_id].get_children_ids()) {
+        auto const& node{m_tree_nodes[child_id]};
+        if (node.get_key_name() == locator.get_key_name() && node.get_type() == locator.get_type())
+        {
+            node_id = child_id;
+            return true;
+        }
+    }
+    return false;
+}
+
+auto SchemaTree::insert_node(TreeNodeLocator const& locator) -> SchemaTreeNode::id_t {
+    SchemaTreeNode::id_t node_id{};
+    if (try_get_node_id(locator, node_id)) {
+        throw OperationFailed(ErrorCode_Failure, __FILE__, __LINE__, "Tree Node already exists.");
+    }
+    node_id = m_tree_nodes.size();
+    m_tree_nodes.emplace_back(
+            node_id,
+            locator.get_parent_id(),
+            locator.get_key_name(),
+            locator.get_type()
+    );
+    m_tree_nodes[locator.get_parent_id()].append_new_child_id(node_id);
+    return node_id;
+}
+
+auto SchemaTree::revert() -> void {
+    if (false == m_snapshot_size.has_value()) {
+        throw OperationFailed(
+                ErrorCode_Failure,
+                __FILE__,
+                __LINE__,
+                "Snapshot was not taken before calling revert."
+        );
+    }
+    while (m_tree_nodes.size() != m_snapshot_size) {
+        auto const& node{m_tree_nodes.back()};
+        m_tree_nodes[node.get_parent_id()].remove_last_appended_child_id();
+        m_tree_nodes.pop_back();
+    }
+    m_snapshot_size.reset();
+}
+}  // namespace clp::ffi

--- a/components/core/src/clp/ffi/SchemaTree.cpp
+++ b/components/core/src/clp/ffi/SchemaTree.cpp
@@ -55,7 +55,7 @@ auto SchemaTree::insert_node(NodeLocator const& locator) -> SchemaTreeNode::id_t
                 ErrorCode_Failure,
                 __FILE__,
                 __LINE__,
-                "Parent node cannot have child."
+                "Non-object nodes cannot have children."
         );
     }
     parent_node.append_new_child(node_id);

--- a/components/core/src/clp/ffi/SchemaTree.cpp
+++ b/components/core/src/clp/ffi/SchemaTree.cpp
@@ -1,6 +1,7 @@
 #include "SchemaTree.hpp"
 
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "../ErrorCode.hpp"
@@ -19,53 +20,55 @@ auto SchemaTree::get_node(SchemaTreeNode::id_t id) const -> SchemaTreeNode const
     return m_tree_nodes[id];
 }
 
-auto SchemaTree::try_get_node_id(
-        TreeNodeLocator const& locator,
-        SchemaTreeNode::id_t& node_id
-) const -> bool {
+auto SchemaTree::try_get_node_id(NodeLocator const& locator
+) const -> std::optional<SchemaTreeNode::id_t> {
     auto const parent_id{static_cast<size_t>(locator.get_parent_id())};
     if (m_tree_nodes.size() <= parent_id) {
         return false;
     }
+    std::optional<SchemaTreeNode::id_t> node_id;
     for (auto const child_id : m_tree_nodes[parent_id].get_children_ids()) {
         auto const& node{m_tree_nodes[child_id]};
         if (node.get_key_name() == locator.get_key_name() && node.get_type() == locator.get_type())
         {
-            node_id = child_id;
-            return true;
+            node_id.emplace(child_id);
+            break;
         }
     }
-    return false;
+    return node_id;
 }
 
-auto SchemaTree::insert_node(TreeNodeLocator const& locator) -> SchemaTreeNode::id_t {
-    SchemaTreeNode::id_t node_id{};
-    if (try_get_node_id(locator, node_id)) {
+auto SchemaTree::insert_node(NodeLocator const& locator) -> SchemaTreeNode::id_t {
+    if (try_get_node_id(locator).has_value()) {
         throw OperationFailed(ErrorCode_Failure, __FILE__, __LINE__, "Node already exists.");
     }
-    node_id = m_tree_nodes.size();
+    auto const node_id{static_cast<SchemaTreeNode::id_t>(m_tree_nodes.size())};
     m_tree_nodes.emplace_back(
             node_id,
             locator.get_parent_id(),
             locator.get_key_name(),
             locator.get_type()
     );
-    m_tree_nodes[locator.get_parent_id()].append_new_child_id(node_id);
+    auto& parent_node{m_tree_nodes[locator.get_parent_id()]};
+    if (SchemaTreeNode::Type::Obj != parent_node.get_type()) {
+        throw OperationFailed(
+                ErrorCode_Failure,
+                __FILE__,
+                __LINE__,
+                "Parent node cannot have child."
+        );
+    }
+    parent_node.append_new_child(node_id);
     return node_id;
 }
 
 auto SchemaTree::revert() -> void {
     if (false == m_snapshot_size.has_value()) {
-        throw OperationFailed(
-                ErrorCode_Failure,
-                __FILE__,
-                __LINE__,
-                "No snapshot exists."
-        );
+        throw OperationFailed(ErrorCode_Failure, __FILE__, __LINE__, "No snapshot exists.");
     }
     while (m_tree_nodes.size() != m_snapshot_size) {
         auto const& node{m_tree_nodes.back()};
-        m_tree_nodes[node.get_parent_id()].remove_last_appended_child_id();
+        m_tree_nodes[node.get_parent_id()].remove_last_appended_child();
         m_tree_nodes.pop_back();
     }
     m_snapshot_size.reset();

--- a/components/core/src/clp/ffi/SchemaTree.cpp
+++ b/components/core/src/clp/ffi/SchemaTree.cpp
@@ -13,7 +13,7 @@ auto SchemaTree::get_node(SchemaTreeNode::id_t id) const -> SchemaTreeNode const
                 ErrorCode_OutOfBounds,
                 __FILE__,
                 __LINE__,
-                "The given tree node id is invalid: " + std::to_string(id)
+                "Invalid node ID: " + std::to_string(id)
         );
     }
     return m_tree_nodes[id];
@@ -41,7 +41,7 @@ auto SchemaTree::try_get_node_id(
 auto SchemaTree::insert_node(TreeNodeLocator const& locator) -> SchemaTreeNode::id_t {
     SchemaTreeNode::id_t node_id{};
     if (try_get_node_id(locator, node_id)) {
-        throw OperationFailed(ErrorCode_Failure, __FILE__, __LINE__, "Tree Node already exists.");
+        throw OperationFailed(ErrorCode_Failure, __FILE__, __LINE__, "Node already exists.");
     }
     node_id = m_tree_nodes.size();
     m_tree_nodes.emplace_back(
@@ -60,7 +60,7 @@ auto SchemaTree::revert() -> void {
                 ErrorCode_Failure,
                 __FILE__,
                 __LINE__,
-                "Snapshot was not taken before calling revert."
+                "No snapshot exists."
         );
     }
     while (m_tree_nodes.size() != m_snapshot_size) {

--- a/components/core/src/clp/ffi/SchemaTree.cpp
+++ b/components/core/src/clp/ffi/SchemaTree.cpp
@@ -1,8 +1,10 @@
 #include "SchemaTree.hpp"
 
+#include <cstddef>
 #include <string>
 
 #include "../ErrorCode.hpp"
+#include "SchemaTreeNode.hpp"
 
 namespace clp::ffi {
 auto SchemaTree::get_node(SchemaTreeNode::id_t id) const -> SchemaTreeNode const& {

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -39,9 +39,11 @@ public:
     };
 
     /**
-     * When locating a tree node, might not always have the tree node id. Instead, we usually use
-     * the parent id, the key name, and the node type to locate a unique tree node. This class wraps
-     * the location information as a non-integer identifier to locate a unique node in the tree.
+     * When constructing the schema tree, we uniquely identify the location of a node being inserted
+     * to the tree by the unique triple of the parent id, the key name, and the node type. The
+     * reason why the triple is unique is because the combination of the key name and the node type
+     * should have no ambiguity for a parent node. This class stores such a triple and act as a
+     * unique identifier for a node in the schema tree.
      */
     class TreeNodeLocator {
     public:

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -96,9 +96,9 @@ public:
      * NOTE: We use the term "Locator" to avoid terms like "Key" or "Identifier" that are already in
      * use.
      */
-    class TreeNodeLocator {
+    class NodeLocator {
     public:
-        TreeNodeLocator(
+        NodeLocator(
                 SchemaTreeNode::id_t parent_id,
                 std::string_view key_name,
                 SchemaTreeNode::Type type
@@ -149,19 +149,18 @@ public:
     /**
      * Tries to get the ID of a node corresponding to the given locator, if the node exists.
      * @param locator
-     * @param node_id Returns the ID of the node if it exists.
-     * @return Whether the node exists.
+     * @return Tree node ID if the node exists.
+     * @return std::nullopt is the node doesn't exist.
      */
-    [[nodiscard]] auto
-    try_get_node_id(TreeNodeLocator const& locator, SchemaTreeNode::id_t& node_id) const -> bool;
+    [[nodiscard]] auto try_get_node_id(NodeLocator const& locator
+    ) const -> std::optional<SchemaTreeNode::id_t>;
 
     /**
      * @param locator
      * @return Whether there is a node that corresponds to the given locator.
      */
-    [[nodiscard]] auto has_node(TreeNodeLocator const& locator) const -> bool {
-        SchemaTreeNode::id_t node_id{};
-        return try_get_node_id(locator, node_id);
+    [[nodiscard]] auto has_node(NodeLocator const& locator) const -> bool {
+        return try_get_node_id(locator).has_value();
     }
 
     /**
@@ -170,7 +169,7 @@ public:
      * @return The ID of the inserted node.
      * @throw OperationFailed if a node that corresponds to the given locator already exists.
      */
-    [[maybe_unused]] auto insert_node(TreeNodeLocator const& locator) -> SchemaTreeNode::id_t;
+    [[maybe_unused]] auto insert_node(NodeLocator const& locator) -> SchemaTreeNode::id_t;
 
     /**
      * Takes a snapshot of the current schema tree (to allow recovery on failure).

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -19,6 +19,7 @@ namespace clp::ffi {
  */
 class SchemaTree {
 public:
+    // Types
     class OperationFailed : public TraceableException {
     public:
         OperationFailed(
@@ -68,16 +69,17 @@ public:
         SchemaTreeNode::Type m_type;
     };
 
+    // Constants
     static constexpr SchemaTreeNode::id_t cRootId{0};
 
     // Constructors
     SchemaTree() { m_tree_nodes.emplace_back(cRootId, cRootId, "", SchemaTreeNode::Type::Obj); }
 
-    // Delete copy constructor and assignment
+    // Disable copy constructor/assignment operator
     SchemaTree(SchemaTree const&) = delete;
     auto operator=(SchemaTree const&) -> SchemaTree& = delete;
 
-    // Define default move constructor and assignment
+    // Define default move constructor/assignment operator
     SchemaTree(SchemaTree&&) = default;
     auto operator=(SchemaTree&&) -> SchemaTree& = default;
 
@@ -98,7 +100,7 @@ public:
      * Tries to get a node id with the provided locator if the node exists.
      * @param locator Locator of a unique tree node.
      * @param node_id Returns the node id if the node exists.
-     * @return true if the node exists, false otherwise.
+     * @return Whether the node exists.
      */
     [[nodiscard]] auto
     try_get_node_id(TreeNodeLocator const& locator, SchemaTreeNode::id_t& node_id) const -> bool;

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -104,7 +104,7 @@ public:
     /**
      * Checks whether there exists a node with the given locator.
      * @param locator
-     * @param true if the node exists, false otherwise.
+     * @return Whether the node exists.
      */
     [[nodiscard]] auto has_node(TreeNodeLocator const& locator) const -> bool {
         SchemaTreeNode::id_t node_id{};

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -1,11 +1,14 @@
 #ifndef CLP_FFI_SCHEMATREE_HPP
 #define CLP_FFI_SCHEMATREE_HPP
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
+#include "../ErrorCode.hpp"
 #include "../TraceableException.hpp"
 #include "SchemaTreeNode.hpp"
 

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -141,7 +141,7 @@ public:
 
     /**
      * @param id
-     * @return The tree node with the given ID.
+     * @return The node with the given ID.
      * @throw OperationFailed if a node with the given ID doesn't exist in the tree.
      */
     [[nodiscard]] auto get_node(SchemaTreeNode::id_t id) const -> SchemaTreeNode const&;
@@ -149,8 +149,8 @@ public:
     /**
      * Tries to get the ID of a node corresponding to the given locator, if the node exists.
      * @param locator
-     * @return Tree node ID if the node exists.
-     * @return std::nullopt is the node doesn't exist.
+     * @return The node's ID if it exists.
+     * @return std::nullopt otherwise.
      */
     [[nodiscard]] auto try_get_node_id(NodeLocator const& locator
     ) const -> std::optional<SchemaTreeNode::id_t>;

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -1,0 +1,144 @@
+#ifndef CLP_FFI_SCHEMATREE_HPP
+#define CLP_FFI_SCHEMATREE_HPP
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "../TraceableException.hpp"
+#include "SchemaTreeNode.hpp"
+
+namespace clp::ffi {
+/**
+ * This class implements a schema tree, providing all necessary methods for upper-layer APIs through
+ * FFI. Nodes are stored using a flattened vector.
+ */
+class SchemaTree {
+public:
+    class OperationFailed : public TraceableException {
+    public:
+        OperationFailed(
+                ErrorCode error_code,
+                char const* const filename,
+                int line_number,
+                std::string message
+        )
+                : TraceableException{error_code, filename, line_number},
+                  m_message{std::move(message)} {}
+
+        [[nodiscard]] auto what() const noexcept -> char const* override {
+            return m_message.c_str();
+        }
+
+    private:
+        std::string m_message;
+    };
+
+    /**
+     * When locating a tree node, might not always have the tree node id. Instead, we usually use
+     * the parent id, the key name, and the node type to locate a unique tree node. This class wraps
+     * the location information as a non-integer identifier to locate a unique node in the tree.
+     */
+    class TreeNodeLocator {
+    public:
+        TreeNodeLocator(
+                SchemaTreeNode::id_t parent_id,
+                std::string_view key_name,
+                SchemaTreeNode::Type type
+        )
+                : m_parent_id{parent_id},
+                  m_key_name{key_name},
+                  m_type{type} {}
+
+        [[nodiscard]] auto get_parent_id() const -> SchemaTreeNode::id_t { return m_parent_id; }
+
+        [[nodiscard]] auto get_key_name() const -> std::string_view { return m_key_name; }
+
+        [[nodiscard]] auto get_type() const -> SchemaTreeNode::Type { return m_type; }
+
+    private:
+        SchemaTreeNode::id_t m_parent_id;
+        std::string_view m_key_name;
+        SchemaTreeNode::Type m_type;
+    };
+
+    static constexpr SchemaTreeNode::id_t cRootId{0};
+
+    // Constructors
+    SchemaTree() { m_tree_nodes.emplace_back(cRootId, cRootId, "", SchemaTreeNode::Type::Obj); }
+
+    // Delete copy constructor and assignment
+    SchemaTree(SchemaTree const&) = delete;
+    auto operator=(SchemaTree const&) -> SchemaTree& = delete;
+
+    // Define default move constructor and assignment
+    SchemaTree(SchemaTree&&) = default;
+    auto operator=(SchemaTree&&) -> SchemaTree& = default;
+
+    // Destructor
+    ~SchemaTree() = default;
+
+    // Methods
+    [[nodiscard]] auto get_size() const -> size_t { return m_tree_nodes.size(); }
+
+    /**
+     * @param id
+     * @return The tree node with the given id.
+     * @throw OperationFailed if the given id is not valid (i.e., out of bound).
+     */
+    [[nodiscard]] auto get_node(SchemaTreeNode::id_t id) const -> SchemaTreeNode const&;
+
+    /**
+     * Tries to get a node id with the provided locator if the node exists.
+     * @param locator Locator of a unique tree node.
+     * @param node_id Returns the node id if the node exists.
+     * @return true if the node exists, false otherwise.
+     */
+    [[nodiscard]] auto
+    try_get_node_id(TreeNodeLocator const& locator, SchemaTreeNode::id_t& node_id) const -> bool;
+
+    /**
+     * Checks whether there exists a node with the given locator.
+     * @param locator
+     * @param true if the node exists, false otherwise.
+     */
+    [[nodiscard]] auto has_node(TreeNodeLocator const& locator) const -> bool {
+        SchemaTreeNode::id_t node_id{};
+        return try_get_node_id(locator, node_id);
+    }
+
+    /**
+     * Inserts a new node to the given locator.
+     * @param locator
+     * @return The node id of the inserted node.
+     * @throw OperationFailed if the node with the given locator already exists.
+     */
+    [[maybe_unused]] auto insert_node(TreeNodeLocator const& locator) -> SchemaTreeNode::id_t;
+
+    /**
+     * Takes a snapshot of the current schema tree for potential recovery on failure.
+     */
+    auto take_snapshot() -> void { m_snapshot_size.emplace(m_tree_nodes.size()); }
+
+    /**
+     * Reverts the tree to the time when the snapshot was taken.
+     * @throw OperationFailed if the snapshot was not taken.
+     */
+    auto revert() -> void;
+
+    /**
+     * Resets the schema tree by removing all the tree nodes except root.
+     */
+    auto reset() -> void {
+        m_snapshot_size.reset();
+        m_tree_nodes.clear();
+        m_tree_nodes.emplace_back(cRootId, cRootId, "", SchemaTreeNode::Type::Obj);
+    }
+
+private:
+    std::optional<size_t> m_snapshot_size{std::nullopt};
+    std::vector<SchemaTreeNode> m_tree_nodes;
+};
+}  // namespace clp::ffi
+#endif

--- a/components/core/src/clp/ffi/SchemaTreeNode.hpp
+++ b/components/core/src/clp/ffi/SchemaTreeNode.hpp
@@ -9,8 +9,8 @@
 
 namespace clp::ffi {
 /**
- * This class implements a node in the schema tree. It stores information of a tree node, including
- * the node type, key name, parent id, and ids of all the child nodes.
+ * A node in clp::ffi::SchemaTree. It stores the node's key name, type, parent's ID, and the IDs of
+ * all its children.
  */
 class SchemaTreeNode {
 public:
@@ -18,7 +18,7 @@ public:
     using id_t = size_t;
 
     /**
-     * Enum defining schema tree node types.
+     * Enum defining the possible node types.
      */
     enum class Type : uint8_t {
         Int = 0,
@@ -61,17 +61,14 @@ public:
     }
 
     /**
-     * Appends a child node id to the end of the children list.
-     * Note: the node id is the node index in the schema tree. It is impossible to check if the node
-     * added is unique in the children list. Therefore, this function does not check whether the
-     * node already exists. It is the caller's responsibility (schema tree) to ensure the node
-     * appended is unique.
-     * @param child_id The node id of the given child.
+     * Appends a child using its node ID.
+     * NOTE: This method doesn't check if a child with the given ID already exists.
+     * @param child_id The child node's ID.
      */
     auto append_new_child_id(id_t child_id) -> void { m_children_ids.push_back(child_id); }
 
     /**
-     * Removes the last appended child id from the children list.
+     * Removes the last appended child ID (if any).
      */
     auto remove_last_appended_child_id() -> void {
         if (m_children_ids.empty()) {

--- a/components/core/src/clp/ffi/SchemaTreeNode.hpp
+++ b/components/core/src/clp/ffi/SchemaTreeNode.hpp
@@ -1,8 +1,10 @@
 #ifndef CLP_FFI_SCHEMATREENODE_HPP
 #define CLP_FFI_SCHEMATREENODE_HPP
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace clp::ffi {

--- a/components/core/src/clp/ffi/SchemaTreeNode.hpp
+++ b/components/core/src/clp/ffi/SchemaTreeNode.hpp
@@ -1,7 +1,6 @@
 #ifndef CLP_FFI_SCHEMATREENODE_HPP
 #define CLP_FFI_SCHEMATREENODE_HPP
 
-#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -15,7 +14,7 @@ namespace clp::ffi {
 class SchemaTreeNode {
 public:
     // Types
-    using id_t = size_t;
+    using id_t = uint32_t;
 
     /**
      * Enum defining the possible node types.
@@ -65,12 +64,12 @@ public:
      * NOTE: This method doesn't check if a child with the given ID already exists.
      * @param child_id The child node's ID.
      */
-    auto append_new_child_id(id_t child_id) -> void { m_children_ids.push_back(child_id); }
+    auto append_new_child(id_t child_id) -> void { m_children_ids.push_back(child_id); }
 
     /**
      * Removes the last appended child ID (if any).
      */
-    auto remove_last_appended_child_id() -> void {
+    auto remove_last_appended_child() -> void {
         if (m_children_ids.empty()) {
             return;
         }

--- a/components/core/src/clp/ffi/SchemaTreeNode.hpp
+++ b/components/core/src/clp/ffi/SchemaTreeNode.hpp
@@ -14,6 +14,7 @@ namespace clp::ffi {
  */
 class SchemaTreeNode {
 public:
+    // Types
     using id_t = size_t;
 
     /**
@@ -35,11 +36,11 @@ public:
               m_key_name{key_name.begin(), key_name.end()},
               m_type{type} {}
 
-    // Delete copy constructor and assignment
+    // Disable copy constructor/assignment operator
     SchemaTreeNode(SchemaTreeNode const&) = delete;
     auto operator=(SchemaTreeNode const&) -> SchemaTreeNode& = delete;
 
-    // Define default move constructor and assignment
+    // Define default move constructor/assignment operator
     SchemaTreeNode(SchemaTreeNode&&) = default;
     auto operator=(SchemaTreeNode&&) -> SchemaTreeNode& = default;
 

--- a/components/core/src/clp/ffi/SchemaTreeNode.hpp
+++ b/components/core/src/clp/ffi/SchemaTreeNode.hpp
@@ -1,0 +1,89 @@
+#ifndef CLP_FFI_SCHEMATREENODE_HPP
+#define CLP_FFI_SCHEMATREENODE_HPP
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace clp::ffi {
+/**
+ * This class implements a node in the schema tree. It stores information of a tree node, including
+ * the node type, key name, parent id, and ids of all the child nodes.
+ */
+class SchemaTreeNode {
+public:
+    using id_t = size_t;
+
+    /**
+     * Enum defining schema tree node types.
+     */
+    enum class Type : uint8_t {
+        Int = 0,
+        Float,
+        Bool,
+        Str,
+        UnstructuredArray,
+        Obj
+    };
+
+    // Constructors
+    SchemaTreeNode(id_t id, id_t parent_id, std::string_view key_name, Type type)
+            : m_id{id},
+              m_parent_id{parent_id},
+              m_key_name{key_name.begin(), key_name.end()},
+              m_type{type} {}
+
+    // Delete copy constructor and assignment
+    SchemaTreeNode(SchemaTreeNode const&) = delete;
+    auto operator=(SchemaTreeNode const&) -> SchemaTreeNode& = delete;
+
+    // Define default move constructor and assignment
+    SchemaTreeNode(SchemaTreeNode&&) = default;
+    auto operator=(SchemaTreeNode&&) -> SchemaTreeNode& = default;
+
+    // Destructor
+    ~SchemaTreeNode() = default;
+
+    // Methods
+    [[nodiscard]] auto get_id() const -> id_t { return m_id; }
+
+    [[nodiscard]] auto get_parent_id() const -> id_t { return m_parent_id; }
+
+    [[nodiscard]] auto get_key_name() const -> std::string_view { return m_key_name; }
+
+    [[nodiscard]] auto get_type() const -> Type { return m_type; }
+
+    [[nodiscard]] auto get_children_ids() const -> std::vector<id_t> const& {
+        return m_children_ids;
+    }
+
+    /**
+     * Appends a child node id to the end of the children list.
+     * Note: the node id is the node index in the schema tree. It is impossible to check if the node
+     * added is unique in the children list. Therefore, this function does not check whether the
+     * node already exists. It is the caller's responsibility (schema tree) to ensure the node
+     * appended is unique.
+     * @param child_id The node id of the given child.
+     */
+    auto append_new_child_id(id_t child_id) -> void { m_children_ids.push_back(child_id); }
+
+    /**
+     * Removes the last appended child id from the children list.
+     */
+    auto remove_last_appended_child_id() -> void {
+        if (m_children_ids.empty()) {
+            return;
+        }
+        m_children_ids.pop_back();
+    }
+
+private:
+    id_t m_id;
+    id_t m_parent_id;
+    std::vector<id_t> m_children_ids;
+    std::string m_key_name;
+    Type m_type;
+};
+}  // namespace clp::ffi
+
+#endif

--- a/components/core/tests/test-ffi_SchemaTree.cpp
+++ b/components/core/tests/test-ffi_SchemaTree.cpp
@@ -1,8 +1,14 @@
+#include <optional>
+#include <vector>
+
 #include <Catch2/single_include/catch2/catch.hpp>
 #include <msgpack.hpp>
 
 #include "../src/clp/ffi/SchemaTree.hpp"
 #include "../src/clp/ffi/SchemaTreeNode.hpp"
+
+using clp::ffi::SchemaTree;
+using clp::ffi::SchemaTreeNode;
 
 namespace {
 /**
@@ -12,9 +18,9 @@ namespace {
  * @return Whether the node is inserted successfully with the expected node id.
  */
 [[nodiscard]] auto insert_node(
-        clp::ffi::SchemaTree& schema_tree,
-        clp::ffi::SchemaTree::TreeNodeLocator locator,
-        clp::ffi::SchemaTreeNode::id_t expected_id
+        SchemaTree& schema_tree,
+        SchemaTree::NodeLocator locator,
+        SchemaTreeNode::id_t expected_id
 ) -> bool;
 
 /**
@@ -24,72 +30,78 @@ namespace {
  * @return Whether the node exists and its ID matches the expected ID.
  */
 [[nodiscard]] auto check_node(
-        clp::ffi::SchemaTree const& schema_tree,
-        clp::ffi::SchemaTree::TreeNodeLocator locator,
-        clp::ffi::SchemaTreeNode::id_t expected_id
+        SchemaTree const& schema_tree,
+        SchemaTree::NodeLocator locator,
+        SchemaTreeNode::id_t expected_id
 ) -> bool;
 
 auto insert_node(
-        clp::ffi::SchemaTree& schema_tree,
-        clp::ffi::SchemaTree::TreeNodeLocator locator,
-        clp::ffi::SchemaTreeNode::id_t expected_id
+        SchemaTree& schema_tree,
+        SchemaTree::NodeLocator locator,
+        SchemaTreeNode::id_t expected_id
 ) -> bool {
-    clp::ffi::SchemaTreeNode::id_t node_id{};
-    return false == schema_tree.try_get_node_id(locator, node_id)
+    return false == schema_tree.has_node(locator)
            && expected_id == schema_tree.insert_node(locator);
 }
 
 auto check_node(
-        clp::ffi::SchemaTree const& schema_tree,
-        clp::ffi::SchemaTree::TreeNodeLocator locator,
-        clp::ffi::SchemaTreeNode::id_t expected_id
+        SchemaTree const& schema_tree,
+        SchemaTree::NodeLocator locator,
+        SchemaTreeNode::id_t expected_id
 ) -> bool {
-    clp::ffi::SchemaTreeNode::id_t node_id{};
-    return schema_tree.try_get_node_id(locator, node_id) && expected_id == node_id;
+    auto const node_id{schema_tree.try_get_node_id(locator)};
+    return node_id.has_value() && node_id.value() == expected_id;
 }
 }  // namespace
 
 TEST_CASE("ffi_schema_tree", "[ffi]") {
-    using clp::ffi::SchemaTree;
-    using clp::ffi::SchemaTreeNode;
-
+    /**
+     * <0:root:Obj>
+     *      |
+     *      |------------> <1:a:Obj>
+     *      |                  |
+     *      |--> <2:a:Int>     |--> <3:b:Obj>
+     *                                  |
+     *                                  |------------> <4:c:Obj>
+     *                                  |                  |
+     *                                  |--> <5:d:Int>     |--> <7:d:UnstructuredArray>
+     *                                  |                  |
+     *                                  |--> <6:d:Bool>    |--> <8:d:Str>
+     */
     SchemaTree schema_tree;
+    std::vector<SchemaTree::NodeLocator> const locators{
+            {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Obj},
+            {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Int},
+            {1, "b", SchemaTreeNode::Type::Obj},
+            {3, "c", SchemaTreeNode::Type::Obj},
+            {3, "d", SchemaTreeNode::Type::Int},
+            {3, "d", SchemaTreeNode::Type::Bool},
+            {4, "d", SchemaTreeNode::Type::UnstructuredArray},
+            {4, "d", SchemaTreeNode::Type::Str}
+    };
 
-    REQUIRE(insert_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Obj}, 1));
-    REQUIRE(insert_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Int}, 2));
-    REQUIRE(insert_node(schema_tree, {1, "b", SchemaTreeNode::Type::Obj}, 3));
-    REQUIRE(insert_node(schema_tree, {3, "c", SchemaTreeNode::Type::Obj}, 4));
+    auto const snapshot_idx{static_cast<SchemaTreeNode::id_t>(locators.size() / 2)};
 
-    schema_tree.take_snapshot();
+    for (SchemaTreeNode::id_t id_to_insert{1}; id_to_insert <= locators.size(); ++id_to_insert) {
+        REQUIRE(insert_node(schema_tree, locators[id_to_insert - 1], id_to_insert));
+        if (snapshot_idx == id_to_insert) {
+            schema_tree.take_snapshot();
+        }
+    }
 
-    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
-    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
-    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
-    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
-
-    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Obj}, 1));
-    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Int}, 2));
-    REQUIRE(check_node(schema_tree, {1, "b", SchemaTreeNode::Type::Obj}, 3));
-    REQUIRE(check_node(schema_tree, {3, "c", SchemaTreeNode::Type::Obj}, 4));
-    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
-    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
-    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
-    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
+    for (SchemaTreeNode::id_t id_to_check{1}; id_to_check <= locators.size(); ++id_to_check) {
+        REQUIRE(check_node(schema_tree, locators[id_to_check - 1], id_to_check));
+    }
 
     schema_tree.revert();
 
-    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Obj}, 1));
-    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Int}, 2));
-    REQUIRE(check_node(schema_tree, {1, "b", SchemaTreeNode::Type::Obj}, 3));
-    REQUIRE(check_node(schema_tree, {3, "c", SchemaTreeNode::Type::Obj}, 4));
+    for (SchemaTreeNode::id_t id_to_insert{snapshot_idx + 1}; id_to_insert <= locators.size();
+         ++id_to_insert)
+    {
+        REQUIRE(insert_node(schema_tree, locators[id_to_insert - 1], id_to_insert));
+    }
 
-    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
-    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
-    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
-    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
-
-    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
-    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
-    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
-    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
+    for (SchemaTreeNode::id_t id_to_check{1}; id_to_check <= locators.size(); ++id_to_check) {
+        REQUIRE(check_node(schema_tree, locators[id_to_check - 1], id_to_check));
+    }
 }

--- a/components/core/tests/test-ffi_SchemaTree.cpp
+++ b/components/core/tests/test-ffi_SchemaTree.cpp
@@ -15,7 +15,7 @@ namespace {
  * @param schema_tree
  * @param locator
  * @param expected_id
- * @return Whether the node is inserted successfully with the expected node id.
+ * @return Whether the node was inserted successfully with the expected ID.
  */
 [[nodiscard]] auto insert_node(
         SchemaTree& schema_tree,
@@ -55,7 +55,7 @@ auto check_node(
 }  // namespace
 
 TEST_CASE("ffi_schema_tree", "[ffi]") {
-    /**
+    /*
      * <0:root:Obj>
      *      |
      *      |------------> <1:a:Obj>

--- a/components/core/tests/test-ffi_SchemaTree.cpp
+++ b/components/core/tests/test-ffi_SchemaTree.cpp
@@ -1,0 +1,88 @@
+#include <chrono>
+#include <fstream>
+#include <iostream>
+
+#include <Catch2/single_include/catch2/catch.hpp>
+#include <json/single_include/nlohmann/json.hpp>
+#include <msgpack.hpp>
+
+#include "../src/clp/ffi/SchemaTree.hpp"
+#include "../src/clp/ffi/SchemaTreeNode.hpp"
+
+namespace {
+/**
+ * @param schema_tree
+ * @param locator
+ * @param expected_id
+ * @return true if the node is successfully inserted with the expected node id; false otherwise.
+ */
+[[nodiscard]] auto insert_node(
+        clp::ffi::SchemaTree& schema_tree,
+        clp::ffi::SchemaTree::TreeNodeLocator locator,
+        clp::ffi::SchemaTreeNode::id_t expected_id
+) -> bool {
+    clp::ffi::SchemaTreeNode::id_t node_id{};
+    return false == schema_tree.try_get_node_id(locator, node_id)
+           && expected_id == schema_tree.insert_node(locator);
+}
+
+/**
+ * @param schema_tree
+ * @param locator
+ * @param expected_id
+ * @return true if the node exists and its id is the same as the expected id; false otherwise.
+ */
+[[nodiscard]] auto check_node(
+        clp::ffi::SchemaTree const& schema_tree,
+        clp::ffi::SchemaTree::TreeNodeLocator locator,
+        clp::ffi::SchemaTreeNode::id_t expected_id
+) -> bool {
+    clp::ffi::SchemaTreeNode::id_t node_id{};
+    return schema_tree.try_get_node_id(locator, node_id) && expected_id == node_id;
+}
+}  // namespace
+
+TEST_CASE("ffi_schema_tree", "[ffi]") {
+    using clp::ffi::SchemaTree;
+    using clp::ffi::SchemaTreeNode;
+
+    SchemaTree schema_tree;
+
+    REQUIRE(insert_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Obj}, 1));
+    REQUIRE(insert_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Int}, 2));
+    REQUIRE(insert_node(schema_tree, {1, "b", SchemaTreeNode::Type::Obj}, 3));
+    REQUIRE(insert_node(schema_tree, {3, "c", SchemaTreeNode::Type::Obj}, 4));
+
+    schema_tree.take_snapshot();
+
+    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
+    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
+    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
+    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
+
+    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Obj}, 1));
+    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Int}, 2));
+    REQUIRE(check_node(schema_tree, {1, "b", SchemaTreeNode::Type::Obj}, 3));
+    REQUIRE(check_node(schema_tree, {3, "c", SchemaTreeNode::Type::Obj}, 4));
+    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
+    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
+    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
+    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
+
+    schema_tree.revert();
+
+    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Obj}, 1));
+    REQUIRE(check_node(schema_tree, {SchemaTree::cRootId, "a", SchemaTreeNode::Type::Int}, 2));
+    REQUIRE(check_node(schema_tree, {1, "b", SchemaTreeNode::Type::Obj}, 3));
+    REQUIRE(check_node(schema_tree, {3, "c", SchemaTreeNode::Type::Obj}, 4));
+
+    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
+    REQUIRE(insert_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
+    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
+    REQUIRE(insert_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
+
+    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Int}, 5));
+    REQUIRE(check_node(schema_tree, {3, "d", SchemaTreeNode::Type::Bool}, 6));
+    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::UnstructuredArray}, 7));
+    REQUIRE(check_node(schema_tree, {4, "d", SchemaTreeNode::Type::Str}, 8));
+}

--- a/components/core/tests/test-ffi_SchemaTree.cpp
+++ b/components/core/tests/test-ffi_SchemaTree.cpp
@@ -21,7 +21,7 @@ namespace {
  * @param schema_tree
  * @param locator
  * @param expected_id
- * @return Whether the node exists and its id matches the expected id.
+ * @return Whether the node exists and its ID matches the expected ID.
  */
 [[nodiscard]] auto check_node(
         clp::ffi::SchemaTree const& schema_tree,

--- a/components/core/tests/test-ffi_SchemaTree.cpp
+++ b/components/core/tests/test-ffi_SchemaTree.cpp
@@ -9,9 +9,27 @@ namespace {
  * @param schema_tree
  * @param locator
  * @param expected_id
- * @return true if the node is successfully inserted with the expected node id; false otherwise.
+ * @return Whether the node is inserted successfully with the expected node id.
  */
 [[nodiscard]] auto insert_node(
+        clp::ffi::SchemaTree& schema_tree,
+        clp::ffi::SchemaTree::TreeNodeLocator locator,
+        clp::ffi::SchemaTreeNode::id_t expected_id
+) -> bool;
+
+/**
+ * @param schema_tree
+ * @param locator
+ * @param expected_id
+ * @return Whether the node exists and its id matches the expected id.
+ */
+[[nodiscard]] auto check_node(
+        clp::ffi::SchemaTree const& schema_tree,
+        clp::ffi::SchemaTree::TreeNodeLocator locator,
+        clp::ffi::SchemaTreeNode::id_t expected_id
+) -> bool;
+
+auto insert_node(
         clp::ffi::SchemaTree& schema_tree,
         clp::ffi::SchemaTree::TreeNodeLocator locator,
         clp::ffi::SchemaTreeNode::id_t expected_id
@@ -21,13 +39,7 @@ namespace {
            && expected_id == schema_tree.insert_node(locator);
 }
 
-/**
- * @param schema_tree
- * @param locator
- * @param expected_id
- * @return true if the node exists and its id is the same as the expected id; false otherwise.
- */
-[[nodiscard]] auto check_node(
+auto check_node(
         clp::ffi::SchemaTree const& schema_tree,
         clp::ffi::SchemaTree::TreeNodeLocator locator,
         clp::ffi::SchemaTreeNode::id_t expected_id

--- a/components/core/tests/test-ffi_SchemaTree.cpp
+++ b/components/core/tests/test-ffi_SchemaTree.cpp
@@ -1,9 +1,4 @@
-#include <chrono>
-#include <fstream>
-#include <iostream>
-
 #include <Catch2/single_include/catch2/catch.hpp>
-#include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
 
 #include "../src/clp/ffi/SchemaTree.hpp"


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR introduces a streaming schema tree implementation designed for IR v2. It has the following components:
- `SchemaTreeNode`: A class that specifies the node information for each node in the schema tree, including a unique ID, a parent ID, key name, type, and children IDs.
- `SchemaTree`: A tree built with SchemaTreeNode, with methods to insert/get tree nodes.
- Unit test: unit test cases to cover basic functionality.

Notice that we already have a schema tree implementation in `clp-s`. The reasons to re-implement the schema tree are the following:
- The schema tree node maintains different information to track a tree node:
   - The types of schema tree nodes in the IR format differ from those in the Archive format. The types we support in IR format are the following:
     - Integer
     - Float
     - String
     - Boolean
     - Unstructured Array
     - Object
   - There is no need to track the count of each node.
- The schema tree is designed to be used in our new IR stream. Compared to the existing implementation, this PR makes it more lightweight:
  - The schema tree does not maintain a hash map for existing nodes. This reduces memory usage and doesn't require `absl::flat_hash_map` when building our FFI libraries. As a tradeoff, the worst-case time complexity of node finding takes O(n) instead of O(1). However, from existing profiling results, this change has negligible influence on the IR v2 stream serialization/deserialization, even when the tree max depth and max width are large.
   - By making these changes, the memory used by the schema tree can be approximated more simply. This can be helpful if we need to build a heuristic to determine when to rotate an IR stream.
- When IR serialization fails, the tree needs to be recovered back to the state before the serialization starts, meaning that all nodes inserted during a failed serialization must be removed. `SchemaTree` has an efficient implementation for this scenario.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Passed `clang-tidy` linter check.
- Ensured the code can be successfully built with `unitTest`.
- Ensured new unit tests passed.
