### PR TITLE
docs: Simplify 'dynamically-structured' to 'JSON' and some minor edits.

### DIFF
--- a/docs/src/user-guide/core-clp-s.md
+++ b/docs/src/user-guide/core-clp-s.md
@@ -1,7 +1,7 @@
-# CLP for dynamically-structured logs
+# CLP for JSON logs
 
-For dynamically-structured logs (e.g., JSON), you can compress, decompress, and search them using
-the `clp-s` binary described below.
+For JSON logs, you can compress, decompress, and search them using the `clp-s` binary described
+below.
 
 ## Compression
 

--- a/docs/src/user-guide/core-container.md
+++ b/docs/src/user-guide/core-container.md
@@ -31,6 +31,6 @@ docker run \
   archives. It will be mounted at `/mnt/data` in the container.
 
 Follow the usage instructions in [clp for unstructured logs](core-unstructured/index) or
-[clp for dynamically-structured logs](core-clp-s), depending on the format of your logs.
+[clp for JSON logs](core-clp-s), depending on the format of your logs.
 
 [1]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-x86-ubuntu-focal

--- a/docs/src/user-guide/core-overview.md
+++ b/docs/src/user-guide/core-overview.md
@@ -18,9 +18,9 @@ A flavour of CLP for unstructured (e.g., free-text) logs.
 
 :::{grid-item-card}
 :link: core-clp-s
-CLP for dynamically-structured logs
+CLP for JSON logs
 ^^^^^^^^^^^^
-A flavour of CLP for dynamically structured (e.g., JSON) logs.
+A flavour of CLP for JSON logs.
 :::
 ::::
 

--- a/docs/src/user-guide/index.md
+++ b/docs/src/user-guide/index.md
@@ -54,8 +54,8 @@ quick-start-search/index
 
 core-overview
 core-container
-core-unstructured/index
 core-clp-s
+core-unstructured/index
 :::
 
 :::{toctree}

--- a/docs/src/user-guide/index.md
+++ b/docs/src/user-guide/index.md
@@ -30,7 +30,7 @@ Resources like log datasets, etc.
 :::
 
 :::{grid-item-card}
-:link: reference-unstructured-schema-file
+:link: reference-json-search-syntax
 Reference
 ^^^
 Reference docs like format specifications, etc.


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

`clp-s` is designed to compress, decompress, and search dynamically-structured logs beyond just JSON (e.g., XML, Protobuf, etc.), but as implemented, we only support JSON logs. So for now, this PR simplifies the language to just JSON to avoid confusing users.

This PR also changes the "Reference" card to link to the first page in the reference section rather than the last.

# Validation performed
<!-- What tests and validation you performed on the change -->

* `task docs:serve`
* Validated that the updates look correct.
