### PR TITLE
High CPU usage fix

### DIFF
--- a/components/webui/imports/api/search/server/publications.js
+++ b/components/webui/imports/api/search/server/publications.js
@@ -18,6 +18,7 @@ import {searchJobCollectionsManager} from "./collections";
  * The interval, in milliseconds, at which the Meteor Mongo collection is polled.
  */
 const COLLECTION_POLL_INTERVAL_MILLIS = 250;
+const IDLE_INTERVAL_MILLIS = 10000;
 
 /**
  * Publishes search results metadata for a specific job.
@@ -50,6 +51,7 @@ Meteor.publish(Meteor.settings.public.SearchResultsMetadataCollectionName, ({sea
  */
 Meteor.publish(Meteor.settings.public.SearchResultsCollectionName, ({
     searchJobId,
+    isActivelyPolling,
 }) => {
     logger.debug(
         `Subscription '${Meteor.settings.public.SearchResultsCollectionName}'`,
@@ -66,7 +68,7 @@ Meteor.publish(Meteor.settings.public.SearchResultsCollectionName, ({
         ],
         limit: SEARCH_MAX_NUM_RESULTS,
         disableOplog: true,
-        pollingIntervalMs: COLLECTION_POLL_INTERVAL_MILLIS,
+        pollingIntervalMs: isActivelyPolling? COLLECTION_POLL_INTERVAL_MILLIS:IDLE_INTERVAL_MILLIS,
     };
 
     return collection.find({}, findOptions);
@@ -82,11 +84,12 @@ Meteor.publish(Meteor.settings.public.SearchResultsCollectionName, ({
  */
 Meteor.publish(Meteor.settings.public.AggregationResultsCollectionName, ({
     aggregationJobId,
+    isActivelyPolling,
 }) => {
     const collection = searchJobCollectionsManager.getOrCreateCollection(aggregationJobId);
     const findOptions = {
         disableOplog: true,
-        pollingIntervalMs: COLLECTION_POLL_INTERVAL_MILLIS,
+        pollingIntervalMs: isActivelyPolling? COLLECTION_POLL_INTERVAL_MILLIS:IDLE_INTERVAL_MILLIS,
     };
 
     return collection.find({}, findOptions);

--- a/components/webui/imports/ui/SearchView/SearchView.jsx
+++ b/components/webui/imports/ui/SearchView/SearchView.jsx
@@ -102,7 +102,8 @@ const SearchView = () => {
         }
 
         Meteor.subscribe(Meteor.settings.public.SearchResultsCollectionName, {
-            searchJobId,
+            searchJobId: searchJobId,
+            isActivelyPolling: resultsMetadata.lastSignal === SEARCH_SIGNAL.REQ_QUERYING,
         });
 
         // NOTE: Although we publish and subscribe using the name
@@ -143,6 +144,7 @@ const SearchView = () => {
         searchJobId,
         fieldToSortBy,
         visibleSearchResultsLimit,
+        resultsMetadata.lastSignal,
     ]);
 
     /**
@@ -155,11 +157,15 @@ const SearchView = () => {
 
         Meteor.subscribe(Meteor.settings.public.AggregationResultsCollectionName, {
             aggregationJobId: aggregationJobId,
+            isActivelyPolling: resultsMetadata.lastSignal === SEARCH_SIGNAL.REQ_QUERYING,
         });
         const collection = dbRef.current.getOrCreateCollection(aggregationJobId);
 
         return collection.find().fetch();
-    }, [aggregationJobId]);
+    }, [
+        aggregationJobId,
+        resultsMetadata.lastSignal,
+    ]);
 
     // State transitions
     useEffect(() => {


### PR DESCRIPTION
# Description
It seems like `disableOplog` is not working properly: CPU usage remains high regardless of its state.
It is observed that CPU usage drops when lowering the polling interval, so `isActivelyPolling` is introduced in `SearchView.js` to switch polling intervals from 25ms to 10s.

It remains a question that why `disableOplog` doesn't work properly.

# Validation performed
1. Open CLP, load log files and wait for completion
2. Make a few search queries (like "1" or "*") and monitor CPU usage in htop
3. Observed that the CPU usage dropped after the searching job is done.

