### PR TITLE
package: Use docker's local logging driver to enable log rotation for package component containers.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -86,6 +86,7 @@ def main(argv):
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-u", f"{os.getuid()}:{os.getgid()}",
         "--name", container_name,
+        "--log-driver", "local",
         "--mount", str(mounts.clp_home),
     ]
     # fmt: on

--- a/components/clp-package-utils/clp_package_utils/scripts/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/decompress.py
@@ -95,6 +95,7 @@ def main(argv):
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-u", f"{os.getuid()}:{os.getgid()}",
         "--name", container_name,
+        "--log-driver", "local",
         "--mount", str(mounts.clp_home),
     ]
     # fmt: on

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -100,6 +100,7 @@ def main(argv):
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-u", f"{os.getuid()}:{os.getgid()}",
         "--name", container_name,
+        "--log-driver", "local",
         "--mount", str(mounts.clp_home),
     ]
     # fmt: on

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -140,6 +140,7 @@ def start_db(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path):
         "docker", "run",
         "-d",
         "--name", container_name,
+        "--log-driver", "local",
         "-e", f"MYSQL_ROOT_PASSWORD={clp_config.database.password}",
         "-e", f"MYSQL_USER={clp_config.database.username}",
         "-e", f"MYSQL_PASSWORD={clp_config.database.password}",
@@ -200,6 +201,7 @@ def create_db_tables(
         "--network", "host",
         "--rm",
         "--name", container_name,
+        "--log-driver", "local",
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-u", f"{os.getuid()}:{os.getgid()}",
         "--mount", str(mounts.clp_home),
@@ -271,6 +273,7 @@ def start_queue(instance_id: str, clp_config: CLPConfig):
         "docker", "run",
         "-d",
         "--name", container_name,
+        "--log-driver", "local",
         # Override RABBITMQ_LOGS since the image sets it to *only* log to stdout
         "-e", f"RABBITMQ_LOGS={rabbitmq_logs_dir / log_filename}",
         "-e", f"RABBITMQ_PID_FILE={rabbitmq_pid_file_path}",
@@ -332,6 +335,7 @@ def start_redis(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path)
         "docker", "run",
         "-d",
         "--name", container_name,
+        "--log-driver", "local",
         "-u", f"{os.getuid()}:{os.getgid()}",
     ]
     # fmt: on
@@ -377,6 +381,7 @@ def start_results_cache(instance_id: str, clp_config: CLPConfig, conf_dir: pathl
         "docker", "run",
         "-d",
         "--name", container_name,
+        "--log-driver", "local",
         "-u", f"{os.getuid()}:{os.getgid()}",
     ]
     # fmt: on
@@ -459,6 +464,7 @@ def generic_start_scheduler(
         "--network", "host",
         "-w", str(CONTAINER_CLP_HOME),
         "--name", container_name,
+        "--log-driver", "local",
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-e", (
             f"BROKER_URL=amqp://"
@@ -581,6 +587,7 @@ def generic_start_worker(
         "--network", "host",
         "-w", str(CONTAINER_CLP_HOME),
         "--name", container_name,
+        "--log-driver", "local",
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-e", (
             f"BROKER_URL=amqp://"
@@ -704,6 +711,7 @@ def start_webui(instance_id: str, clp_config: CLPConfig, mounts: CLPDockerMounts
         "-d",
         "--network", "host",
         "--name", container_name,
+        "--log-driver", "local",
         "-e", f"NODE_PATH={node_path}",
         "-e", f"MONGO_URL={clp_config.results_cache.get_uri()}",
         "-e", f"PORT={clp_config.webui.port}",
@@ -770,6 +778,7 @@ def start_reducer(
         "--network", "host",
         "-w", str(CONTAINER_CLP_HOME),
         "--name", container_name,
+        "--log-driver", "local",
         "-e", f"PYTHONPATH={clp_site_packages_dir}",
         "-e", f"CLP_LOGS_DIR={container_logs_dir}",
         "-e", f"CLP_LOGGING_LEVEL={clp_config.reducer.logging_level}",


### PR DESCRIPTION
# References

# Description
Docker containers by default use [json-file logging driver](https://docs.docker.com/config/containers/logging/json-file/) which keeps logging to a single file without any log rotation. 
It doesn't cause any issue in the opensource now.
However, if a CLP package component generates logs at a rapid pace due to error, or due to a change in the logging strategy in the future. The default json-file logging driver could potentially lead to a disk space issue. 
In fact, this have caused a real issue before https://github.com/y-scope/clp/issues/393 was fixed.

To avoid the issue, we let docker containers use the [local logging driver](https://docs.docker.com/config/containers/logging/local/), which defaults to use log rotation with 100MB threshold.


# Validation performed
1. Built the package and confirmed that the components can start without any issue and can compress and search
2. Confirmed that log rotation is working by reverting the fix for https://github.com/y-scope/clp/issues/393 and observed output logs are (1) being rotated (2) never exceed 100MB.

