### PR TITLE
[WIP] clp-package: Pass search arguments via msgpack object instead of command line to search processes.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -16,7 +16,11 @@ import pymongo
 from clp_py_utils.clp_config import Database, ResultsCache, SEARCH_JOBS_TABLE_NAME
 from clp_py_utils.sql_adapter import SQL_Adapter
 from job_orchestration.scheduler.constants import SearchJobStatus
-from job_orchestration.scheduler.job_config import AggregationConfig, SearchConfig
+from job_orchestration.scheduler.job_config import (
+    AggregationConfig,
+    OutputDestination,
+    SearchConfig,
+)
 
 from clp_package_utils.general import (
     CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH,
@@ -83,6 +87,12 @@ def create_and_monitor_job_in_db(
     do_count_aggregation: bool | None,
     count_by_time_bucket_size: int | None,
 ):
+    output_destination = None
+    if network_address is not None:
+        output_destination = OutputDestination(
+            type="network",
+            params=list(network_address),
+        )
     search_config = SearchConfig(
         query_string=wildcard_query,
         begin_timestamp=begin_timestamp,
@@ -90,7 +100,7 @@ def create_and_monitor_job_in_db(
         ignore_case=ignore_case,
         max_num_results=0,  # unlimited number of results
         path_filter=path_filter,
-        network_address=network_address,
+        output_destination=output_destination,
     )
     if do_count_aggregation is not None:
         search_config.aggregation_config = AggregationConfig(

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -9,6 +9,7 @@
 #include <boost/program_options/option.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <json/single_include/nlohmann/json.hpp>
 
 #include "../../reducer/types.hpp"
 #include "../CommandLineArgumentsBase.hpp"
@@ -19,7 +20,8 @@ class CommandLineArguments : public CommandLineArgumentsBase {
 public:
     // Types
     enum class OutputHandlerType : uint8_t {
-        Network = 0,
+        None = 0,
+        Network,
         Reducer,
         ResultsCache,
     };
@@ -77,43 +79,28 @@ public:
 private:
     // Methods
     /**
-     * Validates output options related to the Network Destination output handler.
-     * @param options_description
-     * @param options Vector of options previously parsed by boost::program_options and which may
-     * contain options that have the unrecognized flag set
-     * @param parsed_options Returns any parsed options that were newly recognized
+     * Validates the extended arguments to search passed by the package.
+     * @param extended_search_arguments
      */
-    void parse_network_dest_output_handler_options(
-            boost::program_options::options_description const& options_description,
-            std::vector<boost::program_options::option> const& options,
-            boost::program_options::variables_map& parsed_options
-    );
+    void parse_extended_search_arguments(nlohmann::json const& extended_search_arguments);
 
     /**
-     * Validates output options related to the Reducer output handler.
-     * @param options_description
-     * @param options Vector of options previously parsed by boost::program_options and which may
-     * contain options that have the unrecognized flag set
-     * @param parsed_options Returns any parsed options that were newly recognized
+     * Validates output options related to the Network Destination output handler.
+     * @param options
      */
-    void parse_reducer_output_handler_options(
-            boost::program_options::options_description const& options_description,
-            std::vector<boost::program_options::option> const& options,
-            boost::program_options::variables_map& parsed_options
-    );
+    void parse_network_dest_output_handler_options(nlohmann::json const& options);
 
     /**
      * Validates output options related to the Results Cache output handler.
-     * @param options_description
-     * @param options Vector of options previously parsed by boost::program_options and which may
-     * contain options that have the unrecognized flag set
-     * @param parsed_options Returns any parsed options that were newly recognized
+     * @param options
      */
-    void parse_results_cache_output_handler_options(
-            boost::program_options::options_description const& options_description,
-            std::vector<boost::program_options::option> const& options,
-            boost::program_options::variables_map& parsed_options
-    );
+    void parse_results_cache_output_handler_options(nlohmann::json const& options);
+
+    /**
+     * Validates the extended arguments to search passed by the package.
+     * @param extended_search_arguments
+     */
+    void parse_extended_aggregation_arguments(nlohmann::json const& extended_aggregation_arguments);
 
     void print_basic_usage() const override;
 
@@ -142,7 +129,7 @@ private:
     bool m_do_count_by_time_aggregation{false};
     int64_t m_count_by_time_bucket_size{0};  // Milliseconds
 
-    OutputHandlerType m_output_handler_type{OutputHandlerType::ResultsCache};
+    OutputHandlerType m_output_handler_type{OutputHandlerType::None};
 };
 }  // namespace clp::clo
 

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -88,13 +88,24 @@ private:
      * Validates output options related to the Network Destination output handler.
      * @param options
      */
-    void parse_network_dest_output_handler_options(nlohmann::json const& options);
+    void parse_network_dest_output_handler_options(nlohmann::json const& params);
 
     /**
      * Validates output options related to the Results Cache output handler.
      * @param options
      */
-    void parse_results_cache_output_handler_options(nlohmann::json const& options);
+    void parse_results_cache_output_handler_options(nlohmann::json const& params);
+
+    /**
+     * Validates output options related to the Reducer output handler.
+     * @param options
+     */
+    void parse_reducer_output_handler_options(nlohmann::json const& params);
+
+    /**
+     * Validate arguments related to the output destination for this job.
+     */
+    void parse_output_destination_arguments(nlohmann::json const& output_destination);
 
     /**
      * Validates the extended arguments to search passed by the package.

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -485,7 +485,7 @@ void CommandLineArguments::parse_extended_search_arguments(
     constexpr char cBeginTimestamp[] = "begin_timestamp";
     constexpr char cEndTimestamp[] = "end_timestamp";
     constexpr char cIgnoreCase[] = "ignore_case";
-    constexpr char cNetworkAddress[] = "network_address";
+    constexpr char cOutputDestination[] = "output_destination";
     constexpr char cMongodbDestination[] = "mongodb_destination";
     constexpr char cAggregationConfig[] = "aggregation_config";
 
@@ -509,22 +509,14 @@ void CommandLineArguments::parse_extended_search_arguments(
         m_ignore_case = extended_search_arguments[cIgnoreCase];
     }
 
-    if (has_non_null_field(extended_search_arguments, cNetworkAddress)) {
-        parse_network_dest_output_handler_options(extended_search_arguments[cNetworkAddress]);
-    }
-
-    if (has_non_null_field(extended_search_arguments, cMongodbDestination)) {
-        parse_results_cache_output_handler_options(extended_search_arguments[cMongodbDestination]);
+    if (has_non_null_field(extended_search_arguments, cOutputDestination)) {
+        parse_output_destination_arguments(extended_search_arguments[cOutputDestination]);
+    } else {
+        throw std::invalid_argument("missing output destination.");
     }
 
     if (has_non_null_field(extended_search_arguments, cAggregationConfig)) {
         parse_extended_aggregation_arguments(extended_search_arguments[cAggregationConfig]);
-    }
-
-    if (OutputHandlerType::Stdout == m_output_handler_type) {
-        throw std::invalid_argument(
-                "No output handler configuration was provided in the extended search arguments"
-        );
     }
 }
 
@@ -532,30 +524,11 @@ void CommandLineArguments::parse_extended_aggregation_arguments(
         nlohmann::json const& extended_aggregation_arguments
 ) {
     constexpr char cJobId[] = "job_id";
-    constexpr char cReducerHost[] = "reducer_host";
-    constexpr char cReducerPort[] = "reducer_port";
     constexpr char cDoCountAggregation[] = "do_count_aggregation";
     constexpr char cCountByTimeBucketSize[] = "count_by_time_bucket_size";
 
-    if (OutputHandlerType::Stdout != m_output_handler_type) {
-        throw std::invalid_argument("multiple conflicting output handlers specified.");
-    }
-    m_output_handler_type = OutputHandlerType::Reducer;
-
-    if (false == has_non_null_field(extended_aggregation_arguments, cReducerHost)) {
-        throw std::invalid_argument("host must be specified.");
-    }
-    m_reducer_host = extended_aggregation_arguments[cReducerHost];
-    if (m_reducer_host.empty()) {
-        throw std::invalid_argument("host cannot be an empty string.");
-    }
-
-    if (false == has_non_null_field(extended_aggregation_arguments, cReducerPort)) {
-        throw std::invalid_argument("port must be specified.");
-    }
-    m_reducer_port = extended_aggregation_arguments[cReducerPort];
-    if (m_reducer_port <= 0) {
-        throw std::invalid_argument("port must be greater than zero.");
+    if (OutputHandlerType::Reducer != m_output_handler_type) {
+        throw std::invalid_argument("aggregation specified, but output handler is not reducer.");
     }
 
     if (false == has_non_null_field(extended_aggregation_arguments, cJobId)) {
@@ -587,17 +560,9 @@ void CommandLineArguments::parse_extended_aggregation_arguments(
     }
 }
 
-void CommandLineArguments::parse_network_dest_output_handler_options(nlohmann::json const& options
-) {
-    if (false == options.is_array() || 2 != options.size()) {
-        throw std::invalid_argument("invalid shape for Network output handler options.");
-    }
-    m_network_dest_host = options[0];
-    m_network_dest_port = options[1];
-
-    if (OutputHandlerType::Stdout != m_output_handler_type) {
-        throw std::invalid_argument("multiple conflicting output handlers specified.");
-    }
+void CommandLineArguments::parse_network_dest_output_handler_options(nlohmann::json const& params) {
+    m_network_dest_host = params[0];
+    m_network_dest_port = params[1];
     m_output_handler_type = OutputHandlerType::Network;
 
     if (m_network_dest_host.empty()) {
@@ -609,17 +574,10 @@ void CommandLineArguments::parse_network_dest_output_handler_options(nlohmann::j
     }
 }
 
-void CommandLineArguments::parse_results_cache_output_handler_options(nlohmann::json const& options
+void CommandLineArguments::parse_results_cache_output_handler_options(nlohmann::json const& params
 ) {
-    if (false == options.is_array() || 2 != options.size()) {
-        throw std::invalid_argument("invalid shape for Results Cache output handler options.");
-    }
-    m_mongodb_uri = options[0];
-    m_mongodb_collection = options[1];
-
-    if (OutputHandlerType::Stdout != m_output_handler_type) {
-        throw std::invalid_argument("multiple conflicting output handlers specified.");
-    }
+    m_mongodb_uri = params[0];
+    m_mongodb_collection = params[1];
     m_output_handler_type = OutputHandlerType::ResultsCache;
 
     if (m_mongodb_uri.empty()) {
@@ -636,6 +594,66 @@ void CommandLineArguments::parse_results_cache_output_handler_options(nlohmann::
 
     if (0 == m_max_num_results) {
         throw std::invalid_argument("max-num-results cannot be 0.");
+    }
+}
+
+void CommandLineArguments::parse_reducer_output_handler_options(nlohmann::json const& params) {
+    m_reducer_host = params[0];
+    m_reducer_port = params[1];
+    m_output_handler_type = OutputHandlerType::Reducer;
+
+    if (m_reducer_host.empty()) {
+        throw std::invalid_argument("host cannot be an empty string.");
+    }
+
+    if (m_reducer_port <= 0) {
+        throw std::invalid_argument("port must be greater than zero.");
+    }
+}
+
+void CommandLineArguments::parse_output_destination_arguments(
+        nlohmann::json const& output_destination
+) {
+    constexpr char cOutputDestinationType[] = "type";
+    constexpr char cOutputDestinationParams[] = "params";
+    constexpr char cNetworkDestination[] = "network";
+    constexpr char cMongodbDestination[] = "mongodb";
+    constexpr char cReducerDestination[] = "reducer";
+
+    if (false == has_non_null_field(output_destination, cOutputDestinationType)) {
+        throw std::invalid_argument("output destination is missing type.");
+    }
+
+    if (false == has_non_null_field(output_destination, cOutputDestinationParams)) {
+        throw std::invalid_argument("output destination is missing parameters.");
+    }
+
+    if (false == output_destination[cOutputDestinationParams].is_array()) {
+        throw std::invalid_argument("output destination params should be an array.");
+    }
+
+    auto& destination_type = output_destination[cOutputDestinationType];
+    auto& params = output_destination[cOutputDestinationParams];
+    if (cNetworkDestination == destination_type) {
+        constexpr size_t cNumNetworkParams = 2;
+        if (cNumNetworkParams != params.size()) {
+            throw std::invalid_argument("network output destination expects two parameters.");
+        }
+        parse_network_dest_output_handler_options(params);
+    } else if (cMongodbDestination == destination_type) {
+        constexpr size_t cNumMongodbParams = 2;
+        if (cNumMongodbParams != params.size()) {
+            throw std::invalid_argument("mongodb output destination expects two parameters.");
+        }
+        parse_results_cache_output_handler_options(params);
+    } else if (cReducerDestination == destination_type) {
+        constexpr size_t cNumReducerParams = 2;
+        if (cNumReducerParams != params.size()) {
+            throw std::invalid_argument("reducer output destination expects two parameters.");
+        }
+        parse_reducer_output_handler_options(params);
+    } else {
+        throw std::invalid_argument("unexpected output destination: " + destination_type.dump());
     }
 }
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -1,8 +1,10 @@
 #include "CommandLineArguments.hpp"
 
 #include <iostream>
+#include <iterator>
 
 #include <boost/program_options.hpp>
+#include <json/single_include/nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
 #include "../clp/cli_utils.hpp"
@@ -54,6 +56,10 @@ bool read_paths_from_file(
         return false;
     }
     return true;
+}
+
+bool has_non_null_field(nlohmann::json const& json, std::string const& key) {
+    return json.count(key) > 0 && false == json[key].is_null();
 }
 }  // namespace
 
@@ -328,7 +334,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             std::string query;
 
             po::options_description search_options;
-            std::string output_handler_name;
+            bool stdin_extended_args{false};
             // clang-format off
             search_options.add_options()(
                     "archives-dir",
@@ -339,18 +345,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::value<std::string>(&m_query),
                     "Query to perform"
             )(
-                    "output-handler",
-                    po::value<std::string>(&output_handler_name)
-            )(
-                    "output-handler-args",
-                    po::value<std::vector<std::string>>()
+                    "stdin-extended-args",
+                    po::bool_switch(&stdin_extended_args),
+                    "Indicates extended search arguments passed via stdin"
             );
             // clang-format on
             po::positional_options_description positional_options;
             positional_options.add("archives-dir", 1);
             positional_options.add("query", 1);
-            positional_options.add("output-handler", 1);
-            positional_options.add("output-handler-args", -1);
 
             po::options_description match_options("Match Controls");
             // clang-format off
@@ -374,75 +376,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             // clang-format on
             search_options.add(match_options);
 
-            po::options_description aggregation_options("Aggregation Options");
-            // clang-format off
-            aggregation_options.add_options()(
-                    "count",
-                    po::bool_switch(&m_do_count_results_aggregation),
-                    "Count the number of results"
-            )(
-                    "count-by-time",
-                    po::value<int64_t>(&m_count_by_time_bucket_size)->value_name("SIZE"),
-                    "Count the number of results in each time span of the given size (ms)"
-            );
-            // clang-format on
-            search_options.add(aggregation_options);
-
-            po::options_description network_output_handler_options("Network Output Handler Options"
-            );
-            // clang-format off
-            network_output_handler_options.add_options()(
-                    "host",
-                    po::value<std::string>(&m_network_dest_host)->value_name("HOST"),
-                    "Network destination host"
-            )(
-                    "port",
-                    po::value<int>(&m_network_dest_port)->value_name("PORT"),
-                    "Network destination port"
-            );
-            // clang-format on
-
-            po::options_description reducer_output_handler_options("Reducer Output Handler Options"
-            );
-            // clang-format off
-            reducer_output_handler_options.add_options()(
-                    "host",
-                    po::value<std::string>(&m_reducer_host)->value_name("HOST"),
-                    "Host the reducer is running on"
-            )(
-                    "port",
-                    po::value<int>(&m_reducer_port)->value_name("PORT"),
-                    "Port the reducer is listening on"
-            )(
-                    "job-id",
-                    po::value<reducer::job_id_t>(&m_job_id)->value_name("ID"),
-                    "Job ID for the requested aggregation operation"
-            );
-            // clang-format on
-
-            po::options_description results_cache_output_handler_options(
-                    "Results Cache Output Handler Options"
-            );
-            results_cache_output_handler_options.add_options()(
-                    "uri",
-                    po::value<std::string>(&m_mongodb_uri)->value_name("URI"),
-                    "MongoDB URI for the results cache"
-            )(
-                    "collection",
-                    po::value<std::string>(&m_mongodb_collection)->value_name("COLLECTION"),
-                    "MongoDB collection to output to"
-            )(
-                    "batch-size",
-                    po::value<uint64_t>(&m_batch_size)->value_name("SIZE")->
-                            default_value(m_batch_size),
-                    "The number of documents to insert into MongoDB per batch"
-            )(
-                    "max-num-results",
-                    po::value<uint64_t>(&m_max_num_results)->value_name("MAX")->
-                            default_value(m_max_num_results),
-                    "The maximum number of results to output"
-            );
-
             std::vector<std::string> unrecognized_options
                     = po::collect_unrecognized(parsed.options, po::include_positional);
             unrecognized_options.erase(unrecognized_options.begin());
@@ -455,24 +388,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             po::notify(parsed_command_line_options);
 
-            constexpr char cNetworkOutputHandlerName[] = "network";
-            constexpr char cReducerOutputHandlerName[] = "reducer";
-            constexpr char cResultsCacheOutputHandlerName[] = "results-cache";
-            constexpr char cStdoutCacheOutputHandlerName[] = "stdout";
-
             if (parsed_command_line_options.count("help")) {
                 print_search_usage();
-                std::cerr << "OUTPUT_HANDLER is one of:" << std::endl;
-                std::cerr << "  " << static_cast<char const*>(cStdoutCacheOutputHandlerName)
-                          << " (default) - Output to stdout" << std::endl;
-                std::cerr << "  " << static_cast<char const*>(cNetworkOutputHandlerName)
-                          << " - Output to a network destination" << std::endl;
-                std::cerr << "  " << static_cast<char const*>(cResultsCacheOutputHandlerName)
-                          << " - Output to the results cache" << std::endl;
-                std::cerr << "  " << static_cast<char const*>(cReducerOutputHandlerName)
-                          << " - Output to the reducer" << std::endl;
-                std::cerr << std::endl;
-
                 std::cerr << "Examples:" << std::endl;
                 std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
                              R"( "level: INFO" and output to stdout)"
@@ -481,44 +398,23 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                           << std::endl;
                 std::cerr << std::endl;
 
-                std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
-                             R"( "level: INFO" and output to the results cache)"
-                          << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
-                          << " " << cResultsCacheOutputHandlerName
-                          << " --uri mongodb://127.0.0.1:27017/test"
-                             " --collection test"
-                          << std::endl;
-                std::cerr << std::endl;
-
-                std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
-                             R"( "level: INFO" and output to a network destination)"
-                          << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
-                          << " " << cNetworkOutputHandlerName
-                          << " --host localhost"
-                             " --port 18000"
-                          << std::endl;
-                std::cerr << std::endl;
-
-                std::cerr << "  # Search archives in archives-dir for logs matching a KQL query"
-                             R"( "level: INFO" and output perform a count aggregation)"
-                          << std::endl;
-                std::cerr << "  " << m_program_name << R"( s archives-dir "level: INFO")"
-                          << " " << cReducerOutputHandlerName << " --count"
-                          << " --host localhost"
-                          << " --port 14009"
-                          << " --job-id 1" << std::endl;
-
                 po::options_description visible_options;
                 visible_options.add(general_options);
                 visible_options.add(match_options);
-                visible_options.add(aggregation_options);
-                visible_options.add(network_output_handler_options);
-                visible_options.add(results_cache_output_handler_options);
-                visible_options.add(reducer_output_handler_options);
                 std::cerr << visible_options << '\n';
                 return ParsingResult::InfoCommand;
+            }
+
+            if (stdin_extended_args) {
+                std::string msgpack_buffer{std::istreambuf_iterator<char>(std::cin), {}};
+                nlohmann::json extended_arguments = nlohmann::json::from_msgpack(
+                        msgpack_buffer.begin(),
+                        msgpack_buffer.end()
+                );
+                // Detecting duplicate arguments must happen before parsing the extended search
+                // arguments to properly detect boolean switch arguments passed on the command line.
+                detect_disallowed_duplicate_arguments(parsed_command_line_options);
+                parse_extended_search_arguments(extended_arguments);
             }
 
             if (m_archives_dir.empty()) {
@@ -544,80 +440,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                         "Timestamp range is invalid - begin timestamp is after end timestamp."
                 );
             }
-
-            if (parsed_command_line_options.count("count-by-time") > 0) {
-                m_do_count_by_time_aggregation = true;
-                if (m_count_by_time_bucket_size <= 0) {
-                    throw std::invalid_argument("Value for count-by-time must be greater than zero."
-                    );
-                }
-            }
-
-            if (parsed_command_line_options.count("output-handler") > 0) {
-                if (static_cast<char const*>(cNetworkOutputHandlerName) == output_handler_name) {
-                    m_output_handler_type = OutputHandlerType::Network;
-                } else if ((static_cast<char const*>(cReducerOutputHandlerName)
-                            == output_handler_name))
-                {
-                    m_output_handler_type = OutputHandlerType::Reducer;
-                } else if ((static_cast<char const*>(cResultsCacheOutputHandlerName)
-                            == output_handler_name))
-                {
-                    m_output_handler_type = OutputHandlerType::ResultsCache;
-                } else if ((static_cast<char const*>(cStdoutCacheOutputHandlerName)
-                            == output_handler_name))
-                {
-                    m_output_handler_type = OutputHandlerType::Stdout;
-                } else if (output_handler_name.empty()) {
-                    throw std::invalid_argument("OUTPUT_HANDLER cannot be an empty string.");
-                } else {
-                    throw std::invalid_argument("Unknown OUTPUT_HANDLER: " + output_handler_name);
-                }
-            }
-
-            if (OutputHandlerType::Network == m_output_handler_type) {
-                parse_network_dest_output_handler_options(
-                        network_output_handler_options,
-                        search_parsed.options,
-                        parsed_command_line_options
-                );
-            } else if (OutputHandlerType::Reducer == m_output_handler_type) {
-                parse_reducer_output_handler_options(
-                        reducer_output_handler_options,
-                        search_parsed.options,
-                        parsed_command_line_options
-                );
-            } else if (OutputHandlerType::ResultsCache == m_output_handler_type) {
-                parse_results_cache_output_handler_options(
-                        results_cache_output_handler_options,
-                        search_parsed.options,
-                        parsed_command_line_options
-                );
-            } else if (m_output_handler_type != OutputHandlerType::Stdout) {
-                throw std::invalid_argument(
-                        "Unhandled OutputHandlerType="
-                        + std::to_string(clp::enum_to_underlying_type(m_output_handler_type))
-                );
-            }
-
-            bool aggregation_was_specified
-                    = m_do_count_by_time_aggregation || m_do_count_results_aggregation;
-            if (aggregation_was_specified && OutputHandlerType::Reducer != m_output_handler_type) {
-                throw std::invalid_argument(
-                        "Aggregations are only supported with the reducer output handler."
-                );
-            } else if ((false == aggregation_was_specified
-                        && OutputHandlerType::Reducer == m_output_handler_type))
-            {
-                throw std::invalid_argument("The reducer output handler currently only supports "
-                                            "count and count-by-time aggregations.");
-            }
-
-            if (m_do_count_by_time_aggregation && m_do_count_results_aggregation) {
-                throw std::invalid_argument(
-                        "The --count-by-time and --count options are mutually exclusive."
-                );
-            }
         }
     } catch (std::exception& e) {
         SPDLOG_ERROR("{}", e.what());
@@ -630,74 +452,180 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
     return ParsingResult::Success;
 }
 
-void CommandLineArguments::parse_network_dest_output_handler_options(
-        po::options_description const& options_description,
-        std::vector<po::option> const& options,
-        po::variables_map& parsed_options
+void CommandLineArguments::detect_disallowed_duplicate_arguments(
+        boost::program_options::variables_map const& options
 ) {
-    clp::parse_unrecognized_options(options_description, options, parsed_options);
+    std::vector<std::string> const cPotentialDuplicateArgs{"tge", "tle", "query"};
+    for (auto arg : cPotentialDuplicateArgs) {
+        if (options.count(arg)) {
+            throw std::invalid_argument(
+                    "Argument " + arg + " can not be used in conjunction with stdin-extended-args"
+            );
+        }
+    }
 
-    if (parsed_options.count("host") == 0) {
+    std::vector<std::pair<bool const&, std::string>> const cPotentialDuplicateBooleanSwitches{
+            {m_ignore_case, "ignore-case"}
+    };
+    for (auto arg : cPotentialDuplicateBooleanSwitches) {
+        if (arg.first) {
+            throw std::invalid_argument(
+                    "Argument " + arg.second
+                    + " can not be used in conjunction with stdin-extended-args"
+            );
+        }
+    }
+}
+
+void CommandLineArguments::parse_extended_search_arguments(
+        nlohmann::json const& extended_search_arguments
+) {
+    constexpr char cQueryString[] = "query_string";
+    constexpr char cMaxNumResults[] = "max_num_results";
+    constexpr char cBeginTimestamp[] = "begin_timestamp";
+    constexpr char cEndTimestamp[] = "end_timestamp";
+    constexpr char cIgnoreCase[] = "ignore_case";
+    constexpr char cNetworkAddress[] = "network_address";
+    constexpr char cMongodbDestination[] = "mongodb_destination";
+    constexpr char cAggregationConfig[] = "aggregation_config";
+
+    if (has_non_null_field(extended_search_arguments, cQueryString)) {
+        m_query = extended_search_arguments[cQueryString];
+    }
+
+    if (has_non_null_field(extended_search_arguments, cMaxNumResults)) {
+        m_max_num_results = extended_search_arguments[cMaxNumResults];
+    }
+
+    if (has_non_null_field(extended_search_arguments, cBeginTimestamp)) {
+        m_search_begin_ts = extended_search_arguments[cBeginTimestamp];
+    }
+
+    if (has_non_null_field(extended_search_arguments, cEndTimestamp)) {
+        m_search_end_ts = extended_search_arguments[cEndTimestamp];
+    }
+
+    if (has_non_null_field(extended_search_arguments, cIgnoreCase)) {
+        m_ignore_case = extended_search_arguments[cIgnoreCase];
+    }
+
+    if (has_non_null_field(extended_search_arguments, cNetworkAddress)) {
+        parse_network_dest_output_handler_options(extended_search_arguments[cNetworkAddress]);
+    }
+
+    if (has_non_null_field(extended_search_arguments, cMongodbDestination)) {
+        parse_results_cache_output_handler_options(extended_search_arguments[cMongodbDestination]);
+    }
+
+    if (has_non_null_field(extended_search_arguments, cAggregationConfig)) {
+        parse_extended_aggregation_arguments(extended_search_arguments[cAggregationConfig]);
+    }
+
+    if (OutputHandlerType::Stdout == m_output_handler_type) {
+        throw std::invalid_argument(
+                "No output handler configuration was provided in the extended search arguments"
+        );
+    }
+}
+
+void CommandLineArguments::parse_extended_aggregation_arguments(
+        nlohmann::json const& extended_aggregation_arguments
+) {
+    constexpr char cJobId[] = "job_id";
+    constexpr char cReducerHost[] = "reducer_host";
+    constexpr char cReducerPort[] = "reducer_port";
+    constexpr char cDoCountAggregation[] = "do_count_aggregation";
+    constexpr char cCountByTimeBucketSize[] = "count_by_time_bucket_size";
+
+    if (OutputHandlerType::Stdout != m_output_handler_type) {
+        throw std::invalid_argument("multiple conflicting output handlers specified.");
+    }
+    m_output_handler_type = OutputHandlerType::Reducer;
+
+    if (false == has_non_null_field(extended_aggregation_arguments, cReducerHost)) {
         throw std::invalid_argument("host must be specified.");
     }
+    m_reducer_host = extended_aggregation_arguments[cReducerHost];
+    if (m_reducer_host.empty()) {
+        throw std::invalid_argument("host cannot be an empty string.");
+    }
+
+    if (false == has_non_null_field(extended_aggregation_arguments, cReducerPort)) {
+        throw std::invalid_argument("port must be specified.");
+    }
+    m_reducer_port = extended_aggregation_arguments[cReducerPort];
+    if (m_reducer_port <= 0) {
+        throw std::invalid_argument("port must be greater than zero.");
+    }
+
+    if (false == has_non_null_field(extended_aggregation_arguments, cJobId)) {
+        throw std::invalid_argument("job-id must be specified.");
+    }
+    m_job_id = extended_aggregation_arguments[cJobId];
+    if (m_job_id < 0) {
+        throw std::invalid_argument("job-id cannot be negative.");
+    }
+
+    if (has_non_null_field(extended_aggregation_arguments, cCountByTimeBucketSize)) {
+        m_do_count_by_time_aggregation = true;
+        m_count_by_time_bucket_size = extended_aggregation_arguments[cCountByTimeBucketSize];
+        if (m_count_by_time_bucket_size <= 0) {
+            throw std::invalid_argument("Value for count-by-time must be greater than zero.");
+        }
+    }
+
+    if (has_non_null_field(extended_aggregation_arguments, cDoCountAggregation)) {
+        m_do_count_results_aggregation = true;
+    }
+
+    if (m_do_count_by_time_aggregation && m_do_count_results_aggregation) {
+        throw std::invalid_argument("The count-by-time and count options are mutually exclusive.");
+    } else if (false == m_do_count_by_time_aggregation && false == m_do_count_results_aggregation) {
+        throw std::invalid_argument(
+                "Aggregation was requested but no aggregation operation specified."
+        );
+    }
+}
+
+void CommandLineArguments::parse_network_dest_output_handler_options(nlohmann::json const& options
+) {
+    if (false == options.is_array() || 2 != options.size()) {
+        throw std::invalid_argument("invalid shape for Network output handler options.");
+    }
+    m_network_dest_host = options[0];
+    m_network_dest_port = options[1];
+
+    if (OutputHandlerType::Stdout != m_output_handler_type) {
+        throw std::invalid_argument("multiple conflicting output handlers specified.");
+    }
+    m_output_handler_type = OutputHandlerType::Network;
+
     if (m_network_dest_host.empty()) {
         throw std::invalid_argument("host cannot be an empty string.");
     }
 
-    if (parsed_options.count("port") == 0) {
-        throw std::invalid_argument("port must be specified.");
-    }
     if (m_network_dest_port <= 0) {
         throw std::invalid_argument("port must be greater than zero.");
     }
 }
 
-void CommandLineArguments::parse_reducer_output_handler_options(
-        po::options_description const& options_description,
-        std::vector<po::option> const& options,
-        po::variables_map& parsed_options
+void CommandLineArguments::parse_results_cache_output_handler_options(nlohmann::json const& options
 ) {
-    clp::parse_unrecognized_options(options_description, options, parsed_options);
+    if (false == options.is_array() || 2 != options.size()) {
+        throw std::invalid_argument("invalid shape for Results Cache output handler options.");
+    }
+    m_mongodb_uri = options[0];
+    m_mongodb_collection = options[1];
 
-    if (parsed_options.count("host") == 0) {
-        throw std::invalid_argument("host must be specified.");
+    if (OutputHandlerType::Stdout != m_output_handler_type) {
+        throw std::invalid_argument("multiple conflicting output handlers specified.");
     }
-    if (m_reducer_host.empty()) {
-        throw std::invalid_argument("host cannot be an empty string.");
-    }
+    m_output_handler_type = OutputHandlerType::ResultsCache;
 
-    if (parsed_options.count("port") == 0) {
-        throw std::invalid_argument("port must be specified.");
-    }
-    if (m_reducer_port <= 0) {
-        throw std::invalid_argument("port must be greater than zero.");
-    }
-
-    if (parsed_options.count("job-id") == 0) {
-        throw std::invalid_argument("job-id must be specified.");
-    }
-    if (m_job_id < 0) {
-        throw std::invalid_argument("job-id cannot be negative.");
-    }
-}
-
-void CommandLineArguments::parse_results_cache_output_handler_options(
-        po::options_description const& options_description,
-        std::vector<po::option> const& options,
-        po::variables_map& parsed_options
-) {
-    clp::parse_unrecognized_options(options_description, options, parsed_options);
-
-    if (parsed_options.count("uri") == 0) {
-        throw std::invalid_argument("uri must be specified.");
-    }
     if (m_mongodb_uri.empty()) {
         throw std::invalid_argument("uri cannot be an empty string.");
     }
 
-    if (parsed_options.count("collection") == 0) {
-        throw std::invalid_argument("collection must be specified.");
-    }
     if (m_mongodb_collection.empty()) {
         throw std::invalid_argument("collection cannot be an empty string.");
     }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -486,7 +486,6 @@ void CommandLineArguments::parse_extended_search_arguments(
     constexpr char cEndTimestamp[] = "end_timestamp";
     constexpr char cIgnoreCase[] = "ignore_case";
     constexpr char cOutputDestination[] = "output_destination";
-    constexpr char cMongodbDestination[] = "mongodb_destination";
     constexpr char cAggregationConfig[] = "aggregation_config";
 
     if (has_non_null_field(extended_search_arguments, cQueryString)) {

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -8,6 +8,7 @@
 #include <boost/program_options/option.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <json/single_include/nlohmann/json.hpp>
 
 #include "../clp/GlobalMetadataDBConfig.hpp"
 #include "../reducer/types.hpp"
@@ -106,41 +107,33 @@ private:
     // Methods
     /**
      * Validates output options related to the Network Destination output handler.
-     * @param options_description
-     * @param options Vector of options previously parsed by boost::program_options and which may
-     * contain options that have the unrecognized flag set
-     * @param parsed_options Returns any parsed options that were newly recognized
+     * @param options
      */
-    void parse_network_dest_output_handler_options(
-            boost::program_options::options_description const& options_description,
-            std::vector<boost::program_options::option> const& options,
-            boost::program_options::variables_map& parsed_options
-    );
-
-    /**
-     * Validates output options related to the Reducer output handler.
-     * @param options_description
-     * @param options Vector of options previously parsed by boost::program_options and which may
-     * contain options that have the unrecognized flag set
-     * @param parsed_options Returns any parsed options that were newly recognized
-     */
-    void parse_reducer_output_handler_options(
-            boost::program_options::options_description const& options_description,
-            std::vector<boost::program_options::option> const& options,
-            boost::program_options::variables_map& parsed_options
-    );
+    void parse_network_dest_output_handler_options(nlohmann::json const& options);
 
     /**
      * Validates output options related to the Results Cache output handler.
-     * @param options_description
-     * @param options Vector of options previously parsed by boost::program_options and which may
-     * contain options that have the unrecognized flag set
-     * @param parsed_options Returns any parsed options that were newly recognized
+     * @param options
      */
-    void parse_results_cache_output_handler_options(
-            boost::program_options::options_description const& options_description,
-            std::vector<boost::program_options::option> const& options,
-            boost::program_options::variables_map& parsed_options
+    void parse_results_cache_output_handler_options(nlohmann::json const& options);
+
+    /**
+     * Validates the extended arguments to search passed by the package.
+     * @param extended_search_arguments
+     */
+    void parse_extended_search_arguments(nlohmann::json const& extended_search_arguments);
+
+    /**
+     * Validates the extended arguments to search passed by the package.
+     * @param extended_search_arguments
+     */
+    void parse_extended_aggregation_arguments(nlohmann::json const& extended_aggregation_arguments);
+
+    /**
+     * Detects arguments that can not be used in conjunction with extended stdin arguments, and
+     * throws an exception if any such arguments are detected.
+     */
+    void detect_disallowed_duplicate_arguments(boost::program_options::variables_map const& options
     );
 
     void print_basic_usage() const;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -109,13 +109,19 @@ private:
      * Validates output options related to the Network Destination output handler.
      * @param options
      */
-    void parse_network_dest_output_handler_options(nlohmann::json const& options);
+    void parse_network_dest_output_handler_options(nlohmann::json const& params);
 
     /**
      * Validates output options related to the Results Cache output handler.
      * @param options
      */
-    void parse_results_cache_output_handler_options(nlohmann::json const& options);
+    void parse_results_cache_output_handler_options(nlohmann::json const& params);
+
+    /**
+     * Validates output options related to the Reducer output handler.
+     * @param options
+     */
+    void parse_reducer_output_handler_options(nlohmann::json const& params);
 
     /**
      * Validates the extended arguments to search passed by the package.
@@ -135,6 +141,8 @@ private:
      */
     void detect_disallowed_duplicate_arguments(boost::program_options::variables_map const& options
     );
+
+    void parse_output_destination_arguments(nlohmann::json const& output_destination);
 
     void print_basic_usage() const;
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -142,6 +142,9 @@ private:
     void detect_disallowed_duplicate_arguments(boost::program_options::variables_map const& options
     );
 
+    /**
+     * Validate arguments related to the output destination for this job.
+     */
     void parse_output_destination_arguments(nlohmann::json const& output_destination);
 
     void print_basic_usage() const;

--- a/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/search/fs_search_task.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict
 
+import msgpack
 from celery.app.task import Task
 from celery.utils.log import get_task_logger
 from clp_py_utils.clp_config import StorageEngine
@@ -23,14 +24,9 @@ def make_command(
     archives_dir: Path,
     archive_id: str,
     search_config: SearchConfig,
-    results_cache_uri: str,
-    results_collection: str,
 ):
     if StorageEngine.CLP == storage_engine:
         command = [str(clp_home / "bin" / "clo"), str(archives_dir / archive_id)]
-        if search_config.path_filter is not None:
-            command.append("--file-path")
-            command.append(search_config.path_filter)
     elif StorageEngine.CLP_S == storage_engine:
         command = [
             str(clp_home / "bin" / "clp-s"),
@@ -38,53 +34,10 @@ def make_command(
             str(archives_dir),
             "--archive-id",
             archive_id,
+            "--stdin-extended-args",
         ]
     else:
         raise ValueError(f"Unsupported storage engine {storage_engine}")
-
-    command.append(search_config.query_string)
-    if search_config.begin_timestamp is not None:
-        command.append("--tge")
-        command.append(str(search_config.begin_timestamp))
-    if search_config.end_timestamp is not None:
-        command.append("--tle")
-        command.append(str(search_config.end_timestamp))
-    if search_config.ignore_case:
-        command.append("--ignore-case")
-
-    if search_config.aggregation_config is not None:
-        aggregation_config = search_config.aggregation_config
-        if aggregation_config.do_count_aggregation is not None:
-            command.append("--count")
-        if aggregation_config.count_by_time_bucket_size is not None:
-            command.append("--count-by-time")
-            command.append(str(aggregation_config.count_by_time_bucket_size))
-
-        # fmt: off
-        command.extend((
-             "reducer",
-             "--host", aggregation_config.reducer_host,
-             "--port", str(aggregation_config.reducer_port),
-             "--job-id", str(aggregation_config.job_id)
-        ))
-        # fmt: on
-    elif search_config.network_address is not None:
-        # fmt: off
-        command.extend((
-            "network",
-            "--host", search_config.network_address[0],
-            "--port", str(search_config.network_address[1])
-        ))
-        # fmt: on
-    else:
-        # fmt: off
-        command.extend((
-            "results-cache",
-            "--uri", results_cache_uri,
-            "--collection", results_collection,
-            "--max-num-results", str(search_config.max_num_results)
-        ))
-        # fmt: on
 
     return command
 
@@ -95,7 +48,6 @@ def search(
     job_id: str,
     search_config_obj: dict,
     archive_id: str,
-    results_cache_uri: str,
 ) -> Dict[str, Any]:
     task_id = str(self.request.id)
     clp_home = Path(os.getenv("CLP_HOME"))
@@ -122,8 +74,6 @@ def search(
             archives_dir=archive_directory,
             archive_id=archive_id,
             search_config=search_config,
-            results_cache_uri=results_cache_uri,
-            results_collection=job_id,
         )
     except ValueError as e:
         logger.error(f"Error creating search command: {e}")
@@ -138,9 +88,14 @@ def search(
         search_command,
         preexec_fn=os.setpgrp,
         close_fds=True,
+        stdin=subprocess.PIPE,
         stdout=clo_log_file,
         stderr=clo_log_file,
     )
+
+    # TODO: do this differently
+    search_proc.stdin.write(msgpack.packb(search_config.dict()))
+    search_proc.stdin.close()
 
     def sigterm_handler(_signo, _stack_frame):
         logger.debug("Entered sigterm handler")

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -39,6 +39,11 @@ class AggregationConfig(BaseModel):
     count_by_time_bucket_size: typing.Optional[int] = None  # Milliseconds
 
 
+class OutputDestination(BaseModel):
+    type: typing.Literal["network", "mongodb", "reducer"]
+    params: typing.List[typing.Any]
+
+
 class SearchConfig(BaseModel):
     query_string: str
     max_num_results: int
@@ -47,15 +52,5 @@ class SearchConfig(BaseModel):
     end_timestamp: typing.Optional[int] = None
     ignore_case: bool = False
     path_filter: typing.Optional[str] = None
-    # Tuple of (host, port)
-    network_address: typing.Optional[typing.Tuple[str, int]] = None
-    # Tuple of (mongodb uri, mongodb collection)
-    mongodb_destination: typing.Optional[typing.Tuple[str, str]] = None
+    output_destination: typing.Optional[OutputDestination] = None
     aggregation_config: typing.Optional[AggregationConfig] = None
-
-    @validator("network_address")
-    def validate_network_address(cls, field):
-        if field is not None and (field[1] < 1 or field[1] > 65535):
-            raise ValueError("Port must be in the range [1, 65535]")
-
-        return field

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -49,6 +49,8 @@ class SearchConfig(BaseModel):
     path_filter: typing.Optional[str] = None
     # Tuple of (host, port)
     network_address: typing.Optional[typing.Tuple[str, int]] = None
+    # Tuple of (mongodb uri, mongodb collection)
+    mongodb_destination: typing.Optional[typing.Tuple[str, str]] = None
     aggregation_config: typing.Optional[AggregationConfig] = None
 
     @validator("network_address")


### PR DESCRIPTION
# Description
This PR modifies clp-s and clo to pass most search arguments via a msgpack object written to stdin instead of via command line arguments. This allows the `fs_search_task` python wrapper to be less smart, and makes it easier to change the arguments passed to our search processes -- now we just need to modify the `SearchConfig` object in `job_config.py` and make clo/clp-s use the new fields directly.

The diff is somewhat large, but mostly consists of simple changes to the `CommandLineArguments` classes of clp-s and clo to take config from a msgpack object instead of from command line arguments.

We also change the search scheduler  to make it augment the `SearchConfig` object with a mongodb output destination when no other output destination is specified. Having the mongodb output destination configured explicitly before the search job gets passed downstream allows downstream components to be less smart, and adding the mongodb output destination needs to happen inside the scheduler to follow our current convention that the job id is the result collection name.

# Validation performed
* Validated that search and aggregation jobs work correctly with clp engine
* Validated that search and aggregation jobs work correctly with clp-s engine

