### PR TITLE
clo: Add orig_file_id and log_event_ix to search results.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -160,9 +160,9 @@ async def worker_connection_handler(reader: asyncio.StreamReader, writer: asynci
                 return
             unpacker.feed(buf)
 
-            # Print out any messages we can decode
+            # Print out any messages we can decode in the form of ORIG_PATH: MSG
             for unpacked in unpacker:
-                print(f"{unpacked[0]}: {unpacked[2]}", end="")
+                print(f"{unpacked[2]}: {unpacked[1]}", end="")
     except asyncio.CancelledError:
         return
     finally:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -162,7 +162,7 @@ async def worker_connection_handler(reader: asyncio.StreamReader, writer: asynci
 
             # Print out any messages we can decode
             for unpacked in unpacker:
-                print(f"{unpacked[0]}: {unpacked[4]}", end="")
+                print(f"{unpacked[0]}: {unpacked[2]}", end="")
     except asyncio.CancelledError:
         return
     finally:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -162,7 +162,7 @@ async def worker_connection_handler(reader: asyncio.StreamReader, writer: asynci
 
             # Print out any messages we can decode
             for unpacked in unpacker:
-                print(f"{unpacked[0]}: {unpacked[2]}", end="")
+                print(f"{unpacked[0]}: {unpacked[4]}", end="")
     except asyncio.CancelledError:
         return
     finally:

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -30,7 +30,7 @@ ErrorCode NetworkOutputHandler::add_result(
         Message const& encoded_message,
         string_view decompressed_message
 ) {
-    msgpack::type::tuple<string, epochtime_t, string, string, size_t> src(
+    msgpack::type::tuple<string, epochtime_t, string, string, uint64_t> src(
             orig_file_path,
             encoded_message.get_ts_in_milli(),
             decompressed_message,

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -1,8 +1,8 @@
 #include "OutputHandler.hpp"
 
 #include <memory>
+#include <string>
 #include <string_view>
-#include <vector>
 
 #include <msgpack.hpp>
 #include <spdlog/spdlog.h>
@@ -73,8 +73,8 @@ ErrorCode ResultsCacheOutputHandler::add_result(
                 orig_file_path,
                 orig_file_id,
                 log_event_ix,
-                decompressed_message,
-                timestamp
+                timestamp,
+                decompressed_message
         ));
     } else if (m_latest_results.top()->timestamp < timestamp) {
         m_latest_results.pop();
@@ -82,8 +82,8 @@ ErrorCode ResultsCacheOutputHandler::add_result(
                 orig_file_path,
                 orig_file_id,
                 log_event_ix,
-                decompressed_message,
-                timestamp
+                timestamp,
+                decompressed_message
         ));
     }
 
@@ -104,8 +104,8 @@ ErrorCode ResultsCacheOutputHandler::flush() {
                     ),
                     bsoncxx::builder::basic::kvp("orig_file_id", std::move(result.orig_file_id)),
                     bsoncxx::builder::basic::kvp("log_event_ix", result.log_event_ix),
-                    bsoncxx::builder::basic::kvp("message", std::move(result.decompressed_message)),
-                    bsoncxx::builder::basic::kvp("timestamp", result.timestamp)
+                    bsoncxx::builder::basic::kvp("timestamp", result.timestamp),
+                    bsoncxx::builder::basic::kvp("message", std::move(result.decompressed_message))
             )));
             count++;
 

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -30,10 +30,10 @@ ErrorCode NetworkOutputHandler::add_result(
         Message const& encoded_message,
         string_view decompressed_message
 ) {
-    msgpack::type::tuple<string, epochtime_t, string, string, uint64_t> src(
-            orig_file_path,
+    msgpack::type::tuple<epochtime_t, string, string, string, uint64_t> src(
             encoded_message.get_ts_in_milli(),
             decompressed_message,
+            orig_file_path,
             orig_file_id,
             encoded_message.get_log_event_ix()
     );

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -30,12 +30,12 @@ ErrorCode NetworkOutputHandler::add_result(
         Message const& encoded_message,
         string_view decompressed_message
 ) {
-    msgpack::type::tuple<string, string, size_t, epochtime_t, string> src(
+    msgpack::type::tuple<string, epochtime_t, string, string, size_t> src(
             orig_file_path,
-            orig_file_id,
-            encoded_message.get_log_event_ix(),
             encoded_message.get_ts_in_milli(),
-            decompressed_message
+            decompressed_message,
+            orig_file_id,
+            encoded_message.get_log_event_ix()
     );
     msgpack::sbuffer m;
     msgpack::pack(m, src);

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -35,6 +35,7 @@ public:
      * @param encoded_message The encoded result.
      * @param decompressed_message The decompressed result.
      * @return ErrorCode_Success if the result was added successfully, or an error code if specified
+     * by the derived class.
      */
     virtual ErrorCode add_result(
             std::string_view orig_file_path,

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -5,6 +5,7 @@
 
 #include <queue>
 #include <string>
+#include <string_view>
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
@@ -29,14 +30,14 @@ public:
     // Methods
     /**
      * Adds a query result to a batch or sends it to the destination.
-     * @param original_path The original path of the file input log event belongs to.
-     * @param original_path The original id of the file input log event belongs to.
-     * @param encoded_message The encoded log event
-     * @param decompressed_message The content of the log event.
+     * @param orig_file_path original path of the file that input log event belongs to
+     * @param orig_file_id original id of the file that input log event belongs to
+     * @param encoded_message encoded log event
+     * @param decompressed_message decompressed log event
      * @return ErrorCode_Success if the result was added successfully, an error code otherwise.
      */
     virtual ErrorCode add_result(
-            std::string_view original_path,
+            std::string_view orig_file_path,
             std::string_view orig_file_id,
             streaming_archive::reader::Message const& encoded_message,
             std::string_view decompressed_message
@@ -87,13 +88,14 @@ public:
     // Methods inherited from Client
     /**
      * Sends a result to the network destination.
-     * @param original_path The original path of the file input log event belongs to.
-     * @param original_path The original id of the file input log event belongs to.
-     * @param encoded_message The encoded log event
-     * @param message The content of the log event.
+     * @param orig_file_path original path of the file that input log event belongs to
+     * @param orig_file_id original id of the file that input log event belongs to
+     * @param encoded_message encoded log event
+     * @param decompressed_message decompressed log event
+     * @return Same as networking::try_send
      */
     ErrorCode add_result(
-            std::string_view original_path,
+            std::string_view orig_file_path,
             std::string_view orig_file_id,
             streaming_archive::reader::Message const& encoded_message,
             std::string_view decompressed_message
@@ -124,20 +126,20 @@ public:
                 std::string_view orig_file_path,
                 std::string_view orig_file_id,
                 size_t log_event_ix,
-                std::string_view decompressed_message,
-                epochtime_t timestamp
+                epochtime_t timestamp,
+                std::string_view decompressed_message
         )
                 : orig_file_path(orig_file_path),
                   orig_file_id(orig_file_id),
                   log_event_ix(log_event_ix),
-                  decompressed_message(decompressed_message),
-                  timestamp(timestamp) {}
+                  timestamp(timestamp),
+                  decompressed_message(decompressed_message) {}
 
         std::string orig_file_path;
         std::string orig_file_id;
         int64_t log_event_ix;
-        std::string decompressed_message;
         epochtime_t timestamp;
+        std::string decompressed_message;
     };
 
     struct QueryResultGreaterTimestampComparator {
@@ -172,14 +174,14 @@ public:
     // Methods inherited from OutputHandler
     /**
      * Adds a result to the batch.
-     * @param original_path The original path of the file input log event belongs to.
-     * @param original_path The original id of the file input log event belongs to.
-     * @param encoded_message The encoded log event
-     * @param message The content of the log event.
-     * @return
+     * @param orig_file_path original path of the file that input log event belongs to
+     * @param orig_file_id original id of the file that input log event belongs to
+     * @param encoded_message encoded log event
+     * @param decompressed_message decompressed log event
+     * @return ErrorCode_Success
      */
     ErrorCode add_result(
-            std::string_view original_path,
+            std::string_view orig_file_path,
             std::string_view orig_file_id,
             streaming_archive::reader::Message const& encoded_message,
             std::string_view decompressed_message
@@ -234,16 +236,8 @@ public:
     explicit CountOutputHandler(int reducer_socket_fd);
 
     // Methods inherited from OutputHandler
-    /**
-     * Adds a result.
-     * @param original_path The original path of the file input log event belongs to.
-     * @param original_path The original id of the file input log event belongs to.
-     * @param encoded_message The encoded log event
-     * @param message The content of the log event.
-     * @return Errorcode
-     */
     ErrorCode add_result(
-            std::string_view original_path,
+            std::string_view orig_file_path,
             std::string_view orig_file_id,
             streaming_archive::reader::Message const& encoded_message,
             std::string_view decompressed_message
@@ -274,7 +268,7 @@ public:
 
     // Methods inherited from OutputHandler
     ErrorCode add_result(
-            std::string_view original_path,
+            std::string_view orig_file_path,
             std::string_view orig_file_id,
             streaming_archive::reader::Message const& encoded_message,
             std::string_view decompressed_message

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -30,11 +30,11 @@ public:
     // Methods
     /**
      * Adds a query result to a batch or sends it to the destination.
-     * @param orig_file_path original path of the file that input log event belongs to
-     * @param orig_file_id original id of the file that input log event belongs to
-     * @param encoded_message encoded log event
-     * @param decompressed_message decompressed log event
-     * @return ErrorCode_Success if the result was added successfully, an error code otherwise.
+     * @param orig_file_path Path of the original file that contains the result.
+     * @param orig_file_id ID of the original file that contains the result.
+     * @param encoded_message The encoded result.
+     * @param decompressed_message The decompressed result.
+     * @return ErrorCode_Success if the result was added successfully, or an error code if specified
      */
     virtual ErrorCode add_result(
             std::string_view orig_file_path,
@@ -88,10 +88,10 @@ public:
     // Methods inherited from Client
     /**
      * Sends a result to the network destination.
-     * @param orig_file_path original path of the file that input log event belongs to
-     * @param orig_file_id original id of the file that input log event belongs to
-     * @param encoded_message encoded log event
-     * @param decompressed_message decompressed log event
+     * @param orig_file_path Path of the original file that contains the result.
+     * @param orig_file_id ID of the original file that contains the result.
+     * @param encoded_message The encoded result.
+     * @param decompressed_message The decompressed result.
      * @return Same as networking::try_send
      */
     ErrorCode add_result(
@@ -172,14 +172,6 @@ public:
     );
 
     // Methods inherited from OutputHandler
-    /**
-     * Adds a result to the batch.
-     * @param orig_file_path original path of the file that input log event belongs to
-     * @param orig_file_id original id of the file that input log event belongs to
-     * @param encoded_message encoded log event
-     * @param decompressed_message decompressed log event
-     * @return ErrorCode_Success
-     */
     ErrorCode add_result(
             std::string_view orig_file_path,
             std::string_view orig_file_id,

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -126,8 +126,9 @@ static SearchFilesResult search_file(
         if (ErrorCode_Success
             != output_handler->add_result(
                     compressed_file.get_orig_path(),
-                    decompressed_message,
-                    compressed_message.get_ts_in_milli()
+                    compressed_file.get_orig_file_id_as_string(),
+                    compressed_message,
+                    decompressed_message
             ))
         {
             result = SearchFilesResult::ResultSendFailure;

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -98,7 +98,7 @@ static SearchFilesResult search_file(
         std::unique_ptr<OutputHandler>& output_handler
 ) {
     File compressed_file;
-    Message compressed_message;
+    Message encoded_message;
     string decompressed_message;
 
     ErrorCode error_code = archive.open_file(compressed_file, file_metadata_ix);
@@ -119,7 +119,7 @@ static SearchFilesResult search_file(
             query,
             archive,
             compressed_file,
-            compressed_message,
+            encoded_message,
             decompressed_message
     ))
     {
@@ -127,7 +127,7 @@ static SearchFilesResult search_file(
             != output_handler->add_result(
                     compressed_file.get_orig_path(),
                     compressed_file.get_orig_file_id_as_string(),
-                    compressed_message,
+                    encoded_message,
                     decompressed_message
             ))
         {

--- a/components/core/src/clp/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.cpp
@@ -175,7 +175,7 @@ bool Archive::decompress_message(
     // Determine which timestamp pattern to use
     auto const& timestamp_patterns = file.get_timestamp_patterns();
     if (!timestamp_patterns.empty()
-        && compressed_msg.get_ix_in_split()
+        && compressed_msg.get_ix_in_file_split()
                    >= timestamp_patterns[file.get_current_ts_pattern_ix()].first)
     {
         while (true) {
@@ -185,7 +185,7 @@ bool Archive::decompress_message(
             }
             auto next_patt_start_message_num
                     = timestamp_patterns[file.get_current_ts_pattern_ix() + 1].first;
-            if (compressed_msg.get_ix_in_split() < next_patt_start_message_num) {
+            if (compressed_msg.get_ix_in_file_split() < next_patt_start_message_num) {
                 // Not yet time for next timestamp pattern
                 break;
             }

--- a/components/core/src/clp/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.cpp
@@ -191,7 +191,7 @@ bool Archive::decompress_message(
     // Determine which timestamp pattern to use
     auto const& timestamp_patterns = file.get_timestamp_patterns();
     if (!timestamp_patterns.empty()
-        && compressed_msg.get_message_number()
+        && compressed_msg.get_ix_in_split()
                    >= timestamp_patterns[file.get_current_ts_pattern_ix()].first)
     {
         while (true) {
@@ -201,7 +201,7 @@ bool Archive::decompress_message(
             }
             auto next_patt_start_message_num
                     = timestamp_patterns[file.get_current_ts_pattern_ix() + 1].first;
-            if (compressed_msg.get_message_number() < next_patt_start_message_num) {
+            if (compressed_msg.get_ix_in_split() < next_patt_start_message_num) {
                 // Not yet time for next timestamp pattern
                 break;
             }

--- a/components/core/src/clp/streaming_archive/reader/File.cpp
+++ b/components/core/src/clp/streaming_archive/reader/File.cpp
@@ -236,7 +236,7 @@ bool File::find_message_in_time_range(
             // Set remaining message properties
             msg.set_logtype_id(logtype_id);
             msg.set_timestamp(timestamp);
-            msg.set_message_number(m_msgs_ix);
+            msg.set_msg_ix(m_begin_message_ix, m_msgs_ix);
 
             found_msg = true;
         }
@@ -283,8 +283,7 @@ SubQuery const* File::find_message_matching_query(Query const& query, Message& m
                         // Message matches completely, so set remaining properties
                         msg.set_logtype_id(logtype_id);
                         msg.set_timestamp(timestamp);
-                        msg.set_message_number(m_msgs_ix);
-
+                        msg.set_msg_ix(m_begin_message_ix, m_msgs_ix);
                         matching_sub_query = sub_query;
                         break;
                     }
@@ -306,7 +305,7 @@ bool File::get_next_message(Message& msg) {
     }
 
     // Get message number
-    msg.set_message_number(m_msgs_ix);
+    msg.set_msg_ix(m_begin_message_ix, m_msgs_ix);
 
     // Get timestamp
     msg.set_timestamp(m_timestamps[m_msgs_ix]);

--- a/components/core/src/clp/streaming_archive/reader/Message.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.cpp
@@ -1,8 +1,12 @@
 #include "Message.hpp"
 
 namespace clp::streaming_archive::reader {
-size_t Message::get_message_number() const {
-    return m_message_number;
+auto Message::get_log_event_ix() const -> size_t {
+    return m_log_event_ix;
+}
+
+auto Message::get_ix_in_split() const -> size_t {
+    return m_ix_in_split;
 }
 
 logtype_dictionary_id_t Message::get_logtype_id() const {
@@ -17,8 +21,9 @@ epochtime_t Message::get_ts_in_milli() const {
     return m_timestamp;
 }
 
-void Message::set_message_number(uint64_t message_number) {
-    m_message_number = message_number;
+auto Message::set_msg_ix(uint64_t split_begin_msg_ix, uint64_t msg_ix_in_split) -> void {
+    m_ix_in_split = msg_ix_in_split;
+    m_log_event_ix = msg_ix_in_split + split_begin_msg_ix;
 }
 
 void Message::set_logtype_id(logtype_dictionary_id_t logtype_id) {

--- a/components/core/src/clp/streaming_archive/reader/Message.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.cpp
@@ -6,7 +6,7 @@ auto Message::get_log_event_ix() const -> size_t {
 }
 
 auto Message::get_ix_in_split() const -> size_t {
-    return m_ix_in_split;
+    return m_ix_in_file_split;
 }
 
 logtype_dictionary_id_t Message::get_logtype_id() const {
@@ -21,9 +21,9 @@ epochtime_t Message::get_ts_in_milli() const {
     return m_timestamp;
 }
 
-auto Message::set_msg_ix(uint64_t split_begin_msg_ix, uint64_t msg_ix_in_split) -> void {
-    m_ix_in_split = msg_ix_in_split;
-    m_log_event_ix = msg_ix_in_split + split_begin_msg_ix;
+auto Message::set_msg_ix(uint64_t file_split_begin_msg_ix, uint64_t msg_ix_in_file_split) -> void {
+    m_ix_in_file_split = msg_ix_in_file_split;
+    m_log_event_ix = m_ix_in_file_split + file_split_begin_msg_ix;
 }
 
 void Message::set_logtype_id(logtype_dictionary_id_t logtype_id) {

--- a/components/core/src/clp/streaming_archive/reader/Message.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.cpp
@@ -5,7 +5,7 @@ auto Message::get_log_event_ix() const -> size_t {
     return m_log_event_ix;
 }
 
-auto Message::get_ix_in_split() const -> size_t {
+auto Message::get_ix_in_file_split() const -> size_t {
     return m_ix_in_file_split;
 }
 

--- a/components/core/src/clp/streaming_archive/reader/Message.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.hpp
@@ -10,12 +10,13 @@ namespace clp::streaming_archive::reader {
 class Message {
 public:
     // Methods
-    size_t get_message_number() const;
+    auto get_log_event_ix() const -> size_t;
+    auto get_ix_in_split() const -> size_t;
     logtype_dictionary_id_t get_logtype_id() const;
     std::vector<encoded_variable_t> const& get_vars() const;
     epochtime_t get_ts_in_milli() const;
 
-    void set_message_number(uint64_t message_number);
+    auto set_msg_ix(uint64_t split_begin_msg_ix, uint64_t msg_ix_in_split) -> void;
     void set_logtype_id(logtype_dictionary_id_t logtype_id);
     void add_var(encoded_variable_t var);
     void set_timestamp(epochtime_t timestamp);
@@ -26,7 +27,8 @@ private:
     friend class Archive;
 
     // Variables
-    size_t m_message_number;
+    size_t m_ix_in_split;
+    size_t m_log_event_ix;
     logtype_dictionary_id_t m_logtype_id;
     std::vector<encoded_variable_t> m_vars;
     epochtime_t m_timestamp;

--- a/components/core/src/clp/streaming_archive/reader/Message.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.hpp
@@ -11,7 +11,7 @@ class Message {
 public:
     // Methods
     auto get_log_event_ix() const -> size_t;
-    auto get_ix_in_split() const -> size_t;
+    auto get_ix_in_file_split() const -> size_t;
     logtype_dictionary_id_t get_logtype_id() const;
     std::vector<encoded_variable_t> const& get_vars() const;
     epochtime_t get_ts_in_milli() const;

--- a/components/core/src/clp/streaming_archive/reader/Message.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Message.hpp
@@ -16,7 +16,7 @@ public:
     std::vector<encoded_variable_t> const& get_vars() const;
     epochtime_t get_ts_in_milli() const;
 
-    auto set_msg_ix(uint64_t split_begin_msg_ix, uint64_t msg_ix_in_split) -> void;
+    auto set_msg_ix(uint64_t file_split_begin_msg_ix, uint64_t msg_ix_in_file_split) -> void;
     void set_logtype_id(logtype_dictionary_id_t logtype_id);
     void add_var(encoded_variable_t var);
     void set_timestamp(epochtime_t timestamp);
@@ -27,8 +27,8 @@ private:
     friend class Archive;
 
     // Variables
-    size_t m_ix_in_split;
     size_t m_log_event_ix;
+    size_t m_ix_in_file_split;
     logtype_dictionary_id_t m_logtype_id;
     std::vector<encoded_variable_t> m_vars;
     epochtime_t m_timestamp;

--- a/components/core/src/clp_s/search/OutputHandler.cpp
+++ b/components/core/src/clp_s/search/OutputHandler.cpp
@@ -24,7 +24,7 @@ NetworkOutputHandler::NetworkOutputHandler(
 }
 
 void NetworkOutputHandler::write(std::string const& message, epochtime_t timestamp) {
-    msgpack::type::tuple<std::string, epochtime_t, std::string> src("", timestamp, message);
+    msgpack::type::tuple<epochtime_t, std::string, std::string> src(timestamp, message, "");
     msgpack::sbuffer m;
     msgpack::pack(m, src);
 
@@ -34,7 +34,7 @@ void NetworkOutputHandler::write(std::string const& message, epochtime_t timesta
 }
 
 void NetworkOutputHandler::write(std::string const& message) {
-    msgpack::type::tuple<std::string, epochtime_t, std::string> src("", 0, message);
+    msgpack::type::tuple<epochtime_t, std::string, std::string> src(0, message, "");
     msgpack::sbuffer m;
     msgpack::pack(m, src);
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
Current CLP's search results contain the original message, timestamp and original file path. However, the original file path is not sufficient to identify the file if multiple file shares the same path (if they are from different file system, or they are both rotated log with the same file name).

In this PR, we add file's original id and the log event index to every search result, which allows us to locate the specific file split that contains the matching result.

The change can be viewed as two smaller change:

1. We add a new member variable "log_event_ix" in the Message.hpp that tracks the index in the original file. The original "message_number" is renamed to "ix_in_split" to improve clarity.
2. We updated the add_results methods in the output handler  to add log_event_ix and original_file_id to the search results output by clo executable.

Note that the new fields are not used in the code yet.

# Validation performed
Built the package and compress a log file locally, Verified that
1. The results can be returned as normal by running search.sh
2. There's no issue when performing a search from webui.
3. Verifiy that extra fields are properly inserted into the results cache

