### PR TITLE
clp-package: Fix several search job cancellation issues

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -163,8 +163,8 @@ async def handle_cancelling_search_jobs(db_conn_pool) -> None:
     with contextlib.closing(db_conn_pool.connect()) as db_conn:
         cancelling_jobs = fetch_cancelling_search_jobs(db_conn)
 
-        for job in cancelling_jobs:
-            job_id = job["job_id"]
+        for cancelling_job in cancelling_jobs:
+            job_id = str(cancelling_job["job_id"])
             if job_id in active_jobs:
                 job = active_jobs.pop(job_id)
                 cancel_job_except_reducer(job)
@@ -459,7 +459,7 @@ async def check_job_status_and_update_db(db_conn_pool, results_cache_uri):
                     error_msg = f"Unexpected msg_type: {msg.msg_type.name}"
                     raise NotImplementedError(error_msg)
 
-            if set_job_status(db_conn, job_id, new_job_status, SearchJobStatus.RUNNING):
+            if set_job_status(db_conn, job_id, new_job_status):
                 if new_job_status == SearchJobStatus.SUCCEEDED:
                     logger.info(f"Completed job {job_id}.")
                 elif reducer_failed:

--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -459,6 +459,8 @@ async def check_job_status_and_update_db(db_conn_pool, results_cache_uri):
                     error_msg = f"Unexpected msg_type: {msg.msg_type.name}"
                     raise NotImplementedError(error_msg)
 
+            # We set the status regardless of the job's previous status to handle the case where the
+            # job is cancelled (status = CANCELLING) while we're in this method.
             if set_job_status(db_conn, job_id, new_job_status):
                 if new_job_status == SearchJobStatus.SUCCEEDED:
                     logger.info(f"Completed job {job_id}.")

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -90,8 +90,8 @@ class SearchJobsDbManager {
         await this.#sqlDbConnPool.query(
             `UPDATE ${this.#searchJobsTableName}
              SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${SEARCH_JOB_STATUS.CANCELLING}
-             WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ? 
-             AND ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} 
+             WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?
+             AND ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS}
              IN (${SEARCH_JOB_STATUS.PENDING}, ${SEARCH_JOB_STATUS.RUNNING})`,
             jobId,
         );

--- a/components/webui/imports/api/search/server/SearchJobsDbManager.js
+++ b/components/webui/imports/api/search/server/SearchJobsDbManager.js
@@ -90,7 +90,9 @@ class SearchJobsDbManager {
         await this.#sqlDbConnPool.query(
             `UPDATE ${this.#searchJobsTableName}
              SET ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} = ${SEARCH_JOB_STATUS.CANCELLING}
-             WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ?`,
+             WHERE ${SEARCH_JOBS_TABLE_COLUMN_NAMES.ID} = ? 
+             AND ${SEARCH_JOBS_TABLE_COLUMN_NAMES.STATUS} 
+             IN (${SEARCH_JOB_STATUS.PENDING}, ${SEARCH_JOB_STATUS.RUNNING})`,
             jobId,
         );
     }


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR addresses several cancellation issues:
+ Previously, when all search tasks completed, sending a cancellation request changed the status to `CANCELLING`. Since the job was already removed from active_jobs, it remained in an intermediate state. This PR ensures that a cancellation request is only sent if the job status is `PENDING` or `RUNNING`. Besides, for completed jobs in `RUNNING` status, even if the cancellation request was sent, the job status is updated to either `SUCCEEDED` or `FAILED` based on the actual completion.
+ The wrong type was passed when handling job cancellation, so that the code never reached cancel_job_except_reducer. This PR fixes this issue.

# Validation performed
<!-- What tests and validation you performed on the change -->
+ Started the package and compressed the [hive-24hrs](https://zenodo.org/records/7094921#.Y5JbH33MKHs) dataset. 
+ In the command line, executed `sbin/search.sh "org.apache.hadoop.metrics2.impl.MetricsConfig: loaded properties from hadoop-metrics2.properties"` and checked `search_jobs` table in the database. 
+ Ran the same query, and cancelled it before it finished. Checked `search_jobs` table in the database. 

