### PR TITLE
docs: Add instructions for using clp-s' array structurization feature.

### DIFF
--- a/docs/src/user-guide/core-clp-s.md
+++ b/docs/src/user-guide/core-clp-s.md
@@ -14,7 +14,8 @@ Usage:
 * `archives-dir` is the directory that archives should be written to.
 * `input-path` is any new-line-delimited JSON (ndjson) log file or directory containing such files.
 * `options` allow you to specify things like which field should be considered as the log event's
-  timestamp (`--timestamp-key <field-path>`).
+  timestamp (`--timestamp-key <field-path>`), or whether to fully parse array entries and encode 
+  them into dedicated columns (`--structurize-arrays`).
   * For a complete list, run `./clp-s c --help`
 
 ### Examples

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -139,10 +139,10 @@ parent1: {parent2: {child: value}}
 ```
 
 :::{caution}
-CLP does not currently support queries for array kv-pairs where only part of the key is known with
-its default configuration. In other words, the key must either be a wildcard (`*`) or it must
-contain no wildcards. Archives compressed using the `--structurize-arrays` flag do not have this
-limitation.
+By default, CLP does not support queries for array kv-pairs where only part of the key is known. In
+other words, the key must either be a wildcard (`*`) or it must contain no wildcards.
+
+Archives compressed using the `--structurize-arrays` flag *do not* have this limitation.
 :::
 
 ### Complex queries

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -139,8 +139,10 @@ parent1: {parent2: {child: value}}
 ```
 
 :::{caution}
-CLP does not currently support queries for array kv-pairs where only part of the key is known. In
-other words, the key must either be a wildcard (`*`) or it must contain no wildcards.
+CLP does not currently support queries for array kv-pairs where only part of the key is known with
+its default configuration. In other words, the key must either be a wildcard (`*`) or it must
+contain no wildcards. Archives compressed using the `--structurize-arrays` flag do not have this
+limitation.
 :::
 
 ### Complex queries


### PR DESCRIPTION
# Description
This is a small docs update to record the existence of the array structurization feature. 

This feature must be turned on by ingesting data using the `--structurize-arrays` flag. It can lead to higher compression ratio some of the time by avoiding dictionary pollution (and should lead to higher compression ratio most of the time after some changes to table packing). On the search side it allows users to search for structures inside of arrays using keys containing wildcards (since the array structure is recorded in the MPT), and will typically make searches inside of arrays much faster.

