### PR TITLE
clp-package: Add Python __future__.annotations import to allow running with Python 3.8.

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/search/search_scheduler.py
@@ -13,6 +13,8 @@ cleared from the cache. Unfortunately, these effects will require manual interve
 TODO Address this limitation.
 """
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import contextlib


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

#416 used syntax that isn't supported by Python 3.8 without the `__future__.annotations` import. The effect of this is that the search scheduler can't run with Python 3.8 (and all searches will seemingly freeze).

This PR adds the import.

# Validation performed
<!-- What tests and validation you performed on the change -->

* Built and started the package in an Ubuntu Focal container
* Compressed some data
* Used `sbin/search.sh` to run a query and ensured that it didn't freeze.
