### PR TITLE
core-clp: Update archive format version due to previous format change in #412.

### DIFF
--- a/components/core/src/clp/streaming_archive/Constants.hpp
+++ b/components/core/src/clp/streaming_archive/Constants.hpp
@@ -4,7 +4,7 @@
 #include "../Defs.h"
 
 namespace clp::streaming_archive {
-constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevVersionFlag | 8;
+constexpr archive_format_version_t cArchiveFormatVersion = cArchiveFormatDevVersionFlag | 9;
 constexpr char cSegmentsDirname[] = "s";
 constexpr char cSegmentListFilename[] = "segment_list.txt";
 constexpr char cLogTypeDictFilename[] = "logtype.dict";


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

#412 added a new field to the archive-local metadata DB, but we forgot to update the archive format version. Ordinarily, changing the format without changing the format version could lead to undefined behaviour when opening an archive created with an old version of clp with the latest version of clp; but luckily, this particular change errors-out due to the missing database column.

This PR updates the version.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that opening an archive created with an old version of clp (before b50e140) with the latest version of clp continues to fail.
