### PR TITLE
gh-actions: Update to latest versions of all actions.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -32,7 +32,7 @@ jobs:
   build-macos:
     runs-on: "macos-12"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -35,7 +35,7 @@ jobs:
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
       clp_changed: "${{steps.filter.outputs.clp}}"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -44,7 +44,7 @@ jobs:
         shell: "bash"
 
       - name: "Filter relevant changes"
-        uses: "dorny/paths-filter@v2"
+        uses: "dorny/paths-filter@v3"
         id: "filter"
         with:
           # Consider changes between the current commit and `main`
@@ -91,7 +91,7 @@ jobs:
     needs: "filter-relevant-changes"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -116,7 +116,7 @@ jobs:
     needs: "filter-relevant-changes"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -141,7 +141,7 @@ jobs:
     needs: "filter-relevant-changes"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -171,7 +171,7 @@ jobs:
       - "filter-relevant-changes"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -199,7 +199,7 @@ jobs:
       - "ubuntu-focal-deps-image"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -228,7 +228,7 @@ jobs:
       - "ubuntu-jammy-deps-image"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -261,7 +261,7 @@ jobs:
       OS_NAME: "ubuntu-focal"
       TMP_OUTPUT_DIR: "/tmp"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -25,7 +25,7 @@ jobs:
       ubuntu_focal_image_changed: "${{steps.filter.outputs.ubuntu_focal_image}}"
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -34,7 +34,7 @@ jobs:
         shell: "bash"
 
       - name: "Filter relevant changes"
-        uses: "dorny/paths-filter@v2"
+        uses: "dorny/paths-filter@v3"
         id: "filter"
         with:
           base: "main"
@@ -53,7 +53,7 @@ jobs:
     needs: "filter-relevant-changes"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 
@@ -74,7 +74,7 @@ jobs:
     needs: "filter-relevant-changes"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -20,7 +20,7 @@ jobs:
         os: ["macos-latest", "ubuntu-latest"]
     runs-on: "${{matrix.os}}"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           submodules: "recursive"
 


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

We're using deprecated versions of [actions/checkout](https://github.com/actions/checkout) and [dorny/paths-filter](https://github.com/dorny/paths-filter). This PR updates them to the latest versions. The release notes don't mention any breaking changes, so this should be safe.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated all workflow jobs succeeded with the exception of [ubuntu-focal-binaries-image](https://github.com/y-scope/clp/blob/main/.github/workflows/clp-core-build.yaml#L249) which requires publishing a container image. The changes to this job mirror the others, so it should succeed when necessary.