### PR TITLE
pr-template: Remove unnecessary references section and add instructions for the PR title.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,14 @@
-# References
-<!-- Any issues or pull requests relevant to this pull request -->
+<!--
+Set the PR title to a meaningful commit message in imperative form. E.g.:
+
+clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
+-->
 
 # Description
-<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
+<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
+
+
 
 # Validation performed
-<!-- What tests and validation you performed on the change -->
+<!-- Describe what tests and validation you performed on the change. -->
 


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The references section of the PR template is rarely used and rarely necessary since GitHub often highlights references in the PR description.

This PR removes the section. This PR also adds some instructions about setting the PR title. More elaborate instructions will be in our contribution guidelines.

# Validation performed
<!-- What tests and validation you performed on the change -->

Rendered the markdown and verified the comments weren't displayed.