### PR TITLE
clp-s: Add support for decompression in ascending timestamp order.

### DIFF
--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -92,7 +92,7 @@ SchemaReader& ArchiveReader::read_table(
         throw OperationFailed(ErrorCodeFileNotFound, __FILENAME__, __LINE__);
     }
 
-    create_schema_reader(
+    initialize_schema_reader(
             m_schema_reader,
             schema_id,
             should_extract_timestamp,
@@ -109,14 +109,14 @@ SchemaReader& ArchiveReader::read_table(
     return m_schema_reader;
 }
 
-std::vector<std::shared_ptr<SchemaReader>> ArchiveReader::load_all_tables() {
+std::vector<std::shared_ptr<SchemaReader>> ArchiveReader::read_all_tables() {
     constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;  // 64 KB
 
     std::vector<std::shared_ptr<SchemaReader>> readers;
     readers.reserve(m_id_to_table_metadata.size());
     for (auto const& [id, table_metadata] : m_id_to_table_metadata) {
         auto schema_reader = std::make_shared<SchemaReader>();
-        create_schema_reader(*schema_reader, id, true, true);
+        initialize_schema_reader(*schema_reader, id, true, true);
 
         m_tables_file_reader.try_seek_from_begin(table_metadata.offset);
         m_tables_decompressor.open(m_tables_file_reader, cDecompressorFileReadBufferCapacity);
@@ -218,7 +218,7 @@ void ArchiveReader::append_unordered_reader_columns(
     }
 }
 
-void ArchiveReader::create_schema_reader(
+void ArchiveReader::initialize_schema_reader(
         SchemaReader& reader,
         int32_t schema_id,
         bool should_extract_timestamp,

--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -114,7 +114,7 @@ std::vector<std::shared_ptr<SchemaReader>> ArchiveReader::load_all_tables() {
 
     std::vector<std::shared_ptr<SchemaReader>> readers;
     readers.reserve(m_id_to_table_metadata.size());
-    for (const auto& [id, table_metadata] : m_id_to_table_metadata) {
+    for (auto const& [id, table_metadata] : m_id_to_table_metadata) {
         auto schema_reader = std::make_shared<SchemaReader>();
         create_schema_reader(*schema_reader, id, true, true);
 

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -92,6 +92,12 @@ public:
     SchemaReader&
     read_table(int32_t schema_id, bool should_extract_timestamp, bool should_marshal_records);
 
+    /**
+     * Loads all of the tables in the archive and returns SchemaReaders for them.
+     * @return the schema readers for every table in the archive
+     */
+    std::vector<std::shared_ptr<SchemaReader>> load_all_tables();
+
     std::shared_ptr<VariableDictionaryReader> get_variable_dictionary() { return m_var_dict; }
 
     std::shared_ptr<LogTypeDictionaryReader> get_log_type_dictionary() { return m_log_dict; }
@@ -125,13 +131,14 @@ public:
 
 private:
     /**
-     * Creates a schema reader for a given schema.
+     * Initializes a schema reader passed by reference to become a reader for a given schema.
+     * @param reader
      * @param schema_id
      * @param should_extract_timestamp
      * @param should_marshal_records
-     * @return a reference to the newly created schema reader initialized with the given parameters
      */
-    SchemaReader& create_schema_reader(
+    void create_schema_reader(
+            SchemaReader& reader,
             int32_t schema_id,
             bool should_extract_timestamp,
             bool should_marshal_records

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -96,7 +96,7 @@ public:
      * Loads all of the tables in the archive and returns SchemaReaders for them.
      * @return the schema readers for every table in the archive
      */
-    std::vector<std::shared_ptr<SchemaReader>> load_all_tables();
+    std::vector<std::shared_ptr<SchemaReader>> read_all_tables();
 
     std::shared_ptr<VariableDictionaryReader> get_variable_dictionary() { return m_var_dict; }
 
@@ -137,7 +137,7 @@ private:
      * @param should_extract_timestamp
      * @param should_marshal_records
      */
-    void create_schema_reader(
+    void initialize_schema_reader(
             SchemaReader& reader,
             int32_t schema_id,
             bool should_extract_timestamp,

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -290,7 +290,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             decompression_options.add_options()(
                     "ordered",
                     po::bool_switch(&m_ordered_decompression),
-                    "Enable in-order decompression by timestamp for this archive"
+                    "Enable decompression in ascending timestamp order for this archive"
             );
             extraction_options.add(decompression_options);
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -286,6 +286,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             );
             extraction_options.add(input_options);
 
+            po::options_description decompression_options("Decompression Options");
+            decompression_options.add_options()(
+                    "ordered",
+                    po::bool_switch(&m_ordered_decompression),
+                    "Enable in-order decompression for this archive"
+            );
+            extraction_options.add(decompression_options);
+
             po::positional_options_description positional_options;
             positional_options.add("archives-dir", 1);
             positional_options.add("output-dir", 1);
@@ -316,6 +324,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 po::options_description visible_options;
                 visible_options.add(general_options);
                 visible_options.add(input_options);
+                visible_options.add(decompression_options);
                 std::cerr << visible_options << std::endl;
                 return ParsingResult::InfoCommand;
             }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -290,7 +290,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             decompression_options.add_options()(
                     "ordered",
                     po::bool_switch(&m_ordered_decompression),
-                    "Enable in-order decompression for this archive"
+                    "Enable in-order decompression by timestamp for this archive"
             );
             extraction_options.add(decompression_options);
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -104,6 +104,8 @@ public:
 
     bool get_structurize_arrays() const { return m_structurize_arrays; }
 
+    bool get_ordered_decompression() const { return m_ordered_decompression; }
+
 private:
     // Methods
     /**
@@ -167,6 +169,7 @@ private:
     bool m_print_archive_stats{false};
     size_t m_max_document_size{512ULL * 1024 * 1024};  // 512 MB
     bool m_structurize_arrays{false};
+    bool m_ordered_decompression{false};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -60,7 +60,7 @@ void JsonConstructor::store() {
 
 void JsonConstructor::construct_in_order(FileWriter& writer) {
     std::string buffer;
-    auto tables = m_archive_reader->load_all_tables();
+    auto tables = m_archive_reader->read_all_tables();
     using ReaderPointer = std::shared_ptr<SchemaReader>;
     auto cmp = [](ReaderPointer& left, ReaderPointer& right) {
         return left->get_next_timestamp() > right->get_next_timestamp();

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -66,10 +66,14 @@ void JsonConstructor::construct_in_order(FileWriter& writer) {
         return left->get_next_timestamp() > right->get_next_timestamp();
     };
     std::priority_queue record_queue(tables.begin(), tables.end(), cmp);
+    // Clear tables vector so that memory gets deallocated after we have marshalled all records for
+    // a given table
+    tables.clear();
     while (false == record_queue.empty()) {
         ReaderPointer next = record_queue.top();
         record_queue.pop();
-        if (next->get_next_message(buffer)) {
+        next->get_next_message(buffer);
+        if (false == next->done()) {
             record_queue.emplace(std::move(next));
         }
         writer.write(buffer.c_str(), buffer.length());

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -1,6 +1,7 @@
 #include "JsonConstructor.hpp"
 
 #include <filesystem>
+#include <queue>
 #include <system_error>
 
 #include <fmt/core.h>
@@ -13,7 +14,8 @@
 namespace clp_s {
 JsonConstructor::JsonConstructor(JsonConstructorOption const& option)
         : m_output_dir(option.output_dir),
-          m_archives_dir(option.archives_dir) {
+          m_archives_dir(option.archives_dir),
+          m_ordered{option.ordered} {
     std::error_code error_code;
     if (false == std::filesystem::create_directory(option.output_dir, error_code) && error_code) {
         throw OperationFailed(
@@ -40,15 +42,38 @@ JsonConstructor::JsonConstructor(JsonConstructorOption const& option)
 
 void JsonConstructor::store() {
     FileWriter writer;
+    // TODO: change this when doing chunking
     writer.open(m_output_dir + "/original", FileWriter::OpenMode::CreateIfNonexistentForAppending);
 
     m_archive_reader = std::make_unique<ArchiveReader>();
     m_archive_reader->open(m_archives_dir);
     m_archive_reader->read_dictionaries_and_metadata();
-    m_archive_reader->store(writer);
+    if (false == m_ordered) {
+        m_archive_reader->store(writer);
+    } else {
+        construct_in_order(writer);
+    }
     m_archive_reader->close();
 
     writer.close();
 }
 
+void JsonConstructor::construct_in_order(FileWriter& writer) {
+    std::string buffer;
+    auto tables = m_archive_reader->load_all_tables();
+    using ReaderPointer = std::shared_ptr<SchemaReader>;
+    auto cmp = [](ReaderPointer& left, ReaderPointer& right) {
+        return left->get_next_timestamp() > right->get_next_timestamp();
+    };
+    std::priority_queue record_queue(tables.begin(), tables.end(), cmp);
+    while (false == record_queue.empty()) {
+        ReaderPointer next = record_queue.top();
+        record_queue.pop();
+        if (next->get_next_message(buffer)) {
+            record_queue.emplace(std::move(next));
+        }
+        writer.write(buffer.c_str(), buffer.length());
+    }
+    writer.close();
+}
 }  // namespace clp_s

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -51,6 +51,11 @@ public:
     void store();
 
 private:
+    /**
+     * Reads all of the tables from m_archive_reader and writes all of the records
+     * they contain to writer in timestamp order.
+     * @param writer
+     */
     void construct_in_order(FileWriter& writer);
 
     std::string m_archives_dir;

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -9,6 +9,7 @@
 #include "ColumnReader.hpp"
 #include "DictionaryReader.hpp"
 #include "ErrorCode.hpp"
+#include "FileWriter.hpp"
 #include "SchemaReader.hpp"
 #include "SchemaTree.hpp"
 #include "TraceableException.hpp"
@@ -17,6 +18,7 @@ namespace clp_s {
 struct JsonConstructorOption {
     std::string archives_dir;
     std::string output_dir;
+    bool ordered;
 };
 
 class JsonConstructor {
@@ -49,8 +51,11 @@ public:
     void store();
 
 private:
+    void construct_in_order(FileWriter& writer);
+
     std::string m_archives_dir;
     std::string m_output_dir;
+    bool m_ordered{false};
 
     std::unique_ptr<ArchiveReader> m_archive_reader;
 };

--- a/components/core/src/clp_s/SchemaReader.hpp
+++ b/components/core/src/clp_s/SchemaReader.hpp
@@ -185,6 +185,11 @@ public:
      */
     static int32_t get_first_column_in_span(std::span<int32_t> schema);
 
+    /**
+     * @return the timestamp found in the row pointed to by m_cur_message
+     */
+    epochtime_t get_next_timestamp() { return m_get_timestamp(); }
+
 private:
     /**
      * Merges the current local schema tree with the section of the global schema tree corresponding

--- a/components/core/src/clp_s/SchemaReader.hpp
+++ b/components/core/src/clp_s/SchemaReader.hpp
@@ -190,6 +190,9 @@ public:
      */
     epochtime_t get_next_timestamp() const { return m_get_timestamp(); }
 
+    /**
+     * @return true if all records in this table have been iterated over, false otherwise
+     */
     bool done() const { return m_cur_message >= m_num_messages; }
 
 private:

--- a/components/core/src/clp_s/SchemaReader.hpp
+++ b/components/core/src/clp_s/SchemaReader.hpp
@@ -188,7 +188,9 @@ public:
     /**
      * @return the timestamp found in the row pointed to by m_cur_message
      */
-    epochtime_t get_next_timestamp() { return m_get_timestamp(); }
+    epochtime_t get_next_timestamp() const { return m_get_timestamp(); }
+
+    bool done() const { return m_cur_message >= m_num_messages; }
 
 private:
     /**

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -271,6 +271,7 @@ int main(int argc, char const* argv[]) {
 
         clp_s::JsonConstructorOption option;
         option.output_dir = command_line_arguments.get_output_dir();
+        option.ordered = command_line_arguments.get_ordered_decompression();
         try {
             auto const& archive_id = command_line_arguments.get_archive_id();
             if (false == archive_id.empty()) {


### PR DESCRIPTION
# Description
This PR adds support to decompress a clp-s archive in timestamp order with the `--ordered` command line option. This is implemented by loading all tables into memory, putting them into a min-heap ordered by the timestamp of the next record in each table, and popping from the heap until all records have been decompressed. The timestamp is pulled from the authoritative timestamp column specified at compression time, and if a table does not contain such a column the timestamp is 0 for ordering purposes.

Note: we don't sort by timestamp within each table, so the logs can end up slightly out of timestamp order (this is probably preferred anyway, since it brings us closer to log order).

This seems to add minimal decompression speed overhead (about 2.5%) for fairly typical archives, though would likely have higher overhead for large archives or archives with many tables (due to extra memory allocations compared to decompressing one table at a time). Similarly there can be significant memory overhead, particularly for large archives. 

# Validation performed
- Validated that records end up sorted in timestamp order after decompression
- Validated that in order decompression results in identical set of records compared to out of order decompression

