### PR TITLE
lint: Apply latest version of eslint-config-yscope.

### DIFF
--- a/components/webui/imports/api/ingestion/server/publications.js
+++ b/components/webui/imports/api/ingestion/server/publications.js
@@ -4,10 +4,13 @@ import {logger} from "/imports/utils/logger";
 import {MONGO_SORT_BY_ID} from "/imports/utils/mongo";
 
 import {
-    CompressionJobsCollection, STATS_COLLECTION_ID, StatsCollection,
+    CompressionJobsCollection,
+    STATS_COLLECTION_ID,
+    StatsCollection,
 } from "../collections";
 import {
-    COMPRESSION_JOB_WAITING_STATES, COMPRESSION_JOBS_TABLE_COLUMN_NAMES,
+    COMPRESSION_JOB_WAITING_STATES,
+    COMPRESSION_JOBS_TABLE_COLUMN_NAMES,
 } from "../constants";
 import CompressionDbManager from "./CompressionDbManager";
 import StatsDbManager from "./StatsDbManager";

--- a/components/webui/imports/ui/SearchView/SearchControls/SearchControlsFilterDrawer/SearchControlsTimeRangeInput/index.jsx
+++ b/components/webui/imports/ui/SearchView/SearchControls/SearchControlsFilterDrawer/SearchControlsTimeRangeInput/index.jsx
@@ -8,7 +8,9 @@ import Row from "react-bootstrap/Row";
 import {
     computeTimeRange,
     convertLocalDateToSameUtcDatetime,
-    convertUtcDatetimeToSameLocalDate, TIME_RANGE_PRESET_LABEL, TIME_UNIT,
+    convertUtcDatetimeToSameLocalDate,
+    TIME_RANGE_PRESET_LABEL,
+    TIME_UNIT,
 } from "/imports/utils/datetime";
 
 import SearchControlsFilterLabel from "../SearchControlsFilterLabel";

--- a/components/webui/imports/ui/SearchView/SearchResults/SearchResultsTable/SearchResultsLoadSensor.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResults/SearchResultsTable/SearchResultsLoadSensor.jsx
@@ -1,5 +1,6 @@
 import {
-    useEffect, useRef,
+    useEffect,
+    useRef,
 } from "react";
 import Spinner from "react-bootstrap/Spinner";
 

--- a/components/webui/imports/ui/SearchView/SearchResults/SearchResultsTable/index.jsx
+++ b/components/webui/imports/ui/SearchView/SearchResults/SearchResultsTable/index.jsx
@@ -4,12 +4,15 @@ import Table from "react-bootstrap/Table";
 import dayjs from "dayjs";
 
 import {
-    faSort, faSortDown, faSortUp,
+    faSort,
+    faSortDown,
+    faSortUp,
 } from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 import {
-    MONGO_SORT_ORDER, SEARCH_RESULTS_FIELDS,
+    MONGO_SORT_ORDER,
+    SEARCH_RESULTS_FIELDS,
 } from "/imports/api/search/constants";
 import {DATETIME_FORMAT_TEMPLATE} from "/imports/utils/datetime";
 

--- a/components/webui/imports/ui/SearchView/SearchStatus.jsx
+++ b/components/webui/imports/ui/SearchView/SearchStatus.jsx
@@ -9,7 +9,8 @@ import {faExclamationCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 import {
-    isSearchSignalQuerying, SEARCH_SIGNAL,
+    isSearchSignalQuerying,
+    SEARCH_SIGNAL,
 } from "/imports/api/search/constants";
 
 import "./SearchStatus.scss";


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The latest version of [y-scope/eslint-config-yscope](https://github.com/y-scope/eslint-config-yscope) enforces one import per line. This PR applies the new rule to the webui.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated lint workflow passes.
