### PR TITLE
ffi: Add WIP Serializer class for the next IR stream format.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -304,6 +304,8 @@ set(SOURCE_FILES_unitTest
         src/clp/ffi/ir_stream/decoding_methods.inc
         src/clp/ffi/ir_stream/encoding_methods.cpp
         src/clp/ffi/ir_stream/encoding_methods.hpp
+        src/clp/ffi/ir_stream/Serializer.cpp
+        src/clp/ffi/ir_stream/Serializer.hpp
         src/clp/ffi/ir_stream/utils.cpp
         src/clp/ffi/ir_stream/utils.hpp
         src/clp/ffi/ir_stream/protocol_constants.hpp

--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -1,0 +1,72 @@
+#include "Serializer.hpp"
+
+#include <cstdint>
+#include <system_error>
+
+#include <boost-outcome/include/boost/outcome/std_result.hpp>
+#include <json/single_include/nlohmann/json.hpp>
+
+#include "../../ir/types.hpp"
+#include "../../time_types.hpp"
+#include "../encoding_methods.hpp"
+#include "encoding_methods.hpp"
+#include "protocol_constants.hpp"
+#include "utils.hpp"
+
+using clp::ir::eight_byte_encoded_variable_t;
+using clp::ir::four_byte_encoded_variable_t;
+
+namespace clp::ffi::ir_stream {
+template <typename encoded_variable_t>
+auto Serializer<encoded_variable_t>::create(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>> {
+    static_assert(
+            (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+             || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+    );
+
+    Serializer<encoded_variable_t> serializer;
+    auto& ir_buf{serializer.m_ir_buf};
+    constexpr BufferView cMagicNumber{
+            static_cast<int8_t const*>(
+                    std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+                            ? cProtocol::EightByteEncodingMagicNumber
+                            : cProtocol::FourByteEncodingMagicNumber
+            ),
+            cProtocol::MagicNumberLength
+    };
+    ir_buf.insert(ir_buf.cend(), cMagicNumber.begin(), cMagicNumber.end());
+
+    nlohmann::json metadata;
+    metadata.emplace(cProtocol::Metadata::VersionKey, cProtocol::Metadata::BetaVersionValue);
+    metadata.emplace(cProtocol::Metadata::VariablesSchemaIdKey, cVariablesSchemaVersion);
+    metadata.emplace(
+            cProtocol::Metadata::VariableEncodingMethodsIdKey,
+            cVariableEncodingMethodsVersion
+    );
+    if (false == serialize_metadata(metadata, ir_buf)) {
+        return std::errc::protocol_error;
+    }
+
+    return std::move(serializer);
+}
+
+template <typename encoded_variable_t>
+auto Serializer<encoded_variable_t>::change_utc_offset(UtcOffset utc_offset) -> void {
+    if (utc_offset != m_curr_utc_offset) {
+        m_curr_utc_offset = utc_offset;
+    }
+    serialize_utc_offset_change(m_curr_utc_offset, m_ir_buf);
+}
+
+// Explicitly declare template specializations so that we can define the template methods in this
+// file
+template auto Serializer<eight_byte_encoded_variable_t>::create(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<Serializer<eight_byte_encoded_variable_t>>;
+template auto Serializer<four_byte_encoded_variable_t>::create(
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<Serializer<four_byte_encoded_variable_t>>;
+template auto Serializer<eight_byte_encoded_variable_t>::change_utc_offset(UtcOffset utc_offset
+) -> void;
+template auto Serializer<four_byte_encoded_variable_t>::change_utc_offset(UtcOffset utc_offset
+) -> void;
+}  // namespace clp::ffi::ir_stream

--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -48,7 +48,7 @@ auto Serializer<encoded_variable_t>::create(
         return std::errc::protocol_error;
     }
 
-    return std::move(serializer);
+    return serializer;
 }
 
 template <typename encoded_variable_t>

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -16,9 +16,10 @@ namespace clp::ffi::ir_stream {
  * necessary internal data structure to track serialization states. It also provides APIs to
  * serialize log events into IR format, as well as APIs to access the serialized IR bytes.
  * Notice that this class is designed to provide serialization functionalities only. The upper-level
- * caller should be responsible to write the serialized bytes into IO streams properly. In addition,
- * it doesn't provide a call to terminate the IR stream. The upper-level caller should decide when
- * to terminate the stream by append `clp::ffi::ir_stream::cProtocol::Eof` at the end of the stream.
+ * caller should be responsible for writing the serialized bytes into IO streams properly. In
+ * addition, it doesn't provide a call to terminate the IR stream. The upper-level caller should
+ * decide when to terminate the stream by append `clp::ffi::ir_stream::cProtocol::Eof` at the end of
+ * the stream.
  * @tparam encoded_variable_t Type of encoded variables in the serialized IR stream.
  */
 template <typename encoded_variable_t>

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -12,14 +12,19 @@
 
 namespace clp::ffi::ir_stream {
 /**
- * A template class for serializing log events into CLP IR format. This class maintains all the
- * necessary internal data structure to track serialization states. It also provides APIs to
- * serialize log events into IR format, as well as APIs to access the serialized IR bytes.
- * Notice that this class is designed to provide serialization functionalities only. The upper-level
- * caller should be responsible for writing the serialized bytes into IO streams properly. In
- * addition, it doesn't provide a call to terminate the IR stream. The upper-level caller should
- * decide when to terminate the stream by append `clp::ffi::ir_stream::cProtocol::Eof` at the end of
- * the stream.
+ * A work-in-progress class for serializing log events into the kv-pair IR format.
+ *
+ * This class:
+ * - maintains all necessary internal data structures to track serialization state;
+ * - provides APIs to serialize log events into the IR format; and
+ * - provides APIs to access the serialized IR bytes.
+ *
+ * NOTE:
+ * - This class is designed only to provide serialization functionalities. Callers are responsible
+ *   for writing the serialized bytes into I/O streams.
+ * - This class doesn't provide an API to terminate the IR stream. Callers should
+ *   terminate the stream by flushing this class' IR buffer to the I/O stream and then writing
+ *   `clp::ffi::ir_stream::cProtocol::Eof` to the I/O stream.
  * @tparam encoded_variable_t Type of encoded variables in the serialized IR stream.
  */
 template <typename encoded_variable_t>
@@ -31,9 +36,9 @@ public:
 
     // Factory functions
     /**
-     * Creates an IR serializer and serialize the preamble at the beginning of the stream.
+     * Creates an IR serializer and serializes the stream's preamble.
      * @return A result containing the serializer or an error code indicating the failure:
-     * - std::errc::protocol_error if failed to serialize the preamble.
+     * - std::errc::protocol_error on failure to serialize the preamble.
      */
     [[nodiscard]] static auto create(
     ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>>;
@@ -51,7 +56,7 @@ public:
 
     // Methods
     /**
-     * @return A view to the underlying IR buffer which contains the serialized IR bytes.
+     * @return A view of the underlying IR buffer which contains the serialized IR bytes.
      */
     [[nodiscard]] auto get_ir_buf_view() const -> BufferView {
         return {m_ir_buf.data(), m_ir_buf.size()};
@@ -68,8 +73,8 @@ public:
     [[nodiscard]] auto get_curr_utc_offset() const -> UtcOffset { return m_curr_utc_offset; }
 
     /**
-     * Changes the UTC offset and serializes the UTC offset change packet into the underlying IR
-     * buffer if the given UTC offset is different with the current UTC offset.
+     * Changes the UTC offset and serializes a UTC offset change packet, if the given UTC offset is
+     * different than the current UTC offset.
      * @param utc_offset
      */
     auto change_utc_offset(UtcOffset utc_offset) -> void;

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -1,0 +1,90 @@
+#ifndef CLP_FFI_IR_STREAM_SERIALIZER_HPP
+#define CLP_FFI_IR_STREAM_SERIALIZER_HPP
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <boost-outcome/include/boost/outcome/std_result.hpp>
+
+#include "../../time_types.hpp"
+#include "../SchemaTree.hpp"
+
+namespace clp::ffi::ir_stream {
+/**
+ * A template class for serializing log events into CLP IR format. This class maintains all the
+ * necessary internal data structure to track serialization states. It also provides APIs to
+ * serialize log events into IR format, as well as APIs to access the serialized IR bytes.
+ * Notice that this class is designed to provide serialization functionalities only. The upper-level
+ * caller should be responsible to write the serialized bytes into IO streams properly. In addition,
+ * it doesn't provide a call to terminate the IR stream. The upper-level caller should decide when
+ * to terminate the stream by append `clp::ffi::ir_stream::cProtocol::Eof` at the end of the stream.
+ * @tparam encoded_variable_t Type of encoded variables in the serialized IR stream.
+ */
+template <typename encoded_variable_t>
+class Serializer {
+public:
+    // Types
+    using Buffer = std::vector<int8_t>;
+    using BufferView = std::span<int8_t const>;
+
+    // Factory functions
+    /**
+     * Creates an IR serializer and serialize the preamble at the beginning of the stream.
+     * @return A result containing the serializer or an error code indicating the failure:
+     * - std::errc::protocol_error if failed to serialize the preamble.
+     */
+    [[nodiscard]] static auto create(
+    ) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>>;
+
+    // Disable copy constructor/assignment operator
+    Serializer(Serializer const&) = delete;
+    auto operator=(Serializer const&) -> Serializer& = delete;
+
+    // Define default move constructor/assignment operator
+    Serializer(Serializer&&) = default;
+    auto operator=(Serializer&&) -> Serializer& = default;
+
+    // Destructor
+    ~Serializer() = default;
+
+    // Methods
+    /**
+     * @return A view to the underlying IR buffer which contains the serialized IR bytes.
+     */
+    [[nodiscard]] auto get_ir_buf_view() const -> BufferView {
+        return {m_ir_buf.data(), m_ir_buf.size()};
+    }
+
+    /**
+     * Clears the underlying IR buffer.
+     */
+    auto clear_ir_buf() -> void { m_ir_buf.clear(); }
+
+    /**
+     * @return The current UTC offset.
+     */
+    [[nodiscard]] auto get_curr_utc_offset() const -> UtcOffset { return m_curr_utc_offset; }
+
+    /**
+     * Changes the UTC offset and serializes the UTC offset change packet into the underlying IR
+     * buffer if the given UTC offset is different with the current UTC offset.
+     * @param utc_offset
+     */
+    auto change_utc_offset(UtcOffset utc_offset) -> void;
+
+private:
+    // Constructors
+    Serializer() = default;
+
+    UtcOffset m_curr_utc_offset{0};
+    Buffer m_ir_buf;
+    SchemaTree m_schema_tree;
+
+    Buffer m_schema_tree_node_buf;
+    Buffer m_key_group_buf;
+    Buffer m_value_group_buf;
+};
+}  // namespace clp::ffi::ir_stream
+
+#endif

--- a/components/core/src/clp/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/clp/ffi/ir_stream/protocol_constants.hpp
@@ -13,6 +13,7 @@ constexpr int8_t LengthUShort = 0x12;
 
 constexpr char VersionKey[] = "VERSION";
 constexpr char VersionValue[] = "0.0.2";
+constexpr char BetaVersionValue[] = "0.1.0-beta";
 
 // The following regex can be used to validate a Semantic Versioning string. The source of the
 // regex can be found here: https://semver.org/

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -118,7 +118,8 @@ template <typename encoded_variable_t>
 [[nodiscard]] auto get_current_ts() -> epoch_time_ms_t;
 
 /**
- * Flushes and cleans the serialized IR bytes into the given byte buffer.
+ * Flushes and clears serialized data from the serializer's underlying IR buffer into the given byte
+ * buffer.
  * @tparam encoded_variable_t
  * @param serializer
  * @param byte_buf
@@ -232,7 +233,7 @@ auto get_current_ts() -> epoch_time_ms_t {
 template <typename encoded_variable_t>
 auto flush_and_clean_serializer_buffer(
         Serializer<encoded_variable_t>& serializer,
-        std::vector<int8_t>& byte_buf
+        vector<int8_t>& byte_buf
 ) -> void {
     auto const view{serializer.get_ir_buf_view()};
     byte_buf.insert(byte_buf.cend(), view.begin(), view.end());
@@ -889,9 +890,8 @@ TEMPLATE_TEST_CASE(
         four_byte_encoded_variable_t,
         eight_byte_encoded_variable_t
 ) {
-    // This is a unit test for IR v2 serializer. At this moment, we do not have the deserializer
-    // implemented yet. Therefore, we can only test whether the preamble packet is serialized as
-    // expected.
+    // This is a unit test for the kv-pair IR serializer. Currently, we haven't yet implemented a
+    // deserializer, so we can only test whether the preamble packet is serialized correctly.
     vector<int8_t> ir_buf;
 
     auto result{Serializer<TestType>::create()};
@@ -921,14 +921,14 @@ TEMPLATE_TEST_CASE(
         REQUIRE((false == is_four_byte_encoding));
     }
 
-    encoded_tag_t metadata_type;
+    encoded_tag_t metadata_type{};
     vector<int8_t> metadata_bytes;
     REQUIRE(
             (IRErrorCode::IRErrorCode_Success
              == deserialize_preamble(buffer_reader, metadata_type, metadata_bytes))
     );
     REQUIRE((clp::ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type));
-    string_view metadata_view{
+    string_view const metadata_view{
             size_checked_pointer_cast<char const>(metadata_bytes.data()),
             metadata_bytes.size()
     };

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -9,6 +9,7 @@
 #include "../src/clp/ffi/ir_stream/decoding_methods.hpp"
 #include "../src/clp/ffi/ir_stream/encoding_methods.hpp"
 #include "../src/clp/ffi/ir_stream/protocol_constants.hpp"
+#include "../src/clp/ffi/ir_stream/Serializer.hpp"
 #include "../src/clp/ir/LogEventDeserializer.hpp"
 #include "../src/clp/ir/types.hpp"
 #include "../src/clp/time_types.hpp"
@@ -30,6 +31,7 @@ using clp::ffi::ir_stream::encoded_tag_t;
 using clp::ffi::ir_stream::get_encoding_type;
 using clp::ffi::ir_stream::IRErrorCode;
 using clp::ffi::ir_stream::serialize_utc_offset_change;
+using clp::ffi::ir_stream::Serializer;
 using clp::ffi::ir_stream::validate_protocol_version;
 using clp::ffi::wildcard_query_matches_any_encoded_var;
 using clp::ir::eight_byte_encoded_variable_t;
@@ -114,6 +116,18 @@ template <typename encoded_variable_t>
  * @return The current UNIX epoch timestamp in milliseconds.
  */
 [[nodiscard]] auto get_current_ts() -> epoch_time_ms_t;
+
+/**
+ * Flushes and cleans the serialized IR bytes into the given byte buffer.
+ * @tparam encoded_variable_t
+ * @param serializer
+ * @param byte_buf
+ */
+template <typename encoded_variable_t>
+auto flush_and_clean_serializer_buffer(
+        Serializer<encoded_variable_t>& serializer,
+        std::vector<int8_t>& byte_buf
+) -> void;
 
 template <typename encoded_variable_t>
 [[nodiscard]] auto serialize_log_events(
@@ -213,6 +227,16 @@ auto create_test_log_events() -> vector<UnstructuredLogEvent> {
 
 auto get_current_ts() -> epoch_time_ms_t {
     return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+}
+
+template <typename encoded_variable_t>
+auto flush_and_clean_serializer_buffer(
+        Serializer<encoded_variable_t>& serializer,
+        std::vector<int8_t>& byte_buf
+) -> void {
+    auto const view{serializer.get_ir_buf_view()};
+    byte_buf.insert(byte_buf.cend(), view.begin(), view.end());
+    serializer.clear_ir_buf();
 }
 }  // namespace
 
@@ -857,4 +881,84 @@ TEMPLATE_TEST_CASE(
     auto result = log_event_deserializer.deserialize_log_event();
     REQUIRE(result.has_error());
     REQUIRE(std::errc::no_message_available == result.error());
+}
+
+TEMPLATE_TEST_CASE(
+        "ffi_ir_stream_Serializer_creation",
+        "[clp][ffi][ir_stream][Serializer]",
+        four_byte_encoded_variable_t,
+        eight_byte_encoded_variable_t
+) {
+    // This is a unit test for IR v2 serializer. At this moment, we do not have the deserializer
+    // implemented yet. Therefore, we can only test whether the preamble packet is serialized as
+    // expected.
+    vector<int8_t> ir_buf;
+
+    auto result{Serializer<TestType>::create()};
+    REQUIRE((false == result.has_error()));
+
+    auto& serializer{result.value()};
+    flush_and_clean_serializer_buffer(serializer, ir_buf);
+    REQUIRE(serializer.get_ir_buf_view().empty());
+
+    constexpr UtcOffset cBeijingUtcOffset{8 * 60 * 60 * 1000};
+    serializer.change_utc_offset(cBeijingUtcOffset);
+    flush_and_clean_serializer_buffer(serializer, ir_buf);
+    REQUIRE(serializer.get_ir_buf_view().empty());
+
+    ir_buf.push_back(clp::ffi::ir_stream::cProtocol::Eof);
+
+    BufferReader buffer_reader{size_checked_pointer_cast<char const>(ir_buf.data()), ir_buf.size()};
+
+    bool is_four_byte_encoding{};
+    REQUIRE(
+            (IRErrorCode::IRErrorCode_Success
+             == get_encoding_type(buffer_reader, is_four_byte_encoding))
+    );
+    if constexpr (std::is_same_v<TestType, four_byte_encoded_variable_t>) {
+        REQUIRE(is_four_byte_encoding);
+    } else {
+        REQUIRE((false == is_four_byte_encoding));
+    }
+
+    encoded_tag_t metadata_type;
+    vector<int8_t> metadata_bytes;
+    REQUIRE(
+            (IRErrorCode::IRErrorCode_Success
+             == deserialize_preamble(buffer_reader, metadata_type, metadata_bytes))
+    );
+    REQUIRE((clp::ffi::ir_stream::cProtocol::Metadata::EncodingJson == metadata_type));
+    string_view metadata_view{
+            size_checked_pointer_cast<char const>(metadata_bytes.data()),
+            metadata_bytes.size()
+    };
+    nlohmann::json const metadata = nlohmann::json::parse(metadata_view);
+
+    nlohmann::json expected_metadata;
+    expected_metadata.emplace(
+            clp::ffi::ir_stream::cProtocol::Metadata::VersionKey,
+            clp::ffi::ir_stream::cProtocol::Metadata::BetaVersionValue
+    );
+    expected_metadata.emplace(
+            clp::ffi::ir_stream::cProtocol::Metadata::VariablesSchemaIdKey,
+            clp::ffi::cVariablesSchemaVersion
+    );
+    expected_metadata.emplace(
+            clp::ffi::ir_stream::cProtocol::Metadata::VariableEncodingMethodsIdKey,
+            clp::ffi::cVariableEncodingMethodsVersion
+    );
+    REQUIRE((expected_metadata == metadata));
+
+    encoded_tag_t encoded_tag{};
+    REQUIRE((IRErrorCode::IRErrorCode_Success == deserialize_tag(buffer_reader, encoded_tag)));
+    REQUIRE((clp::ffi::ir_stream::cProtocol::Payload::UtcOffsetChange == encoded_tag));
+    UtcOffset utc_offset_change{0};
+    REQUIRE(
+            (IRErrorCode::IRErrorCode_Success
+             == deserialize_utc_offset_change(buffer_reader, utc_offset_change))
+    );
+    REQUIRE((cBeijingUtcOffset == utc_offset_change));
+
+    REQUIRE((IRErrorCode::IRErrorCode_Success == deserialize_tag(buffer_reader, encoded_tag)));
+    REQUIRE((clp::ffi::ir_stream::cProtocol::Eof == encoded_tag));
 }


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
When migrating to the next IR stream format, there are two important differences:
1. The serialization is no longer stateless in the next IR format. The stream has to maintain a schema tree across the entire IR stream.
2. In the current IR format, bytes can be written into the IR buffer in the same order as encoded: first encoded variables, then logtype, and finally timestamp. This is not true in the next IR format. For structured key-value pairs, the overall packet of a new record would be: [new_schema_tree_nodes, keys, values]. Each sub-packet has to be encoded in a separate buffer and merged into one after the entire record is processed. This means we need more than one internal buffer during the serialization, even though only the final merged buffer is exposed to the upper layer APIs.

To adapt to these changes, we wrap all the necessary data structures into a new class named `Serializer` to keep track of the states, as well as maintain necessary data structures. In details:
- It maintains an underlying schema tree for the stream.
- It maintains all the necessary internal buffers for serialization. These internal buffers are private members. In the future PRs, serialization methods will be added as member functions and they will have direct access to these buffers.
- It provides an API to access the view of the serialized IR buffer (containing serialized bytes).

Note: this class is designed to provide serialization functionalities only. The upper-level caller should be responsible for writing the serialized bytes into IO streams properly. In addition, it doesn't provide a call to terminate the IR stream. The upper-level caller should decide when to terminate the stream by append `clp::ffi::ir_stream::cProtocol::Eof` at the end of the stream.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Added a unit test case to ensure the serializer can be successfully created with the preamble section serialized properly; also tested to ensure it can properly serialize a UTC offset change.
- Passsed `clang-tidy` checks for the `Serializer` implementation.
- Didn't execute `clang-tidy` against the unit test file since it is not synchronized with the latest coding guideline.
