### PR TITLE
core-clp: Refactor `LibarchiveFileReader` to properly handle empty data blocks (fixes #389).

### DIFF
--- a/components/core/src/clp/LibarchiveFileReader.cpp
+++ b/components/core/src/clp/LibarchiveFileReader.cpp
@@ -229,7 +229,7 @@ auto LibarchiveFileReader::peek_buffered_data() const -> std::span<char const> {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
     if (nullptr == m_data_block) {
-        return {static_cast<char const*>(nullptr), 0};
+        return {static_cast<char const*>(m_data_block), 0};
     }
     if (m_pos_in_file < m_data_block_pos_in_file) {
         // Position in the file is before the current data block, so we return nulls corresponding

--- a/components/core/src/clp/LibarchiveFileReader.cpp
+++ b/components/core/src/clp/LibarchiveFileReader.cpp
@@ -206,7 +206,7 @@ void LibarchiveFileReader::close() {
     m_pos_in_file = 0;
 }
 
-ErrorCode LibarchiveFileReader::try_load_nonempty_data_block() {
+auto LibarchiveFileReader::try_load_nonempty_data_block() -> ErrorCode {
     if (nullptr == m_archive) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
@@ -250,7 +250,7 @@ auto LibarchiveFileReader::peek_buffered_data() const -> std::span<char const> {
     return {buf, buf_size};
 }
 
-ErrorCode LibarchiveFileReader::read_next_nonempty_data_block() {
+auto LibarchiveFileReader::read_next_nonempty_data_block() -> ErrorCode {
     m_data_block_length = 0;
     m_pos_in_data_block = 0;
     while (0 == m_data_block_length) {

--- a/components/core/src/clp/LibarchiveFileReader.cpp
+++ b/components/core/src/clp/LibarchiveFileReader.cpp
@@ -229,7 +229,7 @@ auto LibarchiveFileReader::peek_buffered_data() const -> std::span<char const> {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
     if (nullptr == m_data_block) {
-        return {static_cast<char const*>(m_data_block), 0};
+        return {};
     }
     if (m_pos_in_file < m_data_block_pos_in_file) {
         // Position in the file is before the current data block, so we return nulls corresponding

--- a/components/core/src/clp/LibarchiveFileReader.hpp
+++ b/components/core/src/clp/LibarchiveFileReader.hpp
@@ -2,6 +2,7 @@
 #define CLP_LIBARCHIVEFILEREADER_HPP
 
 #include <array>
+#include <span>
 #include <string>
 
 #include <archive.h>
@@ -30,13 +31,7 @@ public:
     };
 
     // Constructors
-    LibarchiveFileReader()
-            : m_archive(nullptr),
-              m_archive_entry(nullptr),
-              m_data_block(nullptr),
-              m_reached_eof(false),
-              m_data_block_pos_in_file(0),
-              m_pos_in_file(0) {}
+    LibarchiveFileReader() = default;
 
     // Methods implementing the ReaderInterface
     /**
@@ -89,43 +84,42 @@ public:
     void close();
 
     /**
-     * Tries to the load a data block from the file if none is loaded
+     * Tries to the load a nonempty data block from the file if none is loaded
      * @return ErrorCode_EndOfFile on EOF
      * @return ErrorCode_Failure on failure
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] ErrorCode try_load_data_block();
+    [[nodiscard]] ErrorCode try_load_nonempty_data_block();
 
     /**
      * Peeks the remaining buffered content without advancing the read head.
      *
      * NOTE: Any subsequent read or seek operations may invalidate the returned buffer.
-     * @param buf Returns a pointer to any buffered data
-     * @param buf_size Returns the number of bytes in the buffer
+     * @return The view of the buffered data
      */
-    void peek_buffered_data(char const*& buf, size_t& buf_size) const;
+    [[nodiscard]] auto peek_buffered_data() const -> std::span<char const>;
 
 private:
     // Methods
     /**
-     * Reads next data block from the archive
+     * Reads next nonempty data block from the archive
      * @return ErrorCode_EndOfFile on EOF
      * @return ErrorCode_Failure on failure
      * @return ErrorCode_Success on success
      */
-    ErrorCode read_next_data_block();
+    ErrorCode read_next_nonempty_data_block();
 
     // Variables
-    struct archive* m_archive;
+    struct archive* m_archive{nullptr};
 
-    struct archive_entry* m_archive_entry;
-    la_int64_t m_data_block_pos_in_file;
-    void const* m_data_block;
-    size_t m_data_block_length;
-    la_int64_t m_pos_in_data_block;
-    bool m_reached_eof;
+    struct archive_entry* m_archive_entry{nullptr};
+    la_int64_t m_data_block_pos_in_file{0};
+    void const* m_data_block{nullptr};
+    size_t m_data_block_length{0};
+    la_int64_t m_pos_in_data_block{0};
+    bool m_reached_eof{false};
 
-    size_t m_pos_in_file;
+    size_t m_pos_in_file{0};
 
     // Nulls for peek
     std::array<char, 4096> m_nulls_for_peek{0};

--- a/components/core/src/clp/LibarchiveFileReader.hpp
+++ b/components/core/src/clp/LibarchiveFileReader.hpp
@@ -89,7 +89,7 @@ public:
      * @return ErrorCode_Failure on failure
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] ErrorCode try_load_nonempty_data_block();
+    [[nodiscard]] auto try_load_nonempty_data_block() -> ErrorCode;
 
     /**
      * Peeks the remaining buffered content without advancing the read head.
@@ -107,7 +107,7 @@ private:
      * @return ErrorCode_Failure on failure
      * @return ErrorCode_Success on success
      */
-    ErrorCode read_next_nonempty_data_block();
+    [[nodiscard]] auto read_next_nonempty_data_block() -> ErrorCode;
 
     // Variables
     struct archive* m_archive{nullptr};


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The current `LibarchiveFileReader` implementation has the following problems:
- It doesn't handle the case where the data block is empty, which is the root cause of #389 
- Not all data members are initialized in the default constructor
- Buffer peeking method's signature can be improved with C++20 enabled

This PR makes the following changes accordingly:
- Handle the empty data block properly. All empty blocks will be skipped and only nonempty blocks can be read
- Initialize all data members in the member declaration (which matches our latest coding guideline)
- Using `std::span` for peeking buffer content


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure CI passed
- Ensure the bug has been fixed in #389

