### PR TITLE
core-clp: Add class to encapsulate `libcurl`'s global resource management.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -475,7 +475,7 @@ set(SOURCE_FILES_unitTest
         tests/test-string_utils.cpp
         tests/test-TimestampPattern.cpp
         tests/test-Utils.cpp
-)
+        )
 add_executable(unitTest ${SOURCE_FILES_unitTest} ${SOURCE_FILES_clp_s_unitTest})
 target_include_directories(unitTest
         PRIVATE

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -282,6 +282,8 @@ set(SOURCE_FILES_unitTest
         src/clp/CurlDownloadHandler.cpp
         src/clp/CurlDownloadHandler.hpp
         src/clp/CurlEasyHandle.hpp
+        src/clp/CurlGlobalInstance.cpp
+        src/clp/CurlGlobalInstance.hpp
         src/clp/CurlOperationFailed.hpp
         src/clp/CurlStringList.hpp
         src/clp/database_utils.cpp
@@ -473,7 +475,7 @@ set(SOURCE_FILES_unitTest
         tests/test-string_utils.cpp
         tests/test-TimestampPattern.cpp
         tests/test-Utils.cpp
-        )
+)
 add_executable(unitTest ${SOURCE_FILES_unitTest} ${SOURCE_FILES_clp_s_unitTest})
 target_include_directories(unitTest
         PRIVATE

--- a/components/core/src/clp/CurlGlobalInstance.cpp
+++ b/components/core/src/clp/CurlGlobalInstance.cpp
@@ -1,6 +1,5 @@
 #include "CurlGlobalInstance.hpp"
 
-#include <cstddef>
 #include <mutex>
 
 #include <curl/curl.h>
@@ -9,11 +8,8 @@
 #include "ErrorCode.hpp"
 
 namespace clp {
-std::mutex CurlGlobalInstance::m_global_mutex;
-size_t CurlGlobalInstance::m_num_living_instances{0};
-
 CurlGlobalInstance::CurlGlobalInstance() {
-    std::unique_lock<std::mutex> const global_lock{m_global_mutex};
+    std::lock_guard<std::mutex> const global_lock{m_global_mutex};
     if (0 == m_num_living_instances) {
         if (auto const err{curl_global_init(CURL_GLOBAL_ALL)}; CURLE_OK != err) {
             throw CurlOperationFailed(
@@ -29,7 +25,7 @@ CurlGlobalInstance::CurlGlobalInstance() {
 }
 
 CurlGlobalInstance::~CurlGlobalInstance() {
-    std::unique_lock<std::mutex> const global_lock{m_global_mutex};
+    std::lock_guard<std::mutex> const global_lock{m_global_mutex};
     --m_num_living_instances;
     if (0 == m_num_living_instances) {
 #if defined(__APPLE__)

--- a/components/core/src/clp/CurlGlobalInstance.cpp
+++ b/components/core/src/clp/CurlGlobalInstance.cpp
@@ -11,7 +11,7 @@ namespace clp {
 CurlGlobalInstance::CurlGlobalInstance() {
     std::lock_guard<std::mutex> const global_lock{m_global_mutex};
     if (0 == m_num_living_instances) {
-        if (auto const err{curl_global_init(CURL_GLOBAL_ALL)}; CURLE_OK != err) {
+        if (auto const err{curl_global_init(CURL_GLOBAL_ALL)}; 0 != err) {
             throw CurlOperationFailed(
                     ErrorCode_Failure,
                     __FILE__,
@@ -30,9 +30,9 @@ CurlGlobalInstance::~CurlGlobalInstance() {
     if (0 == m_num_living_instances) {
 #if defined(__APPLE__)
         // NOTE: On macOS, calling `curl_global_init` after `curl_global_cleanup` will fail with
-        // CURLE_SSL_CONNECT_ERROR. Thus, for now, we skip `deinit` on macOS. Related issues:
-        // - https://github.com/curl/curl/issues/12525
-        // - https://github.com/curl/curl/issues/13805
+        // CURLE_SSL_CONNECT_ERROR. Thus, for now, we skip `deinit` on macOS. Luckily, it is safe to
+        // call `curl_global_init` multiple times without calling `curl_global_cleanup`. Related
+        // issues:
         // TODO: Remove this conditional logic when the issues are resolved.
         return;
 #else

--- a/components/core/src/clp/CurlGlobalInstance.cpp
+++ b/components/core/src/clp/CurlGlobalInstance.cpp
@@ -1,0 +1,47 @@
+#include "CurlGlobalInstance.hpp"
+
+#include <cstddef>
+#include <mutex>
+
+#include <curl/curl.h>
+
+#include "CurlOperationFailed.hpp"
+#include "ErrorCode.hpp"
+
+namespace clp {
+std::mutex CurlGlobalInstance::m_global_mutex;
+size_t CurlGlobalInstance::m_num_living_instances{0};
+
+CurlGlobalInstance::CurlGlobalInstance() {
+    std::unique_lock<std::mutex> const global_lock{m_global_mutex};
+    if (0 == m_num_living_instances) {
+        if (auto const err{curl_global_init(CURL_GLOBAL_ALL)}; CURLE_OK != err) {
+            throw CurlOperationFailed(
+                    ErrorCode_Failure,
+                    __FILE__,
+                    __LINE__,
+                    err,
+                    "`curl_global_init` failed."
+            );
+        }
+    }
+    ++m_num_living_instances;
+}
+
+CurlGlobalInstance::~CurlGlobalInstance() {
+    std::unique_lock<std::mutex> const global_lock{m_global_mutex};
+    --m_num_living_instances;
+    if (0 == m_num_living_instances) {
+#if defined(__APPLE__)
+        // NOTE: On macOS, calling `curl_global_init` after `curl_global_cleanup` will fail with
+        // CURLE_SSL_CONNECT_ERROR. Thus, for now, we skip `deinit` on macOS. Related issues:
+        // - https://github.com/curl/curl/issues/12525
+        // - https://github.com/curl/curl/issues/13805
+        // TODO: Remove this conditional logic when the issues are resolved.
+        return;
+#else
+        curl_global_cleanup();
+#endif
+    }
+}
+}  // namespace clp

--- a/components/core/src/clp/CurlGlobalInstance.cpp
+++ b/components/core/src/clp/CurlGlobalInstance.cpp
@@ -9,7 +9,7 @@
 
 namespace clp {
 CurlGlobalInstance::CurlGlobalInstance() {
-    std::scoped_lock<std::mutex> const global_lock{m_ref_count_mutex};
+    std::scoped_lock const global_lock{m_ref_count_mutex};
     if (0 == m_ref_count) {
         if (auto const err{curl_global_init(CURL_GLOBAL_ALL)}; 0 != err) {
             throw CurlOperationFailed(
@@ -25,7 +25,7 @@ CurlGlobalInstance::CurlGlobalInstance() {
 }
 
 CurlGlobalInstance::~CurlGlobalInstance() {
-    std::scoped_lock<std::mutex> const global_lock{m_ref_count_mutex};
+    std::scoped_lock const global_lock{m_ref_count_mutex};
     --m_ref_count;
     if (0 == m_ref_count) {
 #if defined(__APPLE__)

--- a/components/core/src/clp/CurlGlobalInstance.cpp
+++ b/components/core/src/clp/CurlGlobalInstance.cpp
@@ -33,6 +33,8 @@ CurlGlobalInstance::~CurlGlobalInstance() {
         // CURLE_SSL_CONNECT_ERROR. Thus, for now, we skip `deinit` on macOS. Luckily, it is safe to
         // call `curl_global_init` multiple times without calling `curl_global_cleanup`. Related
         // issues:
+        // - https://github.com/curl/curl/issues/12525
+        // - https://github.com/curl/curl/issues/13805
         // TODO: Remove this conditional logic when the issues are resolved.
         return;
 #else

--- a/components/core/src/clp/CurlGlobalInstance.hpp
+++ b/components/core/src/clp/CurlGlobalInstance.hpp
@@ -27,8 +27,8 @@ public:
     ~CurlGlobalInstance();
 
 private:
-    static inline std::mutex m_global_mutex;
-    static inline size_t m_num_living_instances{0};
+    static inline std::mutex m_ref_count_mutex;
+    static inline size_t m_ref_count{0};
 };
 }  // namespace clp
 

--- a/components/core/src/clp/CurlGlobalInstance.hpp
+++ b/components/core/src/clp/CurlGlobalInstance.hpp
@@ -1,0 +1,34 @@
+#ifndef CLP_CURLGLOBALINSTANCE_HPP
+#define CLP_CURLGLOBALINSTANCE_HPP
+
+#include <cstddef>
+#include <mutex>
+
+namespace clp {
+/**
+ * Class to wrap `libcurl`'s global initialization/de-initialization calls. Before using any
+ * `libcurl` functionalities, an instance of this function must be created to ensure underlying
+ * `libcurl` resources have been initialized. This class maintains a static reference count to all
+ * the living instances. De-initialization happens when the reference count reaches 0.
+ */
+class CurlGlobalInstance {
+public:
+    // Constructors
+    CurlGlobalInstance();
+
+    // Disable copy/move constructors/assignment operators
+    CurlGlobalInstance(CurlGlobalInstance const&) = delete;
+    CurlGlobalInstance(CurlGlobalInstance&&) = delete;
+    auto operator=(CurlGlobalInstance const&) -> CurlGlobalInstance& = delete;
+    auto operator=(CurlGlobalInstance&&) -> CurlGlobalInstance& = delete;
+
+    // Destructor
+    ~CurlGlobalInstance();
+
+private:
+    static std::mutex m_global_mutex;
+    static size_t m_num_living_instances;
+};
+}  // namespace clp
+
+#endif  // CLP_CURLGLOBALINSTANCE_HPP

--- a/components/core/src/clp/CurlGlobalInstance.hpp
+++ b/components/core/src/clp/CurlGlobalInstance.hpp
@@ -6,8 +6,8 @@
 
 namespace clp {
 /**
- * Class to wrap `libcurl`'s global initialization/de-initialization calls. Before using any
- * `libcurl` functionalities, an instance of this function must be created to ensure underlying
+ * Class to wrap `libcurl`'s global initialization/de-initialization calls using RAII. Before using
+ * any `libcurl` functionalities, an instance of this function must be created to ensure underlying
  * `libcurl` resources have been initialized. This class maintains a static reference count to all
  * the living instances. De-initialization happens when the reference count reaches 0.
  */
@@ -26,8 +26,8 @@ public:
     ~CurlGlobalInstance();
 
 private:
-    static std::mutex m_global_mutex;
-    static size_t m_num_living_instances;
+    static inline std::mutex m_global_mutex;
+    static inline size_t m_num_living_instances;
 };
 }  // namespace clp
 

--- a/components/core/src/clp/CurlGlobalInstance.hpp
+++ b/components/core/src/clp/CurlGlobalInstance.hpp
@@ -7,16 +7,17 @@
 namespace clp {
 /**
  * Class to wrap `libcurl`'s global initialization/de-initialization calls using RAII. Before using
- * any `libcurl` functionalities, an instance of this function must be created to ensure underlying
- * `libcurl` resources have been initialized. This class maintains a static reference count to all
- * the living instances. De-initialization happens when the reference count reaches 0.
+ * any `libcurl` functionalities, an instance of this class must be created. Although unnecessasry,
+ * it can be safely instantiated multiple times; it maintains a static reference count to all
+ * existing instances and only di-initializes `libcurl`'s global resources when the reference count
+ * reaches 0.
  */
 class CurlGlobalInstance {
 public:
     // Constructors
     CurlGlobalInstance();
 
-    // Disable copy/move constructors/assignment operators
+    // Disable copy/move constructors and assignment operators
     CurlGlobalInstance(CurlGlobalInstance const&) = delete;
     CurlGlobalInstance(CurlGlobalInstance&&) = delete;
     auto operator=(CurlGlobalInstance const&) -> CurlGlobalInstance& = delete;

--- a/components/core/src/clp/CurlGlobalInstance.hpp
+++ b/components/core/src/clp/CurlGlobalInstance.hpp
@@ -9,7 +9,7 @@ namespace clp {
  * Class to wrap `libcurl`'s global initialization/de-initialization calls using RAII. Before using
  * any `libcurl` functionalities, an instance of this class must be created. Although unnecessasry,
  * it can be safely instantiated multiple times; it maintains a static reference count to all
- * existing instances and only di-initializes `libcurl`'s global resources when the reference count
+ * existing instances and only de-initializes `libcurl`'s global resources when the reference count
  * reaches 0.
  */
 class CurlGlobalInstance {

--- a/components/core/src/clp/CurlGlobalInstance.hpp
+++ b/components/core/src/clp/CurlGlobalInstance.hpp
@@ -27,7 +27,7 @@ public:
 
 private:
     static inline std::mutex m_global_mutex;
-    static inline size_t m_num_living_instances;
+    static inline size_t m_num_living_instances{0};
 };
 }  // namespace clp
 

--- a/components/core/src/clp/NetworkReader.hpp
+++ b/components/core/src/clp/NetworkReader.hpp
@@ -70,23 +70,9 @@ public:
     static constexpr size_t cMinBufferSize{512};
 
     /**
-     * Initializes static resources for this class. This must be called before using the class.
-     * @return ErrorCode_Success on success.
-     * @return ErrorCode_Failure if libcurl initialization failed.
-     */
-    [[nodiscard]] static auto init() -> ErrorCode;
-
-    /**
-     * De-initializes any static resources.
-     */
-    static auto deinit() -> void;
-
-    /**
      * Constructs a reader to stream data from the given URL, starting at the given offset.
-     * TODO: the current implementation doesn't handle the case when the given offset is out of
-     * range. The file_pos will be set to an invalid state if this happens, which can be
-     * problematic if the other part of the program depends on this position. It can be fixed by
-     * capturing the error code 416 in the response header.
+     * Note: This class depends on `libcurl`. An instance of `clp::CurlGlobalInstance` must remain
+     * alive for the entire lifespan of any instance of this class to maintain proper functionality.
      * @param src_url
      * @param offset Index of the byte at which to start the download
      * @param disable_caching Whether to disable the caching.
@@ -245,8 +231,6 @@ private:
         size_t m_offset{0};
         bool m_disable_caching{false};
     };
-
-    static bool m_static_init_complete;
 
     /**
      * Submits a request to abort the ongoing curl download session.

--- a/components/core/src/clp/NetworkReader.hpp
+++ b/components/core/src/clp/NetworkReader.hpp
@@ -18,6 +18,7 @@
 #include <curl/curl.h>
 
 #include "CurlDownloadHandler.hpp"
+#include "CurlGlobalInstance.hpp"
 #include "ErrorCode.hpp"
 #include "ReaderInterface.hpp"
 #include "Thread.hpp"
@@ -72,7 +73,10 @@ public:
     /**
      * Constructs a reader to stream data from the given URL, starting at the given offset.
      * NOTE: This class depends on `libcurl`, so an instance of `clp::CurlGlobalInstance` must
-     * remain alive for the entire lifespan of any instance of this class.
+     * remain alive for the entire lifespan of any instance of this class. For safety concern, a
+     * `clp::CurlGlobalInstance` instance is added as a member variable in this class. However, it
+     * is suggested to instantiate `clp::CurlGlobalInstance` inside the top entry of the code to
+     * minimize `libcurl` resource init/deinit overhead.
      * @param src_url
      * @param offset Index of the byte at which to start the download
      * @param disable_caching Whether to disable the caching.
@@ -291,6 +295,8 @@ private:
     [[nodiscard]] auto at_least_one_byte_downloaded() const -> bool {
         return m_at_least_one_byte_downloaded.load();
     }
+
+    CurlGlobalInstance m_curl_global_instance;
 
     std::string m_src_url;
 

--- a/components/core/src/clp/NetworkReader.hpp
+++ b/components/core/src/clp/NetworkReader.hpp
@@ -71,8 +71,8 @@ public:
 
     /**
      * Constructs a reader to stream data from the given URL, starting at the given offset.
-     * Note: This class depends on `libcurl`. An instance of `clp::CurlGlobalInstance` must remain
-     * alive for the entire lifespan of any instance of this class to maintain proper functionality.
+     * NOTE: This class depends on `libcurl`, so an instance of `clp::CurlGlobalInstance` must
+     * remain alive for the entire lifespan of any instance of this class.
      * @param src_url
      * @param offset Index of the byte at which to start the download
      * @param disable_caching Whether to disable the caching.

--- a/components/core/src/clp/NetworkReader.hpp
+++ b/components/core/src/clp/NetworkReader.hpp
@@ -73,10 +73,17 @@ public:
     /**
      * Constructs a reader to stream data from the given URL, starting at the given offset.
      * NOTE: This class depends on `libcurl`, so an instance of `clp::CurlGlobalInstance` must
-     * remain alive for the entire lifespan of any instance of this class. For safety concern, a
-     * `clp::CurlGlobalInstance` instance is added as a member variable in this class. However, it
-     * is suggested to instantiate `clp::CurlGlobalInstance` inside the top entry of the code to
-     * minimize `libcurl` resource init/deinit overhead.
+     * remain alive for the entire lifespan of any instance of this class.
+     *
+     * This class maintains an instance of `CurlGlobalInstance` in case the user forgets to
+     * instantiate one, but it is better for performance if the user instantiates one. For instance,
+     * if the user doesn't instantiate a `CurlGlobalInstance` and only ever creates one
+     * `NetworkReader` at a time, then every construction and destruction of `NetworkReader` would
+     * cause `libcurl` to init and deinit. In contrast, if the user instantiates a
+     * `CurlGlobalInstance` before instantiating any `NetworkReader`s, then the `CurlGlobalInstance`
+     * maintained by this class will simply be a reference to the existing one rather than
+     * initializing and deinitializing `libcurl`.
+     *
      * @param src_url
      * @param offset Index of the byte at which to start the download
      * @param disable_caching Whether to disable the caching.

--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -67,12 +67,12 @@ auto get_content(clp::ReaderInterface& reader, size_t read_buf_size) -> std::vec
 }  // namespace
 
 TEST_CASE("network_reader_basic", "[NetworkReader]") {
-    clp::CurlGlobalInstance const curl_global_instance;
     clp::FileReader ref_reader;
     ref_reader.open(get_test_input_local_path());
     auto const expected{get_content(ref_reader)};
     ref_reader.close();
 
+    clp::CurlGlobalInstance const curl_global_instance;
     clp::NetworkReader reader{get_test_input_remote_url()};
     auto const actual{get_content(reader)};
     auto const ret_code{reader.get_curl_ret_code()};
@@ -83,7 +83,6 @@ TEST_CASE("network_reader_basic", "[NetworkReader]") {
 }
 
 TEST_CASE("network_reader_with_offset_and_seek", "[NetworkReader]") {
-    clp::CurlGlobalInstance const curl_global_instance;
     constexpr size_t cOffset{319};
     clp::FileReader ref_reader;
     ref_reader.open(get_test_input_local_path());
@@ -94,6 +93,7 @@ TEST_CASE("network_reader_with_offset_and_seek", "[NetworkReader]") {
 
     // Read from an offset onwards by starting the download from that offset.
     {
+        clp::CurlGlobalInstance const curl_global_instance;
         clp::NetworkReader reader{get_test_input_remote_url(), cOffset};
         auto const actual{get_content(reader)};
         auto const ret_code{reader.get_curl_ret_code()};
@@ -106,6 +106,7 @@ TEST_CASE("network_reader_with_offset_and_seek", "[NetworkReader]") {
 
     // Read from an offset onwards by seeking to that offset.
     {
+        clp::CurlGlobalInstance const curl_global_instance;
         clp::NetworkReader reader(get_test_input_remote_url());
         reader.seek_from_begin(cOffset);
         auto const actual{get_content(reader)};
@@ -119,14 +120,13 @@ TEST_CASE("network_reader_with_offset_and_seek", "[NetworkReader]") {
 }
 
 TEST_CASE("network_reader_destruct", "[NetworkReader]") {
-    clp::CurlGlobalInstance const curl_global_instance;
-
     // We sleep to fill out all the buffers, and then we delete the reader. The destructor will try
     // to abort the underlying download and then destroy the instance. So should ensure destructor
     // is successfully executed without deadlock or exceptions.
     bool no_exception{true};
     try {
         // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+        clp::CurlGlobalInstance const curl_global_instance;
         auto reader{std::make_unique<clp::NetworkReader>(
                 get_test_input_remote_url(),
                 0,
@@ -147,10 +147,9 @@ TEST_CASE("network_reader_destruct", "[NetworkReader]") {
 }
 
 TEST_CASE("network_reader_illegal_offset", "[NetworkReader]") {
-    clp::CurlGlobalInstance const curl_global_instance;
-
     // Try to read from an out-of-bound offset.
     constexpr size_t cIllegalOffset{UINT32_MAX};
+    clp::CurlGlobalInstance const curl_global_instance;
     clp::NetworkReader reader{get_test_input_remote_url(), cIllegalOffset};
     while (true) {
         auto const ret_code{reader.get_curl_ret_code()};

--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -53,7 +53,6 @@ auto get_test_input_path_relative_to_tests_dir() -> std::filesystem::path {
 }
 
 auto get_content(clp::ReaderInterface& reader, size_t read_buf_size) -> std::vector<char> {
-    clp::CurlGlobalInstance const curl_global_instance;
     std::vector<char> buf;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
     auto const read_buf{std::make_unique<char[]>(read_buf_size)};


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Before this PR, we reply on static methods `clp::NetworkReader::init/deinit` to initialize `libcurl` global resources. However, there are downsides of the current implementation:
1. Curl resource management should not be specific to a particular application of `libcurl`; there should be a dedicated approach, instead of being a part of `clp::NetworkReader`
2. The current way of doing init/deinit is just a wrapper to `libcurl`'s C style resource management. It has nothing guaranteed about the object life cycle. This is the root cause of some of the workflow failure, such as this one: https://github.com/y-scope/clp/actions/runs/9613911655/job/26517641592, where the global deinit happens before `clp::NetworkReader` instance gets out of its life cycle.

This PR introduces a specialized class `clp::CurlGlobalInstance` for managing curl resources using the RAII pattern. Similar to mongodb, users must create an instance of a specific class to initialize the resources. Resource deallocation occurs automatically when the object is destroyed. To manage multiple instances, a thread-safe static reference count is used to track all active instances. This prevents double-initialization and ensures that global resources are not deallocated while they are still needed by other instances.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Ensure the code gets built properly without linter errors
2. Ensure `clp::NetworkReader` works as expected after switching to this new class

