### PR TITLE
clp-package: Add support for running package as root (fixes #500).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -292,7 +292,9 @@ def start_queue(instance_id: str, clp_config: CLPConfig):
         # directories writable by that user.
         # NOTE: This doesn't affect the host user's access to the directories since they're `root`.
         container_user = "rabbitmq"
-        chown_recursively(queue_logs_dir, 999, 999)
+        default_container_user_id = 999
+        default_container_group_id = 999
+        chown_recursively(queue_logs_dir, default_container_user_id, default_container_group_id)
 
     # fmt: off
     cmd = [
@@ -365,10 +367,10 @@ def start_redis(instance_id: str, clp_config: CLPConfig, conf_dir: pathlib.Path)
         # directories writable by that user.
         # NOTE: This doesn't affect the host user's access to the directories since they're `root`.
         container_user = "redis"
-        container_user_id = 999
-        container_group_id = 999
-        chown_recursively(redis_data_dir, container_user_id, container_group_id)
-        chown_recursively(redis_logs_dir, container_user_id, container_group_id)
+        default_container_user_id = 999
+        default_container_group_id = 999
+        chown_recursively(redis_data_dir, default_container_user_id, default_container_group_id)
+        chown_recursively(redis_logs_dir, default_container_user_id, default_container_group_id)
 
     # fmt: off
     cmd = [
@@ -438,10 +440,10 @@ def start_results_cache(instance_id: str, clp_config: CLPConfig, conf_dir: pathl
         # directories writable by that user.
         # NOTE: This doesn't affect the host user's access to the directories since they're `root`.
         container_user = "mongodb"
-        container_user_id = 999
-        container_group_id = 999
-        chown_recursively(data_dir, container_user_id, container_group_id)
-        chown_recursively(logs_dir, container_user_id, container_group_id)
+        default_container_user_id = 999
+        default_container_group_id = 999
+        chown_recursively(data_dir, default_container_user_id, default_container_group_id)
+        chown_recursively(logs_dir, default_container_user_id, default_container_group_id)
 
     # fmt: off
     cmd = [

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -94,10 +94,10 @@ def chown_recursively(
 ):
     """
     Recursively changes the owner of the given path to the given user ID and group ID.
-    :param path: 
-    :param user_id: 
-    :param group_id: 
-    """    
+    :param path:
+    :param user_id:
+    :param group_id:
+    """
     chown_cmd = ["chown", "--recursive", f"{user_id}:{group_id}", str(path)]
     subprocess.run(chown_cmd, stdout=subprocess.DEVNULL, check=True)
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
When running container as root user, redis, results cache and rabbitmq containers lose the write permission to log and data directories.
This PR adds a temporary fix. We let the container run with their default user and change the ownership of the log directories when the current user is root.
Also adds a start up check for redis



# Validation performed
1. Run clp package with root, confirmed that package can run properly
2. Run clp package with non-root. Stop and restart the same package as root, confirmed that package can run properly, indicating that ownership of the folders and their contents has been changed successfully

