### PR TITLE
clo: Use relative path for file metadata output by an IR extraction job.

### DIFF
--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -192,7 +192,7 @@ bool extract_ir(CommandLineArguments const& command_line_args) {
             results.emplace_back(std::move(bsoncxx::builder::basic::make_document(
                     bsoncxx::builder::basic::kvp(
                             clp::clo::cResultsCacheKeys::IrOutput::Path,
-                            dest_ir_path.string()
+                            dest_ir_file_name
                     ),
                     bsoncxx::builder::basic::kvp(
                             clp::clo::cResultsCacheKeys::OrigFileId,


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
This PR replaces the absolute path in the results cache with relative path. The relative path is preferred because different worker containers may have different mounts, so they may not share the same absolute path.



# Validation performed
Manually submitted an IR extraction job and verified that the path in results cache is expected

