### PR TITLE
linting: Add log-viewer-webui to js-lint tasks.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,6 +9,7 @@ vars:
   # Paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
+  G_LATEST_NODEJS_DIR: "{{.G_BUILD_DIR}}/nodejs-latest"
   G_METEOR_BUILD_DIR: "{{.G_BUILD_DIR}}/meteor"
   G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
@@ -203,6 +204,18 @@ tasks:
       - "server/**/*"
       - "tests/**/*"
     generates: ["{{.CHECKSUM_FILE}}"]
+
+  nodejs-latest:
+    internal: true
+    vars:
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "{{.G_LATEST_NODEJS_DIR}}"
+    cmds:
+      - task: "nodejs"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          NODEJS_VERSION: "latest"
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
 
   webui-nodejs:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -353,7 +353,10 @@ tasks:
           OUTPUT_FILE: "{{.SERVER_CHECKSUM_FILE}}"
       # This command must be last
       - >-
-        cat "{{.CLIENT_CHECKSUM_FILE}}" "{{.PACKAGE_CHECKSUM_FILE}}" "{{.SERVER_CHECKSUM_FILE}}"
+        cat
+        "{{.CLIENT_CHECKSUM_FILE}}"
+        "{{.PACKAGE_CHECKSUM_FILE}}"
+        "{{.SERVER_CHECKSUM_FILE}}"
         > "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.G_BUILD_DIR}}/nodejs-22.md5"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,6 +27,7 @@ tasks:
   clean:
     cmds:
       - "rm -rf '{{.G_BUILD_DIR}}'"
+      - task: "clean-log-viewer-webui"
       - task: "clean-python-component"
         vars:
           COMPONENT: "clp-package-utils"
@@ -36,6 +37,18 @@ tasks:
       - task: "clean-python-component"
         vars:
           COMPONENT: "job-orchestration"
+      - task: "clean-webui"
+
+  clean-log-viewer-webui:
+    cmds:
+      - "rm -rf 'components/log-viewer-webui/client/node_modules'"
+      - "rm -rf 'components/log-viewer-webui/node_modules'"
+      - "rm -rf 'components/log-viewer-webui/server/node_modules'"
+
+  clean-webui:
+    cmds:
+      - "rm -rf 'components/webui/.meteor/local'"
+      - "rm -rf 'components/webui/node_modules'"
 
   clp-json-pkg-tar:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,8 +9,8 @@ vars:
   # Paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
-  G_NODEJS_22_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
   G_METEOR_BUILD_DIR: "{{.G_BUILD_DIR}}/meteor"
+  G_NODEJS_22_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
   G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -336,7 +336,7 @@ tasks:
           DATA_DIR: "{{.PACKAGE_OUTPUT_DIR}}"
     cmds:
       - "rm -f {{.CHECKSUM_FILE}}"
-      - "rm -rf '{{.CLIENT_OUTPUT_DIR}}' '{{.PACKAGE_OUTPUT_DIR}}' '{{.SERVER_OUTPUT_DIR}}'"
+      - task: "clean-log-viewer-webui"
       - "PATH='{{.G_LATEST_NODEJS_DIR}}/bin':$PATH npm run init"
       # These commands must be last
       - task: "utils:compute-checksum"
@@ -355,7 +355,15 @@ tasks:
       - >-
         cat "{{.CLIENT_CHECKSUM_FILE}}" "{{.PACKAGE_CHECKSUM_FILE}}" "{{.SERVER_CHECKSUM_FILE}}"
         > "{{.CHECKSUM_FILE}}"
-    sources: ["{{.G_BUILD_DIR}}/nodejs-latest.md5", "{{.TASKFILE}}"]
+    sources:
+      - "{{.G_BUILD_DIR}}/nodejs-latest.md5"
+      - "{{.TASKFILE}}"
+      - "client/package.json"
+      - "client/package-lock.json"
+      - "package.json"
+      - "package-lock.json"
+      - "server/package.json"
+      - "server/package-lock.json"
     generates:
       - "{{.CHECKSUM_FILE}}"
       - "{{.CLIENT_CHECKSUM_FILE}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -223,7 +223,7 @@ tasks:
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_LATEST_NODEJS_DIR}}"
-    run: once
+    run: "once"
     cmds:
       - task: "nodejs"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ vars:
   # Paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
-  G_LATEST_NODEJS_DIR: "{{.G_BUILD_DIR}}/nodejs-latest"
+  G_NODEJS_22_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
   G_METEOR_BUILD_DIR: "{{.G_BUILD_DIR}}/meteor"
   G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
@@ -218,17 +218,17 @@ tasks:
       - "tests/**/*"
     generates: ["{{.CHECKSUM_FILE}}"]
 
-  nodejs-latest:
+  nodejs-22:
     internal: true
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.G_LATEST_NODEJS_DIR}}"
+      OUTPUT_DIR: "{{.G_NODEJS_22_DIR}}"
     run: "once"
     cmds:
       - task: "nodejs"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          NODEJS_VERSION: "latest"
+          NODEJS_VERSION: "v22.4.0"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
 
   webui-nodejs:
@@ -321,7 +321,7 @@ tasks:
       SERVER_OUTPUT_DIR: "{{.SRC_DIR}}/server/node_modules"
     dir: "{{.SRC_DIR}}"
     deps:
-      - "nodejs-latest"
+      - "nodejs-22"
       - task: "utils:validate-checksum"
         vars:
           CHECKSUM_FILE: "{{.CLIENT_CHECKSUM_FILE}}"
@@ -337,7 +337,7 @@ tasks:
     cmds:
       - "rm -f {{.CHECKSUM_FILE}}"
       - task: "clean-log-viewer-webui"
-      - "PATH='{{.G_LATEST_NODEJS_DIR}}/bin':$PATH npm run init"
+      - "PATH='{{.G_NODEJS_22_DIR}}/bin':$PATH npm run init"
       # These commands must be last
       - task: "utils:compute-checksum"
         vars:
@@ -356,7 +356,7 @@ tasks:
         cat "{{.CLIENT_CHECKSUM_FILE}}" "{{.PACKAGE_CHECKSUM_FILE}}" "{{.SERVER_CHECKSUM_FILE}}"
         > "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.G_BUILD_DIR}}/nodejs-latest.md5"
+      - "{{.G_BUILD_DIR}}/nodejs-22.md5"
       - "{{.TASKFILE}}"
       - "client/package.json"
       - "client/package-lock.json"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -210,6 +210,7 @@ tasks:
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_LATEST_NODEJS_DIR}}"
+    run: once
     cmds:
       - task: "nodejs"
         vars:
@@ -286,6 +287,67 @@ tasks:
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources: ["{{.TASKFILE}}"]
     generates: ["{{.CHECKSUM_FILE}}"]
+
+  # NOTE: The log-viewer-webui has three different node_modules directories (client, server, and the
+  # top-level one we call "package"), meaning we have to create three different checksums. To allow
+  # tasks which depend on this task to only have to check one checksum file, we concatenate the
+  # three checksum files into one.
+  log-viewer-webui-node-modules:
+    internal: true
+    vars:
+      # Checksum files
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      CLIENT_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-client-node-modules.md5"
+      PACKAGE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-package-node-modules.md5"
+      SERVER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-server-node-modules.md5"
+
+      # Directories
+      SRC_DIR: "{{.TASKFILE_DIR}}/components/log-viewer-webui"
+      CLIENT_OUTPUT_DIR: "{{.SRC_DIR}}/client/node_modules"
+      PACKAGE_OUTPUT_DIR: "{{.SRC_DIR}}/node_modules"
+      SERVER_OUTPUT_DIR: "{{.SRC_DIR}}/server/node_modules"
+    dir: "{{.SRC_DIR}}"
+    deps:
+      - "nodejs-latest"
+      - task: "utils:validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CLIENT_CHECKSUM_FILE}}"
+          DATA_DIR: "{{.CLIENT_OUTPUT_DIR}}"
+      - task: "utils:validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.SERVER_CHECKSUM_FILE}}"
+          DATA_DIR: "{{.SERVER_OUTPUT_DIR}}"
+      - task: "utils:validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.PACKAGE_CHECKSUM_FILE}}"
+          DATA_DIR: "{{.PACKAGE_OUTPUT_DIR}}"
+    cmds:
+      - "rm -f {{.CHECKSUM_FILE}}"
+      - "rm -rf '{{.CLIENT_OUTPUT_DIR}}' '{{.PACKAGE_OUTPUT_DIR}}' '{{.SERVER_OUTPUT_DIR}}'"
+      - "PATH='{{.G_LATEST_NODEJS_DIR}}/bin':$PATH npm run init"
+      # These commands must be last
+      - task: "utils:compute-checksum"
+        vars:
+          DATA_DIR: "{{.CLIENT_OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CLIENT_CHECKSUM_FILE}}"
+      - task: "utils:compute-checksum"
+        vars:
+          DATA_DIR: "{{.PACKAGE_OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.PACKAGE_CHECKSUM_FILE}}"
+      - task: "utils:compute-checksum"
+        vars:
+          DATA_DIR: "{{.SERVER_OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.SERVER_CHECKSUM_FILE}}"
+      # This command must be last
+      - >-
+        cat "{{.CLIENT_CHECKSUM_FILE}}" "{{.PACKAGE_CHECKSUM_FILE}}" "{{.SERVER_CHECKSUM_FILE}}"
+        > "{{.CHECKSUM_FILE}}"
+    sources: ["{{.G_BUILD_DIR}}/nodejs-latest.md5", "{{.TASKFILE}}"]
+    generates:
+      - "{{.CHECKSUM_FILE}}"
+      - "{{.CLIENT_CHECKSUM_FILE}}"
+      - "{{.PACKAGE_CHECKSUM_FILE}}"
+      - "{{.SERVER_CHECKSUM_FILE}}"
 
   meteor:
     run: "once"

--- a/docs/src/dev-guide/components-log-viewer-webui.md
+++ b/docs/src/dev-guide/components-log-viewer-webui.md
@@ -50,7 +50,25 @@ npm test
 
 ## Linting
 
-To check for linting errors in either the client or server:
+You can lint this component either as part of the entire project or as a standalone component.
+
+### Lint as part of the project
+
+To check for linting errors:
+
+```shell
+task lint:js-check
+```
+
+To also fix linting errors (if possible):
+
+```shell
+task lint:js-fix
+```
+
+### Lint the component alone
+
+To check for linting errors:
 
 ```shell
 npm run lint:check

--- a/docs/src/dev-guide/components-log-viewer-webui.md
+++ b/docs/src/dev-guide/components-log-viewer-webui.md
@@ -60,7 +60,7 @@ To check for linting errors:
 task lint:js-check
 ```
 
-To also fix linting errors (if possible):
+To also fix linting errors (if applicable):
 
 ```shell
 task lint:js-fix
@@ -74,7 +74,7 @@ To check for linting errors:
 npm run lint:check
 ```
 
-To also fix linting errors (if possible):
+To also fix linting errors (if applicable):
 
 ```shell
 npm run lint:fix

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,8 +1,7 @@
 version: "3"
 
 vars:
-  G_LINTER_NODEJS_BUILD_DIR: "{{.G_BUILD_DIR}}/linter-nodejs"
-  G_LINTER_NODEJS_BIN_DIR: "{{.G_LINTER_NODEJS_BUILD_DIR}}/bin"
+  G_LATEST_NODEJS_BIN_DIR: "{{.G_LATEST_NODEJS_DIR}}/bin"
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
 
 tasks:
@@ -134,7 +133,7 @@ tasks:
           - "components/webui"
         cmd: |-
           cd "{{.ITEM}}"
-          PATH="{{.G_LINTER_NODEJS_BIN_DIR}}":$PATH npm run "lint:{{.LINT_CMD}}"
+          PATH="{{.G_LATEST_NODEJS_BIN_DIR}}":$PATH npm run "lint:{{.LINT_CMD}}"
 
   py:
     internal: true
@@ -153,18 +152,6 @@ tasks:
           black --color --line-length 100 {{.BLACK_FLAGS}} .
           ruff check {{.RUFF_FLAGS}} .
 
-  linter-nodejs:
-    internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
-      OUTPUT_DIR: "{{.G_LINTER_NODEJS_BUILD_DIR}}"
-    cmds:
-      - task: ":nodejs"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          NODEJS_VERSION: "latest"
-          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
-
   linter-node-modules:
     internal: true
     deps:
@@ -174,7 +161,7 @@ tasks:
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_DIR: "{{.OUTPUT_DIR}}"
-      - "linter-nodejs"
+      - ":nodejs-latest"
     dir: "{{.WEBUI_LINTER_DIR}}"
     vars:
       WEBUI_LINTER_DIR: "{{.ROOT_DIR}}/components/webui/linter"
@@ -182,14 +169,14 @@ tasks:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "PATH='{{.G_LINTER_NODEJS_BIN_DIR}}':$PATH npm update"
+      - "PATH='{{.G_LATEST_NODEJS_BIN_DIR}}':$PATH npm update"
       # This command must be last
       - task: ":utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.G_BUILD_DIR}}/lint#linter-nodejs.md5"
+      - "{{.G_BUILD_DIR}}/nodejs-latest.md5"
       - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -3,6 +3,8 @@ version: "3"
 vars:
   G_LATEST_NODEJS_BIN_DIR: "{{.G_LATEST_NODEJS_DIR}}/bin"
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
+  G_LOG_VIEWER_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/log-viewer-webui"
+  G_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
 
 tasks:
   check:
@@ -46,9 +48,6 @@ tasks:
     sources: *cpp_source_files
 
   js-check:
-    vars:
-      LOG_VIEWER_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/log-viewer-webui"
-      WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
     cmds:
       - task: "js"
         vars:
@@ -57,31 +56,52 @@ tasks:
       - "{{.G_BUILD_DIR}}/lint#linter-node-modules.md5"
       - "{{.G_BUILD_DIR}}/log-viewer-webui-node-modules.md5"
       - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
-      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.css"
-      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.jsx"
-      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/package.json"
-      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/webpack.config.js"
-      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/*.js"
-      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/package.json"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.css"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.jsx"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/package.json"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/webpack.config.js"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/*.js"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/package.json"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
-      - "{{.WEBUI_SRC_DIR}}/client/**/*.js"
-      - "{{.WEBUI_SRC_DIR}}/client/**/*.jsx"
-      - "{{.WEBUI_SRC_DIR}}/imports/**/*.js"
-      - "{{.WEBUI_SRC_DIR}}/imports/**/*.jsx"
-      - "{{.WEBUI_SRC_DIR}}/launcher.js"
-      - "{{.WEBUI_SRC_DIR}}/package.json"
-      - "{{.WEBUI_SRC_DIR}}/server/**/*.js"
-      - "{{.WEBUI_SRC_DIR}}/server/**/*.jsx"
-      - "{{.WEBUI_SRC_DIR}}/tests/**/*.js"
-      - "{{.WEBUI_SRC_DIR}}/tests/**/*.jsx"
+      - "{{.G_WEBUI_SRC_DIR}}/client/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/client/**/*.jsx"
+      - "{{.G_WEBUI_SRC_DIR}}/imports/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/imports/**/*.jsx"
+      - "{{.G_WEBUI_SRC_DIR}}/launcher.js"
+      - "{{.G_WEBUI_SRC_DIR}}/package.json"
+      - "{{.G_WEBUI_SRC_DIR}}/server/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/server/**/*.jsx"
+      - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.jsx"
 
   js-fix:
     cmds:
       - task: "js"
         vars:
           LINT_CMD: "fix"
-    sources: *js_source_files
+    sources:
+      - "{{.G_BUILD_DIR}}/lint#linter-node-modules.md5"
+      - "{{.G_BUILD_DIR}}/log-viewer-webui-node-modules.md5"
+      - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.css"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.jsx"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/package.json"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/webpack.config.js"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/*.js"
+      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/package.json"
+      - "{{.ROOT_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
+      - "{{.G_WEBUI_SRC_DIR}}/client/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/client/**/*.jsx"
+      - "{{.G_WEBUI_SRC_DIR}}/imports/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/imports/**/*.jsx"
+      - "{{.G_WEBUI_SRC_DIR}}/launcher.js"
+      - "{{.G_WEBUI_SRC_DIR}}/package.json"
+      - "{{.G_WEBUI_SRC_DIR}}/server/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/server/**/*.jsx"
+      - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.js"
+      - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.jsx"
 
   py-check:
     cmds:

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,9 +1,9 @@
 version: "3"
 
 vars:
-  G_LATEST_NODEJS_BIN_DIR: "{{.G_LATEST_NODEJS_DIR}}/bin"
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
   G_LOG_VIEWER_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/log-viewer-webui"
+  G_NODEJS_22_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
   G_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
 
 tasks:
@@ -161,7 +161,7 @@ tasks:
           - "components/webui"
         cmd: |-
           cd "{{.ITEM}}"
-          PATH="{{.G_LATEST_NODEJS_BIN_DIR}}":$PATH npm run "lint:{{.LINT_CMD}}"
+          PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run "lint:{{.LINT_CMD}}"
 
   py:
     internal: true
@@ -189,7 +189,7 @@ tasks:
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_DIR: "{{.OUTPUT_DIR}}"
-      - ":nodejs-latest"
+      - ":nodejs-22"
     dir: "{{.WEBUI_LINTER_DIR}}"
     vars:
       WEBUI_LINTER_DIR: "{{.ROOT_DIR}}/components/webui/linter"
@@ -197,14 +197,14 @@ tasks:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "PATH='{{.G_LATEST_NODEJS_BIN_DIR}}':$PATH npm update"
+      - "PATH='{{.G_NODEJS_22_BIN_DIR}}':$PATH npm update"
       # This command must be last
       - task: ":utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
     sources:
-      - "{{.G_BUILD_DIR}}/nodejs-latest.md5"
+      - "{{.G_BUILD_DIR}}/nodejs-22.md5"
       - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -80,28 +80,7 @@ tasks:
       - task: "js"
         vars:
           LINT_CMD: "fix"
-    sources:
-      - "{{.G_BUILD_DIR}}/lint#linter-node-modules.md5"
-      - "{{.G_BUILD_DIR}}/log-viewer-webui-node-modules.md5"
-      - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
-      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.css"
-      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.jsx"
-      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/package.json"
-      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/webpack.config.js"
-      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/*.js"
-      - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/package.json"
-      - "{{.ROOT_DIR}}/Taskfile.yml"
-      - "{{.TASKFILE}}"
-      - "{{.G_WEBUI_SRC_DIR}}/client/**/*.js"
-      - "{{.G_WEBUI_SRC_DIR}}/client/**/*.jsx"
-      - "{{.G_WEBUI_SRC_DIR}}/imports/**/*.js"
-      - "{{.G_WEBUI_SRC_DIR}}/imports/**/*.jsx"
-      - "{{.G_WEBUI_SRC_DIR}}/launcher.js"
-      - "{{.G_WEBUI_SRC_DIR}}/package.json"
-      - "{{.G_WEBUI_SRC_DIR}}/server/**/*.js"
-      - "{{.G_WEBUI_SRC_DIR}}/server/**/*.jsx"
-      - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.js"
-      - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.jsx"
+    sources: *js_source_files
 
   py-check:
     cmds:

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -62,8 +62,6 @@ tasks:
       - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/webpack.config.js"
       - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/*.js"
       - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/package.json"
-      - "{{.ROOT_DIR}}/Taskfile.yml"
-      - "{{.TASKFILE}}"
       - "{{.G_WEBUI_SRC_DIR}}/client/**/*.js"
       - "{{.G_WEBUI_SRC_DIR}}/client/**/*.jsx"
       - "{{.G_WEBUI_SRC_DIR}}/imports/**/*.js"
@@ -74,6 +72,8 @@ tasks:
       - "{{.G_WEBUI_SRC_DIR}}/server/**/*.jsx"
       - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.js"
       - "{{.G_WEBUI_SRC_DIR}}/tests/**/*.jsx"
+      - "{{.ROOT_DIR}}/Taskfile.yml"
+      - "{{.TASKFILE}}"
 
   js-fix:
     cmds:

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -128,9 +128,13 @@ tasks:
     requires:
       vars: ["LINT_CMD"]
     deps: ["linter-node-modules"]
-    dir: "components/webui"
     cmds:
-      - "PATH='{{.G_LINTER_NODEJS_BIN_DIR}}':$PATH npm run 'lint:{{.LINT_CMD}}'"
+      - for:
+          - "components/log-viewer-webui"
+          - "components/webui"
+        cmd: |-
+          cd "{{.ITEM}}"
+          PATH="{{.G_LINTER_NODEJS_BIN_DIR}}":$PATH npm run "lint:{{.LINT_CMD}}"
 
   py:
     internal: true

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -46,7 +46,9 @@ tasks:
     sources: *cpp_source_files
 
   js-check:
-    dir: "components/webui"
+    vars:
+      LOG_VIEWER_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/log-viewer-webui"
+      WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
     cmds:
       - task: "js"
         vars:
@@ -55,21 +57,26 @@ tasks:
       - "{{.G_BUILD_DIR}}/lint#linter-node-modules.md5"
       - "{{.G_BUILD_DIR}}/log-viewer-webui-node-modules.md5"
       - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
+      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.css"
+      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/**/*.jsx"
+      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/package.json"
+      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/client/src/webpack.config.js"
+      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/*.js"
+      - "{{.LOG_VIEWER_WEBUI_SRC_DIR}}/server/src/**/package.json"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
-      - "client/**/*.js"
-      - "client/**/*.jsx"
-      - "imports/**/*.js"
-      - "imports/**/*.jsx"
-      - "launcher.js"
-      - "package.json"
-      - "server/**/*.js"
-      - "server/**/*.jsx"
-      - "tests/**/*.js"
-      - "tests/**/*.jsx"
+      - "{{.WEBUI_SRC_DIR}}/client/**/*.js"
+      - "{{.WEBUI_SRC_DIR}}/client/**/*.jsx"
+      - "{{.WEBUI_SRC_DIR}}/imports/**/*.js"
+      - "{{.WEBUI_SRC_DIR}}/imports/**/*.jsx"
+      - "{{.WEBUI_SRC_DIR}}/launcher.js"
+      - "{{.WEBUI_SRC_DIR}}/package.json"
+      - "{{.WEBUI_SRC_DIR}}/server/**/*.js"
+      - "{{.WEBUI_SRC_DIR}}/server/**/*.jsx"
+      - "{{.WEBUI_SRC_DIR}}/tests/**/*.js"
+      - "{{.WEBUI_SRC_DIR}}/tests/**/*.jsx"
 
   js-fix:
-    dir: "components/webui"
     cmds:
       - task: "js"
         vars:

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -53,6 +53,7 @@ tasks:
           LINT_CMD: "check"
     sources: &js_source_files
       - "{{.G_BUILD_DIR}}/lint#linter-node-modules.md5"
+      - "{{.G_BUILD_DIR}}/log-viewer-webui-node-modules.md5"
       - "{{.G_BUILD_DIR}}/webui-node-modules.md5"
       - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
@@ -126,7 +127,7 @@ tasks:
     internal: true
     requires:
       vars: ["LINT_CMD"]
-    deps: ["linter-node-modules"]
+    deps: [":log-viewer-webui-node-modules", "linter-node-modules"]
     cmds:
       - for:
           - "components/log-viewer-webui"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This adds the new `log-viewer-webui` component to the JS linting tasks.

To support this change we also:
* Moved and renamed the `linter-nodejs` task into the main Taskfile as `nodejs-latest` since it can be used both for linting and running the `log-viewer-webui`.
* Added tasks to clean the generated files in the source directories of the web-related components.
* Added a task, `log-viewer-webui-node-modules`, to install the dependencies of the `log-viewer-webui`.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Validated `task lint:js-check` found no violations in the current code.
* Introduced a style violation in each of the log-viewer-webui client, log-viewer-webui server, and webui.
* Validated `task lint-js-check` found each violation (one at a time).
* Validated `task lint:js-fix` fixed all violations.
* Validated `task clean-log-viewer-webui` and `task clean-webui` worked correctly.