### PR TITLE
clp-package: Add log-viewer-webui as a component.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,10 +9,10 @@ vars:
   # Paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
+  G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
   G_METEOR_BUILD_DIR: "{{.G_BUILD_DIR}}/meteor"
   G_NODEJS_22_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
-  G_LOG_VIEWER_WEBUI_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
-  G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
+  G_NODEJS_22_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
   G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"
@@ -70,12 +70,15 @@ tasks:
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_PACKAGE_BUILD_DIR}}"
+    env:
+      NODE_ENV: "production"
     deps:
       - "core"
       - "clp-package-utils"
       - "clp-py-utils"
       - "init"
       - "job-orchestration"
+      - "log-viewer-webui"
       - "package-venv"
       - task: "utils:validate-checksum"
         vars:
@@ -83,7 +86,6 @@ tasks:
           DATA_DIR: "{{.OUTPUT_DIR}}"
       - "webui"
       - "webui-nodejs"
-      - "log-viewer-webui"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "rsync -a components/package-template/src/ '{{.OUTPUT_DIR}}'"
@@ -111,23 +113,25 @@ tasks:
         "{{.OUTPUT_DIR}}/bin/node-14"
       - >-
         rsync -a
-        "{{.G_LOG_VIEWER_WEBUI_BIN_DIR}}/node"
+        "{{.G_NODEJS_22_BIN_DIR}}/node"
         "{{.OUTPUT_DIR}}/bin/node-22"
       - "mkdir -p '{{.OUTPUT_DIR}}/var/www/'"
       - >-
         rsync -a
         "{{.G_WEBUI_BUILD_DIR}}/"
         "{{.OUTPUT_DIR}}/var/www/webui/"
+      # Don't use clean-install because meteor doesn't generate
+      # package-lock.json that clean-install depends on
       - |-
         cd "{{.OUTPUT_DIR}}/var/www/webui/programs/server"
-        PATH="{{.G_WEBUI_NODEJS_BIN_DIR}}":$PATH npm clean-install
+        PATH="{{.G_WEBUI_NODEJS_BIN_DIR}}":$PATH npm install
       - >-
         rsync -a
         "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/"
         "{{.OUTPUT_DIR}}/var/www/log_viewer/"
       - |-
         cd "{{.OUTPUT_DIR}}/var/www/log_viewer/server"
-        PATH="{{.G_LOG_VIEWER_WEBUI_BIN_DIR}}":$PATH npm clean-install
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm clean-install
       # This command must be last
       - task: "utils:compute-checksum"
         vars:
@@ -205,10 +209,14 @@ tasks:
       OUTPUT_DIR: "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "rsync -a client server {{.OUTPUT_DIR}}/"
+      - "rsync -a client {{.OUTPUT_DIR}}/"
       - |-
         cd "{{.OUTPUT_DIR}}/client"
-        PATH="{{.G_LOG_VIEWER_WEBUI_BIN_DIR}}":$PATH npm run build
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build
+      - "mkdir {{.OUTPUT_DIR}}/server"
+      - |-
+        cd server
+        rsync -a src package-lock.json package.json {{.OUTPUT_DIR}}/server/
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,15 +9,15 @@ vars:
   # Paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
+  G_LOG_VIEWER_WEBUI_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
+  G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
   G_METEOR_BUILD_DIR: "{{.G_BUILD_DIR}}/meteor"
   G_NODEJS_22_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
   G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"
   G_WEBUI_NODEJS_BUILD_DIR: "{{.G_BUILD_DIR}}/webui-nodejs"
-  G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
   G_WEBUI_NODEJS_BIN_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}/bin"
-  G_LOG_VIEWER_WEBUI_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
 
   # Versions
   G_PACKAGE_VERSION: "0.2.0-dev"
@@ -353,6 +353,7 @@ tasks:
   # tasks which depend on this task to only have to check one checksum file, we concatenate the
   # three checksum files into one.
   log-viewer-webui-node-modules:
+    internal: true
     vars:
       # Checksum files
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,9 @@ vars:
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"
   G_WEBUI_NODEJS_BUILD_DIR: "{{.G_BUILD_DIR}}/webui-nodejs"
+  G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
   G_WEBUI_NODEJS_BIN_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}/bin"
+  G_LOG_VIEWER_WEBUI_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
 
   # Versions
   G_PACKAGE_VERSION: "0.2.0-dev"
@@ -81,6 +83,7 @@ tasks:
           DATA_DIR: "{{.OUTPUT_DIR}}"
       - "webui"
       - "webui-nodejs"
+      - "log-viewer-webui"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "rsync -a components/package-template/src/ '{{.OUTPUT_DIR}}'"
@@ -101,16 +104,30 @@ tasks:
         "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp"
         "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
         "{{.G_CORE_COMPONENT_BUILD_DIR}}/reducer-server"
-        "{{.G_WEBUI_NODEJS_BIN_DIR}}/node"
         "{{.OUTPUT_DIR}}/bin/"
+      - >-
+        rsync -a
+        "{{.G_WEBUI_NODEJS_BIN_DIR}}/node"
+        "{{.OUTPUT_DIR}}/bin/node-14"
+      - >-
+        rsync -a
+        "{{.G_LOG_VIEWER_WEBUI_BIN_DIR}}/node"
+        "{{.OUTPUT_DIR}}/bin/node-22"
       - "mkdir -p '{{.OUTPUT_DIR}}/var/www/'"
       - >-
         rsync -a
         "{{.G_WEBUI_BUILD_DIR}}/"
-        "{{.OUTPUT_DIR}}/var/www/"
+        "{{.OUTPUT_DIR}}/var/www/webui/"
       - |-
-        cd "{{.OUTPUT_DIR}}/var/www/programs/server"
+        cd "{{.OUTPUT_DIR}}/var/www/webui/programs/server"
         PATH="{{.G_WEBUI_NODEJS_BIN_DIR}}":$PATH npm install
+      - >-
+        rsync -a
+        "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/"
+        "{{.OUTPUT_DIR}}/var/www/log_viewer/"
+      - |-
+        cd "{{.OUTPUT_DIR}}/var/www/log_viewer/server"
+        PATH="{{.G_LOG_VIEWER_WEBUI_BIN_DIR}}":$PATH npm i
       # This command must be last
       - task: "utils:compute-checksum"
         vars:
@@ -173,6 +190,36 @@ tasks:
     - task: "python-component"
       vars:
         COMPONENT: "{{.TASK}}"
+
+  log-viewer-webui:
+    deps:
+      - "init"
+      - "log-viewer-webui-node-modules"
+      - task: "utils:validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+    dir: "components/log-viewer-webui"
+    vars:
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}"
+    cmds:
+      - "rm -rf '{{.OUTPUT_DIR}}'"
+      - "rsync -a client server {{.OUTPUT_DIR}}/"
+      - |-
+        cd "{{.OUTPUT_DIR}}/client"
+        PATH="{{.G_LOG_VIEWER_WEBUI_BIN_DIR}}":$PATH npm run build
+      - task: "utils:compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+    sources:
+      - "{{.G_BUILD_DIR}}/log-viewer-modules.md5"
+      - "{{.TASKFILE}}"
+      - "*"
+      - "client/**/*"
+      - "server/**/*"
+    generates: ["{{.CHECKSUM_FILE}}"]
 
   webui:
     deps:
@@ -306,7 +353,6 @@ tasks:
   # tasks which depend on this task to only have to check one checksum file, we concatenate the
   # three checksum files into one.
   log-viewer-webui-node-modules:
-    internal: true
     vars:
       # Checksum files
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,13 +79,13 @@ tasks:
       - "init"
       - "job-orchestration"
       - "log-viewer-webui"
+      - "nodejs-14"
       - "package-venv"
       - task: "utils:validate-checksum"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_DIR: "{{.OUTPUT_DIR}}"
       - "webui"
-      - "nodejs-14"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "rsync -a components/package-template/src/ '{{.OUTPUT_DIR}}'"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,10 +9,10 @@ vars:
   # Paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
-  G_LOG_VIEWER_WEBUI_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
-  G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
   G_METEOR_BUILD_DIR: "{{.G_BUILD_DIR}}/meteor"
   G_NODEJS_22_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
+  G_LOG_VIEWER_WEBUI_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
+  G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
   G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,13 +11,13 @@ vars:
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
   G_LOG_VIEWER_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/log-viewer-webui"
   G_METEOR_BUILD_DIR: "{{.G_BUILD_DIR}}/meteor"
-  G_NODEJS_22_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
-  G_NODEJS_22_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
+  G_NODEJS_14_BUILD_DIR: "{{.G_BUILD_DIR}}/nodejs-14"
+  G_NODEJS_14_BIN_DIR: "{{.G_NODEJS_14_BUILD_DIR}}/bin"
+  G_NODEJS_22_BUILD_DIR: "{{.G_BUILD_DIR}}/nodejs-22"
+  G_NODEJS_22_BIN_DIR: "{{.G_NODEJS_22_BUILD_DIR}}/bin"
   G_PACKAGE_BUILD_DIR: "{{.G_BUILD_DIR}}/clp-package"
   G_PACKAGE_VENV_DIR: "{{.G_BUILD_DIR}}/package-venv"
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"
-  G_WEBUI_NODEJS_BUILD_DIR: "{{.G_BUILD_DIR}}/webui-nodejs"
-  G_WEBUI_NODEJS_BIN_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}/bin"
 
   # Versions
   G_PACKAGE_VERSION: "0.2.0-dev"
@@ -85,7 +85,7 @@ tasks:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_DIR: "{{.OUTPUT_DIR}}"
       - "webui"
-      - "webui-nodejs"
+      - "nodejs-14"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "rsync -a components/package-template/src/ '{{.OUTPUT_DIR}}'"
@@ -109,7 +109,7 @@ tasks:
         "{{.OUTPUT_DIR}}/bin/"
       - >-
         rsync -a
-        "{{.G_WEBUI_NODEJS_BIN_DIR}}/node"
+        "{{.G_NODEJS_14_BIN_DIR}}/node"
         "{{.OUTPUT_DIR}}/bin/node-14"
       - >-
         rsync -a
@@ -124,7 +124,7 @@ tasks:
       # package-lock.json that clean-install depends on
       - |-
         cd "{{.OUTPUT_DIR}}/var/www/webui/programs/server"
-        PATH="{{.G_WEBUI_NODEJS_BIN_DIR}}":$PATH npm install
+        PATH="{{.G_NODEJS_14_BIN_DIR}}":$PATH npm install
       - >-
         rsync -a
         "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/"
@@ -280,7 +280,7 @@ tasks:
     internal: true
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.G_NODEJS_22_DIR}}"
+      OUTPUT_DIR: "{{.G_NODEJS_22_BUILD_DIR}}"
     run: "once"
     cmds:
       - task: "nodejs"
@@ -289,11 +289,11 @@ tasks:
           NODEJS_VERSION: "v22.4.0"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
 
-  webui-nodejs:
+  nodejs-14:
     internal: true
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.G_WEBUI_NODEJS_BUILD_DIR}}"
+      OUTPUT_DIR: "{{.G_NODEJS_14_BUILD_DIR}}"
     cmds:
       - task: "nodejs"
         vars:
@@ -395,7 +395,7 @@ tasks:
     cmds:
       - "rm -f {{.CHECKSUM_FILE}}"
       - task: "clean-log-viewer-webui"
-      - "PATH='{{.G_NODEJS_22_DIR}}/bin':$PATH npm run init"
+      - "PATH='{{.G_NODEJS_22_BIN_DIR}}':$PATH npm run init"
       # These commands must be last
       - task: "utils:compute-checksum"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,11 +67,11 @@ tasks:
           STORAGE_ENGINE: "clp"
 
   package:
+    env:
+      NODE_ENV: "production"
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_PACKAGE_BUILD_DIR}}"
-    env:
-      NODE_ENV: "production"
     deps:
       - "core"
       - "clp-package-utils"
@@ -120,8 +120,8 @@ tasks:
         rsync -a
         "{{.G_WEBUI_BUILD_DIR}}/"
         "{{.OUTPUT_DIR}}/var/www/webui/"
-      # Don't use clean-install because meteor doesn't generate
-      # package-lock.json that clean-install depends on
+      # Avoid using `npm clean-install` because Meteor does not generate a `package-lock.json` file,
+      # which `clean-install` depends on.
       - |-
         cd "{{.OUTPUT_DIR}}/var/www/webui/programs/server"
         PATH="{{.G_NODEJS_14_BIN_DIR}}":$PATH npm install

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -15,6 +15,7 @@ from clp_py_utils.clp_config import (
     CLP_DEFAULT_CREDENTIALS_FILE_PATH,
     CLPConfig,
     DB_COMPONENT_NAME,
+    LOG_VIEWER_WEBUI_COMPONENT_NAME,
     QUEUE_COMPONENT_NAME,
     REDIS_COMPONENT_NAME,
     REDUCER_COMPONENT_NAME,
@@ -494,3 +495,16 @@ def validate_webui_config(
         raise ValueError(f"{WEBUI_COMPONENT_NAME} logs directory is invalid: {ex}")
 
     validate_port(f"{WEBUI_COMPONENT_NAME}.port", clp_config.webui.host, clp_config.webui.port)
+
+
+def validate_log_viewer_config(clp_config: CLPConfig, logs_dir: pathlib.Path):
+    try:
+        validate_path_could_be_dir(logs_dir)
+    except ValueError as ex:
+        raise ValueError(f"{LOG_VIEWER_WEBUI_COMPONENT_NAME} logs directory is invalid: {ex}")
+
+    validate_port(
+        f"{LOG_VIEWER_WEBUI_COMPONENT_NAME}.port",
+        clp_config.log_viewer_webui.host,
+        clp_config.log_viewer_webui.port,
+    )

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -797,7 +797,7 @@ def start_log_viewer_webui(instance_id: str, clp_config: CLPConfig, mounts: CLPD
         "--name", container_name,
         "--log-driver", "local",
         "-e", f"NODE_PATH={node_path}",
-        "-e", f"CLIENT_DIR=../client/dist",
+        "-e", f"CLIENT_DIR={container_log_viewer_dir}/client/dist",
         "-e", f"PORT={clp_config.log_viewer_webui.port}",
         "-e", f"HOST={clp_config.log_viewer_webui.host}",
         "-e", f"NODE_ENV=production",
@@ -929,6 +929,7 @@ def main(argv):
     reducer_server_parser = component_args_parser.add_parser(REDUCER_COMPONENT_NAME)
     add_num_workers_argument(reducer_server_parser)
     component_args_parser.add_parser(WEBUI_COMPONENT_NAME)
+    component_args_parser.add_parser(LOG_VIEWER_WEBUI_COMPONENT_NAME)
 
     parsed_args = args_parser.parse_args(argv[1:])
 

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -11,6 +11,7 @@ from clp_py_utils.clp_config import (
     COMPRESSION_WORKER_COMPONENT_NAME,
     CONTROLLER_TARGET_NAME,
     DB_COMPONENT_NAME,
+    LOG_VIEWER_WEBUI_COMPONENT_NAME,
     QUERY_SCHEDULER_COMPONENT_NAME,
     QUERY_WORKER_COMPONENT_NAME,
     QUEUE_COMPONENT_NAME,
@@ -134,6 +135,9 @@ def main(argv):
 
         already_exited_containers = []
         force = parsed_args.force
+        if target in (ALL_TARGET_NAME, LOG_VIEWER_WEBUI_COMPONENT_NAME):
+            container_name = f"clp-{LOG_VIEWER_WEBUI_COMPONENT_NAME}-{instance_id}"
+            stop_running_container(container_name, already_exited_containers, force)
         if target in (ALL_TARGET_NAME, WEBUI_COMPONENT_NAME):
             container_name = f"clp-{WEBUI_COMPONENT_NAME}-{instance_id}"
             stop_running_container(container_name, already_exited_containers, force)

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -93,6 +93,7 @@ def main(argv):
     component_args_parser.add_parser(COMPRESSION_WORKER_COMPONENT_NAME)
     component_args_parser.add_parser(QUERY_WORKER_COMPONENT_NAME)
     component_args_parser.add_parser(WEBUI_COMPONENT_NAME)
+    component_args_parser.add_parser(LOG_VIEWER_WEBUI_COMPONENT_NAME)
 
     parsed_args = args_parser.parse_args(argv[1:])
 
@@ -107,7 +108,12 @@ def main(argv):
         clp_config = load_config_file(config_file_path, default_config_file_path, clp_home)
 
         # Validate and load necessary credentials
-        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, DB_COMPONENT_NAME):
+        if target in (
+            ALL_TARGET_NAME,
+            CONTROLLER_TARGET_NAME,
+            DB_COMPONENT_NAME,
+            LOG_VIEWER_WEBUI_COMPONENT_NAME,
+        ):
             validate_and_load_db_credentials_file(clp_config, clp_home, False)
         if target in (
             ALL_TARGET_NAME,

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -154,6 +154,21 @@ def _validate_logging_level(cls, field):
         )
 
 
+def _validate_host(cls, field):
+    if "" == field:
+        raise ValueError(f"{cls.__name__}.host cannot be empty.")
+
+
+def _validate_port(cls, field):
+    min_valid_port = 0
+    max_valid_port = 2 ** 16 - 1
+    if min_valid_port > field or max_valid_port < field:
+        raise ValueError(
+            f"{cls.__name__}.port is not within valid range "
+            f"{min_valid_port}-{max_valid_port}."
+        )
+
+
 class CompressionScheduler(BaseModel):
     jobs_poll_delay: float = 0.1  # seconds
     logging_level: str = "INFO"
@@ -362,19 +377,12 @@ class WebUi(BaseModel):
 
     @validator("host")
     def validate_host(cls, field):
-        if "" == field:
-            raise ValueError(f"{WEBUI_COMPONENT_NAME}.host cannot be empty.")
+        _validate_host(cls, field)
         return field
 
     @validator("port")
     def validate_port(cls, field):
-        min_valid_port = 0
-        max_valid_port = 2**16 - 1
-        if min_valid_port > field or max_valid_port < field:
-            raise ValueError(
-                f"{WEBUI_COMPONENT_NAME}.port is not within valid range "
-                f"{min_valid_port}-{max_valid_port}."
-            )
+        _validate_port(cls, field)
         return field
 
     @validator("logging_level")
@@ -390,19 +398,12 @@ class LogViewerWebUi(BaseModel):
 
     @validator("host")
     def validate_host(cls, field):
-        if "" == field:
-            raise ValueError(f"{LOG_VIEWER_WEBUI_COMPONENT_NAME}.host cannot be empty.")
+        _validate_host(cls, field)
         return field
 
     @validator("port")
     def validate_port(cls, field):
-        min_valid_port = 0
-        max_valid_port = 2**16 - 1
-        if min_valid_port > field or max_valid_port < field:
-            raise ValueError(
-                f"{LOG_VIEWER_WEBUI_COMPONENT_NAME}.port is not within valid range "
-                f"{min_valid_port}-{max_valid_port}."
-            )
+        _validate_port(cls, field)
         return field
 
 

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -161,11 +161,10 @@ def _validate_host(cls, field):
 
 def _validate_port(cls, field):
     min_valid_port = 0
-    max_valid_port = 2 ** 16 - 1
+    max_valid_port = 2**16 - 1
     if min_valid_port > field or max_valid_port < field:
         raise ValueError(
-            f"{cls.__name__}.port is not within valid range "
-            f"{min_valid_port}-{max_valid_port}."
+            f"{cls.__name__}.port is not within valid range " f"{min_valid_port}-{max_valid_port}."
         )
 
 

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -26,6 +26,7 @@ QUERY_SCHEDULER_COMPONENT_NAME = "query_scheduler"
 COMPRESSION_WORKER_COMPONENT_NAME = "compression_worker"
 QUERY_WORKER_COMPONENT_NAME = "query_worker"
 WEBUI_COMPONENT_NAME = "webui"
+LOG_VIEWER_WEBUI_COMPONENT_NAME = "log_viewer_webui"
 
 # Target names
 ALL_TARGET_NAME = ""
@@ -382,6 +383,29 @@ class WebUi(BaseModel):
         return field
 
 
+class LogViewerWebUi(BaseModel):
+    host: str = "localhost"
+    port: int = 3000
+    logging_level: str = "INFO"
+
+    @validator("host")
+    def validate_host(cls, field):
+        if "" == field:
+            raise ValueError(f"{LOG_VIEWER_WEBUI_COMPONENT_NAME}.host cannot be empty.")
+        return field
+
+    @validator("port")
+    def validate_port(cls, field):
+        min_valid_port = 0
+        max_valid_port = 2**16 - 1
+        if min_valid_port > field or max_valid_port < field:
+            raise ValueError(
+                f"{LOG_VIEWER_WEBUI_COMPONENT_NAME}.port is not within valid range "
+                f"{min_valid_port}-{max_valid_port}."
+            )
+        return field
+
+
 class CLPConfig(BaseModel):
     execution_container: typing.Optional[str]
 
@@ -398,6 +422,7 @@ class CLPConfig(BaseModel):
     compression_worker: CompressionWorker = CompressionWorker()
     query_worker: QueryWorker = QueryWorker()
     webui: WebUi = WebUi()
+    log_viewer_webui: LogViewerWebUi = LogViewerWebUi()
     credentials_file_path: pathlib.Path = CLP_DEFAULT_CREDENTIALS_FILE_PATH
 
     archive_output: ArchiveOutput = ArchiveOutput()

--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -60,6 +60,10 @@
 #  port: 4000
 #  logging_level: "INFO"
 #
+#log_viewer_webui
+#  host: "localhost"
+#  port: 3000
+#
 ## Where archives should be output to
 #archive_output:
 #  directory: "var/data/archives"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -3,7 +3,6 @@ version: "3"
 vars:
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
   G_LOG_VIEWER_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/log-viewer-webui"
-  G_NODEJS_22_BIN_DIR: "{{.G_NODEJS_22_BUILD_DIR}}/bin"
   G_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
 
 tasks:

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -3,7 +3,7 @@ version: "3"
 vars:
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
   G_LOG_VIEWER_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/log-viewer-webui"
-  G_NODEJS_22_BIN_DIR: "{{.G_NODEJS_22_DIR}}/bin"
+  G_NODEJS_22_BIN_DIR: "{{.G_NODEJS_22_BUILD_DIR}}/bin"
   G_WEBUI_SRC_DIR: "{{.ROOT_DIR}}/components/webui"
 
 tasks:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
This PR adds log_viewer as a component into the CLP package. The PR consists of three small changes.
1. Adds the log_viewer into Taskfile.yml
2. Packages node-22 into the package and distinguish it from the node-14
3. Updates the start-clp script to launch log_viewer



# Validation performed
Built a clp package and launched log_viewer
1. Confirmed that the container doesn't generate any error message
2. Tested with example route http://127.0.0.1:3000/examples/get/Alice
3. Started and stopped the log viewer webui with start-clp log_viewer_webui and stop-clp log_viewer_webui

