### PR TITLE
clp-package: Fix bugs introduced in #460:

### DIFF
--- a/components/job-orchestration/job_orchestration/executor/query/extract_ir_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_ir_task.py
@@ -45,7 +45,7 @@ def make_command(
         ]
         if extract_ir_config.target_uncompressed_size is not None:
             command.append("--target-size")
-            command.append(extract_ir_config.target_uncompressed_size)
+            command.append(str(extract_ir_config.target_uncompressed_size))
     else:
         logger.error(f"Unsupported storage engine {storage_engine}")
         return None

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -129,7 +129,7 @@ def search(
         archive_id=archive_id,
         search_config=search_config,
         results_cache_uri=results_cache_uri,
-        results_collection=str(task_id),
+        results_collection=job_id,
     )
     if not task_command:
         return report_command_creation_failure(


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
This PR fixes two bugs in query worker scripts, introduced by https://github.com/y-scope/clp/pull/460
1. Fixes a bug where the search results are written to task_id collection. They should be written to job_id collection
2. Fixes a bug where an int is converted to string before joined as part of the command


# Validation performed
Tested with log viewer.

