### PR TITLE
Add initial implementation of regex_utils library containing a regex to wildcard string translator and a corresponding std::error_code enum and category.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -209,8 +209,8 @@ set(sqlite_DYNAMIC_LIBS "dl;m;pthread")
 include(cmake/Modules/FindLibraryDependencies.cmake)
 FindDynamicLibraryDependencies(sqlite "${sqlite_DYNAMIC_LIBS}")
 
-add_subdirectory(src/clp/string_utils)
 add_subdirectory(src/clp/regex_utils)
+add_subdirectory(src/clp/string_utils)
 
 add_subdirectory(src/clp/clg)
 add_subdirectory(src/clp/clo)
@@ -305,11 +305,11 @@ set(SOURCE_FILES_unitTest
         src/clp/ffi/ir_stream/decoding_methods.inc
         src/clp/ffi/ir_stream/encoding_methods.cpp
         src/clp/ffi/ir_stream/encoding_methods.hpp
+        src/clp/ffi/ir_stream/protocol_constants.hpp
         src/clp/ffi/ir_stream/Serializer.cpp
         src/clp/ffi/ir_stream/Serializer.hpp
         src/clp/ffi/ir_stream/utils.cpp
         src/clp/ffi/ir_stream/utils.hpp
-        src/clp/ffi/ir_stream/protocol_constants.hpp
         src/clp/ffi/SchemaTree.cpp
         src/clp/ffi/SchemaTree.hpp
         src/clp/ffi/SchemaTreeNode.hpp
@@ -436,10 +436,10 @@ set(SOURCE_FILES_unitTest
         src/clp/StringReader.hpp
         src/clp/Thread.cpp
         src/clp/Thread.hpp
+        src/clp/time_types.hpp
         src/clp/TimestampPattern.cpp
         src/clp/TimestampPattern.hpp
         src/clp/TraceableException.hpp
-        src/clp/time_types.hpp
         src/clp/type_utils.hpp
         src/clp/utf8_utils.cpp
         src/clp/utf8_utils.hpp
@@ -471,12 +471,12 @@ set(SOURCE_FILES_unitTest
         tests/test-NetworkReader.cpp
         tests/test-ParserWithUserSchema.cpp
         tests/test-query_methods.cpp
+        tests/test-regex_utils.cpp
         tests/test-Segment.cpp
         tests/test-SQLiteDB.cpp
         tests/test-Stopwatch.cpp
         tests/test-StreamingCompression.cpp
         tests/test-string_utils.cpp
-        tests/test-regex_utils.cpp
         tests/test-TimestampPattern.cpp
         tests/test-utf8_utils.cpp
         tests/test-Utils.cpp
@@ -499,8 +499,8 @@ target_link_libraries(unitTest
         spdlog::spdlog
         ${sqlite_LIBRARY_DEPENDENCIES}
         ${STD_FS_LIBS}
-        clp::string_utils
         clp::regex_utils
+        clp::string_utils
         yaml-cpp::yaml-cpp
         ZStd::ZStd
         )

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -210,6 +210,7 @@ include(cmake/Modules/FindLibraryDependencies.cmake)
 FindDynamicLibraryDependencies(sqlite "${sqlite_DYNAMIC_LIBS}")
 
 add_subdirectory(src/clp/string_utils)
+add_subdirectory(src/clp/regex_utils)
 
 add_subdirectory(src/clp/clg)
 add_subdirectory(src/clp/clo)
@@ -475,6 +476,7 @@ set(SOURCE_FILES_unitTest
         tests/test-Stopwatch.cpp
         tests/test-StreamingCompression.cpp
         tests/test-string_utils.cpp
+        tests/test-regex_utils.cpp
         tests/test-TimestampPattern.cpp
         tests/test-utf8_utils.cpp
         tests/test-Utils.cpp
@@ -498,6 +500,7 @@ target_link_libraries(unitTest
         ${sqlite_LIBRARY_DEPENDENCIES}
         ${STD_FS_LIBS}
         clp::string_utils
+        clp::regex_utils
         yaml-cpp::yaml-cpp
         ZStd::ZStd
         )

--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -1,21 +1,20 @@
 set(
         REGEX_UTILS_HEADER_LIST
-        "ErrorCode.hpp"
-        "RegexToWildcardTranslatorConfig.hpp"
         "constants.hpp"
+        "ErrorCode.hpp"
         "regex_translation_utils.hpp"
+        "RegexToWildcardTranslatorConfig.hpp"
 )
 add_library(
         regex_utils
-        regex_translation_utils.cpp
         ErrorCode.cpp
+        regex_translation_utils.cpp
         ${REGEX_UTILS_HEADER_LIST}
 )
 add_library(clp::regex_utils ALIAS regex_utils)
 target_include_directories(regex_utils
-        PUBLIC
-        ../
         PRIVATE
+        ../
         "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_compile_features(regex_utils PRIVATE cxx_std_20)

--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(
+        REGEX_UTILS_HEADER_LIST
+        "ErrorCode.hpp"
+        "RegexToWildcardTranslatorConfig.hpp"
+        "constants.hpp"
+        "regex_translation_utils.hpp"
+)
+add_library(
+        regex_utils
+        regex_translation_utils.cpp
+        ErrorCode.cpp
+        ${REGEX_UTILS_HEADER_LIST}
+)
+add_library(clp::regex_utils ALIAS regex_utils)
+target_include_directories(regex_utils
+        PUBLIC
+        ../
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/submodules"
+)
+target_compile_features(regex_utils PRIVATE cxx_std_20)

--- a/components/core/src/clp/regex_utils/ErrorCode.cpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.cpp
@@ -4,13 +4,14 @@
 #include <string_view>
 #include <system_error>
 
-using std::error_category;
+namespace clp::regex_utils {
 using std::error_code;
+
+namespace {
+using std::error_category;
 using std::string;
 using std::string_view;
 
-namespace clp::regex_utils {
-namespace {
 /**
  * Class for giving the error codes more detailed string descriptions.
  */

--- a/components/core/src/clp/regex_utils/ErrorCode.cpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.cpp
@@ -1,0 +1,78 @@
+#include "regex_utils/ErrorCode.hpp"
+
+#include <string>
+#include <string_view>
+#include <system_error>
+
+using std::error_category;
+using std::error_code;
+using std::string;
+using std::string_view;
+
+namespace clp::regex_utils {
+
+/**
+ * Class for giving the error codes more detailed string descriptions.
+ * This class does not need to be seen outside the std error code wrapper implementation.
+ */
+class ErrorCodeCategory : public error_category {
+public:
+    /**
+     * @return The class of errors.
+     */
+    [[nodiscard]] char const* name() const noexcept override;
+
+    /**
+     * @param The error code encoded in int.
+     * @return The descriptive message for the error.
+     */
+    [[nodiscard]] string message(int ev) const override;
+};
+
+auto ErrorCodeCategory::name() const noexcept -> char const* {
+    return "regex utility";
+}
+
+auto ErrorCodeCategory::message(int ev) const -> string {
+    switch (static_cast<ErrorCode>(ev)) {
+        case ErrorCode::Success:
+            return "Success.";
+
+        case ErrorCode::IllegalState:
+            return "Unrecognized state.";
+
+        case ErrorCode::Star:
+            return "Failed to translate due to metachar `*` (zero or more occurences).";
+
+        case ErrorCode::Plus:
+            return "Failed to translate due to metachar `+` (one or more occurences).";
+
+        case ErrorCode::Question:
+            return "Currently does not support returning a list of wildcard translations. The "
+                   "metachar `?` (lazy match) may be supported in the future.";
+
+        case ErrorCode::Pipe:
+            return "Currently does not support returning a list of wildcard translations. The "
+                   "regex OR condition feature may be supported in the future.";
+
+        case ErrorCode::Caret:
+            return "Failed to translate due to start anchor `^` in the middle of the string.";
+
+        case ErrorCode::Dollar:
+            return "Failed to translate due to end anchor `$` in the middle of the string.";
+
+        case ErrorCode::UnmatchedParenthesis:
+            return "Unmatched opening `(` or closing `)`.";
+
+        default:
+            return "(unrecognized error)";
+    }
+}
+
+ErrorCodeCategory const cTheErrorCodeCategory{};
+
+auto make_error_code(ErrorCode e) -> error_code {
+    return {static_cast<int>(e), cTheErrorCodeCategory};
+}
+
+}  // namespace clp::regex_utils

--- a/components/core/src/clp/regex_utils/ErrorCode.cpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.cpp
@@ -10,23 +10,22 @@ using std::string;
 using std::string_view;
 
 namespace clp::regex_utils {
-
+namespace {
 /**
  * Class for giving the error codes more detailed string descriptions.
- * This class does not need to be seen outside the std error code wrapper implementation.
  */
 class ErrorCodeCategory : public error_category {
 public:
     /**
      * @return The class of errors.
      */
-    [[nodiscard]] char const* name() const noexcept override;
+    [[nodiscard]] auto name() const noexcept -> char const* override;
 
     /**
      * @param The error code encoded in int.
      * @return The descriptive message for the error.
      */
-    [[nodiscard]] string message(int ev) const override;
+    [[nodiscard]] auto message(int ev) const -> string override;
 };
 
 auto ErrorCodeCategory::name() const noexcept -> char const* {
@@ -69,10 +68,10 @@ auto ErrorCodeCategory::message(int ev) const -> string {
     }
 }
 
-ErrorCodeCategory const cTheErrorCodeCategory{};
+ErrorCodeCategory const cErrorCodeCategoryInstance;
+}  // namespace
 
 auto make_error_code(ErrorCode e) -> error_code {
-    return {static_cast<int>(e), cTheErrorCodeCategory};
+    return {static_cast<int>(e), cErrorCodeCategoryInstance};
 }
-
 }  // namespace clp::regex_utils

--- a/components/core/src/clp/regex_utils/ErrorCode.cpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.cpp
@@ -40,24 +40,28 @@ auto ErrorCodeCategory::message(int ev) const -> string {
         case ErrorCode::IllegalState:
             return "Unrecognized state.";
 
-        case ErrorCode::Star:
-            return "Failed to translate due to metachar `*` (zero or more occurences).";
+        case ErrorCode::UntranslatableStar:
+            return "Unable to express regex quantifier `*` in wildcard, which repeats a token for "
+                   "zero or more occurences, unless it is combined with a wildcard `.`";
 
-        case ErrorCode::Plus:
-            return "Failed to translate due to metachar `+` (one or more occurences).";
+        case ErrorCode::UntranslatablePlus:
+            return "Unable to express regex quantifier `+` in wildcard, which repeats a token for "
+                   "one or more occurences, unless it is combined with a wildcard `.`";
 
-        case ErrorCode::Question:
-            return "Currently does not support returning a list of wildcard translations. The "
-                   "metachar `?` (lazy match) may be supported in the future.";
+        case ErrorCode::UnsupportedQuestionMark:
+            return "Unable to express regex quantifier `?` in wildcard, which makes the preceding "
+                   "token optional, unless the translator supports returning a list of possible "
+                   "wildcard translations.";
 
-        case ErrorCode::Pipe:
-            return "Currently does not support returning a list of wildcard translations. The "
-                   "regex OR condition feature may be supported in the future.";
+        case ErrorCode::UnsupportedPipe:
+            return "Unable to express regex OR `|` in wildcard, which allows the query string to "
+                   "match a single token out of a series of options, unless the translator "
+                   "supports returning a list of possible wildcard translations.";
 
-        case ErrorCode::Caret:
+        case ErrorCode::IllegalCaret:
             return "Failed to translate due to start anchor `^` in the middle of the string.";
 
-        case ErrorCode::Dollar:
+        case ErrorCode::IllegalDollarSign:
             return "Failed to translate due to end anchor `$` in the middle of the string.";
 
         case ErrorCode::UnmatchedParenthesis:

--- a/components/core/src/clp/regex_utils/ErrorCode.hpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.hpp
@@ -13,18 +13,13 @@ namespace clp::regex_utils {
 enum class ErrorCode : uint8_t {
     Success = 0,
     IllegalState,
-    Star,
-    Plus,
-    Question,
-    Pipe,
-    Caret,
-    Dollar,
-    DisallowedEscapeSequence,
+    UntranslatableStar,
+    UntranslatablePlus,
+    UnsupportedQuestionMark,
+    UnsupportedPipe,
+    IllegalCaret,
+    IllegalDollarSign,
     UnmatchedParenthesis,
-    UnsupportedCharsets,
-    IncompleteCharsetStructure,
-    UnsupportedQuantifier,
-    TokenUnquantifiable,
 };
 
 /**

--- a/components/core/src/clp/regex_utils/ErrorCode.hpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.hpp
@@ -6,7 +6,6 @@
 #include <type_traits>
 
 namespace clp::regex_utils {
-
 /**
  * Enum class for propagating and handling various regex utility errors.
  * More detailed descriptions can be found in ErrorCode.cpp.
@@ -35,7 +34,6 @@ enum class ErrorCode : uint8_t {
  * @return The corresponding std::error_code type variable.
  */
 [[nodiscard]] auto make_error_code(ErrorCode ec) -> std::error_code;
-
 }  // namespace clp::regex_utils
 
 namespace std {

--- a/components/core/src/clp/regex_utils/ErrorCode.hpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.hpp
@@ -1,0 +1,46 @@
+#ifndef CLP_REGEX_UTILS_ERRORCODE_HPP
+#define CLP_REGEX_UTILS_ERRORCODE_HPP
+
+#include <cstdint>
+#include <system_error>
+#include <type_traits>
+
+namespace clp::regex_utils {
+
+/**
+ * Enum class for propagating and handling various regex utility errors.
+ * More detailed descriptions can be found in ErrorCode.cpp.
+ */
+enum class ErrorCode : uint8_t {
+    Success = 0,
+    IllegalState,
+    Star,
+    Plus,
+    Question,
+    Pipe,
+    Caret,
+    Dollar,
+    DisallowedEscapeSequence,
+    UnmatchedParenthesis,
+    UnsupportedCharsets,
+    IncompleteCharsetStructure,
+    UnsupportedQuantifier,
+    TokenUnquantifiable,
+};
+
+/**
+ * Wrapper function to turn a regular enum class into an std::error_code.
+ *
+ * @param An error code enum.
+ * @return The corresponding std::error_code type variable.
+ */
+[[nodiscard]] auto make_error_code(ErrorCode ec) -> std::error_code;
+
+}  // namespace clp::regex_utils
+
+namespace std {
+template <>
+struct is_error_code_enum<clp::regex_utils::ErrorCode> : true_type {};
+}  // namespace std
+
+#endif  // CLP_REGEX_UTILS_ERRORCODE_HPP

--- a/components/core/src/clp/regex_utils/README.md
+++ b/components/core/src/clp/regex_utils/README.md
@@ -31,12 +31,12 @@ using clp::regex_utils::regex_to_wildcard;
 
 // Other code
 
-auto result = regex_to_wildcard(wildcard_str);
+auto result{regex_to_wildcard(wildcard_str)};
 if (result.has_error()) {
-    auto err_code = result.error();
+    auto err_code{result.error()};
     // Handle error
 } else {
-    auto regex_str = result.value();
+    auto regex_str{result.value()};
     // Do things with the translated string
 }
 ```
@@ -47,7 +47,7 @@ if (result.has_error()) {
 #include <regex_utils/RegexToWildcardTranslatorConfig.hpp>
 
 RegexToWildcardTranslatorConfig config{true, false, /*...other booleans*/};
-auto result = regex_to_wildcard(wildcard_str, config);
+auto result{regex_to_wildcard(wildcard_str, config)};
 
 // Same as above
 ```

--- a/components/core/src/clp/regex_utils/README.md
+++ b/components/core/src/clp/regex_utils/README.md
@@ -19,17 +19,41 @@ metacharacters above, CLP should use the wildcard version.
 
 ### Includes
 
-* To use the translator:
+* The translator function returns a `Result<T,E>` type, which can either contain a value or an error
+code.
 
-```shell
+To use the translator:
+
+```cpp
 #include <regex_utils/regex_translation_utils.hpp>
+
+using clp::regex_utils::regex_to_wildcard;
+
+// Other code
+
+auto result = regex_to_wildcard(wildcard_str);
+if (result.has_error()) {
+    auto err_code = result.error();
+    // Handle error
+} else {
+    auto regex_str = result.value();
+    // Do things with the translated string
+}
 ```
 
 * To add custom configuration to the translator:
 
-```shell
+```cpp
 #include <regex_utils/RegexToWildcardTranslatorConfig.hpp>
+
+RegexToWildcardTranslatorConfig config{true, false, //...other booleans};
+auto result = regex_to_wildcard(wildcard_str, config);
+
+// Same as above
 ```
+
+For a detailed description on the options order and usage, see the
+[Custom Configuration](#custom-configuration) section.
 
 ### Functionalities
 
@@ -37,6 +61,7 @@ metacharacters above, CLP should use the wildcard version.
   - Turn `.` into `?`
   - Turn `.*` into `*`
   - Turn `.+` into `?*`
+  - E.g. `abc.*def.ghi.+` will get translated to `abc*def?ghi?*`
 
 ### Custom configuration
 

--- a/components/core/src/clp/regex_utils/README.md
+++ b/components/core/src/clp/regex_utils/README.md
@@ -1,0 +1,46 @@
+# Regex_utils
+
+This library contains useful utilities to handle all regex related tasks.
+
+## Regex to Wildcard Translator
+
+### Goal
+
+Performs a best-effort translation to turn a regex string to an equivalent wildcard string.
+
+CLP currently only recognizes three meta-characters in the wildcard syntax:
+
+* `?` Matches any single character
+* `*` Matches zero or more characters
+* `\` Suppresses the special meaning of meta characters (including itself)
+
+If the regex query can actually be expressed as a wildcard query only deploying the three
+metacharacters above, CLP should use the wildcard version.
+
+### Includes
+
+* To use the translator:
+
+```shell
+#include <regex_utils/regex_translation_utils.hpp>
+```
+
+* To add custom configuration to the translator:
+
+```shell
+#include <regex_utils/RegexToWildcardTranslatorConfig.hpp>
+```
+
+### Functionalities
+
+* Wildcards
+  - Turn `.` into `?`
+  - Turn `.*` into `*`
+  - Turn `.+` into `?*`
+
+### Custom configuration
+
+* `add_prefix_suffix_wildcards`: in the absence of regex anchors, add prefix or suffix wildcards so
+the query becomes a substring query.
+  - E.g. `info.*system` gets translated into `*info*system*` which makes the original query a
+  substring query.

--- a/components/core/src/clp/regex_utils/README.md
+++ b/components/core/src/clp/regex_utils/README.md
@@ -19,8 +19,8 @@ metacharacters above, CLP should use the wildcard version.
 
 ### Includes
 
-* The translator function returns a `Result<T,E>` type, which can either contain a value or an error
-code.
+* The translator function returns a `Result<std::string, std::error_code>` type, which can either
+contain a value or an error code.
 
 To use the translator:
 
@@ -46,7 +46,7 @@ if (result.has_error()) {
 ```cpp
 #include <regex_utils/RegexToWildcardTranslatorConfig.hpp>
 
-RegexToWildcardTranslatorConfig config{true, false, //...other booleans};
+RegexToWildcardTranslatorConfig config{true, false, /*...other booleans*/};
 auto result = regex_to_wildcard(wildcard_str, config);
 
 // Same as above
@@ -64,6 +64,12 @@ For a detailed description on the options order and usage, see the
   - E.g. `abc.*def.ghi.+` will get translated to `abc*def?ghi?*`
 
 ### Custom configuration
+
+The `RegexToWildcardTranslatorConfig` class objects are currently immutable once instantiated. The
+constructor takes the following arguments in order:
+
+* `case_insensitive_wildcard`: to be added later along with the character set translation
+implementation.
 
 * `add_prefix_suffix_wildcards`: in the absence of regex anchors, add prefix or suffix wildcards so
 the query becomes a substring query.

--- a/components/core/src/clp/regex_utils/RegexToWildcardTranslatorConfig.hpp
+++ b/components/core/src/clp/regex_utils/RegexToWildcardTranslatorConfig.hpp
@@ -1,0 +1,46 @@
+#ifndef CLP_REGEX_UTILS_REGEXTOWILDCARDTRANSLATORCONFIG_HPP
+#define CLP_REGEX_UTILS_REGEXTOWILDCARDTRANSLATORCONFIG_HPP
+
+namespace clp::regex_utils {
+
+class RegexToWildcardTranslatorConfig {
+public:
+    // Constructors
+    RegexToWildcardTranslatorConfig(
+            bool case_insensitive_wildcard,
+            bool add_prefix_suffix_wildcards
+    )
+            : m_case_insensitive_wildcard{case_insensitive_wildcard},
+              m_add_prefix_suffix_wildcards{add_prefix_suffix_wildcards} {};
+
+    // Getters
+
+    /**
+     * @return True if the final translated wildcard string will be fed into
+     *         a case-insensitive wildcard analyzer. In such cases, we can
+     *         safely translate charset patterns such as [aA] [Bb] into singular
+     *         lowercase characters a, b.
+     */
+    [[nodiscard]] auto case_insensitive_wildcard() const -> bool {
+        return m_case_insensitive_wildcard;
+    }
+
+    /**
+     * @return True if in the absense of starting or ending anchors in the
+     *         regex string, we append prefix or suffix zero or more characters
+     *         wildcards. In other words, this config is true if the search
+     *         is a substring search, and false if the search is an exact search.
+     */
+    [[nodiscard]] auto add_prefix_suffix_wildcards() const -> bool {
+        return m_add_prefix_suffix_wildcards;
+    }
+
+private:
+    // Variables
+    bool m_case_insensitive_wildcard;
+    bool m_add_prefix_suffix_wildcards;
+};
+
+}  // namespace clp::regex_utils
+
+#endif  // CLP_REGEX_UTILS_REGEXTOWILDCARDTRANSLATORCONFIG_HPP

--- a/components/core/src/clp/regex_utils/RegexToWildcardTranslatorConfig.hpp
+++ b/components/core/src/clp/regex_utils/RegexToWildcardTranslatorConfig.hpp
@@ -2,10 +2,15 @@
 #define CLP_REGEX_UTILS_REGEXTOWILDCARDTRANSLATORCONFIG_HPP
 
 namespace clp::regex_utils {
-
+/**
+ * Allows users to customize and fine tune how to translate a regex string to wildcard.
+ *
+ * This class won't affect the core logic and state trasition mechanics of the regex to wildcard
+ * translator, but it can make the translator more versatile. For detailed descriptions of how each
+ * option should be used, see the getter function docstrings.
+ */
 class RegexToWildcardTranslatorConfig {
 public:
-    // Constructors
     RegexToWildcardTranslatorConfig(
             bool case_insensitive_wildcard,
             bool add_prefix_suffix_wildcards
@@ -13,23 +18,19 @@ public:
             : m_case_insensitive_wildcard{case_insensitive_wildcard},
               m_add_prefix_suffix_wildcards{add_prefix_suffix_wildcards} {};
 
-    // Getters
-
     /**
-     * @return True if the final translated wildcard string will be fed into
-     *         a case-insensitive wildcard analyzer. In such cases, we can
-     *         safely translate charset patterns such as [aA] [Bb] into singular
-     *         lowercase characters a, b.
+     * @return True if the final translated wildcard string will be fed into a case-insensitive
+     * wildcard analyzer. In such cases, we can safely translate charset patterns such as [aA] [Bb]
+     * into singular lowercase characters a, b.
      */
     [[nodiscard]] auto case_insensitive_wildcard() const -> bool {
         return m_case_insensitive_wildcard;
     }
 
     /**
-     * @return True if in the absense of starting or ending anchors in the
-     *         regex string, we append prefix or suffix zero or more characters
-     *         wildcards. In other words, this config is true if the search
-     *         is a substring search, and false if the search is an exact search.
+     * @return True if in the absense of starting or ending anchors in the regex string, we append
+     * prefix or suffix zero or more characters wildcards. In other words, this config is true if
+     * the search is a substring search, and false if the search is an exact search.
      */
     [[nodiscard]] auto add_prefix_suffix_wildcards() const -> bool {
         return m_add_prefix_suffix_wildcards;
@@ -40,7 +41,6 @@ private:
     bool m_case_insensitive_wildcard;
     bool m_add_prefix_suffix_wildcards;
 };
-
 }  // namespace clp::regex_utils
 
 #endif  // CLP_REGEX_UTILS_REGEXTOWILDCARDTRANSLATORCONFIG_HPP

--- a/components/core/src/clp/regex_utils/constants.hpp
+++ b/components/core/src/clp/regex_utils/constants.hpp
@@ -2,7 +2,6 @@
 #define CLP_REGEX_UTILS_CONSTANTS_HPP
 
 namespace clp::regex_utils {
-
 // Wildcard meta characters
 constexpr char cZeroOrMoreCharsWildcard{'*'};
 constexpr char cSingleCharWildcard{'?'};
@@ -15,7 +14,6 @@ constexpr char cRegexStartAnchor{'^'};
 constexpr char cRegexEndAnchor{'$'};
 constexpr char cEscapeChar{'\\'};
 constexpr char cCharsetNegate{'^'};
-
 }  // namespace clp::regex_utils
 
 #endif  // CLP_REGEX_UTILS_CONSTANTS_HPP

--- a/components/core/src/clp/regex_utils/constants.hpp
+++ b/components/core/src/clp/regex_utils/constants.hpp
@@ -1,0 +1,21 @@
+#ifndef CLP_REGEX_UTILS_CONSTANTS_HPP
+#define CLP_REGEX_UTILS_CONSTANTS_HPP
+
+namespace clp::regex_utils {
+
+// Wildcard meta characters
+constexpr char cZeroOrMoreCharsWildcard{'*'};
+constexpr char cSingleCharWildcard{'?'};
+
+// Regex meta characters
+constexpr char cRegexZeroOrMore{'*'};
+constexpr char cRegexOneOrMore{'+'};
+constexpr char cRegexZeroOrOne{'?'};
+constexpr char cRegexStartAnchor{'^'};
+constexpr char cRegexEndAnchor{'$'};
+constexpr char cEscapeChar{'\\'};
+constexpr char cCharsetNegate{'^'};
+
+}  // namespace clp::regex_utils
+
+#endif  // CLP_REGEX_UTILS_CONSTANTS_HPP

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -169,7 +169,7 @@ auto normal_state_transition(
 }
 
 /**
- * Attempt to translate regex wildcard patterns that start with `.` character.
+ * Attempts to translate regex wildcard patterns that start with `.` character.
  *
  * Performs the following translation if possible:
  * <ul>
@@ -201,7 +201,9 @@ auto dot_state_transition(
     return ErrorCode::Success;
 }
 
-// Once we've seen the end anchor, we should not expect any other character to appear.
+/**
+ * Disallows the appearances of other characters after encountering an end anchor in the string.
+ */
 auto end_state_transition(
         [[maybe_unused]] TranslatorState& state,
         string_view::const_iterator& it,

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -150,15 +150,15 @@ auto normal_state_transition(
             state.set_next_state(TranslatorState::RegexPatternState::END);
             break;
         case cRegexZeroOrMore:
-            return ErrorCode::Star;
+            return ErrorCode::UntranslatableStar;
         case cRegexOneOrMore:
-            return ErrorCode::Plus;
+            return ErrorCode::UntranslatablePlus;
         case cRegexZeroOrOne:
-            return ErrorCode::Question;
+            return ErrorCode::UnsupportedQuestionMark;
         case '|':
-            return ErrorCode::Pipe;
+            return ErrorCode::UnsupportedPipe;
         case cRegexStartAnchor:
-            return ErrorCode::Caret;
+            return ErrorCode::IllegalCaret;
         case ')':
             return ErrorCode::UnmatchedParenthesis;
         default:
@@ -209,7 +209,7 @@ auto end_state_transition(
         [[maybe_unused]] RegexToWildcardTranslatorConfig const& config
 ) -> error_code {
     if (cRegexEndAnchor != *it) {
-        return ErrorCode::Dollar;
+        return ErrorCode::IllegalDollarSign;
     }
     return ErrorCode::Success;
 }

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -12,8 +12,15 @@
 #include "regex_utils/ErrorCode.hpp"
 #include "regex_utils/RegexToWildcardTranslatorConfig.hpp"
 
-using namespace clp::regex_utils;
-
+using clp::regex_utils::cRegexEndAnchor;
+using clp::regex_utils::cRegexOneOrMore;
+using clp::regex_utils::cRegexStartAnchor;
+using clp::regex_utils::cRegexZeroOrMore;
+using clp::regex_utils::cRegexZeroOrOne;
+using clp::regex_utils::cSingleCharWildcard;
+using clp::regex_utils::cZeroOrMoreCharsWildcard;
+using clp::regex_utils::ErrorCode;
+using clp::regex_utils::RegexToWildcardTranslatorConfig;
 using std::error_code;
 using std::string;
 using std::string_view;

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -1,0 +1,221 @@
+#include "regex_utils/regex_translation_utils.hpp"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include <boost-outcome/include/boost/outcome/config.hpp>
+#include <boost-outcome/include/boost/outcome/std_result.hpp>
+
+#include "regex_utils/constants.hpp"
+#include "regex_utils/ErrorCode.hpp"
+#include "regex_utils/RegexToWildcardTranslatorConfig.hpp"
+
+using namespace clp::regex_utils;
+
+using std::error_code;
+using std::string;
+using std::string_view;
+
+namespace {
+// Internal utility class and function declarations
+/**
+ * Class for storing regex translation analysis states, capture group, quantifier information, etc.
+ */
+class TranslatorState;
+
+// State transition functions common signature
+using StateTransitionFunc
+        = auto(TranslatorState&,
+               string_view::const_iterator&,
+               string&,
+               RegexToWildcardTranslatorConfig const&) -> error_code;
+
+// State transition functions whose names correspond to the current analysis state.
+[[nodiscard]] StateTransitionFunc normal_state_transition;
+[[nodiscard]] StateTransitionFunc dot_state_transition;
+[[nodiscard]] StateTransitionFunc end_state_transition;
+[[nodiscard]] StateTransitionFunc final_state_cleanup;
+
+class TranslatorState {
+public:
+    // Regex translation pattern analysis states.
+    enum class RegexPatternState : uint8_t {
+        // The initial state, where characters have no special meanings and are treated literally.
+        NORMAL = 0,
+        // Encountered a period `.`. Expecting wildcard expression.
+        DOT,
+        // Encountered a dollar sign `$`, meaning the regex string has reached the end anchor.
+        END,
+    };
+
+    // Constructor
+    TranslatorState() = default;
+
+    // Getters
+    [[nodiscard]] auto get_state() const -> RegexPatternState { return m_state; }
+
+    // Setters
+    auto set_next_state(RegexPatternState const& state) -> void { m_state = state; }
+
+private:
+    // Variables
+    RegexPatternState m_state{RegexPatternState::NORMAL};
+};
+}  // namespace
+
+namespace clp::regex_utils {
+// Main API
+auto regex_to_wildcard(string_view regex_str) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<string> {
+    RegexToWildcardTranslatorConfig const default_config{false, false};
+    return regex_to_wildcard(regex_str, default_config);
+}
+
+auto regex_to_wildcard(string_view regex_str, RegexToWildcardTranslatorConfig const& config)
+        -> BOOST_OUTCOME_V2_NAMESPACE::std_result<string> {
+    if (regex_str.empty()) {
+        return string();
+    }
+
+    // Initialize translation state, scan position, and return string
+    TranslatorState state;
+    string_view::const_iterator it = regex_str.cbegin();
+    string wildcard_str;
+
+    // If there is no starting anchor character, append multichar wildcard prefix
+    if (cRegexStartAnchor == *it) {
+        ++it;
+    } else if (config.add_prefix_suffix_wildcards()) {
+        wildcard_str += cZeroOrMoreCharsWildcard;
+    }
+
+    error_code ec{};
+    while (it != regex_str.end()) {
+        // Main state transition table
+        switch (state.get_state()) {
+            case TranslatorState::RegexPatternState::NORMAL:
+                ec = normal_state_transition(state, it, wildcard_str, config);
+                break;
+            case TranslatorState::RegexPatternState::DOT:
+                ec = dot_state_transition(state, it, wildcard_str, config);
+                break;
+            case TranslatorState::RegexPatternState::END:
+                ec = end_state_transition(state, it, wildcard_str, config);
+                break;
+            default:
+                ec = ErrorCode::IllegalState;
+                break;
+        }
+        if (ec) {
+            return ec;
+        }
+        ++it;
+    }
+
+    // Do the final state check and clean up
+    ec = final_state_cleanup(state, it, wildcard_str, config);
+    if (ec) {
+        return ec;
+    }
+    return wildcard_str;
+}
+}  // namespace clp::regex_utils
+
+namespace {
+
+auto normal_state_transition(
+        TranslatorState& state,
+        string_view::const_iterator& it,
+        string& wildcard_str,
+        RegexToWildcardTranslatorConfig const& /*config*/
+) -> error_code {
+    char const ch = *it;
+    switch (ch) {
+        case '.':
+            state.set_next_state(TranslatorState::RegexPatternState::DOT);
+            break;
+        case cRegexEndAnchor:
+            state.set_next_state(TranslatorState::RegexPatternState::END);
+            break;
+        case cRegexZeroOrMore:
+            return ErrorCode::Star;
+        case cRegexOneOrMore:
+            return ErrorCode::Plus;
+        case cRegexZeroOrOne:
+            return ErrorCode::Question;
+        case '|':
+            return ErrorCode::Pipe;
+        case cRegexStartAnchor:
+            return ErrorCode::Caret;
+        case ')':
+            return ErrorCode::UnmatchedParenthesis;
+        default:
+            wildcard_str += ch;
+            break;
+    }
+    return ErrorCode::Success;
+}
+
+auto dot_state_transition(
+        TranslatorState& state,
+        string_view::const_iterator& it,
+        string& wildcard_str,
+        RegexToWildcardTranslatorConfig const& /*config*/
+) -> error_code {
+    switch (*it) {
+        case cZeroOrMoreCharsWildcard:
+            // .* gets translated to *
+            wildcard_str += cZeroOrMoreCharsWildcard;
+            break;
+        case cRegexOneOrMore:
+            // .+ gets translated to ?*
+            wildcard_str = wildcard_str + cSingleCharWildcard + cZeroOrMoreCharsWildcard;
+            break;
+        default:
+            // . gets translated to ?
+            wildcard_str += cSingleCharWildcard;
+            // Backtrack the scan by one position to handle the current char in the next iteration.
+            --it;
+            break;
+    }
+    state.set_next_state(TranslatorState::RegexPatternState::NORMAL);
+    return ErrorCode::Success;
+}
+
+auto end_state_transition(
+        TranslatorState& /*state*/,
+        string_view::const_iterator& it,
+        string& /*wildcard_str*/,
+        RegexToWildcardTranslatorConfig const& /*config*/
+) -> error_code {
+    if (cRegexEndAnchor != *it) {
+        return ErrorCode::Dollar;
+    }
+    return ErrorCode::Success;
+}
+
+auto final_state_cleanup(
+        TranslatorState& state,
+        string_view::const_iterator& /*it*/,
+        string& wildcard_str,
+        RegexToWildcardTranslatorConfig const& config
+) -> error_code {
+    switch (state.get_state()) {
+        case TranslatorState::RegexPatternState::DOT:
+            // The last character is a single `.`, without the possibility of becoming a
+            // multichar wildcard
+            wildcard_str += cSingleCharWildcard;
+            break;
+        default:
+            break;
+    }
+
+    if (TranslatorState::RegexPatternState::END != state.get_state()
+        && config.add_prefix_suffix_wildcards())
+    {
+        wildcard_str += cZeroOrMoreCharsWildcard;
+    }
+    return ErrorCode::Success;
+}
+}  // namespace

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -5,7 +5,6 @@
 #include <string_view>
 #include <system_error>
 
-#include <boost-outcome/include/boost/outcome/config.hpp>
 #include <boost-outcome/include/boost/outcome/std_result.hpp>
 
 #include "regex_utils/constants.hpp"

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -11,11 +11,11 @@
 #include "regex_utils/ErrorCode.hpp"
 #include "regex_utils/RegexToWildcardTranslatorConfig.hpp"
 
+namespace clp::regex_utils {
 using std::error_code;
 using std::string;
 using std::string_view;
 
-namespace clp::regex_utils {
 namespace {
 /**
  * Class for storing regex translation analysis states, capture group, quantifier information, etc.

--- a/components/core/src/clp/regex_utils/regex_translation_utils.hpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.hpp
@@ -1,0 +1,39 @@
+#ifndef CLP_REGEX_UTILS_REGEX_UTILS_HPP
+#define CLP_REGEX_UTILS_REGEX_UTILS_HPP
+
+#include <string>
+#include <string_view>
+
+#include <boost-outcome/include/boost/outcome/config.hpp>
+#include <boost-outcome/include/boost/outcome/std_result.hpp>
+
+#include "regex_utils/RegexToWildcardTranslatorConfig.hpp"
+
+namespace clp::regex_utils {
+
+/**
+ * Call the regex to wildcard translation function with a default configuration that has all the
+ * options as false. For more details on the config options, see
+ * RegexToWildcardTranslatorConfig.hpp.
+ *
+ * @param regex_str The regex string to be translated.
+ * @return The translated wildcard string.
+ */
+[[nodiscard]] auto regex_to_wildcard(std::string_view regex_str
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<std::string>;
+
+/**
+ * Translated a given regex string to wildcard with a custom configuration. For more details on the
+ * config options, see RegexToWildcardTranslatorConfig.hpp.
+ *
+ * @param regex_str The regex string to be translated.
+ * @return The translated wildcard string.
+ */
+[[nodiscard]] auto regex_to_wildcard(
+        std::string_view regex_str,
+        RegexToWildcardTranslatorConfig const& config
+) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<std::string>;
+
+}  // namespace clp::regex_utils
+
+#endif  // CLP_REGEX_UTILS_REGEX_UTILS_HPP

--- a/components/core/src/clp/regex_utils/regex_translation_utils.hpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.hpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <string_view>
 
-#include <boost-outcome/include/boost/outcome/config.hpp>
 #include <boost-outcome/include/boost/outcome/std_result.hpp>
 
 #include "regex_utils/RegexToWildcardTranslatorConfig.hpp"

--- a/components/core/src/clp/regex_utils/regex_translation_utils.hpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.hpp
@@ -4,26 +4,24 @@
 #include <string>
 #include <string_view>
 
-#include <boost-outcome/include/boost/outcome/std_result.hpp>
+#include <outcome/single-header/outcome.hpp>
 
 #include "regex_utils/RegexToWildcardTranslatorConfig.hpp"
 
 namespace clp::regex_utils {
 
 /**
- * Call the regex to wildcard translation function with a default configuration that has all the
- * options as false. For more details on the config options, see
- * RegexToWildcardTranslatorConfig.hpp.
+ * Translate a given regex string to wildcard with the default configuration that has all the
+ * options set to false.
  *
  * @param regex_str The regex string to be translated.
  * @return The translated wildcard string.
  */
 [[nodiscard]] auto regex_to_wildcard(std::string_view regex_str
-) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<std::string>;
+) -> OUTCOME_V2_NAMESPACE::std_result<std::string>;
 
 /**
- * Translated a given regex string to wildcard with a custom configuration. For more details on the
- * config options, see RegexToWildcardTranslatorConfig.hpp.
+ * Translate a given regex string to wildcard with a custom configuration.
  *
  * @param regex_str The regex string to be translated.
  * @return The translated wildcard string.
@@ -31,7 +29,7 @@ namespace clp::regex_utils {
 [[nodiscard]] auto regex_to_wildcard(
         std::string_view regex_str,
         RegexToWildcardTranslatorConfig const& config
-) -> BOOST_OUTCOME_V2_NAMESPACE::std_result<std::string>;
+) -> OUTCOME_V2_NAMESPACE::std_result<std::string>;
 
 }  // namespace clp::regex_utils
 

--- a/components/core/tests/test-regex_utils.cpp
+++ b/components/core/tests/test-regex_utils.cpp
@@ -1,0 +1,24 @@
+#include <regex_utils/ErrorCode.hpp>
+#include <regex_utils/regex_translation_utils.hpp>
+
+#include <Catch2/single_include/catch2/catch.hpp>
+
+using clp::regex_utils::regex_to_wildcard;
+
+TEST_CASE("regex_to_wildcard", "[regex_utils][regex_to_wildcard]") {
+    // Test empty string
+    REQUIRE(regex_to_wildcard("").value().empty());
+
+    // Test simple wildcard translations
+    REQUIRE((regex_to_wildcard("xyz").value() == "xyz"));
+    REQUIRE((regex_to_wildcard(". xyz .* zyx .").value() == "? xyz * zyx ?"));
+    REQUIRE((regex_to_wildcard(". xyz .+ zyx .*").value() == "? xyz ?* zyx *"));
+
+    // Test unescaped meta characters
+    REQUIRE((regex_to_wildcard(".? xyz .* zyx .").error() == clp::regex_utils::ErrorCode::Question)
+    );
+    REQUIRE((regex_to_wildcard(". xyz .** zyx .").error() == clp::regex_utils::ErrorCode::Star));
+    REQUIRE((regex_to_wildcard(". xyz .*+ zyx .").error() == clp::regex_utils::ErrorCode::Plus));
+    REQUIRE((regex_to_wildcard(". xyz |.* zyx .").error() == clp::regex_utils::ErrorCode::Pipe));
+    REQUIRE((regex_to_wildcard(". xyz ^.* zyx .").error() == clp::regex_utils::ErrorCode::Caret));
+}

--- a/components/core/tests/test-regex_utils.cpp
+++ b/components/core/tests/test-regex_utils.cpp
@@ -18,11 +18,11 @@ TEST_CASE("regex_to_wildcard", "[regex_utils][regex_to_wildcard]") {
     REQUIRE((regex_to_wildcard(". xyz .+ zyx .*").value() == "? xyz ?* zyx *"));
 
     // Test unescaped meta characters
-    REQUIRE((regex_to_wildcard(".? xyz .* zyx .").error() == ErrorCode::Question));
-    REQUIRE((regex_to_wildcard(". xyz .** zyx .").error() == ErrorCode::Star));
-    REQUIRE((regex_to_wildcard(". xyz .*+ zyx .").error() == ErrorCode::Plus));
-    REQUIRE((regex_to_wildcard(". xyz |.* zyx .").error() == ErrorCode::Pipe));
-    REQUIRE((regex_to_wildcard(". xyz ^.* zyx .").error() == ErrorCode::Caret));
+    REQUIRE((regex_to_wildcard(".? xyz .* zyx .").error() == ErrorCode::UnsupportedQuestionMark));
+    REQUIRE((regex_to_wildcard(". xyz .** zyx .").error() == ErrorCode::UntranslatableStar));
+    REQUIRE((regex_to_wildcard(". xyz .*+ zyx .").error() == ErrorCode::UntranslatablePlus));
+    REQUIRE((regex_to_wildcard(". xyz |.* zyx .").error() == ErrorCode::UnsupportedPipe));
+    REQUIRE((regex_to_wildcard(". xyz ^.* zyx .").error() == ErrorCode::IllegalCaret));
 }
 
 // Test anchors and prefix/suffix wildcards
@@ -34,5 +34,5 @@ TEST_CASE("regex_to_wildcard_anchor_config", "[regex_utils][regex_to_wildcard][a
     REQUIRE((regex_to_wildcard("xyz", config).value() == "*xyz*"));
     REQUIRE((regex_to_wildcard("xyz$$", config).value() == "*xyz"));
 
-    REQUIRE((regex_to_wildcard("xyz$zyx$", config).error() == ErrorCode::Dollar));
+    REQUIRE((regex_to_wildcard("xyz$zyx$", config).error() == ErrorCode::IllegalDollarSign));
 }

--- a/components/core/tests/test-regex_utils.cpp
+++ b/components/core/tests/test-regex_utils.cpp
@@ -25,8 +25,8 @@ TEST_CASE("regex_to_wildcard", "[regex_utils][regex_to_wildcard]") {
     REQUIRE((regex_to_wildcard(". xyz ^.* zyx .").error() == ErrorCode::IllegalCaret));
 }
 
-// Test anchors and prefix/suffix wildcards
 TEST_CASE("regex_to_wildcard_anchor_config", "[regex_utils][regex_to_wildcard][anchor_config]") {
+    // Test anchors and prefix/suffix wildcards
     RegexToWildcardTranslatorConfig const config{false, true};
     REQUIRE(((regex_to_wildcard("^", config).value() == "*")));
     REQUIRE((regex_to_wildcard("$", config).value() == "*"));

--- a/docs/src/dev-guide/components-core/index.md
+++ b/docs/src/dev-guide/components-core/index.md
@@ -91,6 +91,7 @@ centos7.4-deps-install
 macos12-deps-install
 ubuntu-focal-deps-install
 ubuntu-jammy-deps-install
+regex-utils
 :::
 
 [feature-req]: https://github.com/y-scope/clp/issues/new?assignees=&labels=enhancement&template=feature-request.yml

--- a/docs/src/dev-guide/components-core/regex-utils.md
+++ b/docs/src/dev-guide/components-core/regex-utils.md
@@ -1,4 +1,4 @@
-# Regex_utils
+# regex_utils library
 
 This library contains useful utilities to handle all regex related tasks.
 
@@ -58,10 +58,10 @@ For a detailed description on the options order and usage, see the
 ### Functionalities
 
 * Wildcards
-  - Turn `.` into `?`
-  - Turn `.*` into `*`
-  - Turn `.+` into `?*`
-  - E.g. `abc.*def.ghi.+` will get translated to `abc*def?ghi?*`
+  * Turn `.` into `?`
+  * Turn `.*` into `*`
+  * Turn `.+` into `?*`
+  * E.g. `abc.*def.ghi.+` will get translated to `abc*def?ghi?*`
 
 ### Custom configuration
 
@@ -69,9 +69,9 @@ The `RegexToWildcardTranslatorConfig` class objects are currently immutable once
 constructor takes the following arguments in order:
 
 * `case_insensitive_wildcard`: to be added later along with the character set translation
-implementation.
+  implementation.
 
 * `add_prefix_suffix_wildcards`: in the absence of regex anchors, add prefix or suffix wildcards so
-the query becomes a substring query.
-  - E.g. `info.*system` gets translated into `*info*system*` which makes the original query a
-  substring query.
+  the query becomes a substring query.
+  * E.g. `info.*system` gets translated into `*info*system*` which makes the original query a
+    substring query.


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
For wildcard queries that are disguised as regex queries, perform a best-effort translation so that CLP can turn such queries into more efficient searches.

Current translation functionalities include:

1. Turn `.` into `?` 
2. `.*` into `*` 
3. `.+` into `?*`

A `std::error_code` wrapper has been implemented for failed translations so that the translation functions have `result<T,E>` return style. 

# Validation performed
Verified in unit tests.

