### PR TITLE
clp-s: Add option to record metadata about decompressed archive chunks.

### DIFF
--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -290,12 +290,12 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             // clang-format off
             metadata_options.add_options()(
                     "mongodb-uri",
-                    po::value<std::string>(&m_mongodb_uri),
-                    "The mongodb database used to record decompression metadata"
+                    po::value<std::string>(&m_mongodb_uri)->value_name("URI"),
+                    "MongoDB URI for the database to write decompression metadata to"
             )(
                     "mongodb-collection",
-                    po::value<std::string>(&m_mongodb_collection),
-                    "The collection used to record decompression metadata"
+                    po::value<std::string>(&m_mongodb_collection)->value_name("COLLECTION"),
+                    "MongoDB collection to write decompression metadata to"
             );
             // clang-format on
             extraction_options.add(metadata_options);
@@ -375,7 +375,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             if (false == m_mongodb_uri.empty() && false == m_ordered_decompression) {
                 throw std::invalid_argument(
-                        "recording decompression metadata only supported for ordered decompression"
+                        "Recording decompression metadata only supported for ordered decompression"
                 );
             }
         } else if ((char)Command::Search == command_input) {

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -286,6 +286,20 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             );
             extraction_options.add(input_options);
 
+            po::options_description metadata_options;
+            // clang-format off
+            metadata_options.add_options()(
+                    "mongodb-uri",
+                    po::value<std::string>(&m_mongodb_uri),
+                    "The mongodb database used to record decompression metadata"
+            )(
+                    "mongodb-collection",
+                    po::value<std::string>(&m_mongodb_collection),
+                    "The collection used to record decompression metadata"
+            );
+            // clang-format on
+            extraction_options.add(metadata_options);
+
             po::options_description decompression_options("Decompression Options");
             // clang-format off
             decompression_options.add_options()(
@@ -347,6 +361,18 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             if (0 != m_ordered_chunk_size && false == m_ordered_decompression) {
                 throw std::invalid_argument("ordered-chunk-size must be used with ordered argument"
+                );
+            }
+
+            if (m_mongodb_uri.empty() ^ m_mongodb_collection.empty()) {
+                throw std::invalid_argument(
+                        "mongodb-uri and mongodb-collection must both be non-empty"
+                );
+            }
+
+            if (false == m_mongodb_uri.empty() && false == m_ordered_decompression) {
+                throw std::invalid_argument(
+                        "recording decompression metadata only supported for ordered decompression"
                 );
             }
         } else if ((char)Command::Search == command_input) {

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -286,20 +286,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             );
             extraction_options.add(input_options);
 
-            po::options_description metadata_options("Metadata Options");
-            // clang-format off
-            metadata_options.add_options()(
-                    "mongodb-uri",
-                    po::value<std::string>(&m_mongodb_uri)->value_name("URI"),
-                    "MongoDB URI for the database to write decompression metadata to"
-            )(
-                    "mongodb-collection",
-                    po::value<std::string>(&m_mongodb_collection)->value_name("COLLECTION"),
-                    "MongoDB collection to write decompression metadata to"
-            );
-            // clang-format on
-            extraction_options.add(metadata_options);
-
             po::options_description decompression_options("Decompression Options");
             // clang-format off
             decompression_options.add_options()(
@@ -315,6 +301,20 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             );
             // clang-format on
             extraction_options.add(decompression_options);
+
+            po::options_description output_metadata_options("Output Metadata Options");
+            // clang-format off
+            output_metadata_options.add_options()(
+                    "mongodb-uri",
+                    po::value<std::string>(&m_mongodb_uri)->value_name("URI"),
+                    "MongoDB URI for the database to write decompression metadata to"
+            )(
+                    "mongodb-collection",
+                    po::value<std::string>(&m_mongodb_collection)->value_name("COLLECTION"),
+                    "MongoDB collection to write decompression metadata to"
+            );
+            // clang-format on
+            extraction_options.add(output_metadata_options);
 
             po::positional_options_description positional_options;
             positional_options.add("archives-dir", 1);
@@ -347,7 +347,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 visible_options.add(general_options);
                 visible_options.add(input_options);
                 visible_options.add(decompression_options);
-                visible_options.add(metadata_options);
+                visible_options.add(output_metadata_options);
                 std::cerr << visible_options << std::endl;
                 return ParsingResult::InfoCommand;
             }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -286,7 +286,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             );
             extraction_options.add(input_options);
 
-            po::options_description metadata_options;
+            po::options_description metadata_options("Metadata Options");
             // clang-format off
             metadata_options.add_options()(
                     "mongodb-uri",
@@ -347,6 +347,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 visible_options.add(general_options);
                 visible_options.add(input_options);
                 visible_options.add(decompression_options);
+                visible_options.add(metadata_options);
                 std::cerr << visible_options << std::endl;
                 return ParsingResult::InfoCommand;
             }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -365,6 +365,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
+            // We use xor to check that these arguments are either both specified or both
+            // unspecified.
             if (m_mongodb_uri.empty() ^ m_mongodb_collection.empty()) {
                 throw std::invalid_argument(
                         "mongodb-uri and mongodb-collection must both be non-empty"

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_JSONCONSTRUCTOR_HPP
 #define CLP_S_JSONCONSTRUCTOR_HPP
 
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -15,12 +16,18 @@
 #include "TraceableException.hpp"
 
 namespace clp_s {
+struct MetadataDbOption {
+    std::string mongodb_uri;
+    std::string mongodb_collection;
+};
+
 struct JsonConstructorOption {
     std::string archives_dir;
     std::string archive_id;
     std::string output_dir;
-    bool ordered;
-    size_t ordered_chunk_size;
+    bool ordered{false};
+    size_t ordered_chunk_size{0};
+    std::optional<MetadataDbOption> metadata_db;
 };
 
 class JsonConstructor {
@@ -59,12 +66,7 @@ private:
      */
     void construct_in_order();
 
-    std::string m_archives_dir;
-    std::string m_archive_id;
-    std::string m_output_dir;
-    bool m_ordered{false};
-    size_t m_ordered_chunk_size{0};
-
+    JsonConstructorOption m_option{};
     std::unique_ptr<ArchiveReader> m_archive_reader;
 };
 }  // namespace clp_s

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -17,6 +17,10 @@
 
 namespace clp_s {
 struct MetadataDbOption {
+    MetadataDbOption(std::string const& uri, std::string const& collection)
+            : mongodb_uri(uri),
+              mongodb_collection(collection) {}
+
     std::string mongodb_uri;
     std::string mongodb_collection;
 };

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -18,8 +18,8 @@
 namespace clp_s {
 struct MetadataDbOption {
     MetadataDbOption(std::string const& uri, std::string const& collection)
-            : mongodb_uri(uri),
-              mongodb_collection(collection) {}
+            : mongodb_uri{uri},
+              mongodb_collection{collection} {}
 
     std::string mongodb_uri;
     std::string mongodb_collection;

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -16,13 +16,13 @@ constexpr char cArchiveLogDictFile[] = "/log.dict";
 constexpr char cArchiveTimestampDictFile[] = "/timestamp.dict";
 constexpr char cArchiveVarDictFile[] = "/var.dict";
 
-namespace results_cache { namespace decompression {
+namespace results_cache::decompression {
 constexpr char cPath[]{"path"};
 constexpr char cOrigFileId[]{"orig_file_id"};
 constexpr char cBeginMsgIx[]{"begin_msg_ix"};
 constexpr char cEndMsgIx[]{"end_msg_ix"};
 constexpr char cIsLastIrChunk[]{"is_last_ir_chunk"};
-}}  // namespace results_cache::decompression
+}  // namespace results_cache::decompression
 
 }  // namespace clp_s::constants
 #endif  // CLP_S_ARCHIVE_CONSTANTS_HPP

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -15,5 +15,14 @@ constexpr char cArchiveArrayDictFile[] = "/array.dict";
 constexpr char cArchiveLogDictFile[] = "/log.dict";
 constexpr char cArchiveTimestampDictFile[] = "/timestamp.dict";
 constexpr char cArchiveVarDictFile[] = "/var.dict";
+
+namespace results_cache { namespace decompression {
+constexpr char cPath[]{"path"};
+constexpr char cOrigFileId[]{"orig_file_id"};
+constexpr char cBeginMsgIx[]{"begin_msg_ix"};
+constexpr char cEndMsgIx[]{"end_msg_ix"};
+constexpr char cIsLastIrChunk[]{"is_last_ir_chunk"};
+}}  // namespace results_cache::decompression
+
 }  // namespace clp_s::constants
 #endif  // CLP_S_ARCHIVE_CONSTANTS_HPP

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -269,11 +269,16 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
 
-        clp_s::JsonConstructorOption option;
+        clp_s::JsonConstructorOption option{};
         option.output_dir = command_line_arguments.get_output_dir();
         option.ordered = command_line_arguments.get_ordered_decompression();
         option.archives_dir = archives_dir;
         option.ordered_chunk_size = command_line_arguments.get_ordered_chunk_size();
+        if (false == command_line_arguments.get_mongodb_uri().empty()) {
+            option.metadata_db
+                    = {command_line_arguments.get_mongodb_uri(),
+                       command_line_arguments.get_mongodb_collection()};
+        }
         try {
             auto const& archive_id = command_line_arguments.get_archive_id();
             if (false == archive_id.empty()) {

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -245,6 +245,7 @@ int main(int argc, char const* argv[]) {
     }
 
     clp_s::TimestampPattern::init();
+    mongocxx::instance const mongocxx_instance{};
 
     CommandLineArguments command_line_arguments("clp-s");
     auto parsing_result = command_line_arguments.parse_arguments(argc, argv);
@@ -300,8 +301,6 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
     } else {
-        mongocxx::instance const mongocxx_instance{};
-
         auto const& query = command_line_arguments.get_query();
         auto query_stream = std::istringstream(query);
         auto expr = kql::parse_kql_expression(query_stream);


### PR DESCRIPTION
# Description
This PR introduces the option to record metadata about decompressed archive chunks to mongodb for the purpose of log viewing. The changes are localized to CommandLineArguments and JsonConstructor.

We record the start and end timestamp of each chunk in the start and end index fields of the metadata since that is the information that will be used to look up and order chunks for viewing in the context of clp-s.

# Validation performed
- Validated that all decompression modes still work correctly when metadata not recorded
- Validated that errors are reported as expected with invalid mongodb uri and collection arguments
- Validated that expected metadata gets written to mongodb when valid uri and collection are passed

