### PR TITLE
regex-utils: Add support for handling escaped regex metacharacters.

### DIFF
--- a/components/core/.clang-format
+++ b/components/core/.clang-format
@@ -75,7 +75,7 @@ IncludeCategories:
   # Library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   - Regex: "<(absl|antlr4|archive|boost|bsoncxx|catch2|curl|date|fmt|json|log_surgeon|mariadb\
-|mongocxx|msgpack|outcome|simdjson|spdlog|sqlite3|string_utils|yaml-cpp|zstd)"
+|mongocxx|msgpack|outcome|regex_utils|simdjson|spdlog|sqlite3|string_utils|yaml-cpp|zstd)"
     Priority: 3
   # C system headers
   - Regex: "^<.+\\.h>"

--- a/components/core/src/clp/regex_utils/ErrorCode.cpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.cpp
@@ -65,6 +65,10 @@ auto ErrorCodeCategory::message(int ev) const -> string {
         case ErrorCode::IllegalDollarSign:
             return "Failed to translate due to end anchor `$` in the middle of the string.";
 
+        case ErrorCode::IllegalEscapeSequence:
+            return "Currently only supports escape sequences that are used to suppress special "
+                   "meanings of regex metacharacters. Alphanumeric characters are disallowed.";
+
         case ErrorCode::UnmatchedParenthesis:
             return "Unmatched opening `(` or closing `)`.";
 

--- a/components/core/src/clp/regex_utils/ErrorCode.hpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.hpp
@@ -19,6 +19,7 @@ enum class ErrorCode : uint8_t {
     UnsupportedPipe,
     IllegalCaret,
     IllegalDollarSign,
+    IllegalEscapeSequence,
     UnmatchedParenthesis,
 };
 

--- a/components/core/src/clp/regex_utils/constants.hpp
+++ b/components/core/src/clp/regex_utils/constants.hpp
@@ -1,7 +1,29 @@
 #ifndef CLP_REGEX_UTILS_CONSTANTS_HPP
 #define CLP_REGEX_UTILS_CONSTANTS_HPP
 
+#include <array>
+#include <cstddef>
+#include <string_view>
+
 namespace clp::regex_utils {
+constexpr size_t cCharBitarraySize = 128;
+
+/**
+ * Create an ASCII character lookup table at compile time.
+ *
+ * @param char_str A string that contains the characters to look up.
+ * @return The lookup table as bit array.
+ */
+[[nodiscard]] constexpr auto create_char_bit_array(std::string_view char_str
+) -> std::array<bool, cCharBitarraySize> {
+    std::array<bool, cCharBitarraySize> bit_array{};
+    bit_array.fill(false);
+    for (char const ch : char_str) {
+        bit_array.at(ch) = true;
+    }
+    return bit_array;
+}
+
 // Wildcard meta characters
 constexpr char cZeroOrMoreCharsWildcard{'*'};
 constexpr char cSingleCharWildcard{'?'};
@@ -14,6 +36,13 @@ constexpr char cRegexStartAnchor{'^'};
 constexpr char cRegexEndAnchor{'$'};
 constexpr char cEscapeChar{'\\'};
 constexpr char cCharsetNegate{'^'};
+
+// Character bitmaps
+// This is a more complete set of meta characters than necessary, as the user might not be fully
+// knowledgeable on which meta characters to escape, and may introduce unnecessary escape sequences.
+constexpr auto cRegexEscapeSeqMetaChars = create_char_bit_array("*+?|^$.{}[]()<>-_/=!\\");
+// This is the set of meta characters that need to be escaped in the wildcard syntax.
+constexpr auto cWildcardMetaChars = create_char_bit_array("?*\\");
 }  // namespace clp::regex_utils
 
 #endif  // CLP_REGEX_UTILS_CONSTANTS_HPP

--- a/components/core/src/clp/regex_utils/constants.hpp
+++ b/components/core/src/clp/regex_utils/constants.hpp
@@ -38,11 +38,12 @@ constexpr char cEscapeChar{'\\'};
 constexpr char cCharsetNegate{'^'};
 
 // Character bitmaps
-// The set of characters that can be preceded with an escape backslash. When escaped, these
-// characters are used as literals.
-constexpr auto cRegexEscapeSeqMetaCharsLUT = create_char_bit_array("*+?|^$.{}[]()<>-_/=!\\");
-// The set of metacharacters that need to be escaped in the wildcard syntax.
-constexpr auto cWildcardMetaCharsLUT = create_char_bit_array("?*\\");
+// The set of regex metacharacters that can be preceded with an escape backslash to be treated as a
+// literal.
+constexpr auto cRegexEscapeSeqMetaCharsLut = create_char_bit_array("*+?|^$.{}[]()<>-_/=!\\");
+// The set of wildcard metacharacters that must remain escaped in the translated string to be
+// treated as a literal.
+constexpr auto cWildcardMetaCharsLut = create_char_bit_array("?*\\");
 }  // namespace clp::regex_utils
 
 #endif  // CLP_REGEX_UTILS_CONSTANTS_HPP

--- a/components/core/src/clp/regex_utils/constants.hpp
+++ b/components/core/src/clp/regex_utils/constants.hpp
@@ -9,7 +9,7 @@ namespace clp::regex_utils {
 constexpr size_t cCharBitarraySize = 128;
 
 /**
- * Create an ASCII character lookup table at compile time.
+ * Creates an ASCII character lookup table at compile time.
  *
  * @param char_str A string that contains the characters to look up.
  * @return The lookup table as bit array.
@@ -18,7 +18,7 @@ constexpr size_t cCharBitarraySize = 128;
 ) -> std::array<bool, cCharBitarraySize> {
     std::array<bool, cCharBitarraySize> bit_array{};
     bit_array.fill(false);
-    for (char const ch : char_str) {
+    for (auto const ch : char_str) {
         bit_array.at(ch) = true;
     }
     return bit_array;
@@ -38,11 +38,11 @@ constexpr char cEscapeChar{'\\'};
 constexpr char cCharsetNegate{'^'};
 
 // Character bitmaps
-// This is a more complete set of meta characters than necessary, as the user might not be fully
-// knowledgeable on which meta characters to escape, and may introduce unnecessary escape sequences.
-constexpr auto cRegexEscapeSeqMetaChars = create_char_bit_array("*+?|^$.{}[]()<>-_/=!\\");
-// This is the set of meta characters that need to be escaped in the wildcard syntax.
-constexpr auto cWildcardMetaChars = create_char_bit_array("?*\\");
+// The set of characters that can be preceded with an escape backslash. When escaped, these
+// characters are used as literals.
+constexpr auto cRegexEscapeSeqMetaCharsLUT = create_char_bit_array("*+?|^$.{}[]()<>-_/=!\\");
+// The set of metacharacters that need to be escaped in the wildcard syntax.
+constexpr auto cWildcardMetaCharsLUT = create_char_bit_array("?*\\");
 }  // namespace clp::regex_utils
 
 #endif  // CLP_REGEX_UTILS_CONSTANTS_HPP

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -94,10 +94,11 @@ using StateTransitionFuncSig
 [[nodiscard]] StateTransitionFuncSig dot_state_transition;
 
 /**
- * Appends regex metacharacters literally to the wildcard string.
+ * Appends an escaped regex metacharacter as a literal character to the wildcard string by
+ * discarding its preceding backslash.
  *
- * These metacharacters are escaped by backslashes, so they have their special meanings suppressed.
- * For metacharacters shared by the regex and the wildcard syntax, keep the escape backslashes.
+ * The preceding backslash must be kept for characters that also have special meanings in the
+ * wildcard syntax, e.g. `abc.\*xyz` should be translated into `abc?\*xyz` instead of `abc?*xyz`.
  */
 [[nodiscard]] StateTransitionFuncSig escaped_state_transition;
 
@@ -178,10 +179,10 @@ auto escaped_state_transition(
         [[maybe_unused]] RegexToWildcardTranslatorConfig const& config
 ) -> error_code {
     auto const ch{*it};
-    if (!cRegexEscapeSeqMetaChars.at(ch)) {
+    if (false == cRegexEscapeSeqMetaCharsLUT.at(ch)) {
         return ErrorCode::IllegalEscapeSequence;
     }
-    if (cWildcardMetaChars.at(ch)) {
+    if (cWildcardMetaCharsLUT.at(ch)) {
         wildcard_str = wildcard_str + cEscapeChar + ch;
     } else {
         wildcard_str += ch;

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -179,10 +179,10 @@ auto escaped_state_transition(
         [[maybe_unused]] RegexToWildcardTranslatorConfig const& config
 ) -> error_code {
     auto const ch{*it};
-    if (false == cRegexEscapeSeqMetaCharsLUT.at(ch)) {
+    if (false == cRegexEscapeSeqMetaCharsLut.at(ch)) {
         return ErrorCode::IllegalEscapeSequence;
     }
-    if (cWildcardMetaCharsLUT.at(ch)) {
+    if (cWildcardMetaCharsLut.at(ch)) {
         wildcard_str = wildcard_str + cEscapeChar + ch;
     } else {
         wildcard_str += ch;

--- a/components/core/tests/test-regex_utils.cpp
+++ b/components/core/tests/test-regex_utils.cpp
@@ -1,8 +1,7 @@
+#include <Catch2/single_include/catch2/catch.hpp>
 #include <regex_utils/ErrorCode.hpp>
 #include <regex_utils/regex_translation_utils.hpp>
 #include <regex_utils/RegexToWildcardTranslatorConfig.hpp>
-
-#include <Catch2/single_include/catch2/catch.hpp>
 
 using clp::regex_utils::ErrorCode;
 using clp::regex_utils::regex_to_wildcard;

--- a/components/core/tests/test-regex_utils.cpp
+++ b/components/core/tests/test-regex_utils.cpp
@@ -25,7 +25,6 @@ TEST_CASE("regex_to_wildcard_unescaped_metachar", "[regex_utils][re2wc][unescape
     REQUIRE((regex_to_wildcard(". xyz $.* zyx .").error() == ErrorCode::IllegalDollarSign));
 }
 
-
 TEST_CASE("regex_to_wildcard_escaped_metachar", "[regex_utils][re2wc][escaped_metachar]") {
     // Escape backslash is superfluous for the following set of characters
     REQUIRE((regex_to_wildcard("<>-_/=!").value() == "<>-_/=!"));

--- a/components/core/tests/test-regex_utils.cpp
+++ b/components/core/tests/test-regex_utils.cpp
@@ -23,6 +23,19 @@ TEST_CASE("regex_to_wildcard", "[regex_utils][regex_to_wildcard]") {
     REQUIRE((regex_to_wildcard(". xyz .*+ zyx .").error() == ErrorCode::UntranslatablePlus));
     REQUIRE((regex_to_wildcard(". xyz |.* zyx .").error() == ErrorCode::UnsupportedPipe));
     REQUIRE((regex_to_wildcard(". xyz ^.* zyx .").error() == ErrorCode::IllegalCaret));
+
+    // Test escaped meta characters
+    REQUIRE((regex_to_wildcard("<>-_/=!").value() == "<>-_/=!"));
+    REQUIRE((regex_to_wildcard("\\<\\>\\-\\_\\/\\=\\!").value() == "<>-_/=!"));
+    REQUIRE(
+            (regex_to_wildcard("\\*\\+\\?\\|\\^\\$\\.\\{\\}\\[\\]\\(\\)\\<\\>\\-\\_\\/\\=\\!\\\\")
+                     .value()
+             == "\\*+\\?|^$.{}[]()<>-_/=!\\\\")
+    );
+    REQUIRE(
+            (regex_to_wildcard("abc\\Qdefghi\\Ejkl").error()
+             == clp::regex_utils::ErrorCode::IllegalEscapeSequence)
+    );
 }
 
 TEST_CASE("regex_to_wildcard_anchor_config", "[regex_utils][regex_to_wildcard][anchor_config]") {

--- a/docs/src/dev-guide/components-core/regex-utils.md
+++ b/docs/src/dev-guide/components-core/regex-utils.md
@@ -63,11 +63,13 @@ For a detailed description on the options order and usage, see the
   * Turn `.+` into `?*`
   * E.g. `abc.*def.ghi.+` will get translated to `abc*def?ghi?*`
 * Metacharacter escape sequences
-  * Append the escaped metacharacters literally to the wildcard output string.
-    * The list of characters that require escaping is `[\/^$.|?*+(){}`.
-    * The list of characters that are optional to escape is `],<>-_=!`. Escaping them will not have
-      any effect (the escape backslash is ignored). This list may be expanded in the future.
+  * An escaped regex metacharacter is treated as a literal and appended to the wildcard output.
+    * The list of characters that require escaping to have their special meanings suppressed is
+      `[\/^$.|?*+(){}`.
+    * Superfluous escape characters are ignored for the following characters: `],<>-_=!`.
     * E.g. `a\[\+b\-\_c-_d` will get translated to `a[+b-_c-_d`
+    * Note: generally, any non-alphanumeric character can be escaped to use it as a literal. The
+      list this utils library supports is non-exhaustive and can be expanded when necessary.
   * For metacharacters shared by both syntaxes, keep the escape backslashes.
     * The list of characters that fall into this category is `*?\`. All wildcard metacharacters are
       also regex metacharacters.

--- a/docs/src/dev-guide/components-core/regex-utils.md
+++ b/docs/src/dev-guide/components-core/regex-utils.md
@@ -62,6 +62,19 @@ For a detailed description on the options order and usage, see the
   * Turn `.*` into `*`
   * Turn `.+` into `?*`
   * E.g. `abc.*def.ghi.+` will get translated to `abc*def?ghi?*`
+* Metacharacter escape sequences
+  * Append the escaped metacharacters literally to the wildcard output string.
+    * The list of characters that require escaping is `[\/^$.|?*+(){}`.
+    * The list of characters that are optional to escape is `],<>-_=!`. Escaping them will not have
+      any effect (the escape backslash is ignored). This list may be expanded in the future.
+    * E.g. `a\[\+b\-\_c-_d` will get translated to `a[+b-_c-_d`
+  * For metacharacters shared by both syntaxes, keep the escape backslashes.
+    * The list of characters that fall into this category is `*?\`. All wildcard metacharacters are
+      also regex metacharacters.
+    * E.g. `a\*b\?c\\d` will get translated to `a\*b\?c\\d` (no change)
+  * Escape sequences with alphanumeric characters are disallowed.
+    * E.g. Special utility escape sequences `\Q`, `\E`, `\A` etc. and back references `\1` `\2` etc.
+      cannot be translated.
 
 ### Custom configuration
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
The regex syntax uses escape sequences to represent its metacharacters literally. 
The translator should de-escape the escaped metacharacter and add it to the wildcard output. Or if the metacharacter is shared by both the regex and the wildcard syntax, it should keep the escape slash.

Escape sequences that escape alphanumeric characters are disallowed since they perform other tasks that are currently not supported by the translator.

# Validation performed
Verified in unit tests

