### PR TITLE
core-clp: Fix ArchiveMetadata deserialization by deserializing previously missed field.

### DIFF
--- a/components/core/src/clp/streaming_archive/ArchiveMetadata.cpp
+++ b/components/core/src/clp/streaming_archive/ArchiveMetadata.cpp
@@ -26,6 +26,7 @@ ArchiveMetadata::ArchiveMetadata(FileReader& file_reader) {
     file_reader.read_numeric_value(m_archive_format_version, false);
     file_reader.read_numeric_value(m_creator_id_len, false);
     file_reader.read_string(m_creator_id_len, m_creator_id, false);
+    file_reader.read_numeric_value(m_creation_idx, false);
     file_reader.read_numeric_value(m_uncompressed_size, false);
     file_reader.read_numeric_value(m_compressed_size, false);
     file_reader.read_numeric_value(m_begin_timestamp, false);


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
In the current CLP archive implementation, we serialize the archive metadata into a file in the compressed archive. When decompressing the archive, we deserialize the metadata. However, the deserialization constructor has a bug to miss the read of `m_creation_idx`. This PR fixes this bug.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Validated on the private repo to ensure the fix works.
