### PR TITLE
clp-package: Add the log-viewer and serve it using the log-viewer-webui.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "components/core/submodules/outcome"]
 	path = components/core/submodules/outcome
 	url = https://github.com/ned14/outcome.git
+[submodule "components/log-viewer-webui/yscope-log-viewer"]
+    path = components/log-viewer-webui/yscope-log-viewer
+    url = git@github.com:y-scope/yscope-log-viewer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,5 +27,5 @@
 	path = components/core/submodules/outcome
 	url = https://github.com/ned14/outcome.git
 [submodule "components/log-viewer-webui/yscope-log-viewer"]
-    path = components/log-viewer-webui/yscope-log-viewer
-    url = git@github.com:y-scope/yscope-log-viewer.git
+	path = components/log-viewer-webui/yscope-log-viewer
+	url = https://github.com/y-scope/yscope-log-viewer.git

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -234,8 +234,10 @@ tasks:
         cd client
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
         --output-path "{{.OUTPUT_DIR}}/client"
+      - |-
+        cd yscope-log-viewer
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
-                --output-path "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/yscope-log-viewer"
+        --output-path "{{.OUTPUT_DIR}}/yscope-log-viewer"
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
@@ -432,7 +434,9 @@ tasks:
       - "PATH='{{.G_NODEJS_22_BIN_DIR}}':$PATH npm run init"
       - |-
         cd yscope-log-viewer
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
+        --output-path "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/yscope-log-viewer"
       # These commands must be last
       - task: "utils:compute-checksum"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -234,11 +234,6 @@ tasks:
         cd client
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
         --output-path "{{.OUTPUT_DIR}}/client"
-      - |-
-        cd yscope-log-viewer
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
-        --output-path "{{.OUTPUT_DIR}}/yscope-log-viewer"
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
@@ -382,9 +377,9 @@ tasks:
       # Checksum files
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       CLIENT_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-client-node-modules.md5"
+      LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE: >
       PACKAGE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-package-node-modules.md5"
       SERVER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-server-node-modules.md5"
-      LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE: >
         {{.G_BUILD_DIR}}/log-viewer-webui-inner-client-node-modules.md5
 
       # Directories
@@ -408,9 +403,9 @@ tasks:
     generates:
       - "{{.CHECKSUM_FILE}}"
       - "{{.CLIENT_CHECKSUM_FILE}}"
+      - "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
       - "{{.PACKAGE_CHECKSUM_FILE}}"
       - "{{.SERVER_CHECKSUM_FILE}}"
-      - "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
     deps:
       - "nodejs-22"
       - task: "utils:validate-checksum"
@@ -433,6 +428,10 @@ tasks:
       - "rm -f {{.CHECKSUM_FILE}}"
       - task: "clean-log-viewer-webui"
       - "PATH='{{.G_NODEJS_22_BIN_DIR}}':$PATH npm run init"
+      - |-
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
+        --output-path "{{.OUTPUT_DIR}}/yscope-log-viewer"
       # These commands must be last
       - task: "utils:compute-checksum"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -429,6 +429,7 @@ tasks:
       - task: "clean-log-viewer-webui"
       - "PATH='{{.G_NODEJS_22_BIN_DIR}}':$PATH npm run init"
       - |-
+        cd yscope-log-viewer
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
         --output-path "{{.OUTPUT_DIR}}/yscope-log-viewer"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -394,6 +394,7 @@ tasks:
       PACKAGE_OUTPUT_DIR: "{{.SRC_DIR}}/node_modules"
       SERVER_OUTPUT_DIR: "{{.SRC_DIR}}/server/node_modules"
     sources:
+      - "{{.G_BUILD_DIR}}/log-viewer-webui-submodules.md5"
       - "{{.G_BUILD_DIR}}/nodejs-22.md5"
       - "{{.TASKFILE}}"
       - "client/package.json"
@@ -412,6 +413,7 @@ tasks:
       - "{{.PACKAGE_CHECKSUM_FILE}}"
       - "{{.SERVER_CHECKSUM_FILE}}"
     deps:
+      - "log-viewer-webui-submodules"
       - "nodejs-22"
       - task: "utils:validate-checksum"
         vars:
@@ -461,6 +463,30 @@ tasks:
         "{{.PACKAGE_CHECKSUM_FILE}}"
         "{{.SERVER_CHECKSUM_FILE}}"
         > "{{.CHECKSUM_FILE}}"
+
+  log-viewer-webui-submodules:
+    internal: true
+    vars:
+      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "yscope-log-viewer"
+    sources:
+      - "{{.TASKFILE}}"
+      - ".gitmodules"
+    dir: "components/log-viewer-webui"
+    generates: ["{{.CHECKSUM_FILE}}"]
+    deps:
+      - "init"
+      - task: "utils:validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+    cmds:
+      - "git submodule update --init --recursive yscope-log-viewer"
+      # This command must be last
+      - task: "utils:compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
   meteor:
     vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -213,7 +213,7 @@ tasks:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}"
     sources:
-      - "{{.G_BUILD_DIR}}/log-viewer-modules.md5"
+      - "{{.G_BUILD_DIR}}/log-viewer-webui-node-modules.md5"
       - "{{.TASKFILE}}"
       - "client/package.json"
       - "client/src/**/*.css"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -434,9 +434,7 @@ tasks:
       - "PATH='{{.G_NODEJS_22_BIN_DIR}}':$PATH npm run init"
       - |-
         cd yscope-log-viewer
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
-        --output-path "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/yscope-log-viewer"
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm install
       # These commands must be last
       - task: "utils:compute-checksum"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -230,14 +230,13 @@ tasks:
           DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
-      - |-
-        cd client
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
-        --output-path "{{.OUTPUT_DIR}}/client"
-      - |-
-        cd yscope-log-viewer
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
-        --output-path "{{.OUTPUT_DIR}}/yscope-log-viewer"
+      - for:
+          - "client"
+          - "yscope-log-viewer"
+        cmd: |-
+          cd "{{.ITEM}}"
+          PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
+          --output-path "{{.OUTPUT_DIR}}/{{.ITEM}}"
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -383,17 +383,16 @@ tasks:
       # Checksum files
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       CLIENT_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-client-node-modules.md5"
-      LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE: >-
-        {{.G_BUILD_DIR}}/log-viewer-webui-inner-client-node-modules.md5
+      LOG_VIEWER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-log-viewer-node-modules.md5"
       PACKAGE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-package-node-modules.md5"
       SERVER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-server-node-modules.md5"
 
       # Directories
       SRC_DIR: "{{.TASKFILE_DIR}}/components/log-viewer-webui"
       CLIENT_OUTPUT_DIR: "{{.SRC_DIR}}/client/node_modules"
+      LOG_VIEWER_OUTPUT_DIR: "{{.SRC_DIR}}/yscope-log-viewer/node_modules"
       PACKAGE_OUTPUT_DIR: "{{.SRC_DIR}}/node_modules"
       SERVER_OUTPUT_DIR: "{{.SRC_DIR}}/server/node_modules"
-      YSCOPE_LOG_VIEWER_OUTPUT_DIR: "{{.SRC_DIR}}/yscope-log-viewer/node_modules"
     sources:
       - "{{.G_BUILD_DIR}}/nodejs-22.md5"
       - "{{.TASKFILE}}"
@@ -409,7 +408,7 @@ tasks:
     generates:
       - "{{.CHECKSUM_FILE}}"
       - "{{.CLIENT_CHECKSUM_FILE}}"
-      - "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
+      - "{{.LOG_VIEWER_CHECKSUM_FILE}}"
       - "{{.PACKAGE_CHECKSUM_FILE}}"
       - "{{.SERVER_CHECKSUM_FILE}}"
     deps:
@@ -428,8 +427,8 @@ tasks:
           DATA_DIR: "{{.PACKAGE_OUTPUT_DIR}}"
       - task: "utils:validate-checksum"
         vars:
-          CHECKSUM_FILE: "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
-          DATA_DIR: "{{.YSCOPE_LOG_VIEWER_OUTPUT_DIR}}"
+          CHECKSUM_FILE: "{{.LOG_VIEWER_CHECKSUM_FILE}}"
+          DATA_DIR: "{{.LOG_VIEWER_OUTPUT_DIR}}"
     cmds:
       - "rm -f {{.CHECKSUM_FILE}}"
       - task: "clean-log-viewer-webui"
@@ -444,23 +443,23 @@ tasks:
           OUTPUT_FILE: "{{.CLIENT_CHECKSUM_FILE}}"
       - task: "utils:compute-checksum"
         vars:
+          DATA_DIR: "{{.LOG_VIEWER_OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.LOG_VIEWER_CHECKSUM_FILE}}"
+      - task: "utils:compute-checksum"
+        vars:
           DATA_DIR: "{{.PACKAGE_OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.PACKAGE_CHECKSUM_FILE}}"
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.SERVER_OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.SERVER_CHECKSUM_FILE}}"
-      - task: "utils:compute-checksum"
-        vars:
-          DATA_DIR: "{{.YSCOPE_LOG_VIEWER_OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
       # This command must be last
       - >-
         cat
         "{{.CLIENT_CHECKSUM_FILE}}"
+        "{{.LOG_VIEWER_CHECKSUM_FILE}}"
         "{{.PACKAGE_CHECKSUM_FILE}}"
         "{{.SERVER_CHECKSUM_FILE}}"
-        "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
         > "{{.CHECKSUM_FILE}}"
 
   meteor:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -219,6 +219,11 @@ tasks:
       - "client/src/**/*.css"
       - "client/src/**/*.jsx"
       - "client/src/webpack.config.js"
+      - "yscope-log-viewer/customized-packages/**/*"
+      - "yscope-log-viewer/package.json"
+      - "yscope-log-viewer/src/**/*"
+      - "yscope-log-viewer/webpack.common.js"
+      - "yscope-log-viewer/webpack.prod.js"
     dir: "components/log-viewer-webui"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -370,18 +370,20 @@ tasks:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
-  # NOTE: The log-viewer-webui has four different node_modules directories
-  # (client, server, log-viewer submodule, and the top-level one we call "package"),
-  # meaning we have to create four different checksums.
-  # To allow tasks which depend on this task to only have to check one checksum file,
-  # we concatenate the three checksum files into one.
+  # NOTE: The log-viewer-webui has four different node_modules directories:
+  # * client
+  # * server
+  # * log-viewer submodule
+  # * the top-level one we call "package"
+  # This means we have to create four different checksums. To allow tasks which depend on this task
+  # to only have to check one checksum file, we concatenate the four checksum files into one.
   log-viewer-webui-node-modules:
     internal: true
     vars:
       # Checksum files
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       CLIENT_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-client-node-modules.md5"
-      LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE: >
+      LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE: >-
         {{.G_BUILD_DIR}}/log-viewer-webui-inner-client-node-modules.md5
       PACKAGE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-package-node-modules.md5"
       SERVER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-server-node-modules.md5"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -234,6 +234,8 @@ tasks:
         cd client
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
         --output-path "{{.OUTPUT_DIR}}/client"
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
+                --output-path "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/yscope-log-viewer"
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
@@ -430,9 +432,7 @@ tasks:
       - "PATH='{{.G_NODEJS_22_BIN_DIR}}':$PATH npm run init"
       - |-
         cd yscope-log-viewer
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
-        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
-        --output-path "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/yscope-log-viewer"
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i
       # These commands must be last
       - task: "utils:compute-checksum"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -219,6 +219,7 @@ tasks:
       - "client/src/**/*.css"
       - "client/src/**/*.jsx"
       - "client/src/webpack.config.js"
+      - "yscope-log-viewer/.babelrc"
       - "yscope-log-viewer/customized-packages/**/*"
       - "yscope-log-viewer/package.json"
       - "yscope-log-viewer/src/**/*"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -460,6 +460,7 @@ tasks:
         "{{.CLIENT_CHECKSUM_FILE}}"
         "{{.PACKAGE_CHECKSUM_FILE}}"
         "{{.SERVER_CHECKSUM_FILE}}"
+        "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
         > "{{.CHECKSUM_FILE}}"
 
   meteor:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,6 +47,7 @@ tasks:
       - "rm -rf 'components/log-viewer-webui/client/node_modules'"
       - "rm -rf 'components/log-viewer-webui/node_modules'"
       - "rm -rf 'components/log-viewer-webui/server/node_modules'"
+      - "rm -rf 'components/log-viewer-webui/yscope-log-viewer/node_modules'"
 
   clean-webui:
     cmds:
@@ -74,7 +75,7 @@ tasks:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_PACKAGE_BUILD_DIR}}"
     sources:
-      - "{{.G_BUILD_DIR}}/log-viewer-webui-client.md5"
+      - "{{.G_BUILD_DIR}}/log-viewer-webui-clients.md5"
       - "{{.G_BUILD_DIR}}/package-venv.md5"
       - "{{.G_BUILD_DIR}}/webui.md5"
       - "{{.G_BUILD_DIR}}/webui-nodejs.md5"
@@ -100,7 +101,7 @@ tasks:
       - "clp-py-utils"
       - "init"
       - "job-orchestration"
-      - "log-viewer-webui-client"
+      - "log-viewer-webui-clients"
       - "nodejs-14"
       - "package-venv"
       - task: "utils:validate-checksum"
@@ -150,6 +151,7 @@ tasks:
       - >-
         rsync -a
         "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/client"
+        "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/yscope-log-viewer"
         "{{.OUTPUT_DIR}}/var/www/log_viewer_webui/"
       - |-
         cd components/log-viewer-webui/server/
@@ -206,7 +208,7 @@ tasks:
       vars:
         COMPONENT: "{{.TASK}}"
 
-  log-viewer-webui-client:
+  log-viewer-webui-clients:
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}"
@@ -232,6 +234,11 @@ tasks:
         cd client
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
         --output-path "{{.OUTPUT_DIR}}/client"
+      - |-
+        cd yscope-log-viewer
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
+        PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
+        --output-path "{{.OUTPUT_DIR}}/yscope-log-viewer"
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
@@ -364,10 +371,11 @@ tasks:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
-  # NOTE: The log-viewer-webui has three different node_modules directories (client, server, and the
-  # top-level one we call "package"), meaning we have to create three different checksums. To allow
-  # tasks which depend on this task to only have to check one checksum file, we concatenate the
-  # three checksum files into one.
+  # NOTE: The log-viewer-webui has four different node_modules directories
+  # (client, server, log-viewer submodule, and the top-level one we call "package"),
+  # meaning we have to create four different checksums.
+  # To allow tasks which depend on this task to only have to check one checksum file,
+  # we concatenate the three checksum files into one.
   log-viewer-webui-node-modules:
     internal: true
     vars:
@@ -376,12 +384,15 @@ tasks:
       CLIENT_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-client-node-modules.md5"
       PACKAGE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-package-node-modules.md5"
       SERVER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-server-node-modules.md5"
+      LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE: >
+        {{.G_BUILD_DIR}}/log-viewer-webui-inner-client-node-modules.md5
 
       # Directories
       SRC_DIR: "{{.TASKFILE_DIR}}/components/log-viewer-webui"
       CLIENT_OUTPUT_DIR: "{{.SRC_DIR}}/client/node_modules"
       PACKAGE_OUTPUT_DIR: "{{.SRC_DIR}}/node_modules"
       SERVER_OUTPUT_DIR: "{{.SRC_DIR}}/server/node_modules"
+      YSCOPE_LOG_VIEWER_OUTPUT_DIR: "{{.SRC_DIR}}/yscope-log-viewer/node_modules"
     sources:
       - "{{.G_BUILD_DIR}}/nodejs-22.md5"
       - "{{.TASKFILE}}"
@@ -391,12 +402,15 @@ tasks:
       - "package-lock.json"
       - "server/package.json"
       - "server/package-lock.json"
+      - "yscope-log-viewer/package.json"
+      - "yscope-log-viewer/package-lock.json"
     dir: "{{.SRC_DIR}}"
     generates:
       - "{{.CHECKSUM_FILE}}"
       - "{{.CLIENT_CHECKSUM_FILE}}"
       - "{{.PACKAGE_CHECKSUM_FILE}}"
       - "{{.SERVER_CHECKSUM_FILE}}"
+      - "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
     deps:
       - "nodejs-22"
       - task: "utils:validate-checksum"
@@ -411,6 +425,10 @@ tasks:
         vars:
           CHECKSUM_FILE: "{{.PACKAGE_CHECKSUM_FILE}}"
           DATA_DIR: "{{.PACKAGE_OUTPUT_DIR}}"
+      - task: "utils:validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
+          DATA_DIR: "{{.YSCOPE_LOG_VIEWER_OUTPUT_DIR}}"
     cmds:
       - "rm -f {{.CHECKSUM_FILE}}"
       - task: "clean-log-viewer-webui"
@@ -428,6 +446,10 @@ tasks:
         vars:
           DATA_DIR: "{{.SERVER_OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.SERVER_CHECKSUM_FILE}}"
+      - task: "utils:compute-checksum"
+        vars:
+          DATA_DIR: "{{.YSCOPE_LOG_VIEWER_OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE}}"
       # This command must be last
       - >-
         cat

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -378,9 +378,9 @@ tasks:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       CLIENT_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-client-node-modules.md5"
       LOG_VIEWER_WEBUI_INNER_CLIENT_CHECKSUM_FILE: >
+        {{.G_BUILD_DIR}}/log-viewer-webui-inner-client-node-modules.md5
       PACKAGE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-package-node-modules.md5"
       SERVER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/log-viewer-webui-server-node-modules.md5"
-        {{.G_BUILD_DIR}}/log-viewer-webui-inner-client-node-modules.md5
 
       # Directories
       SRC_DIR: "{{.TASKFILE_DIR}}/components/log-viewer-webui"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -432,7 +432,7 @@ tasks:
         cd yscope-log-viewer
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm i && \
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm run build -- \
-        --output-path "{{.OUTPUT_DIR}}/yscope-log-viewer"
+        --output-path "{{.G_LOG_VIEWER_WEBUI_BUILD_DIR}}/yscope-log-viewer"
       # These commands must be last
       - task: "utils:compute-checksum"
         vars:

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -816,7 +816,7 @@ def start_log_viewer_webui(
         "MongoDbIrFilesCollectionName": clp_config.results_cache.ir_collection_name,
         "ClientDir": str(container_log_viewer_webui_dir / "client"),
         "IrFilesDir": str(container_clp_config.ir_output.directory),
-        "LogViewerDir": str(container_log_viewer_webui_dir / "yscope-log-viewer")
+        "LogViewerDir": str(container_log_viewer_webui_dir / "yscope-log-viewer"),
     }
     settings_json = read_and_update_settings_json(settings_json_path, settings_json_updates)
     with open(settings_json_path, "w") as settings_json_file:

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -816,6 +816,7 @@ def start_log_viewer_webui(
         "MongoDbIrFilesCollectionName": clp_config.results_cache.ir_collection_name,
         "ClientDir": str(container_log_viewer_webui_dir / "client"),
         "IrFilesDir": str(container_clp_config.ir_output.directory),
+        "LogViewerDir": str(container_log_viewer_webui_dir / "yscope-log-viewer")
     }
     settings_json = read_and_update_settings_json(settings_json_path, settings_json_updates)
     with open(settings_json_path, "w") as settings_json_file:

--- a/components/log-viewer-webui/server/settings.json
+++ b/components/log-viewer-webui/server/settings.json
@@ -9,5 +9,6 @@
     "MongoDbIrFilesCollectionName": "ir-files",
 
     "ClientDir": "../client/dist",
-    "IrFilesDir": "../../../build/clp-package/var/data/ir"
+    "IrFilesDir": "../../../build/clp-package/var/data/ir",
+    "YlvDir": "../yscope-log-viewer/dist"
 }

--- a/components/log-viewer-webui/server/settings.json
+++ b/components/log-viewer-webui/server/settings.json
@@ -10,5 +10,5 @@
 
     "ClientDir": "../client/dist",
     "IrFilesDir": "../../../build/clp-package/var/data/ir",
-    "YlvDir": "../yscope-log-viewer/dist"
+    "LogViewerDir": "../yscope-log-viewer/dist"
 }

--- a/components/log-viewer-webui/server/src/app.js
+++ b/components/log-viewer-webui/server/src/app.js
@@ -1,14 +1,11 @@
 import fastify from "fastify";
-import * as path from "node:path";
 import process from "node:process";
-import {fileURLToPath} from "node:url";
-
-import {fastifyStatic} from "@fastify/static";
 
 import settings from "../settings.json" with {type: "json"};
 import DbManager from "./DbManager.js";
 import exampleRoutes from "./routes/example.js";
 import queryRoutes from "./routes/query.js";
+import staticRoutes from "./routes/static.js";
 
 
 /**
@@ -26,30 +23,8 @@ const app = async ({
     sqlDbPass,
 }) => {
     const server = fastify(fastifyOptions);
-    const filename = fileURLToPath(import.meta.url);
-    const dirname = path.dirname(filename);
-    const parentDirname = path.resolve(dirname, "..");
 
     if ("test" !== process.env.NODE_ENV) {
-        let irFilesDir = settings.IrFilesDir;
-        if (false === path.isAbsolute(irFilesDir)) {
-            irFilesDir = path.resolve(parentDirname, irFilesDir);
-        }
-        await server.register(fastifyStatic, {
-            prefix: "/ir",
-            root: irFilesDir,
-        });
-
-        let logViewerDir = settings.LogViewerDir;
-        if (false === path.isAbsolute(logViewerDir)) {
-            logViewerDir = path.resolve(parentDirname, logViewerDir);
-        }
-        await server.register(fastifyStatic, {
-            prefix: "/log-viewer",
-            root: logViewerDir,
-            decorateReply: false,
-        });
-
         await server.register(DbManager, {
             mysqlConfig: {
                 database: settings.SqlDbName,
@@ -68,20 +43,7 @@ const app = async ({
         });
     }
 
-    if ("production" === process.env.NODE_ENV) {
-        // In the development environment, we expect the client to use a separate webserver that
-        // supports live reloading.
-        if (false === path.isAbsolute(settings.ClientDir)) {
-            throw new Error("`clientDir` must be an absolute path.");
-        }
-
-        await server.register(fastifyStatic, {
-            prefix: "/",
-            root: settings.ClientDir,
-            decorateReply: false,
-        });
-    }
-
+    await server.register(staticRoutes);
     await server.register(exampleRoutes);
     await server.register(queryRoutes);
 

--- a/components/log-viewer-webui/server/src/app.js
+++ b/components/log-viewer-webui/server/src/app.js
@@ -70,6 +70,12 @@ const app = async ({
             root: settings.ClientDir,
             decorateReply: false,
         });
+
+        await server.register(fastifyStatic, {
+            prefix: "/",
+            root: settings.YlvDir,
+            decorateReply: false,
+        });
     }
 
     await server.register(exampleRoutes);

--- a/components/log-viewer-webui/server/src/app.js
+++ b/components/log-viewer-webui/server/src/app.js
@@ -73,7 +73,7 @@ const app = async ({
 
         await server.register(fastifyStatic, {
             prefix: "/",
-            root: settings.YlvDir,
+            root: settings.LogViewerDir,
             decorateReply: false,
         });
     }

--- a/components/log-viewer-webui/server/src/app.js
+++ b/components/log-viewer-webui/server/src/app.js
@@ -40,6 +40,16 @@ const app = async ({
             root: irFilesDir,
         });
 
+        let logViewerDir = settings.LogViewerDir;
+        if (false === path.isAbsolute(logViewerDir)) {
+            logViewerDir = path.resolve(parentDirname, logViewerDir);
+        }
+        await server.register(fastifyStatic, {
+            prefix: "/log-viewer",
+            root: logViewerDir,
+            decorateReply: false,
+        });
+
         await server.register(DbManager, {
             mysqlConfig: {
                 database: settings.SqlDbName,
@@ -68,12 +78,6 @@ const app = async ({
         await server.register(fastifyStatic, {
             prefix: "/",
             root: settings.ClientDir,
-            decorateReply: false,
-        });
-
-        await server.register(fastifyStatic, {
-            prefix: "/",
-            root: settings.LogViewerDir,
             decorateReply: false,
         });
     }

--- a/components/log-viewer-webui/server/src/routes/static.js
+++ b/components/log-viewer-webui/server/src/routes/static.js
@@ -1,0 +1,55 @@
+import path from "node:path";
+import process from "node:process";
+import {fileURLToPath} from "node:url";
+
+import {fastifyStatic} from "@fastify/static";
+
+import settings from "../../settings.json" with {type: "json"};
+
+
+/**
+ * Create static files serving routes.
+ *
+ * @param {import("fastify").FastifyInstance} fastify
+ * @param {import("fastify").FastifyPluginOptions} options
+ */
+const routes = async (fastify, options) => {
+    const filename = fileURLToPath(import.meta.url);
+    const dirname = path.dirname(filename);
+    const rootDirname = path.resolve(dirname, "../..");
+
+    let irFilesDir = settings.IrFilesDir;
+    if (false === path.isAbsolute(irFilesDir)) {
+        irFilesDir = path.resolve(rootDirname, irFilesDir);
+    }
+    await fastify.register(fastifyStatic, {
+        prefix: "/ir",
+        root: irFilesDir,
+    });
+
+    let logViewerDir = settings.LogViewerDir;
+    if (false === path.isAbsolute(logViewerDir)) {
+        logViewerDir = path.resolve(rootDirname, logViewerDir);
+    }
+    await fastify.register(fastifyStatic, {
+        prefix: "/log-viewer",
+        root: logViewerDir,
+        decorateReply: false,
+    });
+
+    if ("production" === process.env.NODE_ENV) {
+        // In the development environment, we expect the client to use a separate webserver that
+        // supports live reloading.
+        if (false === path.isAbsolute(settings.ClientDir)) {
+            throw new Error("`clientDir` must be an absolute path.");
+        }
+
+        await fastify.register(fastifyStatic, {
+            prefix: "/",
+            root: settings.ClientDir,
+            decorateReply: false,
+        });
+    }
+};
+
+export default routes;

--- a/components/log-viewer-webui/server/src/routes/static.js
+++ b/components/log-viewer-webui/server/src/routes/static.js
@@ -8,7 +8,7 @@ import settings from "../../settings.json" with {type: "json"};
 
 
 /**
- * Create static files serving routes.
+ * Creates static files serving routes.
  *
  * @param {import("fastify").FastifyInstance} fastify
  * @param {import("fastify").FastifyPluginOptions} options

--- a/components/log-viewer-webui/server/src/routes/static.js
+++ b/components/log-viewer-webui/server/src/routes/static.js
@@ -40,13 +40,14 @@ const routes = async (fastify, options) => {
     if ("production" === process.env.NODE_ENV) {
         // In the development environment, we expect the client to use a separate webserver that
         // supports live reloading.
-        if (false === path.isAbsolute(settings.ClientDir)) {
-            throw new Error("`clientDir` must be an absolute path.");
+        let clientDir = settings.ClientDir;
+        if (false === path.isAbsolute(clientDir)) {
+            clientDir = path.resolve(rootDirname, settings.ClientDir);
         }
 
         await fastify.register(fastifyStatic, {
             prefix: "/",
-            root: settings.ClientDir,
+            root: clientDir,
             decorateReply: false,
         });
     }


### PR DESCRIPTION
# Description
Integrate yscope-log-viewer to clp:
1. Add it to `.gitmodules`, putting it within `log-viewer-webui`.
2. Register it in fastify.
3. In `Taskfile.yml`, create checksum and build tasks.


# Validation performed
Run `task package`, the build should give no errors.
In `clp/build/clp-package/sbin`, run `start-clp.sh`, access localhost:3000/log-viewer/index.html, observe log viewer is loaded.
