### PR TITLE
package: Add `--exclude` option to exclude components from being started.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -1050,7 +1050,7 @@ def main(argv):
     if 0 != len(excluded_components):
         for component in excluded_components:
             if component not in COMPONENT_NAMES:
-                raise ValueError(f"Unrecognized component {component} in --exclude list")
+                raise ValueError(f"Unrecognized component {component} in --exclude list.")
         logger.info(f"Starting all components except: {excluded_components}")
 
     try:

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -60,7 +60,7 @@ from clp_package_utils.general import (
 )
 
 # Constants
-COMPONENT_NAMES = [
+COMPONENT_NAMES = (
     CONTROLLER_TARGET_NAME,
     DB_COMPONENT_NAME,
     QUEUE_COMPONENT_NAME,
@@ -73,7 +73,7 @@ COMPONENT_NAMES = [
     REDUCER_COMPONENT_NAME,
     WEBUI_COMPONENT_NAME,
     LOG_VIEWER_WEBUI_COMPONENT_NAME,
-]
+)
 
 # Setup logging
 # Create logger

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -993,6 +993,8 @@ def main(argv):
         help="CLP package configuration file.",
     )
 
+    args_parser.add_argument("--exclude", "-no", nargs="+", default=[], help="Exclude component(s) from being started.")
+
     component_args_parser = args_parser.add_subparsers(dest="target")
     component_args_parser.add_parser(CONTROLLER_TARGET_NAME)
     component_args_parser.add_parser(DB_COMPONENT_NAME)
@@ -1012,10 +1014,10 @@ def main(argv):
 
     parsed_args = args_parser.parse_args(argv[1:])
 
+    target = ALL_TARGET_NAME
+    exclude = parsed_args.exclude
     if parsed_args.target:
         target = parsed_args.target
-    else:
-        target = ALL_TARGET_NAME
 
     try:
         check_dependencies()
@@ -1096,15 +1098,15 @@ def main(argv):
         conf_dir = clp_home / "etc"
 
         # Start components
-        if target in (ALL_TARGET_NAME, DB_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, DB_COMPONENT_NAME) and DB_COMPONENT_NAME not in exclude:
             start_db(instance_id, clp_config, conf_dir)
-        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, DB_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, DB_COMPONENT_NAME) and CONTROLLER_TARGET_NAME not in exclude and DB_COMPONENT_NAME not in exclude:
             create_db_tables(instance_id, clp_config, container_clp_config, mounts)
-        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, QUEUE_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, QUEUE_COMPONENT_NAME) and CONTROLLER_TARGET_NAME not in exclude and QUEUE_COMPONENT_NAME not in exclude:
             start_queue(instance_id, clp_config)
-        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, REDIS_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, REDIS_COMPONENT_NAME) and CONTROLLER_TARGET_NAME not in exclude and REDIS_COMPONENT_NAME not in exclude:
             start_redis(instance_id, clp_config, conf_dir)
-        if target in (ALL_TARGET_NAME, RESULTS_CACHE_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, RESULTS_CACHE_COMPONENT_NAME) and RESULTS_CACHE_COMPONENT_NAME not in exclude:
             start_results_cache(instance_id, clp_config, conf_dir)
         if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, RESULTS_CACHE_COMPONENT_NAME):
             create_results_cache_indices(instance_id, clp_config, container_clp_config, mounts)
@@ -1112,21 +1114,21 @@ def main(argv):
             ALL_TARGET_NAME,
             CONTROLLER_TARGET_NAME,
             COMPRESSION_SCHEDULER_COMPONENT_NAME,
-        ):
+        ) and CONTROLLER_TARGET_NAME not in exclude and COMPRESSION_SCHEDULER_COMPONENT_NAME not in exclude:
             start_compression_scheduler(instance_id, clp_config, container_clp_config, mounts)
-        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, QUERY_SCHEDULER_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, CONTROLLER_TARGET_NAME, QUERY_SCHEDULER_COMPONENT_NAME) and CONTROLLER_TARGET_NAME not in exclude and QUERY_SCHEDULER_COMPONENT_NAME not in exclude:
             start_query_scheduler(instance_id, clp_config, container_clp_config, mounts)
-        if target in (ALL_TARGET_NAME, COMPRESSION_WORKER_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, COMPRESSION_WORKER_COMPONENT_NAME) and COMPRESSION_WORKER_COMPONENT_NAME not in exclude:
             start_compression_worker(
                 instance_id, clp_config, container_clp_config, num_workers, mounts
             )
-        if target in (ALL_TARGET_NAME, QUERY_WORKER_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, QUERY_WORKER_COMPONENT_NAME) and QUERY_WORKER_COMPONENT_NAME not in exclude:
             start_query_worker(instance_id, clp_config, container_clp_config, num_workers, mounts)
-        if target in (ALL_TARGET_NAME, REDUCER_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, REDUCER_COMPONENT_NAME) and REDUCER_COMPONENT_NAME not in exclude:
             start_reducer(instance_id, clp_config, container_clp_config, num_workers, mounts)
-        if target in (ALL_TARGET_NAME, WEBUI_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, WEBUI_COMPONENT_NAME) and WEBUI_COMPONENT_NAME not in exclude:
             start_webui(instance_id, clp_config, mounts)
-        if target in (ALL_TARGET_NAME, LOG_VIEWER_WEBUI_COMPONENT_NAME):
+        if target in (ALL_TARGET_NAME, LOG_VIEWER_WEBUI_COMPONENT_NAME) and LOG_VIEWER_WEBUI_COMPONENT_NAME not in exclude:
             start_log_viewer_webui(instance_id, clp_config, container_clp_config, mounts)
 
     except Exception as ex:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
When developing / testing certain components which provide a live reload debug server, other CLP components also need to be started for functionality verifications. Previously, developers have been starting the whole CLP package and later stopping the component(s) to be debugged, to avoid resource (e.g. TCP host + port) conflicts. The approach works but has proven to be inconvenience and prone to manual errors. This PR:
1. Add `--exclude` option to exclude components from being started.

# Validation performed
1. Built the package.
    ```
    cd <clp-root>
    task
    ```
2. Started the package, excluding components `webui` and `log_viewer_webui`.
    ```
    cd build/clp-package/sbin
    ./start-clp.sh --exclude webui log_viewer_webui
    ```
3. Observed all components started except `webui` and `log_viewer_webui`.