### PR TITLE
regex-utils: Add support for translating regex character sets into wildcards when possible.

### DIFF
--- a/components/core/src/clp/regex_utils/ErrorCode.cpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.cpp
@@ -72,6 +72,12 @@ auto ErrorCodeCategory::message(int ev) const -> string {
         case ErrorCode::UnmatchedParenthesis:
             return "Unmatched opening `(` or closing `)`.";
 
+        case ErrorCode::IncompleteCharsetStructure:
+            return "Unmatched closing `]` at the end of the string.";
+
+        case ErrorCode::UnsupportedCharsetPattern:
+            return "Currently only supports character set that contains a single character.";
+
         default:
             return "(unrecognized error)";
     }

--- a/components/core/src/clp/regex_utils/ErrorCode.cpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.cpp
@@ -76,7 +76,8 @@ auto ErrorCodeCategory::message(int ev) const -> string {
             return "Unmatched closing `]` at the end of the string.";
 
         case ErrorCode::UnsupportedCharsetPattern:
-            return "Currently only supports character set that contains a single character.";
+            return "Currently only supports character set that can be reduced to a single "
+                   "character.";
 
         default:
             return "(unrecognized error)";

--- a/components/core/src/clp/regex_utils/ErrorCode.hpp
+++ b/components/core/src/clp/regex_utils/ErrorCode.hpp
@@ -21,6 +21,8 @@ enum class ErrorCode : uint8_t {
     IllegalDollarSign,
     IllegalEscapeSequence,
     UnmatchedParenthesis,
+    IncompleteCharsetStructure,
+    UnsupportedCharsetPattern,
 };
 
 /**

--- a/components/core/src/clp/regex_utils/constants.hpp
+++ b/components/core/src/clp/regex_utils/constants.hpp
@@ -44,6 +44,9 @@ constexpr auto cRegexEscapeSeqMetaCharsLut = create_char_bit_array("*+?|^$.{}[](
 // The set of wildcard metacharacters that must remain escaped in the translated string to be
 // treated as a literal.
 constexpr auto cWildcardMetaCharsLut = create_char_bit_array("?*\\");
+// The set of metacharacters that can be preceded with an escape backslash in the regex character
+// set to be treated as a literal.
+constexpr auto cRegexCharsetEscapeSeqMetaCharsLut = create_char_bit_array("^-]\\");
 }  // namespace clp::regex_utils
 
 #endif  // CLP_REGEX_UTILS_CONSTANTS_HPP

--- a/docs/src/dev-guide/components-core/regex-utils.md
+++ b/docs/src/dev-guide/components-core/regex-utils.md
@@ -77,14 +77,21 @@ For a detailed description on the options order and usage, see the
   * Escape sequences with alphanumeric characters are disallowed.
     * E.g. Special utility escape sequences `\Q`, `\E`, `\A` etc. and back references `\1` `\2` etc.
       cannot be translated.
+* Character set
+  * Reduces a character set into a single character if possible.
+    * A trivial character set containing a single character or a single escaped metacharacter.
+      * E.g. `[a]` into `a`, `[\^]` into `^`
+    * If the `case_insensitive_wildcard` config is turned on, the translator can also reduce the
+      following patterns into a single lowercase character:
+      * E.g. `[aA]` into `a`, `[Bb]` into `b`, `[xX][Yy][zZ]` into `xyz`
 
 ### Custom configuration
 
 The `RegexToWildcardTranslatorConfig` class objects are currently immutable once instantiated. The
 constructor takes the following arguments in order:
 
-* `case_insensitive_wildcard`: to be added later along with the character set translation
-  implementation.
+* `case_insensitive_wildcard`: see *Character set* bullet point in the [Functionalities]
+  (#functionalities) section.
 
 * `add_prefix_suffix_wildcards`: in the absence of regex anchors, add prefix or suffix wildcards so
   the query becomes a substring query.

--- a/docs/src/dev-guide/components-core/regex-utils.md
+++ b/docs/src/dev-guide/components-core/regex-utils.md
@@ -82,16 +82,18 @@ For a detailed description on the options order and usage, see the
     * A trivial character set containing a single character or a single escaped metacharacter.
       * E.g. `[a]` into `a`, `[\^]` into `^`
     * If the `case_insensitive_wildcard` config is turned on, the translator can also reduce the
-      following patterns into a single lowercase character:
+      case-insensitive style character set patterns into a single lowercase character:
       * E.g. `[aA]` into `a`, `[Bb]` into `b`, `[xX][Yy][zZ]` into `xyz`
 
 ### Custom configuration
 
-The `RegexToWildcardTranslatorConfig` class objects are currently immutable once instantiated. The
-constructor takes the following arguments in order:
+The `RegexToWildcardTranslatorConfig` class objects are currently immutable once instantiated. By
+default, all of the options are set to `false`.
 
-* `case_insensitive_wildcard`: see *Character set* bullet point in the [Functionalities]
-  (#functionalities) section.
+The constructor takes the following option arguments in order:
+
+* `case_insensitive_wildcard`: see **Character set** bullet point in the
+  [Functionalities](#functionalities) section.
 
 * `add_prefix_suffix_wildcards`: in the absence of regex anchors, add prefix or suffix wildcards so
   the query becomes a substring query.


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
Implements the following functionality:
  * Reduces a character set into a single character if possible.
    * A trivial character set containing a single character or a single escaped metacharacter.
      * E.g. `[a]` into `a`, `[\^]` into `^`
    * If the `case_insensitive_wildcard` config is turned on, the translator can also reduce the
      case-insensitive style character set patterns into a single lowercase character:
      * E.g. `[aA]` into `a`, `[Bb]` into `b`, `[xX][Yy][zZ]` into `xyz`

# Validation performed
Verified in unit tests

