### PR TITLE
core-clp: Add `EncodedTextAst` class to represent parsed and encoded unstructured text strings.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -347,6 +347,7 @@ set(SOURCE_FILES_unitTest
         src/clp/Grep.cpp
         src/clp/Grep.hpp
         src/clp/ir/constants.hpp
+        src/clp/ir/ClpString.hpp
         src/clp/ir/LogEvent.hpp
         src/clp/ir/LogEventDeserializer.cpp
         src/clp/ir/LogEventDeserializer.hpp
@@ -482,7 +483,8 @@ set(SOURCE_FILES_unitTest
         tests/test-TimestampPattern.cpp
         tests/test-utf8_utils.cpp
         tests/test-Utils.cpp
-        )
+        src/clp/ir/ClpString.hpp
+)
 add_executable(unitTest ${SOURCE_FILES_unitTest} ${SOURCE_FILES_clp_s_unitTest})
 target_include_directories(unitTest
         PRIVATE

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -483,8 +483,7 @@ set(SOURCE_FILES_unitTest
         tests/test-TimestampPattern.cpp
         tests/test-utf8_utils.cpp
         tests/test-Utils.cpp
-        src/clp/ir/ClpString.hpp
-)
+        )
 add_executable(unitTest ${SOURCE_FILES_unitTest} ${SOURCE_FILES_clp_s_unitTest})
 target_include_directories(unitTest
         PRIVATE

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -347,7 +347,7 @@ set(SOURCE_FILES_unitTest
         src/clp/Grep.cpp
         src/clp/Grep.hpp
         src/clp/ir/constants.hpp
-        src/clp/ir/ClpString.hpp
+        src/clp/ir/EncodedTextAst.hpp
         src/clp/ir/LogEvent.hpp
         src/clp/ir/LogEventDeserializer.cpp
         src/clp/ir/LogEventDeserializer.hpp

--- a/components/core/src/clp/EncodedVariableInterpreter.cpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.cpp
@@ -234,7 +234,8 @@ void EncodedVariableInterpreter::encode_and_add_to_dictionary(
         size_t& raw_num_bytes
 ) {
     logtype_dict_entry.clear();
-    logtype_dict_entry.reserve_constant_length(log_event.get_logtype().length());
+    auto const& log_message = log_event.get_message();
+    logtype_dict_entry.reserve_constant_length(log_message.get_logtype().length());
 
     raw_num_bytes = 0;
 
@@ -284,9 +285,9 @@ void EncodedVariableInterpreter::encode_and_add_to_dictionary(
     };
 
     ffi::ir_stream::generic_decode_message<false>(
-            log_event.get_logtype(),
-            log_event.get_encoded_vars(),
-            log_event.get_dict_vars(),
+            log_message.get_logtype(),
+            log_message.get_encoded_vars(),
+            log_message.get_dict_vars(),
             constant_handler,
             encoded_int_handler,
             encoded_float_handler,

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -33,7 +33,7 @@ set(
         ../GlobalSQLiteMetadataDB.hpp
         ../Grep.cpp
         ../Grep.hpp
-        ../ir/ClpString.hpp
+        ../ir/EncodedTextAst.hpp
         ../ir/LogEvent.hpp
         ../ir/parsing.cpp
         ../ir/parsing.hpp

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -33,6 +33,7 @@ set(
         ../GlobalSQLiteMetadataDB.hpp
         ../Grep.cpp
         ../Grep.hpp
+        ../ir/ClpString.hpp
         ../ir/LogEvent.hpp
         ../ir/parsing.cpp
         ../ir/parsing.hpp

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -34,6 +34,7 @@ set(
         ../FileWriter.hpp
         ../Grep.cpp
         ../Grep.hpp
+        ../ir/ClpString.hpp
         ../ir/LogEvent.hpp
         ../ir/LogEventSerializer.cpp
         ../ir/LogEventSerializer.hpp

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -34,7 +34,7 @@ set(
         ../FileWriter.hpp
         ../Grep.cpp
         ../Grep.hpp
-        ../ir/ClpString.hpp
+        ../ir/EncodedTextAst.hpp
         ../ir/LogEvent.hpp
         ../ir/LogEventSerializer.cpp
         ../ir/LogEventSerializer.hpp

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -41,6 +41,7 @@ set(
         ../GlobalSQLiteMetadataDB.cpp
         ../GlobalSQLiteMetadataDB.hpp
         ../ir/constants.hpp
+        ../ir/ClpString.hpp
         ../ir/LogEvent.hpp
         ../ir/LogEventDeserializer.cpp
         ../ir/LogEventDeserializer.hpp

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -41,7 +41,7 @@ set(
         ../GlobalSQLiteMetadataDB.cpp
         ../GlobalSQLiteMetadataDB.hpp
         ../ir/constants.hpp
-        ../ir/ClpString.hpp
+        ../ir/EncodedTextAst.hpp
         ../ir/LogEvent.hpp
         ../ir/LogEventDeserializer.cpp
         ../ir/LogEventDeserializer.hpp

--- a/components/core/src/clp/ir/ClpString.hpp
+++ b/components/core/src/clp/ir/ClpString.hpp
@@ -1,0 +1,61 @@
+#ifndef CLP_IR_CLPSTRING_HPP
+#define CLP_IR_CLPSTRING_HPP
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "types.hpp"
+
+namespace clp::ir {
+/**
+ * A class representing a CLP string encoded using CLP's IR.
+ * @tparam encoded_variable_t The type of encoded variables in the event.
+ */
+template <typename encoded_variable_t>
+class ClpString {
+public:
+    // Constructor
+    explicit ClpString(
+            std::string logtype,
+            std::vector<std::string> dict_vars,
+            std::vector<encoded_variable_t> encoded_vars
+    )
+            : m_logtype{std::move(logtype)},
+              m_dict_vars{std::move(dict_vars)},
+              m_encoded_vars{std::move(encoded_vars)} {}
+
+    // Disable copy constructor and assignment operator
+    ClpString(ClpString const&) = delete;
+    auto operator=(ClpString const&) -> ClpString& = delete;
+
+    // Default move constructor and assignment operator
+    ClpString(ClpString&&) = default;
+    auto operator=(ClpString&&) -> ClpString& = default;
+
+    // Destructor
+    ~ClpString() = default;
+
+    // Methods
+    [[nodiscard]] auto get_logtype() const -> std::string const& { return m_logtype; }
+
+    [[nodiscard]] auto get_dict_vars() const -> std::vector<std::string> const& {
+        return m_dict_vars;
+    }
+
+    [[nodiscard]] auto get_encoded_vars() const -> std::vector<encoded_variable_t> const& {
+        return m_encoded_vars;
+    }
+
+private:
+    // Variables
+    std::string m_logtype;
+    std::vector<std::string> m_dict_vars;
+    std::vector<encoded_variable_t> m_encoded_vars;
+};
+
+using EightByteEncodingClpString = ClpString<eight_byte_encoded_variable_t>;
+using FourByteEncodingClpString = ClpString<four_byte_encoded_variable_t>;
+}  // namespace clp::ir
+
+#endif  // CLP_IR_CLPSTRING_HPP

--- a/components/core/src/clp/ir/EncodedTextAst.hpp
+++ b/components/core/src/clp/ir/EncodedTextAst.hpp
@@ -9,8 +9,8 @@
 
 namespace clp::ir {
 /**
- * Class that defines CLP IR's encoded text strings, which consists of a logtype and variables.
- * @tparam encoded_variable_t The type of encoded variables.
+ * A parsed and encoded unstructured text string.
+ * @tparam encoded_variable_t The type of encoded variables in the string.
  */
 template <typename encoded_variable_t>
 class EncodedTextAst {

--- a/components/core/src/clp/ir/EncodedTextAst.hpp
+++ b/components/core/src/clp/ir/EncodedTextAst.hpp
@@ -1,5 +1,5 @@
-#ifndef CLP_IR_CLPSTRING_HPP
-#define CLP_IR_CLPSTRING_HPP
+#ifndef CLP_IR_ENCODEDTEXTAST_HPP
+#define CLP_IR_ENCODEDTEXTAST_HPP
 
 #include <string>
 #include <utility>
@@ -9,14 +9,14 @@
 
 namespace clp::ir {
 /**
- * A class representing a CLP string encoded using CLP's IR.
- * @tparam encoded_variable_t The type of encoded variables in the event.
+ * Class that defines CLP IR's encoded text strings, which consists of a logtype and variables.
+ * @tparam encoded_variable_t The type of encoded variables.
  */
 template <typename encoded_variable_t>
-class ClpString {
+class EncodedTextAst {
 public:
     // Constructor
-    explicit ClpString(
+    explicit EncodedTextAst(
             std::string logtype,
             std::vector<std::string> dict_vars,
             std::vector<encoded_variable_t> encoded_vars
@@ -26,15 +26,15 @@ public:
               m_encoded_vars{std::move(encoded_vars)} {}
 
     // Disable copy constructor and assignment operator
-    ClpString(ClpString const&) = delete;
-    auto operator=(ClpString const&) -> ClpString& = delete;
+    EncodedTextAst(EncodedTextAst const&) = delete;
+    auto operator=(EncodedTextAst const&) -> EncodedTextAst& = delete;
 
     // Default move constructor and assignment operator
-    ClpString(ClpString&&) = default;
-    auto operator=(ClpString&&) -> ClpString& = default;
+    EncodedTextAst(EncodedTextAst&&) = default;
+    auto operator=(EncodedTextAst&&) -> EncodedTextAst& = default;
 
     // Destructor
-    ~ClpString() = default;
+    ~EncodedTextAst() = default;
 
     // Methods
     [[nodiscard]] auto get_logtype() const -> std::string const& { return m_logtype; }
@@ -54,8 +54,8 @@ private:
     std::vector<encoded_variable_t> m_encoded_vars;
 };
 
-using EightByteEncodingClpString = ClpString<eight_byte_encoded_variable_t>;
-using FourByteEncodingClpString = ClpString<four_byte_encoded_variable_t>;
+using EightByteEncodedTextAst = EncodedTextAst<eight_byte_encoded_variable_t>;
+using FourByteEncodedTextAst = EncodedTextAst<four_byte_encoded_variable_t>;
 }  // namespace clp::ir
 
-#endif  // CLP_IR_CLPSTRING_HPP
+#endif  // CLP_IR_ENCODEDTEXTAST_HPP

--- a/components/core/src/clp/ir/LogEvent.hpp
+++ b/components/core/src/clp/ir/LogEvent.hpp
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include "ClpString.hpp"
+#include "EncodedTextAst.hpp"
 #include "time_types.hpp"
 #include "types.hpp"
 
@@ -34,21 +34,15 @@ public:
 
     [[nodiscard]] auto get_utc_offset() const -> UtcOffset { return m_utc_offset; }
 
-    [[nodiscard]] auto get_logtype() const -> std::string const& { return m_message.get_logtype(); }
-
-    [[nodiscard]] auto get_dict_vars() const -> std::vector<std::string> const& {
-        return m_message.get_dict_vars();
-    }
-
-    [[nodiscard]] auto get_encoded_vars() const -> std::vector<encoded_variable_t> const& {
-        return m_message.get_encoded_vars();
+    [[nodiscard]] auto get_message() const -> EncodedTextAst<encoded_variable_t> const& {
+        return m_message;
     }
 
 private:
     // Variables
     epoch_time_ms_t m_timestamp{0};
     UtcOffset m_utc_offset{0};
-    ClpString<encoded_variable_t> m_message;
+    EncodedTextAst<encoded_variable_t> m_message;
 };
 }  // namespace clp::ir
 

--- a/components/core/src/clp/ir/LogEvent.hpp
+++ b/components/core/src/clp/ir/LogEvent.hpp
@@ -2,9 +2,10 @@
 #define CLP_IR_LOGEVENT_HPP
 
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "../Defs.h"
+#include "ClpString.hpp"
 #include "time_types.hpp"
 #include "types.hpp"
 
@@ -26,32 +27,28 @@ public:
     )
             : m_timestamp{timestamp},
               m_utc_offset{utc_offset},
-              m_logtype{std::move(logtype)},
-              m_dict_vars{std::move(dict_vars)},
-              m_encoded_vars{std::move(encoded_vars)} {}
+              m_message{std::move(logtype), std::move(dict_vars), std::move(encoded_vars)} {}
 
     // Methods
     [[nodiscard]] auto get_timestamp() const -> epoch_time_ms_t { return m_timestamp; }
 
     [[nodiscard]] auto get_utc_offset() const -> UtcOffset { return m_utc_offset; }
 
-    [[nodiscard]] auto get_logtype() const -> std::string const& { return m_logtype; }
+    [[nodiscard]] auto get_logtype() const -> std::string const& { return m_message.get_logtype(); }
 
     [[nodiscard]] auto get_dict_vars() const -> std::vector<std::string> const& {
-        return m_dict_vars;
+        return m_message.get_dict_vars();
     }
 
     [[nodiscard]] auto get_encoded_vars() const -> std::vector<encoded_variable_t> const& {
-        return m_encoded_vars;
+        return m_message.get_encoded_vars();
     }
 
 private:
     // Variables
     epoch_time_ms_t m_timestamp{0};
     UtcOffset m_utc_offset{0};
-    std::string m_logtype;
-    std::vector<std::string> m_dict_vars;
-    std::vector<encoded_variable_t> m_encoded_vars;
+    ClpString<encoded_variable_t> m_message;
 };
 }  // namespace clp::ir
 

--- a/components/core/src/clp/ir/LogEvent.hpp
+++ b/components/core/src/clp/ir/LogEvent.hpp
@@ -21,13 +21,11 @@ public:
     LogEvent(
             epoch_time_ms_t timestamp,
             UtcOffset utc_offset,
-            std::string logtype,
-            std::vector<std::string> dict_vars,
-            std::vector<encoded_variable_t> encoded_vars
+            EncodedTextAst<encoded_variable_t> message
     )
             : m_timestamp{timestamp},
               m_utc_offset{utc_offset},
-              m_message{std::move(logtype), std::move(dict_vars), std::move(encoded_vars)} {}
+              m_message{std::move(message)} {}
 
     // Methods
     [[nodiscard]] auto get_timestamp() const -> epoch_time_ms_t { return m_timestamp; }

--- a/components/core/src/clp/ir/LogEventDeserializer.cpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.cpp
@@ -8,6 +8,7 @@
 
 #include "../ffi/ir_stream/decoding_methods.hpp"
 #include "../ffi/ir_stream/protocol_constants.hpp"
+#include "EncodedTextAst.hpp"
 #include "types.hpp"
 
 namespace clp::ir {
@@ -124,7 +125,11 @@ auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event(
         timestamp = m_prev_msg_timestamp;
     }
 
-    return LogEvent<encoded_variable_t>{timestamp, m_utc_offset, logtype, dict_vars, encoded_vars};
+    return LogEvent<encoded_variable_t>{
+            timestamp,
+            m_utc_offset,
+            EncodedTextAst<encoded_variable_t>{logtype, dict_vars, encoded_vars}
+    };
 }
 
 // Explicitly declare template specializations so that we can define the template methods in this

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -912,7 +912,7 @@ TEMPLATE_TEST_CASE(
         REQUIRE(log_event.get_utc_offset() == ref_log_event.get_utc_offset());
         // We only compare the logtype since decoding messages from logtype + variables is not yet
         // supported by our public interfaces
-        REQUIRE(log_event.get_logtype() == encoded_logtypes.at(log_event_idx));
+        REQUIRE(log_event.get_message().get_logtype() == encoded_logtypes.at(log_event_idx));
         ++log_event_idx;
     }
     auto result = log_event_deserializer.deserialize_log_event();


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds a dedicated class for parsed and encoded text strings, named `EncodedTextAst`. Essentially, this PR introduces a new concept to split the text message part from the current `LogEvent`, generalizing the tuple of {logtype, dict vars, encoded vars} to its dedicated type.
In the coming PRs, this class will be used to represent encoded text string values in the key-value pair format CLP IR, extending its usage from an unstructured log message to a more general encoded string.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Ensure all unit tests passed after updating `clp::ir::LogEvent` to use `EncodedTextAst`.
