### PR TITLE
Taskfile: Remove container OS name and version from built package name.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -542,9 +542,7 @@ tasks:
     internal: true
     vars:
       VERSIONED_PACKAGE_NAME:
-        sh: |
-          source /etc/os-release
-          echo "clp-{{.FLAVOUR}}-${ID}-${VERSION_CODENAME}-$(arch)-v{{.G_PACKAGE_VERSION}}"
+        sh: "echo clp-{{.FLAVOUR}}-$(arch)-v{{.G_PACKAGE_VERSION}}"
       OUTPUT_DIR: "{{.G_BUILD_DIR}}/{{.VERSIONED_PACKAGE_NAME}}"
       OUTPUT_FILE: "{{.OUTPUT_DIR}}.tar.gz"
     requires:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The current name for package release builds is `clp-<flavour>-ubuntu-focal-<arch>-v<version>`, where items in angle-brackets are populated with the relevant values. This name may imply to users that they can only use the release builds on Ubuntu Focal, but this isn't the case since we run all CLP components in Ubuntu Focal containers.

This PR removes the OS name and version from the package release names to avoid confusion.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated that `task clp-text-pkg-tar` and `task clp-json-pkg-tar` built package tars with names that didn't include the OS name and version.