### PR TITLE
core: Add `Array` template class to abstract a fixed-size contiguous buffer whose size is determined at runtime.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -269,6 +269,7 @@ set(SOURCE_FILES_clp_s_unitTest
 )
 
 set(SOURCE_FILES_unitTest
+        src/clp/Array.hpp
         src/clp/BufferedFileReader.cpp
         src/clp/BufferedFileReader.hpp
         src/clp/BufferReader.cpp
@@ -472,6 +473,7 @@ set(SOURCE_FILES_unitTest
         submodules/sqlite3/sqlite3.h
         submodules/sqlite3/sqlite3ext.h
         tests/LogSuppressor.hpp
+        tests/test-Array.cpp
         tests/test-BufferedFileReader.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp

--- a/components/core/src/clp/Array.hpp
+++ b/components/core/src/clp/Array.hpp
@@ -11,8 +11,8 @@
 namespace clp {
 /**
  * Class for a runtime fix-sized array.
- * @tparam T The type of elements in the array. The type must be default initializable so that the
- * class doesn't need to implement an initializer list constructor.
+ * @tparam T The type of elements in the array. The type must be default initializable so that this
+ * class doesn't need to implement a constructor which takes an initializer list.
  */
 template <typename T>
 requires(std::is_fundamental_v<T> || std::default_initializable<T>)

--- a/components/core/src/clp/Array.hpp
+++ b/components/core/src/clp/Array.hpp
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
-#include <span>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -46,9 +45,9 @@ public:
 
     // Constructors
     // NOLINTNEXTLINE(*-avoid-c-arrays)
-    explicit Array(size_t size) : m_ptr{std::make_unique<T[]>(size)}, m_size{size} {
+    explicit Array(size_t size) : m_data{std::make_unique<T[]>(size)}, m_size{size} {
         if constexpr (std::is_fundamental_v<T>) {
-            memset(m_ptr.get(), 0, m_size * sizeof(T));
+            memset(m_data.get(), 0, m_size * sizeof(T));
         }
     }
 
@@ -64,27 +63,53 @@ public:
     ~Array() = default;
 
     // Methods
+    /**
+     * @return Whether the array is empty.
+     */
     [[nodiscard]] auto empty() const -> bool { return 0 == size(); }
 
+    /**
+     * @return The size of the array.
+     */
     [[nodiscard]] auto size() const -> size_t { return m_size; }
 
+    /**
+     * @return The ptr of the underlying data buffer.
+     */
+    [[nodiscard]] auto data() -> T* { return m_data.get(); }
+
+    /**
+     * @return The ptr of the underlying data buffer.
+     */
+    [[nodiscard]] auto data() const -> T const* { return m_data.get(); }
+
+    /**
+     * @param idx
+     * @return The element at the given index.
+     * @throw `OperationFailed` if the given index is out of bound.
+     */
     [[nodiscard]] auto at(size_t idx) -> T& {
         assert_idx(idx);
-        return m_ptr[idx];
+        return m_data[idx];
     }
 
+    /**
+     * @param idx
+     * @return The element at the given index.
+     * @throw `OperationFailed` if the given index is out of bound.
+     */
     [[nodiscard]] auto at(size_t idx) const -> T const& {
         assert_idx(idx);
-        return m_ptr[idx];
+        return m_data[idx];
     }
 
-    [[nodiscard]] auto begin() -> Iterator { return m_ptr.get(); }
+    [[nodiscard]] auto begin() -> Iterator { return m_data.get(); }
 
-    [[nodiscard]] auto end() -> Iterator { return m_ptr.get() + m_size; }
+    [[nodiscard]] auto end() -> Iterator { return m_data.get() + m_size; }
 
-    [[nodiscard]] auto begin() const -> ConstIterator { return m_ptr.get(); }
+    [[nodiscard]] auto begin() const -> ConstIterator { return m_data.get(); }
 
-    [[nodiscard]] auto end() const -> ConstIterator { return m_ptr.get() + m_size; }
+    [[nodiscard]] auto end() const -> ConstIterator { return m_data.get() + m_size; }
 
 private:
     /**
@@ -104,7 +129,7 @@ private:
 
     // Variables
     // NOLINTNEXTLINE(*-avoid-c-arrays)
-    std::unique_ptr<T[]> m_ptr;
+    std::unique_ptr<T[]> m_data;
     size_t m_size;
 };
 }  // namespace clp

--- a/components/core/src/clp/Array.hpp
+++ b/components/core/src/clp/Array.hpp
@@ -1,0 +1,112 @@
+#ifndef CLP_ARRAY_HPP
+#define CLP_ARRAY_HPP
+
+#include <cstddef>
+#include <cstring>
+#include <memory>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "ErrorCode.hpp"
+#include "TraceableException.hpp"
+
+namespace clp {
+/**
+ * Class for a run-time fix-sized array.
+ * @tparam T The type of the element in the array. The type must be default constructable.
+ */
+template <typename T>
+requires(std::is_fundamental_v<T> || std::is_default_constructible_v<T>)
+class Array {
+public:
+    // Types
+    using Iterator = T*;
+    using ConstIterator = T const*;
+
+    class OperationFailed : public TraceableException {
+    public:
+        OperationFailed(
+                ErrorCode error_code,
+                char const* const filename,
+                int line_number,
+                std::string message
+        )
+                : TraceableException{error_code, filename, line_number},
+                  m_message{std::move(message)} {}
+
+        [[nodiscard]] auto what() const noexcept -> char const* override {
+            return m_message.c_str();
+        }
+
+    private:
+        std::string m_message;
+    };
+
+    // Constructors
+    // NOLINTNEXTLINE(*-avoid-c-arrays)
+    explicit Array(size_t size) : m_ptr{std::make_unique<T[]>(size)}, m_size{size} {
+        if constexpr (std::is_fundamental_v<T>) {
+            memset(m_ptr.get(), 0, m_size * sizeof(T));
+        }
+    }
+
+    // Disable copy constructor and assignment operator
+    Array(Array const&) = delete;
+    auto operator=(Array const&) -> Array& = delete;
+
+    // Default move constructor and assignment operator
+    Array(Array&&) = default;
+    auto operator=(Array&&) -> Array& = default;
+
+    // Destructor
+    ~Array() = default;
+
+    // Methods
+    [[nodiscard]] auto empty() const -> bool { return 0 == size(); }
+
+    [[nodiscard]] auto size() const -> size_t { return m_size; }
+
+    [[nodiscard]] auto at(size_t idx) -> T& {
+        assert_idx(idx);
+        return m_ptr[idx];
+    }
+
+    [[nodiscard]] auto at(size_t idx) const -> T const& {
+        assert_idx(idx);
+        return m_ptr[idx];
+    }
+
+    [[nodiscard]] auto begin() -> Iterator { return m_ptr.get(); }
+
+    [[nodiscard]] auto end() -> Iterator { return m_ptr.get() + m_size; }
+
+    [[nodiscard]] auto begin() const -> ConstIterator { return m_ptr.get(); }
+
+    [[nodiscard]] auto end() const -> ConstIterator { return m_ptr.get() + m_size; }
+
+private:
+    /**
+     * @param idx
+     * @throw `OperationFailed` if the given index is out of bound.
+     */
+    auto assert_idx(size_t idx) -> void {
+        if (idx >= m_size) {
+            throw OperationFailed(
+                    ErrorCode_OutOfBounds,
+                    __FILE__,
+                    __LINE__,
+                    "`clp::Array access out of bound.`"
+            );
+        }
+    }
+
+    // Variables
+    // NOLINTNEXTLINE(*-avoid-c-arrays)
+    std::unique_ptr<T[]> m_ptr;
+    size_t m_size;
+};
+}  // namespace clp
+
+#endif  // CLP_ARRAY_HPP

--- a/components/core/src/clp/Array.hpp
+++ b/components/core/src/clp/Array.hpp
@@ -13,11 +13,12 @@
 
 namespace clp {
 /**
- * Class for a run-time fix-sized array.
- * @tparam T The type of the element in the array. The type must be default constructable.
+ * Class for a runtime fix-sized array.
+ * @tparam T The type of elements in the array. The type must be default initializable so that the
+ * class doesn't need to implement an initializer list constructor.
  */
 template <typename T>
-requires(std::is_fundamental_v<T> || std::is_default_constructible_v<T>)
+requires(std::is_fundamental_v<T> || std::is_default_initializable<T>)
 class Array {
 public:
     // Types
@@ -74,12 +75,12 @@ public:
     [[nodiscard]] auto size() const -> size_t { return m_size; }
 
     /**
-     * @return The ptr of the underlying data buffer.
+     * @return A pointer to the underlying data buffer.
      */
     [[nodiscard]] auto data() -> T* { return m_data.get(); }
 
     /**
-     * @return The ptr of the underlying data buffer.
+     * @return A pointer to the underlying data buffer.
      */
     [[nodiscard]] auto data() const -> T const* { return m_data.get(); }
 

--- a/components/core/tests/test-Array.cpp
+++ b/components/core/tests/test-Array.cpp
@@ -1,0 +1,45 @@
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include <Catch2/single_include/catch2/catch.hpp>
+
+#include "../src/clp/Array.hpp"
+
+using clp::Array;
+using std::vector;
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("array_fundamental", "[clp::Array]") {
+    constexpr size_t cBufferSize{1024};
+
+    vector<int> std_vector;
+    for (int i{0}; i < cBufferSize; ++i) {
+        std_vector.push_back(i);
+    }
+
+    Array<int> clp_array{cBufferSize};
+    auto const& clp_array_const_ref = clp_array;
+    std::for_each(clp_array_const_ref.begin(), clp_array_const_ref.end(), [](int i) -> void {
+        REQUIRE((0 == i));
+    });
+
+    std::copy(std_vector.cbegin(), std_vector.cend(), clp_array.begin());
+
+    size_t idx{0};
+    for (auto const val : clp_array) {
+        REQUIRE((val == clp_array.at(idx)));
+        REQUIRE((val == std_vector.at(idx)));
+        ++idx;
+    }
+    REQUIRE((cBufferSize == idx));
+    REQUIRE_THROWS(clp_array.at(idx));
+}
+
+TEST_CASE("array_default_constructable", "[clp::Array]") {
+    vector<std::string> const std_vector{"yscope", "clp", "clp::Array", "default_constructable"};
+    Array<std::string> clp_array{std_vector.size()};
+    std::copy(std_vector.cbegin(), std_vector.cend(), clp_array.begin());
+    REQUIRE(std::equal(std_vector.begin(), std_vector.end(), clp_array.begin(), clp_array.end()));
+}

--- a/components/core/tests/test-Array.cpp
+++ b/components/core/tests/test-Array.cpp
@@ -12,6 +12,12 @@ using std::vector;
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("array_fundamental", "[clp::Array]") {
+    Array<int> clp_array_empty{0};
+    REQUIRE(clp_array_empty.empty());
+    // NOLINTNEXTLINE(readability-container-size-empty)
+    REQUIRE((0 == clp_array_empty.size()));
+    REQUIRE((clp_array_empty.begin() == clp_array_empty.end()));
+
     constexpr size_t cBufferSize{1024};
 
     vector<int> std_vector;
@@ -38,6 +44,12 @@ TEST_CASE("array_fundamental", "[clp::Array]") {
 }
 
 TEST_CASE("array_default_initializable", "[clp::Array]") {
+    Array<std::string> clp_array_empty{0};
+    REQUIRE(clp_array_empty.empty());
+    // NOLINTNEXTLINE(readability-container-size-empty)
+    REQUIRE((0 == clp_array_empty.size()));
+    REQUIRE((clp_array_empty.begin() == clp_array_empty.end()));
+
     vector<std::string> const std_vector{"yscope", "clp", "clp::Array", "default_initializable"};
     Array<std::string> clp_array{std_vector.size()};
     std::copy(std_vector.cbegin(), std_vector.cend(), clp_array.begin());

--- a/components/core/tests/test-Array.cpp
+++ b/components/core/tests/test-Array.cpp
@@ -37,8 +37,8 @@ TEST_CASE("array_fundamental", "[clp::Array]") {
     REQUIRE_THROWS(clp_array.at(idx));
 }
 
-TEST_CASE("array_default_constructable", "[clp::Array]") {
-    vector<std::string> const std_vector{"yscope", "clp", "clp::Array", "default_constructable"};
+TEST_CASE("array_default_initializable", "[clp::Array]") {
+    vector<std::string> const std_vector{"yscope", "clp", "clp::Array", "default_initializable"};
     Array<std::string> clp_array{std_vector.size()};
     std::copy(std_vector.cbegin(), std_vector.cend(), clp_array.begin());
     REQUIRE(std::equal(std_vector.begin(), std_vector.end(), clp_array.begin(), clp_array.end()));


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
In the current CLP, we use unique pointers of C-style arrays across the code base whenever we need a fix-sized buffer. This violates `clang-tidy` suggestions which advocate deprecating C-style arrays. However, existing `std` containers have limitations to use.
- For `std::vector`, it is hard to control the underlying storage. The storage size is controlled by its capacity but not the size. Also, the vector can't be made immutable to use the storage as a buffer to receive data (such as the use case in `NetworkReader`). This means there's no way to avoid reallocation/resizing by mistakes. Declaring a vector and using its underlying `data()` buffer will not provide any safety.
- For `std::array`, the size must be given in the compile time.

Therefore, we introduce our own implementation of arrays, `clp::Array`, which is a fix-sized array where the size is determined during the run-time. We use `std::unique_ptr` to manage the underlying buffer storage (which is allocated in the heap), and a member to keep track of the size to avoid out-of-bound access. This PR implements the basic features of our array, including methods for random access and iterators. At this stage, the underlying element of the array must be default initializable so that we don't have to implement the initializer list constructor yet.
APIs of this class are designed to mirror `std` containers.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows can be built.
- Add unit tests to cover the basic usages against fundamental types and default constructible aggregated types, and ensure the iterator is compatible with `std` algorithms.

