### PR TITLE
gh-actions: Enforce using a x86 macOS runner for linting to support Meteor.

### DIFF
--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -17,7 +17,9 @@ jobs:
   lint-check:
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        # We use macos-13 since the macos-14/macos-latest runners use an M1 chip and Meteor doesn't
+        # support ARM yet.
+        os: ["macos-13", "ubuntu-latest"]
     runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@v4"
@@ -32,7 +34,7 @@ jobs:
         shell: "bash"
         run: "npm install -g @go-task/cli"
 
-      - if: "matrix.os == 'macos-latest'"
+      - if: "matrix.os == 'macos-13'"
         name: "Install coreutils (for md5sum)"
         run: "brew install coreutils"
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

[Recent linting workflows](https://github.com/y-scope/clp/actions/runs/10410438988/job/28832288576) on macOS have been timing out when trying to download an ARM Meteor binary for macOS. This is because the GH runner `macos-latest` points at an M1 runner and there is no ARM binary for Meteor.

This PR fixes the GH runner to `macos-13` (an x86 runner) for the macOS linting workflow to avoid the issue.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated the macos linting workflow passes.
