### PR TITLE
core: Replace `typedef`s with type aliases.

### DIFF
--- a/components/core/src/clp/Defs.h
+++ b/components/core/src/clp/Defs.h
@@ -7,19 +7,19 @@
 
 namespace clp {
 // Types
-typedef int64_t epochtime_t;
+using epochtime_t = int64_t;
 constexpr epochtime_t cEpochTimeMin = std::numeric_limits<epochtime_t>::min();
 constexpr epochtime_t cEpochTimeMax = std::numeric_limits<epochtime_t>::max();
 
-typedef uint64_t variable_dictionary_id_t;
+using variable_dictionary_id_t = uint64_t;
 constexpr variable_dictionary_id_t cVariableDictionaryIdMax
         = std::numeric_limits<variable_dictionary_id_t>::max();
 
-typedef int64_t logtype_dictionary_id_t;
+using logtype_dictionary_id_t = int64_t;
 constexpr logtype_dictionary_id_t cLogtypeDictionaryIdMax
         = std::numeric_limits<logtype_dictionary_id_t>::max();
 
-typedef uint16_t archive_format_version_t;
+using archive_format_version_t = uint16_t;
 // This flag is used to maintain two separate streams of archive format
 // versions:
 // - Development versions (which can change frequently as necessary) which
@@ -28,12 +28,12 @@ typedef uint16_t archive_format_version_t;
 //   as possible) which should not have the flag
 constexpr archive_format_version_t cArchiveFormatDevVersionFlag = 0x8000;
 
-typedef uint64_t segment_id_t;
+using segment_id_t = uint64_t;
 constexpr segment_id_t cInvalidSegmentId = std::numeric_limits<segment_id_t>::max();
 
-typedef int64_t encoded_variable_t;
+using encoded_variable_t = int64_t;
 
-typedef uint64_t group_id_t;
+using group_id_t = uint64_t;
 
 // Constants
 constexpr char cDefaultConfigFilename[] = ".clp.rc";

--- a/components/core/src/clp/DictionaryWriter.hpp
+++ b/components/core/src/clp/DictionaryWriter.hpp
@@ -83,7 +83,7 @@ public:
 
 protected:
     // Types
-    typedef std::unordered_map<std::string, DictionaryIdType> value_to_id_t;
+    using value_to_id_t = std::unordered_map<std::string, DictionaryIdType>;
 
     // Variables
     bool m_is_open;

--- a/components/core/src/clp/Grep.hpp
+++ b/components/core/src/clp/Grep.hpp
@@ -22,7 +22,7 @@ public:
      * @param decompressed_msg
      * @param custom_arg Custom argument for the output function
      */
-    using OutputFunc = void(*)(
+    using OutputFunc = void (*)(
             std::string const& orig_file_path,
             streaming_archive::reader::Message const& compressed_msg,
             std::string const& decompressed_msg,

--- a/components/core/src/clp/Grep.hpp
+++ b/components/core/src/clp/Grep.hpp
@@ -22,7 +22,7 @@ public:
      * @param decompressed_msg
      * @param custom_arg Custom argument for the output function
      */
-    typedef void (*OutputFunc)(
+    using OutputFunc = void(*)(
             std::string const& orig_file_path,
             streaming_archive::reader::Message const& compressed_msg,
             std::string const& decompressed_msg,

--- a/components/core/src/clp_s/Defs.hpp
+++ b/components/core/src/clp_s/Defs.hpp
@@ -11,7 +11,7 @@
 
 namespace clp_s {
 // Types
-typedef int64_t epochtime_t;
+using epochtime_t = int64_t;
 static epochtime_t const cEpochTimeMin = INT64_MIN;
 static epochtime_t const cEpochTimeMax = INT64_MAX;
 static double const cDoubleEpochTimeMin = std::numeric_limits<double>::lowest();
@@ -20,21 +20,21 @@ static double const cDoubleEpochTimeMax = std::numeric_limits<double>::max();
 #define MICROSECONDS_TO_EPOCHTIME(x) 0
 #define EPOCHTIME_T_PRINTF_FMT PRId64
 
-typedef uint64_t variable_dictionary_id_t;
+using variable_dictionary_id_t = uint64_t;
 static variable_dictionary_id_t const cVariableDictionaryIdMax = UINT64_MAX;
-typedef int64_t logtype_dictionary_id_t;
+using logtype_dictionary_id_t = int64_t;
 static logtype_dictionary_id_t const cLogtypeDictionaryIdMax = INT64_MAX;
 
-typedef uint16_t archive_format_version_t;
+using archive_format_version_t = uint16_t;
 // This flag is used to maintain two separate streams of archive format versions:
 // - Development versions (which can change frequently as necessary) which should have the flag
 // - Production versions (which should be changed with care and as infrequently as possible)
 // which should not have the flag
 constexpr archive_format_version_t cArchiveFormatDevelopmentVersionFlag = 0x8000;
 
-typedef uint64_t file_id_t;
-typedef uint64_t segment_id_t;
-typedef int64_t encoded_variable_t;
+using file_id_t = uint64_t;
+using segment_id_t = uint64_t;
+using encoded_variable_t = int64_t;
 }  // namespace clp_s
 
 // Macros

--- a/components/core/src/clp_s/DictionaryWriter.hpp
+++ b/components/core/src/clp_s/DictionaryWriter.hpp
@@ -50,7 +50,7 @@ public:
 
 protected:
     // Types
-    typedef std::unordered_map<std::string, DictionaryIdType> value_to_id_t;
+    using value_to_id_t = std::unordered_map<std::string, DictionaryIdType>;
 
     // Variables
     bool m_is_open;

--- a/components/core/src/clp_s/ReaderUtils.hpp
+++ b/components/core/src/clp_s/ReaderUtils.hpp
@@ -18,7 +18,7 @@ public:
                 : TraceableException(error_code, filename, line_number) {}
     };
 
-    typedef std::map<int32_t, Schema> SchemaMap;
+    using SchemaMap = std::map<int32_t, Schema>;
     static constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;  // 64 KB
 
     /**

--- a/components/core/src/clp_s/TimestampDictionaryReader.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.hpp
@@ -73,9 +73,8 @@ public:
     }
 
 private:
-    typedef std::map<uint64_t, TimestampPattern> id_to_pattern_t;
-    typedef std::vector<std::pair<std::vector<std::string>, TimestampEntry*>>
-            tokenized_column_to_range_t;
+    using id_to_pattern_t = std::map<uint64_t, TimestampPattern>;
+    using tokenized_column_to_range_t = std::vector<std::pair<std::vector<std::string>, TimestampEntry*>>;
 
     // Variables
     bool m_is_open;

--- a/components/core/src/clp_s/TimestampDictionaryReader.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.hpp
@@ -74,7 +74,8 @@ public:
 
 private:
     using id_to_pattern_t = std::map<uint64_t, TimestampPattern>;
-    using tokenized_column_to_range_t = std::vector<std::pair<std::vector<std::string>, TimestampEntry*>>;
+    using tokenized_column_to_range_t
+            = std::vector<std::pair<std::vector<std::string>, TimestampEntry*>>;
 
     // Variables
     bool m_is_open;

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -107,7 +107,7 @@ private:
             ZstdCompressor& compressor
     );
 
-    typedef std::unordered_map<TimestampPattern const*, uint64_t> pattern_to_id_t;
+    using pattern_to_id_t = std::unordered_map<TimestampPattern const*, uint64_t>;
 
     // Variables
     bool m_is_open;

--- a/components/core/src/clp_s/search/ColumnDescriptor.hpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.hpp
@@ -72,7 +72,7 @@ private:
     std::string m_token;
 };
 
-typedef std::vector<DescriptorToken> DescriptorList;
+using DescriptorList = std::vector<DescriptorToken>;
 
 DescriptorList tokenize_descriptor(std::vector<std::string> const& descriptors);
 

--- a/components/core/src/clp_s/search/Expression.hpp
+++ b/components/core/src/clp_s/search/Expression.hpp
@@ -8,7 +8,7 @@
 #include "Value.hpp"
 
 namespace clp_s::search {
-typedef std::list<std::shared_ptr<Value>> OpList;
+using OpList = std::list<std::shared_ptr<Value>>;
 
 /**
  * Top level class for all logical expressions which represent filters

--- a/components/core/src/clp_s/search/Integral.hpp
+++ b/components/core/src/clp_s/search/Integral.hpp
@@ -8,7 +8,7 @@
 #include "Literal.hpp"
 
 namespace clp_s::search {
-typedef std::variant<int64_t, double> Integral64;
+using Integral64 = std::variant<int64_t, double>;
 
 // FIXME: figure out why String types are part of this bitmask
 constexpr LiteralTypeBitmask cIntegralLiteralTypes = cIntegralTypes | VarStringT;

--- a/components/core/src/clp_s/search/Literal.hpp
+++ b/components/core/src/clp_s/search/Literal.hpp
@@ -24,7 +24,7 @@ enum LiteralType : uint32_t {
     UnknownT = ((uint32_t)1) << 31
 };
 
-typedef uint32_t LiteralTypeBitmask;
+using LiteralTypeBitmask = uint32_t;
 
 constexpr LiteralTypeBitmask cIntegralTypes = LiteralType::IntegerT | LiteralType::FloatT;
 constexpr LiteralTypeBitmask cAllTypes = TypesEnd - 1;

--- a/components/core/src/clp_s/search/OrOfAndForm.hpp
+++ b/components/core/src/clp_s/search/OrOfAndForm.hpp
@@ -8,8 +8,8 @@
 #include "Transformation.hpp"
 
 namespace clp_s::search {
-typedef std::vector<std::shared_ptr<Expression>> ExpressionVector;
-typedef std::list<std::shared_ptr<Expression>> ExpressionList;
+using ExpressionVector = std::vector<std::shared_ptr<Expression>>;
+using ExpressionList = std::list<std::shared_ptr<Expression>>;
 
 // TODO: handle degenerate forms like empty or/and expressions
 class OrOfAndForm : public Transformation {

--- a/components/core/src/glt/Defs.h
+++ b/components/core/src/glt/Defs.h
@@ -8,21 +8,21 @@
 
 namespace glt {
 // Types
-typedef int64_t epochtime_t;
+using epochtime_t = int64_t;
 constexpr epochtime_t cEpochTimeMin = std::numeric_limits<epochtime_t>::min();
 constexpr epochtime_t cEpochTimeMax = std::numeric_limits<epochtime_t>::max();
 #define SECONDS_TO_EPOCHTIME(x) x * 1000
 #define MICROSECONDS_TO_EPOCHTIME(x) 0
 
-typedef uint64_t variable_dictionary_id_t;
+using variable_dictionary_id_t = uint64_t;
 constexpr variable_dictionary_id_t cVariableDictionaryIdMax
         = std::numeric_limits<variable_dictionary_id_t>::max();
 
-typedef int64_t logtype_dictionary_id_t;
+using logtype_dictionary_id_t = int64_t;
 constexpr logtype_dictionary_id_t cLogtypeDictionaryIdMax
         = std::numeric_limits<logtype_dictionary_id_t>::max();
 
-typedef uint16_t archive_format_version_t;
+using archive_format_version_t = uint16_t;
 // This flag is used to maintain two separate streams of archive format
 // versions:
 // - Development versions (which can change frequently as necessary) which
@@ -31,19 +31,19 @@ typedef uint16_t archive_format_version_t;
 //   as possible) which should not have the flag
 constexpr archive_format_version_t cArchiveFormatDevVersionFlag = 0x8000;
 
-typedef uint32_t file_id_t;
-typedef uint64_t segment_id_t;
+using file_id_t = uint32_t;
+using segment_id_t = uint64_t;
 constexpr segment_id_t cInvalidSegmentId = std::numeric_limits<segment_id_t>::max();
 
-typedef size_t offset_t;
-typedef int64_t encoded_variable_t;
-typedef uint64_t combined_table_id_t;
+using offset_t = size_t;
+using encoded_variable_t = int64_t;
+using combined_table_id_t = uint64_t;
 
-typedef uint64_t group_id_t;
+using group_id_t = uint64_t;
 
-typedef uint64_t pipeline_id_t;
+using pipeline_id_t = uint64_t;
 constexpr pipeline_id_t cPipelineIdMax = std::numeric_limits<pipeline_id_t>::max();
-typedef std::atomic_uint64_t atomic_pipeline_id_t;
+using atomic_pipeline_id_t = std::atomic_uint64_t;
 
 // Macros
 // Rounds up VALUE to be a multiple of MULTIPLE

--- a/components/core/src/glt/DictionaryWriter.hpp
+++ b/components/core/src/glt/DictionaryWriter.hpp
@@ -98,7 +98,7 @@ public:
 
 protected:
     // Types
-    typedef std::unordered_map<std::string, DictionaryIdType> value_to_id_t;
+    using value_to_id_t = std::unordered_map<std::string, DictionaryIdType>;
 
     // Variables
     bool m_is_open;

--- a/components/core/src/glt/Grep.hpp
+++ b/components/core/src/glt/Grep.hpp
@@ -20,7 +20,7 @@ public:
      * @param decompressed_msg
      * @param custom_arg Custom argument for the output function
      */
-    typedef void (*OutputFunc)(
+    using OutputFunc = void(*)(
             std::string const& orig_file_path,
             streaming_archive::reader::Message const& compressed_msg,
             std::string const& decompressed_msg,

--- a/components/core/src/glt/Grep.hpp
+++ b/components/core/src/glt/Grep.hpp
@@ -20,7 +20,7 @@ public:
      * @param decompressed_msg
      * @param custom_arg Custom argument for the output function
      */
-    using OutputFunc = void(*)(
+    using OutputFunc = void (*)(
             std::string const& orig_file_path,
             streaming_archive::reader::Message const& compressed_msg,
             std::string const& decompressed_msg,

--- a/components/core/src/glt/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/glt/streaming_archive/reader/Archive.hpp
@@ -42,12 +42,12 @@ public:
      * @param decompressed_msg
      * @param custom_arg Custom argument for the output function
      */
-    typedef void (*OutputFunc)(
-            std::string const& orig_file_path,
-            streaming_archive::reader::Message const& compressed_msg,
-            std::string const& decompressed_msg,
-            void* custom_arg
-    );
+    using OutputFunc = void(*)(
+        std::string const& orig_file_path,
+        streaming_archive::reader::Message const& compressed_msg,
+        std::string const& decompressed_msg,
+        void* custom_arg
+        );
     // Methods
     /**
      * Opens archive for reading

--- a/components/core/src/glt/streaming_archive/reader/Archive.hpp
+++ b/components/core/src/glt/streaming_archive/reader/Archive.hpp
@@ -42,12 +42,12 @@ public:
      * @param decompressed_msg
      * @param custom_arg Custom argument for the output function
      */
-    using OutputFunc = void(*)(
-        std::string const& orig_file_path,
-        streaming_archive::reader::Message const& compressed_msg,
-        std::string const& decompressed_msg,
-        void* custom_arg
-        );
+    using OutputFunc = void (*)(
+            std::string const& orig_file_path,
+            streaming_archive::reader::Message const& compressed_msg,
+            std::string const& decompressed_msg,
+            void* custom_arg
+    );
     // Methods
     /**
      * Opens archive for reading


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Refactored the core code such that all the alias statements with the form 

`typedef [original-type] [your-alias]; `

were instead in the form

`using [your-alias] = [original-type];`


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Built and past unit tests
