### PR TITLE
regex-utils: Use `PUBLIC` include visibility for public library headers; Add missing link targets.

### DIFF
--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(
 )
 add_library(clp::regex_utils ALIAS regex_utils)
 target_include_directories(regex_utils
-        PRIVATE
+        PUBLIC
         ../
         "${PROJECT_SOURCE_DIR}/submodules"
 )

--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -17,4 +17,5 @@ target_include_directories(regex_utils
         ../
         "${PROJECT_SOURCE_DIR}/submodules"
 )
+target_link_libraries(regex_utils PRIVATE clp::string_utils)
 target_compile_features(regex_utils PRIVATE cxx_std_20)


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
In the current CMake setting of `regex_utils`, we set the visibility of `target_include_directories` to `PRIVATE`, meaning it is only visible to the library. However, the include path `../` should be made public otherwise library users cannot properly include the header without extra configurations in their CMake. This problem is not discovered in the current `unitTest` build because `clp::string_utils` has its CMake settings properly, and `clp::regex_utils` share the same include root with `clp::string_utils`. If we create a new target and only link against `clp::regex_utils`, the include path of the library won't be automatically resolved.
Another issue found is that the library is using `clp::string_utils`, but `clp::string_utils` is not added in the link targets.
This PR solves the problem by switching the visibility from `PRIVATE` to `PUBLIC` and adding a link target lists.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Ensure a target that only links against `regex_utils` can be successfully built.

