### PR TITLE
core: Mark spdlog specialization functions as const (fixes #524).

### DIFF
--- a/components/core/src/clp/spdlog_with_specializations.hpp
+++ b/components/core/src/clp/spdlog_with_specializations.hpp
@@ -16,7 +16,7 @@ struct fmt::formatter<clp::ErrorCode> {
     }
 
     template <typename FormatContext>
-    auto format(clp::ErrorCode const& error_code, FormatContext& ctx) {
+    auto format(clp::ErrorCode const& error_code, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", static_cast<size_t>(error_code));
     }
 };
@@ -30,7 +30,8 @@ struct fmt::formatter<clp::ffi::search::ExactVariableToken<encoded_variable_t>> 
 
     template <typename FormatContext>
     auto
-    format(clp::ffi::search::ExactVariableToken<encoded_variable_t> const& v, FormatContext& ctx) {
+    format(clp::ffi::search::ExactVariableToken<encoded_variable_t> const& v,
+           FormatContext& ctx) const {
         return fmt::format_to(
                 ctx.out(),
                 "ExactVariableToken(\"{}\") as {}",
@@ -48,7 +49,8 @@ struct fmt::formatter<clp::ffi::search::WildcardToken<encoded_variable_t>> {
     }
 
     template <typename FormatContext>
-    auto format(clp::ffi::search::WildcardToken<encoded_variable_t> const& v, FormatContext& ctx) {
+    auto
+    format(clp::ffi::search::WildcardToken<encoded_variable_t> const& v, FormatContext& ctx) const {
         return fmt::format_to(
                 ctx.out(),
                 "WildcardToken(\"{}\") as {}TokenType({}){}",

--- a/components/core/src/glt/spdlog_with_specializations.hpp
+++ b/components/core/src/glt/spdlog_with_specializations.hpp
@@ -16,7 +16,7 @@ struct fmt::formatter<glt::ErrorCode> {
     }
 
     template <typename FormatContext>
-    auto format(glt::ErrorCode const& error_code, FormatContext& ctx) {
+    auto format(glt::ErrorCode const& error_code, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", static_cast<size_t>(error_code));
     }
 };
@@ -30,7 +30,8 @@ struct fmt::formatter<glt::ffi::search::ExactVariableToken<encoded_variable_t>> 
 
     template <typename FormatContext>
     auto
-    format(glt::ffi::search::ExactVariableToken<encoded_variable_t> const& v, FormatContext& ctx) {
+    format(glt::ffi::search::ExactVariableToken<encoded_variable_t> const& v,
+           FormatContext& ctx) const {
         return fmt::format_to(
                 ctx.out(),
                 "ExactVariableToken(\"{}\") as {}",
@@ -48,7 +49,8 @@ struct fmt::formatter<glt::ffi::search::WildcardToken<encoded_variable_t>> {
     }
 
     template <typename FormatContext>
-    auto format(glt::ffi::search::WildcardToken<encoded_variable_t> const& v, FormatContext& ctx) {
+    auto
+    format(glt::ffi::search::WildcardToken<encoded_variable_t> const& v, FormatContext& ctx) const {
         return fmt::format_to(
                 ctx.out(),
                 "WildcardToken(\"{}\") as {}TokenType({}){}",


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As #524 mentions, the version of fmtlib installed by default using Homebrew has changed from v10 to v11. v11's [release notes](https://github.com/fmtlib/fmt/releases/tag/11.0.0) specify:

> Started enforcing that formatter::format is const for compatibility with std::format (https://github.com/fmtlib/fmt/issues/3447).

Accordingly, this PR updates our `formatter::format` specializations to be `const`.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated the [clp-core-build-macos](https://github.com/y-scope/clp/blob/main/.github/workflows/clp-core-build-macos.yaml) workflow now succeeds.