### PR TITLE
core: Replace `std::unique_ptr<char[]>` with `Array<char>` in `NetworkReader`.

### DIFF
--- a/components/core/src/clp/NetworkReader.cpp
+++ b/components/core/src/clp/NetworkReader.cpp
@@ -129,7 +129,7 @@ NetworkReader::NetworkReader(
           m_buffer_pool_size{std::max(cMinBufferPoolSize, buffer_pool_size)},
           m_buffer_size{std::max(cMinBufferSize, buffer_size)} {
     for (size_t i = 0; i < m_buffer_pool_size; ++i) {
-        m_buffer_pool.emplace_back(Array<char>(m_buffer_size));
+        m_buffer_pool.emplace_back(m_buffer_size);
     }
     m_downloader_thread = std::make_unique<DownloaderThread>(*this, offset, disable_caching);
     m_downloader_thread->start();

--- a/components/core/src/clp/NetworkReader.cpp
+++ b/components/core/src/clp/NetworkReader.cpp
@@ -10,6 +10,7 @@
 
 #include <curl/curl.h>
 
+#include "Array.hpp"
 #include "CurlDownloadHandler.hpp"
 #include "CurlOperationFailed.hpp"
 #include "ErrorCode.hpp"
@@ -128,8 +129,7 @@ NetworkReader::NetworkReader(
           m_buffer_pool_size{std::max(cMinBufferPoolSize, buffer_pool_size)},
           m_buffer_size{std::max(cMinBufferSize, buffer_size)} {
     for (size_t i = 0; i < m_buffer_pool_size; ++i) {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-        m_buffer_pool.emplace_back(std::make_unique<char[]>(m_buffer_size));
+        m_buffer_pool.emplace_back(Array<char>(m_buffer_size));
     }
     m_downloader_thread = std::make_unique<DownloaderThread>(*this, offset, disable_caching);
     m_downloader_thread->start();
@@ -248,7 +248,10 @@ auto NetworkReader::acquire_empty_buffer() -> void {
             return;
         }
     }
-    m_curr_downloader_buf.emplace(m_buffer_pool.at(m_curr_downloader_buf_idx).get(), m_buffer_size);
+    m_curr_downloader_buf.emplace(
+            m_buffer_pool.at(m_curr_downloader_buf_idx).data(),
+            m_buffer_size
+    );
 }
 
 auto NetworkReader::release_empty_buffer() -> void {
@@ -264,7 +267,7 @@ auto NetworkReader::enqueue_filled_buffer() -> void {
     }
     std::unique_lock<std::mutex> const buffer_resource_lock{m_buffer_resource_mutex};
     m_filled_buffer_queue.emplace(
-            m_buffer_pool.at(m_curr_downloader_buf_idx).get(),
+            m_buffer_pool.at(m_curr_downloader_buf_idx).data(),
             m_buffer_size - m_curr_downloader_buf.value().size()
     );
 

--- a/components/core/src/clp/NetworkReader.cpp
+++ b/components/core/src/clp/NetworkReader.cpp
@@ -10,7 +10,6 @@
 
 #include <curl/curl.h>
 
-#include "Array.hpp"
 #include "CurlDownloadHandler.hpp"
 #include "CurlOperationFailed.hpp"
 #include "ErrorCode.hpp"

--- a/components/core/src/clp/NetworkReader.hpp
+++ b/components/core/src/clp/NetworkReader.hpp
@@ -17,6 +17,7 @@
 
 #include <curl/curl.h>
 
+#include "Array.hpp"
 #include "CurlDownloadHandler.hpp"
 #include "CurlGlobalInstance.hpp"
 #include "ErrorCode.hpp"
@@ -106,7 +107,7 @@ public:
     );
 
     // Destructor
-    virtual ~NetworkReader();
+    ~NetworkReader() override;
 
     // Copy/Move Constructors
     // These are disabled since this class' synchronization primitives are non-copyable and
@@ -330,8 +331,7 @@ private:
     size_t m_buffer_size{cDefaultBufferSize};
     size_t m_curr_downloader_buf_idx{0};
 
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-    std::vector<std::unique_ptr<char[]>> m_buffer_pool;
+    std::vector<Array<char>> m_buffer_pool;
     std::queue<BufferView> m_filled_buffer_queue;
     std::optional<BufferView> m_curr_downloader_buf;
     std::optional<BufferView> m_curr_reader_buf;

--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -11,6 +11,7 @@
 #include <Catch2/single_include/catch2/catch.hpp>
 #include <curl/curl.h>
 
+#include "../src/clp/Array.hpp"
 #include "../src/clp/CurlDownloadHandler.hpp"
 #include "../src/clp/CurlGlobalInstance.hpp"
 #include "../src/clp/ErrorCode.hpp"
@@ -65,12 +66,11 @@ auto get_test_input_path_relative_to_tests_dir() -> std::filesystem::path {
 
 auto get_content(clp::ReaderInterface& reader, size_t read_buf_size) -> std::vector<char> {
     std::vector<char> buf;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-    auto const read_buf{std::make_unique<char[]>(read_buf_size)};
+    clp::Array<char> read_buf{read_buf_size};
     for (bool has_more_content{true}; has_more_content;) {
         size_t num_bytes_read{};
-        has_more_content = reader.read(read_buf.get(), read_buf_size, num_bytes_read);
-        std::string_view const view{read_buf.get(), num_bytes_read};
+        has_more_content = reader.read(read_buf.data(), read_buf_size, num_bytes_read);
+        std::string_view const view{read_buf.data(), num_bytes_read};
         buf.insert(buf.cend(), view.cbegin(), view.cend());
     }
     return buf;


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
As introduced in #513, `clp::Array` is a safe substitute for `std::unique_ptr` when we need a runtime-sized array. This PR replaces the use of `std::unique_ptr` with `clp::Array` in `NetworkReader,` where the array is used as the byte buffer to receive bytes from the underlying `libcurl` handler.
This PR should server as an example showing how to refactor the current code base to eliminate the use of `unique_ptr` with our array implementation.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Ensure workflows passed.
2. Related unit tests passed.
