### PR TITLE
docs: Fix dependency install script path and add missing requirement for building the package.

### DIFF
--- a/docs/src/dev-guide/building-package.md
+++ b/docs/src/dev-guide/building-package.md
@@ -12,9 +12,16 @@ prebuilt version instead, check out the [releases](https://github.com/y-scope/cl
     extra configuration.
 * Python 3.8 or newer
 * python3-venv
+* python3-dev
 * [Task](https://taskfile.dev/)
 
 ## Setup
+
+Clone the repo and sub-components
+
+```shell
+git clone --recurse-submodules https://github.com/y-scope/clp.git
+```
 
 Initialize the project
 
@@ -25,7 +32,7 @@ tools/scripts/deps-download/init.sh
 Install CLP core's dependencies
 
 ```shell
-components/core/tools/ubuntu-focal/install-all.sh
+components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
 ```
 
 ## Build

--- a/docs/src/dev-guide/building-package.md
+++ b/docs/src/dev-guide/building-package.md
@@ -11,17 +11,11 @@ prebuilt version instead, check out the [releases](https://github.com/y-scope/cl
   * It should be possible to build a package for a different environment, it just requires a some
     extra configuration.
 * Python 3.8 or newer
-* python3-venv
 * python3-dev
+* python3-venv
 * [Task](https://taskfile.dev/)
 
 ## Setup
-
-Clone the repo and sub-components
-
-```shell
-git clone --recurse-submodules https://github.com/y-scope/clp.git
-```
 
 Initialize the project
 
@@ -29,11 +23,11 @@ Initialize the project
 tools/scripts/deps-download/init.sh
 ```
 
-Install CLP core's dependencies
-
-```shell
-components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
-```
+Install CLP core's dependencies based on your OS:
+* [CentOS Stream 9](centos-stream-9-deps-install)
+* [macOS 12](macos12-deps-install)
+* [Ubuntu 20.04](ubuntu-focal-deps-install)
+* [Ubuntu 22.04](ubuntu-jammy-deps-install)
 
 ## Build
 

--- a/docs/src/dev-guide/building-package.md
+++ b/docs/src/dev-guide/building-package.md
@@ -23,11 +23,11 @@ Initialize the project
 tools/scripts/deps-download/init.sh
 ```
 
-Install CLP core's dependencies based on your OS:
-* [CentOS Stream 9](https://docs.yscope.com/clp/main/dev-guide/components-core/centos7.4-deps-install.html)
-* [macOS 12](https://docs.yscope.com/clp/main/dev-guide/components-core/macos12-deps-install.html)
-* [Ubuntu 20.04](https://docs.yscope.com/clp/main/dev-guide/components-core/ubuntu-focal-deps-install.html)
-* [Ubuntu 22.04](https://docs.yscope.com/clp/main/dev-guide/components-core/ubuntu-jammy-deps-install.html)
+Install CLP core's dependencies
+
+```shell
+components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh
+```
 
 ## Build
 

--- a/docs/src/dev-guide/building-package.md
+++ b/docs/src/dev-guide/building-package.md
@@ -24,10 +24,10 @@ tools/scripts/deps-download/init.sh
 ```
 
 Install CLP core's dependencies based on your OS:
-* [CentOS Stream 9](centos-stream-9-deps-install)
-* [macOS 12](macos12-deps-install)
-* [Ubuntu 20.04](ubuntu-focal-deps-install)
-* [Ubuntu 22.04](ubuntu-jammy-deps-install)
+* [CentOS Stream 9](https://docs.yscope.com/clp/main/dev-guide/components-core/centos7.4-deps-install.html)
+* [macOS 12](https://docs.yscope.com/clp/main/dev-guide/components-core/macos12-deps-install.html)
+* [Ubuntu 20.04](https://docs.yscope.com/clp/main/dev-guide/components-core/ubuntu-focal-deps-install.html)
+* [Ubuntu 22.04](https://docs.yscope.com/clp/main/dev-guide/components-core/ubuntu-jammy-deps-install.html)
 
 ## Build
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds `python3-dev` as a requirement for building the package and fixes a path to a dependency install script in the docs. `python3-dev` is necessary for installing Python packages that need to build C extensions.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated that building the package after installing python3-dev succeeded.