### PR TITLE
Temporarily lock clang-format to v18.x to resolve lint failures.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,4 @@
 black>=24.4.2
-clang-format>=18.1.5
+clang-format==18.1.8
 ruff>=0.4.4
 yamllint>=1.35.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black>=24.4.2
-clang-format==18.1.8
+# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
+clang-format~=18.1
 ruff>=0.4.4
 yamllint>=1.35.1


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The lint workflow, as reported in #545 
This PR locks the clang-format version to 18.1.8 (which is the latest version 18 release in PyPI) as a temporary solution. We will fix this properly later by adapting clang-format version 19.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Ensure the lint workflow passed: https://github.com/LinZhihao-723/clp/actions/runs/11018322868


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `clang-format` dependency to ensure compatibility and maintain formatting standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->