### PR TITLE
[WIP] Add support for ingesting logs from Kafka

### DIFF
--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -65,6 +65,8 @@ set(
         JsonParser.cpp
         JsonParser.hpp
         JsonSerializer.hpp
+        KafkaReader.cpp
+        KafkaReader.hpp
         ParsedMessage.hpp
         ReaderUtils.cpp
         ReaderUtils.hpp
@@ -194,6 +196,7 @@ target_link_libraries(
         Boost::filesystem Boost::iostreams Boost::program_options
         clp::string_utils
         kql
+        rdkafka
         MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
         msgpack-cxx

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -36,6 +36,11 @@ public:
         Stdout,
     };
 
+    enum class InputSourceType : uint8_t {
+        Filesystem = 0,
+        Kafka
+    };
+
     // Constructors
     explicit CommandLineArguments(std::string const& program_name) : m_program_name(program_name) {}
 
@@ -108,6 +113,18 @@ public:
 
     size_t get_ordered_chunk_size() const { return m_ordered_chunk_size; }
 
+    InputSourceType get_input_source() const { return m_input_source; }
+
+    std::string const& get_kafka_topic() const { return m_kafka_topic; }
+
+    int32_t get_kafka_partition() const { return m_kafka_partition; }
+
+    int64_t get_kafka_offset() const { return m_kafka_offset; }
+
+    size_t get_num_kafka_messages() const { return m_kafka_num_messages; }
+
+    std::string const& get_kafka_config_file() const { return m_kafka_config_file; }
+
 private:
     // Methods
     /**
@@ -173,6 +190,14 @@ private:
     bool m_structurize_arrays{false};
     bool m_ordered_decompression{false};
     size_t m_ordered_chunk_size{0};
+
+    // Input source variables
+    InputSourceType m_input_source{InputSourceType::Filesystem};
+    std::string m_kafka_topic;
+    int32_t m_kafka_partition{};
+    int64_t m_kafka_offset{};
+    size_t m_kafka_num_messages{};
+    std::string m_kafka_config_file;
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -420,7 +420,7 @@ void JsonParser::parse_line(ondemand::value line, int32_t parent_node_id, std::s
     while (!object_stack.empty());
 }
 
-void JsonParser::parse_from_kafka() {
+bool JsonParser::parse_from_kafka() {
     KafkaReader reader{
             m_kafka_option.kafka_config_file,
             m_kafka_option.topic,
@@ -452,13 +452,13 @@ void JsonParser::parse_from_kafka() {
         m_current_parsed_message.clear();
     };
 
-    reader.consume_messages(consume_message, m_kafka_option.num_messages);
+    return -1 != reader.consume_messages(consume_message, m_kafka_option.num_messages);
 }
 
 bool JsonParser::parse() {
     if (CommandLineArguments::InputSourceType::Kafka == m_input_source) {
         try {
-            parse_from_kafka();
+            return parse_from_kafka();
         } catch (TraceableException& e) {
             SPDLOG_ERROR(
                     "Encountered error - {} - while trying to parse logs from Kafka",
@@ -466,7 +466,6 @@ bool JsonParser::parse() {
             );
             return false;
         }
-        return true;
     }
 
     for (auto& file_path : m_file_paths) {

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -109,8 +109,9 @@ private:
     /**
      * Parses input from kafka according to the configuration specified in `m_kafka_option`.
      * @throws KafkaReader::OperationFailed
+     * @return true on success, false otherwise
      */
-    void parse_from_kafka();
+    bool parse_from_kafka();
 
     std::vector<std::string> m_file_paths;
 

--- a/components/core/src/clp_s/KafkaReader.cpp
+++ b/components/core/src/clp_s/KafkaReader.cpp
@@ -133,6 +133,10 @@ auto KafkaReader::consume_messages(std::function<void(char*, size_t)> consume, s
             );
             return -1;
         }
+        if (0 == rc) {
+            SPDLOG_ERROR("Expected messages from Kafka but received none.");
+            return -1;
+        }
 
         bool error{false};
         for (size_t i = 0; i < rc; ++i) {

--- a/components/core/src/clp_s/KafkaReader.cpp
+++ b/components/core/src/clp_s/KafkaReader.cpp
@@ -53,4 +53,79 @@ KafkaReader::~KafkaReader() {
     rd_kafka_topic_destroy(m_topic);
     rd_kafka_destroy(m_consumer);
 }
+
+auto KafkaReader::consume_messages(std::function<char*, size_t> consume, size_t num_messages)
+        -> ssize_t {
+    constexpr size_t cBatchSize = 128;
+    constexpr int cTimeoutMs = 1000;
+    ssize_t num_messages_consumed{0};
+    std::array<rd_kafka_message_t*, cBatchSize> messages;
+
+    bool end_of_partition{false};
+    size_t num_messages_remaining = do {
+        size_t batch_size = num_messages < cBatchSize ? num_messages : cBatchSize;
+        auto rc = rd_kafka_consume_batch(
+                m_consumer,
+                m_partition,
+                cTimeoutMs,
+                messages.data(),
+                batch_size
+        );
+        if (-1 == rc) {
+            // Note: if we want to support backing off to longer timeouts we need to check if the
+            // error is ETIMEDOUT and conditionally retry the consume batch request.
+            auto err = rd_kafka_last_error();
+            SPDLOG_ERROR(
+                    "Encountered error while trying to consume batch from kafka: {}",
+                    rd_kafka_err2str(err)
+            );
+            return -1;
+        }
+
+        bool error{false};
+        for (size_t i = 0; i < rc; ++i) {
+            rd_kafka_message_t* cur_message = messages[i];
+            if (cur_message->err) {
+                // Handle end of partition error
+                if (RD_KAFKA_RESP_ERR__PARTITION_EOF != cur_message->err) {
+                    end_of_partition = true;
+                } else {
+                    SPDLOG_ERROR(
+                            "Encountered error while consuming kafka messages: {}",
+                            rd_kafka_err2str(cur_message->err)
+                    );
+                    error = true;
+                }
+
+                rd_kafka_message_destroy(cur_message);
+                continue;
+            }
+
+            num_messages_consumed += 1;
+            consume(cur_message->payload, cur_message->len);
+            rd_kafka_message_destroy(cur_message);
+        }
+
+        // Defer returning error until after the loop to make sure rd_kafka_message_destroy is
+        // called for every message.
+        if (error) {
+            return -1;
+        }
+
+        // This shouldn't happen outside of implementation or library bugs, but it is worth checking
+        // for safety.
+        if (num_messages_consumed > num_messages) {
+            SPDLOG_ERROR(
+                    "Received {} messages from Kafka when expecting {}",
+                    num_messages_consumed,
+                    num_messages
+            );
+            return -1;
+        }
+        num_messages_remaining = num_messages - num_messages_consumed;
+    }
+    while (0 < num_messages_remaining && false == end_of_partition)
+        ;
+    return num_messages_consumed;
+}
 }  // namespace clp_s

--- a/components/core/src/clp_s/KafkaReader.cpp
+++ b/components/core/src/clp_s/KafkaReader.cpp
@@ -62,7 +62,8 @@ auto KafkaReader::consume_messages(std::function<char*, size_t> consume, size_t 
     std::array<rd_kafka_message_t*, cBatchSize> messages;
 
     bool end_of_partition{false};
-    size_t num_messages_remaining = do {
+    size_t num_messages_remaining{num_messages};
+    do {
         size_t batch_size = num_messages < cBatchSize ? num_messages : cBatchSize;
         auto rc = rd_kafka_consume_batch(
                 m_consumer,
@@ -123,9 +124,7 @@ auto KafkaReader::consume_messages(std::function<char*, size_t> consume, size_t 
             return -1;
         }
         num_messages_remaining = num_messages - num_messages_consumed;
-    }
-    while (0 < num_messages_remaining && false == end_of_partition)
-        ;
+    } while (0 < num_messages_remaining && false == end_of_partition);
     return num_messages_consumed;
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/KafkaReader.cpp
+++ b/components/core/src/clp_s/KafkaReader.cpp
@@ -23,9 +23,8 @@ auto KafkaReader::populate_config_from_yaml_file(
         }
         auto kafka_config = config[cKafkaConfig];
         for (auto it = kafka_config.begin(); it != kafka_config.end(); ++it) {
-            YAML::Node config_property_node = it->second;
-            std::string const& key = config_property_node.Tag();
-            std::string value = config_property_node.as<std::string>();
+            std::string key = it->first.as<std::string>();
+            std::string value = it->second.as<std::string>();
 
             auto rc = rd_kafka_conf_set(
                     conf,

--- a/components/core/src/clp_s/KafkaReader.cpp
+++ b/components/core/src/clp_s/KafkaReader.cpp
@@ -1,0 +1,56 @@
+#include "KafkaReader.hpp"
+
+#include <librdkafka/rdkafka.h>
+
+#include <array>
+
+#include <spdlog/spdlog.h>
+
+namespace clp_s {
+KafkaReader::KafkaReader(std::string const& topic, int32_t partition, int64_t offset)
+        : m_partition(partition) {
+    constexpr size_t cErrorBufferSize = 512;
+    std::array<char, cErrorBufferSize> error_msg{};
+    auto conf = rd_kafka_conf_new();
+
+    // set_config(k, v, conf) multiple times
+
+    m_consumer = rd_kafka_new(RD_KAFKA_CONSUMER, conf, error_msg.data(), error_msg.size());
+    if (nullptr == m_consumer) {
+        rd_kafka_conf_destroy(conf);
+        rd_kafka_destroy(m_consumer);
+        SPDLOG_ERROR("Encountered error while creating kafka consumer: {}", error_msg.data());
+        throw OperationFailed(ErrorCodeFailure, __FILENAME__, __LINE__);
+    }
+    // On success m_consumer takes ownership of conf, so we can stop tracking it here.
+    conf = nullptr;
+
+    rd_kafka_topic_conf_t* topic_conf{nullptr};
+    m_topic = rd_kafka_topic_new(m_consumer, topic.c_str(), topic_conf);
+    if (nullptr == m_topic) {
+        auto err = rd_kafka_last_error();
+        SPDLOG_ERROR("Encountered error while creating kafka topic: {}", rd_kafka_err2str(err));
+        rd_kafka_topic_destroy(m_topic);
+        rd_kafka_destroy(m_consumer);
+        throw OperationFailed(ErrorCodeFailure, __FILENAME__, __LINE__);
+    }
+    // On success m_topic takes ownership of topic_conf, so we can stop tracking it here.
+    topic_conf = nullptr;
+
+    // This function returns -1 on error, but reports the specific error using thread local errno.
+    constexpr int cKafkaConsumeStartErrorCode = -1;
+    if (cKafkaConsumeStartErrorCode == rd_kafka_consume_start(m_topic, partition, offset)) {
+        auto err = rd_kafka_last_error();
+        SPDLOG_ERROR("Encountered error while starting kafka consumer: {}", rd_kafka_err2str(err));
+        rd_kafka_topic_destroy(m_topic);
+        rd_kafka_destroy(m_consumer);
+        throw OperationFailed(ErrorCodeFailure, __FILENAME__, __LINE__);
+    }
+}
+
+KafkaReader::~KafkaReader() {
+    rd_kafka_consume_stop(m_topic, m_partition);
+    rd_kafka_topic_destroy(m_topic);
+    rd_kafka_destroy(m_consumer);
+}
+}  // namespace clp_s

--- a/components/core/src/clp_s/KafkaReader.hpp
+++ b/components/core/src/clp_s/KafkaReader.hpp
@@ -6,7 +6,9 @@
 #include "TraceableException.hpp"
 
 namespace clp_s {
-
+/**
+ * This class
+ */
 class KafkaReader {
 public:
     class OperationFailed : public TraceableException {
@@ -17,7 +19,20 @@ public:
     };
 
     // Constructors
-    explicit KafkaReader(std::string const& topic, int32_t partition, int64_t offset);
+    /**
+     * KafkaReader constructor.
+     * @param config_file YAML configuration file for the Kafka consumer.
+     * @param topic topic to consume from.
+     * @param partition partition to consume from.
+     * @param offset starting offset to consume from.
+     * @throws KafkaReader::OperationFailed
+     */
+    explicit KafkaReader(
+            std::string const& config_file,
+            std::string const& topic,
+            int32_t partition,
+            int64_t offset
+    );
 
     // Destructor
     ~KafkaReader();
@@ -34,9 +49,27 @@ public:
      * @param num_messages the number of messages to consume
      * @return the number of messages consumed, or -1 on error
      */
-    auto consume_messages(std::function<char*, size_t> consume, size_t num_messages) -> ssize_t;
+    auto
+    consume_messages(std::function<void(char*, size_t)> consume, size_t num_messages) -> ssize_t;
 
 private:
+    /**
+     * Populate Kafka consumer configuration from a YAML config.
+     *
+     * String key-value pairs should be specified under a top-level "kafka" object. e.g.
+     *
+     * kafka:
+     *   boostrap.servers: "localhost:3001,localhost:3002"
+     *
+     * All options from the Global configuration properties from the following link should work:
+     * https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
+     * @param config_file path to YAML config file
+     * @param conf kafka configuration object to populate
+     * @return true on success and false otherwise
+     */
+    static auto
+    populate_config_from_yaml_file(std::string const& config_file, rd_kafka_conf_t* conf) -> bool;
+
     rd_kafka_t* m_consumer{nullptr};
     rd_kafka_topic_t* m_topic{nullptr};
     int32_t m_partition{};

--- a/components/core/src/clp_s/KafkaReader.hpp
+++ b/components/core/src/clp_s/KafkaReader.hpp
@@ -28,6 +28,14 @@ public:
     auto operator=(KafkaReader&) -> KafkaReader& = delete;
     auto operator=(KafkaReader&&) -> KafkaReader& = delete;
 
+    /**
+     * Consume up to num_messages messages from this KafkaReader.
+     * @param consume a function which accepts the raw bytes and payload length for each message
+     * @param num_messages the number of messages to consume
+     * @return the number of messages consumed, or -1 on error
+     */
+    auto consume_messages(std::function<char*, size_t> consume, size_t num_messages) -> ssize_t;
+
 private:
     rd_kafka_t* m_consumer{nullptr};
     rd_kafka_topic_t* m_topic{nullptr};

--- a/components/core/src/clp_s/KafkaReader.hpp
+++ b/components/core/src/clp_s/KafkaReader.hpp
@@ -7,7 +7,8 @@
 
 namespace clp_s {
 /**
- * This class
+ * This class provides a high-level interface to consume messages from a Kafka topic starting at
+ * a given partition and offset.
  */
 class KafkaReader {
 public:

--- a/components/core/src/clp_s/KafkaReader.hpp
+++ b/components/core/src/clp_s/KafkaReader.hpp
@@ -1,0 +1,36 @@
+#include <librdkafka/rdkafka.h>
+
+#include <functional>
+#include <string>
+
+#include "TraceableException.hpp"
+
+namespace clp_s {
+
+class KafkaReader {
+public:
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
+    };
+
+    // Constructors
+    explicit KafkaReader(std::string const& topic, int32_t partition, int64_t offset);
+
+    // Destructor
+    ~KafkaReader();
+
+    // Disable copy/move constructors/assignment operators
+    KafkaReader(KafkaReader&) = delete;
+    KafkaReader(KafkaReader&&) = delete;
+    auto operator=(KafkaReader&) -> KafkaReader& = delete;
+    auto operator=(KafkaReader&&) -> KafkaReader& = delete;
+
+private:
+    rd_kafka_t* m_consumer{nullptr};
+    rd_kafka_topic_t* m_topic{nullptr};
+    int32_t m_partition{};
+};
+}  // namespace clp_s

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -85,6 +85,7 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     }
 
     clp_s::JsonParserOption option{};
+    option.input_source = command_line_arguments.get_input_source();
     option.file_paths = command_line_arguments.get_file_paths();
     option.archives_dir = archives_dir.string();
     option.target_encoded_size = command_line_arguments.get_target_encoded_size();
@@ -93,6 +94,15 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     option.timestamp_key = command_line_arguments.get_timestamp_key();
     option.print_archive_stats = command_line_arguments.print_archive_stats();
     option.structurize_arrays = command_line_arguments.get_structurize_arrays();
+
+    if (CommandLineArguments::InputSourceType::Kafka == option.input_source) {
+        clp_s::KafkaOption& kafka_option = option.kafka_option;
+        kafka_option.topic = command_line_arguments.get_kafka_topic();
+        kafka_option.partition = command_line_arguments.get_kafka_partition();
+        kafka_option.offset = command_line_arguments.get_kafka_offset();
+        kafka_option.num_messages = command_line_arguments.get_num_kafka_messages();
+        kafka_option.kafka_config_file = command_line_arguments.get_kafka_config_file();
+    }
 
     auto const& db_config_container = command_line_arguments.get_metadata_db_config();
     if (db_config_container.has_value()) {

--- a/components/core/tools/scripts/lib_install/centos-stream-9/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/centos-stream-9/install-prebuilt-packages.sh
@@ -13,6 +13,7 @@ dnf install -y \
     java-11-openjdk \
     libarchive-devel \
     libcurl-devel \
+    librdkafka-devel \
     libzstd-devel \
     make \
     mariadb-connector-c-devel \

--- a/components/core/tools/scripts/lib_install/macos-12/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos-12/install-all.sh
@@ -16,6 +16,7 @@ brew install \
   go-task \
   java11 \
   libarchive \
+  librdkafka \
   lz4 \
   mariadb-connector-c \
   mongo-cxx-driver \

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -20,6 +20,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   libcurl4 \
   libcurl4-openssl-dev \
   libmariadb-dev \
+  librdkafka-dev \
   libssl-dev \
   make \
   openjdk-11-jdk \

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
@@ -20,6 +20,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   libcurl4 \
   libcurl4-openssl-dev \
   libmariadb-dev \
+  librdkafka-dev \
   libssl-dev \
   openjdk-11-jdk \
   pkg-config \


### PR DESCRIPTION
# Description
This PR adds support for ingesting log data from Kafka by integrating with the `librdkafka` C library. A user specifies the Kafka topic they want to consume from, the partition, the starting offset, and the number of Kafka messages they would like to consume on the command line. Users must also specify a path to a config file containing configuration options for kafka such as the list of bootstrapping brokers to connect to.

This configuration file is written in YAML, and may look something like:

```
kafka:
  boostrap.servers: "localhost:9092,localhost:9093"
  debug: "all"
```

and accepts any configuration option from the global configuration properties [here](https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html).

The debug option enables internal debug logging from the librdkafka library, and is useful for diagnosing connection issues with Kafka.

Note that while this config file can be used for simple userid/password authentication it can't handle more advanced authentication flows. If we need to support some of the more advanced security options like authenticating with an OAUTH provider it seems like librdkafka requires us to implement some callback functions to reach out to an OAUTH broker on our own.

This PR is marked WIP since the end to end flow of ingesting logs from Kafka has not been fully validated.

# Validation performed
* Validated that process exits without hanging when the Kafka broker can not be reached

