### PR TITLE
core: Extract `TransactionManager` from `clp::ffi::ir_stream::Deserializer`; Improve class' docs and require nothrow for its handlers.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -480,6 +480,7 @@ set(SOURCE_FILES_unitTest
         src/clp/TimestampPattern.cpp
         src/clp/TimestampPattern.hpp
         src/clp/TraceableException.hpp
+        src/clp/TransactionManager.hpp
         src/clp/type_utils.hpp
         src/clp/utf8_utils.cpp
         src/clp/utf8_utils.hpp

--- a/components/core/src/clp/TransactionManager.hpp
+++ b/components/core/src/clp/TransactionManager.hpp
@@ -1,0 +1,51 @@
+#ifndef CLP_TRANSACTIONMANAGER_HPP
+#define CLP_TRANSACTIONMANAGER_HPP
+
+#include <type_traits>
+
+namespace clp {
+/**
+ * Class to perform different actions depending on whether a transaction succeeds or fails. The
+ * default state assumes the transaction fails.
+ * @tparam SuccessHandler A cleanup lambda to call on success.
+ * @tparam FailureHandler A cleanup lambda to call on failure.
+ */
+template <typename SuccessHandler, typename FailureHandler>
+requires(std::is_invocable_v<SuccessHandler> && std::is_invocable_v<FailureHandler>)
+class TransactionManager {
+public:
+    // Constructor
+    TransactionManager(SuccessHandler success_handler, FailureHandler failure_handler)
+            : m_success_handler{success_handler},
+              m_failure_handler{failure_handler} {}
+
+    // Delete copy/move constructor and assignment
+    TransactionManager(TransactionManager const&) = delete;
+    TransactionManager(TransactionManager&&) = delete;
+    auto operator=(TransactionManager const&) -> TransactionManager& = delete;
+    auto operator=(TransactionManager&&) -> TransactionManager& = delete;
+
+    // Destructor
+    ~TransactionManager() {
+        if (m_success) {
+            m_success_handler();
+        } else {
+            m_failure_handler();
+        }
+    }
+
+    // Methods
+    /**
+     * Marks the transaction as successful.
+     */
+    auto mark_success() -> void { m_success = true; }
+
+private:
+    // Variables
+    SuccessHandler m_success_handler;
+    FailureHandler m_failure_handler;
+    bool m_success{false};
+};
+}  // namespace clp
+
+#endif  // CLP_TRANSACTIONMANAGER_HPP

--- a/components/core/src/clp/TransactionManager.hpp
+++ b/components/core/src/clp/TransactionManager.hpp
@@ -5,8 +5,8 @@
 
 namespace clp {
 /**
- * Class to perform different actions depending on whether a transaction succeeds or fails. The
- * default state assumes the transaction fails.
+ * A class that on destruction, performs different actions depending on whether a transaction
+ * succeeds or fails. The default state assumes the transaction fails.
  * @tparam SuccessHandler A cleanup lambda to call on success.
  * @tparam FailureHandler A cleanup lambda to call on failure.
  */

--- a/components/core/src/clp/TransactionManager.hpp
+++ b/components/core/src/clp/TransactionManager.hpp
@@ -11,7 +11,7 @@ namespace clp {
  * @tparam FailureHandler A cleanup lambda to call on failure.
  */
 template <typename SuccessHandler, typename FailureHandler>
-requires(std::is_invocable_v<SuccessHandler> && std::is_invocable_v<FailureHandler>)
+requires(std::is_nothrow_invocable_v<SuccessHandler> && std::is_nothrow_invocable_v<FailureHandler>)
 class TransactionManager {
 public:
     // Constructor

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.cpp
@@ -5,7 +5,6 @@
 #include <string_view>
 #include <system_error>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.cpp
@@ -79,8 +79,8 @@ auto Deserializer::deserialize_to_next_log_event(clp::ReaderInterface& reader
     auto const utc_offset_snapshot{m_utc_offset};
     m_schema_tree->take_snapshot();
     TransactionManager revert_manager{
-            []() -> void {},
-            [&]() -> void {
+            []() noexcept -> void {},
+            [&]() noexcept -> void {
                 m_utc_offset = utc_offset_snapshot;
                 m_schema_tree->revert();
             }


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
`TransactionManager` is introduced in #511 to perform an RAII-style success/failure management. It was added as a local helper class inside the deserializer implementation. This PR extracts it as a stand-alone general helper class for two reasons:
1. This class is general enough that other parts of the code base may find it helpful.
2. As planned in #539, the implementation file will be removed shortly if we templatize the IR deserializer.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure workflows passed.
- Ensure unit tests passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `TransactionManager` class for enhanced transaction handling with customizable success and failure handlers.

- **Bug Fixes**
	- Removed the `TransactionManager` class from the deserialization process, simplifying error handling and state management.

- **Documentation**
	- Updated build configuration to include the new `TransactionManager.hpp` header file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->