### PR TITLE
gh-actions: Remove pre-installed Go binaries that conflict with brew's installs on macOS (fixes #551).

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -52,6 +52,7 @@ jobs:
           rm -f /usr/local/bin/idle3*
           rm -f /usr/local/bin/pydoc3*
           rm -f /usr/local/bin/python3*
+          rm -f /urs/local/bin/go*
 
       - name: "Install dependencies"
         run: "./components/core/tools/scripts/lib_install/macos-12/install-all.sh"

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -49,10 +49,10 @@ jobs:
       - name: "Remove preinstalled binaries which conflict with brew's installs"
         run: |
           rm -f /usr/local/bin/2to3*
+          rm -f /usr/local/bin/go*
           rm -f /usr/local/bin/idle3*
           rm -f /usr/local/bin/pydoc3*
           rm -f /usr/local/bin/python3*
-          rm -f /urs/local/bin/go*
 
       - name: "Install dependencies"
         run: "./components/core/tools/scripts/lib_install/macos-12/install-all.sh"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fixes #551 by removing pre-installed Go binaries. The pre-installed Go binaries prevent `brew` from installing Go properly. This PR fixes the issue by removing the pre-installed binaries before running `brew`.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Ensure all workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build workflow to remove conflicting Go binaries during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->