### PR TITLE
Temporarily lock Sphinx to v8.0.2 to resolve docs build failure. 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ myst-parser>=2.0.0
 # Locked to avoid pydata/pydata-sphinx-theme#1676 until its fix is released in a version above
 # 0.15.2
 pydata-sphinx-theme==0.14.4
-# Locked to avoid the following issue until the fix is released:
+# Locked to avoid the following issue until a fix is released:
 # https://github.com/sphinx-doc/sphinx/issues/13002
 sphinx==8.0.2
 sphinx_design>=0.5.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,9 @@ myst-parser>=2.0.0
 # Locked to avoid pydata/pydata-sphinx-theme#1676 until its fix is released in a version above
 # 0.15.2
 pydata-sphinx-theme==0.14.4
-sphinx>=7.3.7
+# Locked to avoid the following issue until the fix is released:
+# https://github.com/sphinx-doc/sphinx/issues/13002
+sphinx==8.0.2
 sphinx_design>=0.5.0
 sphinx-copybutton>=0.5.2
 sphinxcontrib-mermaid>=0.9.2


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Recent doc build workflows failed: https://github.com/y-scope/clp/actions/runs/11297119298 due to the following issue: https://github.com/sphinx-doc/sphinx/issues/13002
This PR locks Sphinx to 8.0.2 as a temporary solution to the problem.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Ensure the workflow passed: https://github.com/LinZhihao-723/clp/actions/runs/11298904378


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the `sphinx` package version to a specific release for improved stability.
	- Added comments for clarity on version locking decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->