### PR TITLE
fix(taskfiles): Trim trailing slash from URL prefix in `download-and-extract-tar` (fixes #577).

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -348,7 +348,7 @@ tasks:
       - "mkdir -p '{{.OUTPUT_TMP_DIR}}'"
       - >-
         curl --fail --location --show-error
-        "{{.URL_PREFIX}}/{{.TAR_NAME}}"
+        "{{trimSuffix "/" .URL_PREFIX}}/{{.TAR_NAME}}"
         --output "{{.TAR_PATH}}"
       - "tar xf '{{.TAR_PATH}}' --directory '{{.OUTPUT_TMP_DIR}}'"
       - "mv '{{.EXTRACTED_DIR}}' '{{.OUTPUT_DIR}}'"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As #577 describes, the extra slash in the nodejs download URL was causing the download to fail. This PR trims any trailing slash from the URL prefix passed to `download-and-extract-ar` to resolve the issue.

NOTE: We can't remove the trailing slash from `NODEJS_VERSION_BASE_URL` since that will prevent us from listing available files when computing `NODEJS_FILE_BASE_NAME`:

https://github.com/y-scope/clp/blob/426cc3d657c67e9fdffe6681e670cba617f4154f/Taskfile.yml#L480-L488

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* `task lint:js-check` succeeds.
* The lint GH workflow succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved URL handling in the download-and-extract-tar task by removing trailing slashes from the URL prefix.
	- Minor adjustments made to comments and formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->