### PR TITLE
fix(ffi): Correct `clp::ffi::ir_stream::Deserializer::deserialize_next_ir_unit`'s return value when failing to read the next IR unit's type tag.

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -66,7 +66,7 @@ public:
     /**
      * Deserializes the stream from the given reader up to and including the next log event IR unit.
      * @param reader
-     * @return std::errc::no_message_available if no tag bytes can be read to determine the next IR
+     * @return std::errc::result_out_of_range if no tag bytes can be read to determine the next IR
      * unit type.
      * @return std::errc::protocol_not_supported if the IR unit type is not supported.
      * @return std::errc::operation_not_permitted if the deserializer already reached the end of
@@ -173,7 +173,7 @@ auto Deserializer<IrUnitHandler>::deserialize_next_ir_unit(ReaderInterface& read
 
     encoded_tag_t tag{};
     if (IRErrorCode::IRErrorCode_Success != deserialize_tag(reader, tag)) {
-        return std::errc::no_message_available;
+        return std::errc::result_out_of_range;
     }
 
     auto const optional_ir_unit_type{get_ir_unit_type_from_tag(tag)};

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -14,7 +14,6 @@
 
 #include "../../ReaderInterface.hpp"
 #include "../../time_types.hpp"
-#include "../KeyValuePairLogEvent.hpp"
 #include "../SchemaTree.hpp"
 #include "decoding_methods.hpp"
 #include "ir_unit_deserialization_methods.hpp"
@@ -66,8 +65,8 @@ public:
     /**
      * Deserializes the stream from the given reader up to and including the next log event IR unit.
      * @param reader
-     * @return std::errc::result_out_of_range if no tag bytes can be read to determine the next IR
-     * unit type.
+     * @return Forwards `deserialize_tag`s return values if no tag bytes can be read to determine
+     * the next IR unit type.
      * @return std::errc::protocol_not_supported if the IR unit type is not supported.
      * @return std::errc::operation_not_permitted if the deserializer already reached the end of
      * stream by deserializing an end-of-stream IR unit in the previous calls.
@@ -172,8 +171,8 @@ auto Deserializer<IrUnitHandler>::deserialize_next_ir_unit(ReaderInterface& read
     }
 
     encoded_tag_t tag{};
-    if (IRErrorCode::IRErrorCode_Success != deserialize_tag(reader, tag)) {
-        return std::errc::result_out_of_range;
+    if (auto const err{deserialize_tag(reader, tag)}; IRErrorCode::IRErrorCode_Success != err) {
+        return ir_error_code_to_errc(err);
     }
 
     auto const optional_ir_unit_type{get_ir_unit_type_from_tag(tag)};


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Before this PR, when the deserializer fails to read the next IR unit's type tag, it returns `std::errc::no_message_available`. However, this error should be equivalent to incomplete IR stream error, which should be the same with `std::errc::result_out_of_range`. This PR fixes this issue.
The PR also removed unused includes from `Deserializer`'s header.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the deserialization process, providing more specific error codes.
	- Improved granularity of error reporting during data deserialization.

- **Documentation**
	- Updated comments to clarify the return value descriptions for improved understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->