### PR TITLE
refactor(ffi): Make `get_schema_subtree_bitmap` a public method of `KeyValuePairLogEvent`.

### DIFF
--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <json/single_include/nlohmann/json.hpp>
 #include <outcome/single-header/outcome.hpp>
@@ -59,6 +60,17 @@ public:
     }
 
     [[nodiscard]] auto get_utc_offset() const -> UtcOffset { return m_utc_offset; }
+
+    /**
+     * @return A result containing a bitmap where every bit corresponds to the ID of a node in the
+     * schema tree, and the set bits correspond to the nodes in the subtree defined by all paths
+     * from the root node to the nodes in `node_id_value_pairs`; or an error code indicating a
+     * failure:
+     * - std::errc::result_out_of_range if a node ID in `node_id_value_pairs` doesn't exist in the
+     *   schema tree.
+     */
+    [[nodiscard]] auto get_schema_subtree_bitmap(
+    ) const -> OUTCOME_V2_NAMESPACE::std_result<std::vector<bool>>;
 
     /**
      * Serializes the log event into a `nlohmann::json` object.


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
After realizing `get_schema_subtree_bitmap` is also useful in language-specific ffi layer, we decided to extract it from the anon-namespace as a member method of `KeyValuePairLogEvent` in this PR.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure unit tests all passed locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to obtain a bitmap representing the schema subtree in the `KeyValuePairLogEvent` class.
	- Enhanced error handling for cases where a node ID does not exist in the schema tree.

- **Bug Fixes**
	- Streamlined the process of obtaining the schema subtree bitmap, improving overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->