### PR TITLE
fix(cmake): Add Homebrew path detection for `mariadb-connector-c` to fix macOS build failure.

### DIFF
--- a/components/core/cmake/Modules/FindMariaDBClient.cmake
+++ b/components/core/cmake/Modules/FindMariaDBClient.cmake
@@ -21,14 +21,22 @@ find_package(PkgConfig)
 pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
 
 if(NOT mariadbclient_PKGCONF_FOUND AND APPLE)
-    execute_process(COMMAND brew --prefix mariadb-connector-c OUTPUT_VARIABLE mariadb_MACOS_PREFIX)
-    string(STRIP "${mariadb_MACOS_PREFIX}" mariadb_MACOS_PREFIX)
-    set(CMAKE_PREFIX_PATH "${mariadb_MACOS_PREFIX};${CMAKE_PREFIX_PATH}")
+    execute_process(
+        COMMAND brew --prefix mariadb-connector-c
+        RESULT_VARIABLE brew_result
+        OUTPUT_VARIABLE mariadbclient_MACOS_PREFIX
+        ERROR_QUIET
+    )
+    if(NOT brew_result EQUAL 0)
+        message(FATAL_ERROR "mariadb-connector-c not found in Homebrew")
+    endif()
+    string(STRIP "${mariadbclient_MACOS_PREFIX}" mariadbclient_MACOS_PREFIX)
+    list(PREPEND CMAKE_PREFIX_PATH ${mariadbclient_MACOS_PREFIX})
     pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
 endif()
 
 if(NOT mariadbclient_PKGCONF_FOUND)
-    message(FATAL_ERROR "pkg_config cannot find mariadb")
+    message(FATAL_ERROR "PkgConfig cannot find mariadb")
 endif()
 
 # Set include directory

--- a/components/core/cmake/Modules/FindMariaDBClient.cmake
+++ b/components/core/cmake/Modules/FindMariaDBClient.cmake
@@ -36,7 +36,7 @@ if(NOT mariadbclient_PKGCONF_FOUND AND APPLE)
 endif()
 
 if(NOT mariadbclient_PKGCONF_FOUND)
-    message(FATAL_ERROR "PkgConfig cannot find mariadb")
+    message(FATAL_ERROR "pkg-config cannot find ${mariadbclient_LIBNAME}")
 endif()
 
 # Set include directory

--- a/components/core/cmake/Modules/FindMariaDBClient.cmake
+++ b/components/core/cmake/Modules/FindMariaDBClient.cmake
@@ -20,6 +20,17 @@ include(cmake/Modules/FindLibraryDependencies.cmake)
 find_package(PkgConfig)
 pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
 
+if (NOT mariadbclient_PKGCONF_FOUND AND APPLE)
+    execute_process(COMMAND brew --prefix mariadb-connector-c OUTPUT_VARIABLE mariadb_MACOS_PREFIX)
+    string(STRIP "${mariadb_MACOS_PREFIX}" mariadb_MACOS_PREFIX)
+    set(CMAKE_PREFIX_PATH "${mariadb_MACOS_PREFIX};${CMAKE_PREFIX_PATH}")
+    pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
+endif()
+
+if (NOT mariadbclient_PKGCONF_FOUND)
+    message(FATAL_ERROR "pkg_config cannot find mariadb")
+endif ()
+
 # Set include directory
 find_path(MariaDBClient_INCLUDE_DIR mysql.h
         HINTS ${mariadbclient_PKGCONF_INCLUDEDIR}

--- a/components/core/cmake/Modules/FindMariaDBClient.cmake
+++ b/components/core/cmake/Modules/FindMariaDBClient.cmake
@@ -20,16 +20,16 @@ include(cmake/Modules/FindLibraryDependencies.cmake)
 find_package(PkgConfig)
 pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
 
-if (NOT mariadbclient_PKGCONF_FOUND AND APPLE)
+if(NOT mariadbclient_PKGCONF_FOUND AND APPLE)
     execute_process(COMMAND brew --prefix mariadb-connector-c OUTPUT_VARIABLE mariadb_MACOS_PREFIX)
     string(STRIP "${mariadb_MACOS_PREFIX}" mariadb_MACOS_PREFIX)
     set(CMAKE_PREFIX_PATH "${mariadb_MACOS_PREFIX};${CMAKE_PREFIX_PATH}")
     pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
 endif()
 
-if (NOT mariadbclient_PKGCONF_FOUND)
+if(NOT mariadbclient_PKGCONF_FOUND)
     message(FATAL_ERROR "pkg_config cannot find mariadb")
-endif ()
+endif()
 
 # Set include directory
 find_path(MariaDBClient_INCLUDE_DIR mysql.h

--- a/components/core/cmake/Modules/FindMariaDBClient.cmake
+++ b/components/core/cmake/Modules/FindMariaDBClient.cmake
@@ -23,12 +23,15 @@ pkg_check_modules(mariadbclient_PKGCONF QUIET "lib${mariadbclient_LIBNAME}")
 if(NOT mariadbclient_PKGCONF_FOUND AND APPLE)
     execute_process(
         COMMAND brew --prefix mariadb-connector-c
-        RESULT_VARIABLE brew_result
+        RESULT_VARIABLE mariadbclient_BREW_RESULT
         OUTPUT_VARIABLE mariadbclient_MACOS_PREFIX
-        ERROR_QUIET
     )
-    if(NOT brew_result EQUAL 0)
-        message(FATAL_ERROR "mariadb-connector-c not found in Homebrew")
+    if(NOT mariadbclient_BREW_RESULT EQUAL 0)
+        message(
+            FATAL_ERROR
+            "pkg-config cannot find ${mariadbclient_LIBNAME} and mariadb-connector-c isn't"
+            " installed via Homebrew"
+        )
     endif()
     string(STRIP "${mariadbclient_MACOS_PREFIX}" mariadbclient_MACOS_PREFIX)
     list(PREPEND CMAKE_PREFIX_PATH ${mariadbclient_MACOS_PREFIX})


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Recent macOS build workflow failed due to the version bump of `mariadb-connector-c`: https://github.com/y-scope/clp/actions/runs/11760063129
The detailed log message:
```
==> Installing mariadb-connector-c
==> Pouring mariadb-connector-c--3.4.1_1.arm64_sonoma.bottle.tar.gz
==> Caveats
mariadb-connector-c is keg-only, which means it was not symlinked into /opt/homebrew,
because it conflicts with mariadb.

If you need to have mariadb-connector-c first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/mariadb-connector-c/bin:$PATH"' >> /Users/runner/.bash_profile

For compilers to find mariadb-connector-c you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/mariadb-connector-c/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/mariadb-connector-c/include"

For pkg-config to find mariadb-connector-c you may need to set:
  export PKG_CONFIG_PATH="/opt/homebrew/opt/mariadb-connector-c/lib/pkgconfig"
```
This PR fixes the issue by changing the cmake file to detect `mariadb-connector-c`'s homebrew path on macOS if `PkgConfig` failed to locate mariadb client.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Tested locally to ensure the built successes with the new cmake and newly installed `mariadb-connector-c`
- Ensure macOS workflow passed: https://github.com/LinZhihao-723/clp/actions/runs/11761344531


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved detection of the MariaDB client library on macOS systems.
	- Enhanced error handling with clearer feedback if the library is not found.

- **Bug Fixes**
	- Resolved issues with package configuration checks for the MariaDB client library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->