### PR TITLE
ci: Schedule GitHub workflows to daily run to detect failures due to upgraded dependencies or environments.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -27,6 +27,9 @@ on:
       - "deps-tasks.yml"
       - "Taskfile.yml"
       - "tools/scripts/deps-download/**"
+  schedule:
+    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    - cron: "15 0 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -28,7 +28,7 @@ on:
       - "Taskfile.yml"
       - "tools/scripts/deps-download/**"
   schedule:
-    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"
   workflow_dispatch:
 

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -24,7 +24,7 @@ on:
       - "tools/scripts/deps-download/**"
       - "!components/core/tools/scripts/lib_install/macos/**"
   schedule:
-    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"
   workflow_dispatch:
 

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -23,6 +23,9 @@ on:
       - "Taskfile.yml"
       - "tools/scripts/deps-download/**"
       - "!components/core/tools/scripts/lib_install/macos/**"
+  schedule:
+    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    - cron: "15 0 * * *"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/clp-docs.yaml
+++ b/.github/workflows/clp-docs.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
   schedule:
-    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"
   workflow_dispatch:
 

--- a/.github/workflows/clp-docs.yaml
+++ b/.github/workflows/clp-docs.yaml
@@ -3,6 +3,9 @@ name: "clp-docs"
 on:
   pull_request:
   push:
+  schedule:
+    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    - cron: "15 0 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -11,6 +11,9 @@ on:
       - ".github/actions/clp-execution-image-build/action.yaml"
       - ".github/workflows/clp-execution-image-build.yaml"
       - "tools/docker-images/**/*"
+  schedule:
+    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    - cron: "15 0 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/clp-execution-image-build.yaml"
       - "tools/docker-images/**/*"
   schedule:
-    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"
   workflow_dispatch:
 

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
   schedule:
-    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"
   workflow_dispatch:
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
After realizing things will break weekly due to gh-action environment upgrades, we decided to schedule our gh workflows to run every midnight so that we know sth is broken.



# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Ensure workflows passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced scheduled triggers for multiple workflows, allowing them to run daily at 00:15 UTC.
		- Workflows affected: `clp-core-build-macos`, `clp-core-build`, `clp-docs`, and `clp-execution-image-build`.
	- Updated comments in the `clp-lint` workflow for clarity regarding the scheduling.

These enhancements improve automation and ensure timely execution of builds and documentation processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->