### PR TITLE
feat(clp-s): Record log-order at compression time.

### DIFF
--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -27,7 +27,7 @@ void ArchiveReader::open(string_view archives_dir, string_view archive_id) {
     m_schema_tree = ReaderUtils::read_schema_tree(archive_path_str);
     m_schema_map = ReaderUtils::read_schemas(archive_path_str);
 
-    m_log_event_idx_column_id = m_schema_tree->get_internal_field_id(constants::cLogEventIdxName);
+    m_log_event_idx_column_id = m_schema_tree->get_metadata_field_id(constants::cLogEventIdxName);
 
     m_table_metadata_file_reader.open(archive_path_str + constants::cArchiveTableMetadataFile);
     m_stream_reader.open_packed_streams(archive_path_str + constants::cArchiveTablesFile);

--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -27,6 +27,8 @@ void ArchiveReader::open(string_view archives_dir, string_view archive_id) {
     m_schema_tree = ReaderUtils::read_schema_tree(archive_path_str);
     m_schema_map = ReaderUtils::read_schemas(archive_path_str);
 
+    m_log_event_idx_column_id = m_schema_tree->get_internal_field_id(constants::cLogEventIdxName);
+
     m_table_metadata_file_reader.open(archive_path_str + constants::cArchiveTableMetadataFile);
     m_stream_reader.open_packed_streams(archive_path_str + constants::cArchiveTablesFile);
 }
@@ -310,6 +312,12 @@ void ArchiveReader::initialize_schema_reader(
         }
         BaseColumnReader* column_reader = append_reader_column(reader, column_id);
 
+        if (column_id == m_log_event_idx_column_id
+            && nullptr != dynamic_cast<Int64ColumnReader*>(column_reader))
+        {
+            reader.mark_column_as_log_event_idx(static_cast<Int64ColumnReader*>(column_reader));
+        }
+
         if (should_extract_timestamp && column_reader && timestamp_column_ids.count(column_id) > 0)
         {
             reader.mark_column_as_timestamp(column_reader);
@@ -346,6 +354,7 @@ void ArchiveReader::close() {
     m_cur_stream_id = 0;
     m_stream_buffer.reset();
     m_stream_buffer_size = 0ULL;
+    m_log_event_idx_column_id = -1;
 }
 
 std::shared_ptr<char[]> ArchiveReader::read_stream(size_t stream_id, bool reuse_buffer) {

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -142,6 +142,11 @@ public:
         m_projection = projection;
     }
 
+    /**
+     * @return true if this archive has log ordering information, and false otherwise.
+     */
+    bool has_log_order() { return m_log_event_idx_column_id >= 0; }
+
 private:
     /**
      * Initializes a schema reader passed by reference to become a reader for a given schema.

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -214,6 +214,7 @@ private:
     std::shared_ptr<char[]> m_stream_buffer{};
     size_t m_stream_buffer_size{0ULL};
     size_t m_cur_stream_id{0ULL};
+    int32_t m_log_event_idx_column_id{-1};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -68,6 +68,7 @@ void ArchiveWriter::close() {
     m_encoded_message_size = 0UL;
     m_uncompressed_size = 0UL;
     m_compressed_size = 0UL;
+    m_next_log_event_id = 0;
 }
 
 void ArchiveWriter::append_message(
@@ -86,6 +87,7 @@ void ArchiveWriter::append_message(
     }
 
     m_encoded_message_size += schema_writer->append_message(message);
+    ++m_next_log_event_id;
 }
 
 size_t ArchiveWriter::get_data_size() {

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_ARCHIVEWRITER_HPP
 #define CLP_S_ARCHIVEWRITER_HPP
 
+#include <string_view>
 #include <utility>
 
 #include <boost/filesystem.hpp>
@@ -93,9 +94,14 @@ public:
      * @param key
      * @return the node id
      */
-    int32_t add_node(int parent_node_id, NodeType type, std::string const& key) {
+    int32_t add_node(int parent_node_id, NodeType type, std::string_view const key) {
         return m_schema_tree.add_node(parent_node_id, type, key);
     }
+
+    /**
+     * @return the Id the next log event should receive when appended to the archive.
+     */
+    int64_t get_next_log_event_id() const { return m_next_log_event_id; }
 
     /**
      * Return a schema's Id and add the schema to the
@@ -174,6 +180,7 @@ private:
     size_t m_encoded_message_size{};
     size_t m_uncompressed_size{};
     size_t m_compressed_size{};
+    int64_t m_next_log_event_id{};
 
     std::string m_id;
 

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -99,7 +99,7 @@ public:
     }
 
     /**
-     * @return the Id the next log event should receive when appended to the archive.
+     * @return The Id that will be assigned to the next log event when appended to the archive.
      */
     int64_t get_next_log_event_id() const { return m_next_log_event_id; }
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -189,11 +189,15 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                     "print-archive-stats",
                     po::bool_switch(&m_print_archive_stats),
-                    "Print statistics (json) about the archive after it's compressed."
+                    "Print statistics (json) about the archixve after it's compressed."
             )(
                     "structurize-arrays",
                     po::bool_switch(&m_structurize_arrays),
                     "Structurize arrays instead of compressing them as clp strings."
+            )(
+                    "disable-log-order",
+                    po::bool_switch(&m_no_record_log_order),
+                    "Do not record log order at ingestion time."
             );
             // clang-format on
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -296,13 +296,13 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             decompression_options.add_options()(
                     "ordered",
                     po::bool_switch(&m_ordered_decompression),
-                    "Enable decompression in ascending timestamp order for this archive"
+                    "Enable decompression in log order for this archive"
             )(
                     "ordered-chunk-size",
                     po::value<size_t>(&m_ordered_chunk_size)
                             ->default_value(m_ordered_chunk_size),
                     "Number of records to include in each output file when decompressing records "
-                    "in ascending timestamp order"
+                    "in log order"
             );
             // clang-format on
             extraction_options.add(decompression_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -189,14 +189,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                     "print-archive-stats",
                     po::bool_switch(&m_print_archive_stats),
-                    "Print statistics (json) about the archixve after it's compressed."
+                    "Print statistics (json) about the archive after it's compressed."
             )(
                     "structurize-arrays",
                     po::bool_switch(&m_structurize_arrays),
                     "Structurize arrays instead of compressing them as clp strings."
             )(
                     "disable-log-order",
-                    po::bool_switch(&m_no_record_log_order),
+                    po::bool_switch(&m_disable_log_order),
                     "Do not record log order at ingestion time."
             );
             // clang-format on

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -112,7 +112,7 @@ public:
 
     std::vector<std::string> const& get_projection_columns() const { return m_projection_columns; }
 
-    bool get_record_log_order() const { return false == m_no_record_log_order; }
+    bool get_record_log_order() const { return false == m_disable_log_order; }
 
 private:
     // Methods
@@ -180,7 +180,7 @@ private:
     bool m_ordered_decompression{false};
     size_t m_ordered_chunk_size{0};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
-    bool m_no_record_log_order{false};
+    bool m_disable_log_order{false};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -112,6 +112,8 @@ public:
 
     std::vector<std::string> const& get_projection_columns() const { return m_projection_columns; }
 
+    bool get_record_log_order() const { return false == m_no_record_log_order; }
+
 private:
     // Methods
     /**
@@ -178,6 +180,7 @@ private:
     bool m_ordered_decompression{false};
     size_t m_ordered_chunk_size{0};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
+    bool m_no_record_log_order{false};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -97,6 +97,8 @@ void JsonConstructor::construct_in_order() {
 
     std::vector<bsoncxx::document::value> results;
     auto finalize_chunk = [&](bool open_new_writer) {
+        // Add one to last_idx to match clp's behaviour of having the end index be exclusive
+        ++last_idx;
         writer.close();
         std::string new_file_name = src_path.string() + "_" + std::to_string(first_idx) + "_"
                                     + std::to_string(last_idx) + ".jsonl";

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -54,7 +54,7 @@ void JsonConstructor::store() {
                     "log order. Falling back to out of order decompression.");
     }
 
-    if (false == m_option.ordered) {
+    if (false == m_option.ordered || false == m_archive_reader->has_log_order()) {
         FileWriter writer;
         writer.open(
                 m_option.output_dir + "/original",

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -48,6 +48,12 @@ void JsonConstructor::store() {
     m_archive_reader = std::make_unique<ArchiveReader>();
     m_archive_reader->open(m_option.archives_dir, m_option.archive_id);
     m_archive_reader->read_dictionaries_and_metadata();
+
+    if (m_option.ordered && false == m_archive_reader->has_log_order()) {
+        SPDLOG_WARN("This archive is missing ordering information and can not be decompressed in "
+                    "log order. Falling back to out of order decompression.");
+    }
+
     if (false == m_option.ordered) {
         FileWriter writer;
         writer.open(

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -66,7 +66,7 @@ public:
 private:
     /**
      * Reads all of the tables from m_archive_reader and writes all of the records
-     * they contain to writer in timestamp order.
+     * they contain to writer in log order.
      */
     void construct_in_order();
 

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -467,8 +467,8 @@ bool JsonParser::parse() {
                 return false;
             }
 
-            // Add internal log_event_idx field to record
-            auto log_event_idx = add_internal_field(constants::cLogEventIdxName, NodeType::Integer);
+            // Add log_event_idx field to metadata for record
+            auto log_event_idx = add_metadata_field(constants::cLogEventIdxName, NodeType::Integer);
             m_current_parsed_message.add_value(
                     log_event_idx,
                     m_archive_writer->get_next_log_event_id()
@@ -534,13 +534,13 @@ bool JsonParser::parse() {
     return true;
 }
 
-int32_t JsonParser::add_internal_field(std::string_view const field_name, NodeType type) {
-    auto internal_subtree_id = m_archive_writer->add_node(
+int32_t JsonParser::add_metadata_field(std::string_view const field_name, NodeType type) {
+    auto metadata_subtree_id = m_archive_writer->add_node(
             constants::cRootNodeId,
-            NodeType::Internal,
-            constants::cInternalSubtreeName
+            NodeType::Metadata,
+            constants::cMetadataSubtreeName
     );
-    return m_archive_writer->add_node(internal_subtree_id, type, field_name);
+    return m_archive_writer->add_node(metadata_subtree_id, type, field_name);
 }
 
 void JsonParser::store() {

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -463,8 +463,7 @@ bool JsonParser::parse() {
             }
 
             // Add internal log_event_idx field to record
-            auto log_event_idx
-                    = get_internal_field_id(constants::cLogEventIdxName, NodeType::Integer);
+            auto log_event_idx = add_internal_field(constants::cLogEventIdxName, NodeType::Integer);
             m_current_parsed_message.add_value(
                     log_event_idx,
                     m_archive_writer->get_next_log_event_id()
@@ -530,7 +529,7 @@ bool JsonParser::parse() {
     return true;
 }
 
-int32_t JsonParser::get_internal_field_id(std::string_view const field_name, NodeType type) {
+int32_t JsonParser::add_internal_field(std::string_view const field_name, NodeType type) {
     auto internal_subtree_id = m_archive_writer->add_node(
             constants::cRootNodeId,
             NodeType::Internal,

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -93,6 +94,14 @@ private:
      * Splits the archive if the size of the archive exceeds the maximum size
      */
     void split_archive();
+
+    /**
+     * Gets the node ID for an internal field, and adds it to the schema tree if it does not exist.
+     *
+     * Note: this method should be called before parsing a record so that internal fields come first
+     * in each table. This isn't strictly necessary, but it is a nice convention.
+     */
+    int32_t get_internal_field_id(std::string_view const field_name, NodeType type);
 
     int m_num_messages;
     std::vector<std::string> m_file_paths;

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -96,7 +96,7 @@ private:
     void split_archive();
 
     /**
-     * Add an internal field to the MPT and get its Id.
+     * Adds an internal field to the MPT and get its Id.
      *
      * Note: this method should be called before parsing a record so that internal fields come first
      * in each table. This isn't strictly necessary, but it is a nice convention.

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -96,12 +96,12 @@ private:
     void split_archive();
 
     /**
-     * Gets the node ID for an internal field, and adds it to the schema tree if it does not exist.
+     * Add an internal field to the MPT and get its Id.
      *
      * Note: this method should be called before parsing a record so that internal fields come first
      * in each table. This isn't strictly necessary, but it is a nice convention.
      */
-    int32_t get_internal_field_id(std::string_view const field_name, NodeType type);
+    int32_t add_internal_field(std::string_view const field_name, NodeType type);
 
     int m_num_messages;
     std::vector<std::string> m_file_paths;

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -31,12 +31,13 @@ struct JsonParserOption {
     std::vector<std::string> file_paths;
     std::string timestamp_key;
     std::string archives_dir;
-    size_t target_encoded_size;
-    size_t max_document_size;
-    size_t min_table_size;
-    int compression_level;
-    bool print_archive_stats;
-    bool structurize_arrays;
+    size_t target_encoded_size{};
+    size_t max_document_size{};
+    size_t min_table_size{};
+    int compression_level{};
+    bool print_archive_stats{};
+    bool structurize_arrays{};
+    bool record_log_order{true};
     std::shared_ptr<clp::GlobalMySQLMetadataDB> metadata_db;
 };
 
@@ -118,6 +119,7 @@ private:
     size_t m_target_encoded_size;
     size_t m_max_document_size;
     bool m_structurize_arrays{false};
+    bool m_record_log_order{true};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -101,7 +101,7 @@ private:
      * Note: this method should be called before parsing a record so that internal fields come first
      * in each table. This isn't strictly necessary, but it is a nice convention.
      */
-    int32_t add_internal_field(std::string_view const field_name, NodeType type);
+    int32_t add_metadata_field(std::string_view const field_name, NodeType type);
 
     int m_num_messages;
     std::vector<std::string> m_file_paths;

--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_JSONSERIALIZER_HPP
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "ColumnReader.hpp"
@@ -66,7 +67,7 @@ public:
         return false;
     }
 
-    void add_special_key(std::string const& key) { m_special_keys.push_back(key); }
+    void add_special_key(std::string_view const key) { m_special_keys.emplace_back(key); }
 
     void begin_object() {
         append_key();
@@ -110,13 +111,13 @@ public:
 
     void append_key() { append_key(m_special_keys[m_special_keys_index++]); }
 
-    void append_key(std::string const& key) {
+    void append_key(std::string_view const key) {
         m_json_string += "\"";
         m_json_string += key;
         m_json_string += "\":";
     }
 
-    void append_value(std::string const& value) {
+    void append_value(std::string_view const value) {
         m_json_string += value;
         m_json_string += ",";
     }

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -18,10 +18,10 @@ std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(std::string const& arc
         throw OperationFailed(error_code, __FILENAME__, __LINE__);
     }
 
+    std::string key;
     for (size_t i = 0; i < num_nodes; i++) {
         int32_t parent_id;
         size_t key_length;
-        std::string key;
         uint8_t node_type;
 
         error_code = schema_tree_decompressor.try_read_numeric_value(parent_id);

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -93,7 +93,7 @@ void SchemaReader::generate_json_string() {
             }
             case JsonSerializer::Op::AddIntField: {
                 column = m_reordered_columns[column_id_index++];
-                auto const& name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
+                auto name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
                 m_json_serializer.append_key(name);
                 m_json_serializer.append_value(
                         std::to_string(std::get<int64_t>(column->extract_value(m_cur_message)))
@@ -109,7 +109,7 @@ void SchemaReader::generate_json_string() {
             }
             case JsonSerializer::Op::AddFloatField: {
                 column = m_reordered_columns[column_id_index++];
-                auto const& name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
+                auto name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
                 m_json_serializer.append_key(name);
                 m_json_serializer.append_value(
                         std::to_string(std::get<double>(column->extract_value(m_cur_message)))
@@ -125,7 +125,7 @@ void SchemaReader::generate_json_string() {
             }
             case JsonSerializer::Op::AddBoolField: {
                 column = m_reordered_columns[column_id_index++];
-                auto const& name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
+                auto name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
                 m_json_serializer.append_key(name);
                 m_json_serializer.append_value(
                         std::get<uint8_t>(column->extract_value(m_cur_message)) != 0 ? "true"
@@ -143,7 +143,7 @@ void SchemaReader::generate_json_string() {
             }
             case JsonSerializer::Op::AddStringField: {
                 column = m_reordered_columns[column_id_index++];
-                auto const& name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
+                auto name = m_global_schema_tree->get_node(column->get_id()).get_key_name();
                 m_json_serializer.append_key(name);
                 m_json_serializer.append_value_from_column_with_quotes(column, m_cur_message);
                 break;
@@ -581,7 +581,7 @@ void SchemaReader::generate_json_template(int32_t id) {
     for (int32_t child_id : children_ids) {
         int32_t child_global_id = m_local_id_to_global_id[child_id];
         auto const& child_node = m_local_schema_tree.get_node(child_id);
-        std::string const& key = child_node.get_key_name();
+        auto key = child_node.get_key_name();
         switch (child_node.get_type()) {
             case NodeType::Object: {
                 m_json_serializer.add_op(JsonSerializer::Op::BeginObject);

--- a/components/core/src/clp_s/SchemaTree.cpp
+++ b/components/core/src/clp_s/SchemaTree.cpp
@@ -5,9 +5,8 @@
 #include "ZstdCompressor.hpp"
 
 namespace clp_s {
-int32_t SchemaTree::add_node(int32_t parent_node_id, NodeType type, std::string const& key) {
-    std::tuple<int32_t, std::string, NodeType> node_key = {parent_node_id, key, type};
-    auto node_it = m_node_map.find(node_key);
+int32_t SchemaTree::add_node(int32_t parent_node_id, NodeType type, std::string_view const key) {
+    auto node_it = m_node_map.find({parent_node_id, key, type});
     if (node_it != m_node_map.end()) {
         auto node_id = node_it->second;
         m_nodes[node_id].increase_count();
@@ -15,16 +14,40 @@ int32_t SchemaTree::add_node(int32_t parent_node_id, NodeType type, std::string 
     }
 
     int32_t node_id = m_nodes.size();
-    auto& node = m_nodes.emplace_back(parent_node_id, node_id, key, type, 0);
+    auto& node = m_nodes.emplace_back(parent_node_id, node_id, std::string{key}, type, 0);
     node.increase_count();
-    if (parent_node_id >= 0) {
+    if (constants::cRootNodeId == parent_node_id) {
+        if (NodeType::Object == type) {
+            m_object_subtree_id = node_id;
+        } else if (NodeType::Internal == type) {
+            m_internal_subtree_id = node_id;
+        }
+    }
+
+    if (constants::cRootNodeId != parent_node_id) {
         auto& parent_node = m_nodes[parent_node_id];
         node.set_depth(parent_node.get_depth() + 1);
         parent_node.add_child(node_id);
     }
-    m_node_map[node_key] = node_id;
+    m_node_map[{parent_node_id, node.get_key_name(), type}] = node_id;
 
     return node_id;
+}
+
+int32_t SchemaTree::get_internal_field_id(std::string_view const field_name) {
+    if (m_internal_subtree_id < 0) {
+        return -1;
+    }
+
+    auto& internal_subtree_node = m_nodes[m_internal_subtree_id];
+    for (auto child_id : internal_subtree_node.get_children_ids()) {
+        auto& child_node = m_nodes[child_id];
+        if (child_node.get_key_name() == field_name) {
+            return child_id;
+        }
+    }
+
+    return -1;
 }
 
 size_t SchemaTree::store(std::string const& archives_dir, int compression_level) {

--- a/components/core/src/clp_s/SchemaTree.cpp
+++ b/components/core/src/clp_s/SchemaTree.cpp
@@ -19,8 +19,8 @@ int32_t SchemaTree::add_node(int32_t parent_node_id, NodeType type, std::string_
     if (constants::cRootNodeId == parent_node_id) {
         if (NodeType::Object == type) {
             m_object_subtree_id = node_id;
-        } else if (NodeType::Internal == type) {
-            m_internal_subtree_id = node_id;
+        } else if (NodeType::Metadata == type) {
+            m_metadata_subtree_id = node_id;
         }
     }
 
@@ -34,13 +34,13 @@ int32_t SchemaTree::add_node(int32_t parent_node_id, NodeType type, std::string_
     return node_id;
 }
 
-int32_t SchemaTree::get_internal_field_id(std::string_view const field_name) {
-    if (m_internal_subtree_id < 0) {
+int32_t SchemaTree::get_metadata_field_id(std::string_view const field_name) {
+    if (m_metadata_subtree_id < 0) {
         return -1;
     }
 
-    auto& internal_subtree_node = m_nodes[m_internal_subtree_id];
-    for (auto child_id : internal_subtree_node.get_children_ids()) {
+    auto& metadata_subtree_node = m_nodes[m_metadata_subtree_id];
+    for (auto child_id : metadata_subtree_node.get_children_ids()) {
         auto& child_node = m_nodes[child_id];
         if (child_node.get_key_name() == field_name) {
             return child_id;

--- a/components/core/src/clp_s/SchemaTree.cpp
+++ b/components/core/src/clp_s/SchemaTree.cpp
@@ -29,7 +29,7 @@ int32_t SchemaTree::add_node(int32_t parent_node_id, NodeType type, std::string_
         node.set_depth(parent_node.get_depth() + 1);
         parent_node.add_child(node_id);
     }
-    m_node_map[{parent_node_id, node.get_key_name(), type}] = node_id;
+    m_node_map.emplace(std::make_tuple(parent_node_id, node.get_key_name(), type), node_id);
 
     return node_id;
 }
@@ -64,9 +64,9 @@ size_t SchemaTree::store(std::string const& archives_dir, int compression_level)
     for (auto const& node : m_nodes) {
         schema_tree_compressor.write_numeric_value(node.get_parent_id());
 
-        std::string const& key = node.get_key_name();
+        auto key = node.get_key_name();
         schema_tree_compressor.write_numeric_value(key.size());
-        schema_tree_compressor.write_string(key);
+        schema_tree_compressor.write(key.begin(), key.size());
         schema_tree_compressor.write_numeric_value(node.get_type());
     }
 

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -90,7 +90,7 @@ private:
     std::vector<int32_t> m_children_ids;
     // We use a buffer so that references to this key name are stable after this SchemaNode is move
     // constructed
-    std::unique_ptr<char[]> m_key_buf;
+    std::unique_ptr<char[]> m_key_name_buf;
     std::string_view m_key_name;
     NodeType m_type;
     int32_t m_count;

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -127,7 +127,7 @@ public:
     }
 
     /**
-     * @return the Id of the root of the Object sub-tree.
+     * @return the Id of the root of the Object sub-tree that records the structure of JSON data.
      * @return -1 if the Object sub-tree does not exist.
      */
     int32_t get_object_subtree_node_id() const { return m_object_subtree_id; }

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -120,11 +120,10 @@ public:
     int32_t get_object_subtree_node_id() const { return m_object_subtree_id; }
 
     /**
-     * Get the field Id of some field in the Internal subtree.
+     * Get the field Id for a specified field within the Internal subtree.
      * @param field_name
      *
-     * @return the field Id of some field in the Internal subtree.
-     * @return -1 if the field does not exist.
+     * @return the field Id if the field exists within the Internal sub-tree, -1 otherwise.
      */
     int32_t get_internal_field_id(std::string_view const field_name);
 

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <absl/container/flat_hash_map.h>
@@ -21,6 +22,7 @@ enum class NodeType : uint8_t {
     NullValue,
     DateString,
     StructuredArray,
+    Internal,
     Unknown = std::underlying_type<NodeType>::type(~0ULL)
 };
 
@@ -81,7 +83,7 @@ class SchemaTree {
 public:
     SchemaTree() = default;
 
-    int32_t add_node(int parent_node_id, NodeType type, std::string const& key);
+    int32_t add_node(int parent_node_id, NodeType type, std::string_view const key);
 
     bool has_node(int32_t id) { return id < m_nodes.size() && id >= 0; }
 
@@ -93,7 +95,26 @@ public:
         return m_nodes[id];
     }
 
-    int32_t get_root_node_id() const { return m_nodes[0].get_id(); }
+    /**
+     * @return the Id of the root of the Object sub-tree.
+     * @return -1 if the Object sub-tree does not exist.
+     */
+    int32_t get_object_subtree_node_id() const { return m_object_subtree_id; }
+
+    /**
+     * Get the field Id of some field in the Internal subtree.
+     * @param field_name
+     *
+     * @return the field Id of some field in the Internal subtree.
+     * @return -1 if the field does not exist.
+     */
+    int32_t get_internal_field_id(std::string_view const field_name);
+
+    /**
+     * @return the Id of the root of the Internal sub-tree.
+     * @return -1 if the Internal sub-tree does not exist.
+     */
+    int32_t get_internal_subtree_node_id() { return m_internal_subtree_id; }
 
     std::vector<SchemaNode> const& get_nodes() const { return m_nodes; }
 
@@ -129,7 +150,9 @@ public:
 
 private:
     std::vector<SchemaNode> m_nodes;
-    absl::flat_hash_map<std::tuple<int32_t, std::string, NodeType>, int32_t> m_node_map;
+    absl::flat_hash_map<std::tuple<int32_t, std::string_view const, NodeType>, int32_t> m_node_map;
+    int32_t m_object_subtree_id{-1};
+    int32_t m_internal_subtree_id{-1};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -21,7 +21,7 @@ constexpr char cArchiveVarDictFile[] = "/var.dict";
 // Schema tree constants
 constexpr char cRootNodeName[] = "";
 constexpr int32_t cRootNodeId = -1;
-constexpr char cInternalSubtreeName[] = "";
+constexpr char cMetadataSubtreeName[] = "";
 constexpr char cLogEventIdxName[] = "log_event_idx";
 
 namespace results_cache::decompression {

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -1,6 +1,8 @@
 #ifndef CLP_S_ARCHIVE_CONSTANTS_HPP
 #define CLP_S_ARCHIVE_CONSTANTS_HPP
 
+#include <cstdint>
+
 namespace clp_s::constants {
 // Schema files
 constexpr char cArchiveSchemaMapFile[] = "/schema_ids";
@@ -16,6 +18,12 @@ constexpr char cArchiveLogDictFile[] = "/log.dict";
 constexpr char cArchiveTimestampDictFile[] = "/timestamp.dict";
 constexpr char cArchiveVarDictFile[] = "/var.dict";
 
+// Schema tree constants
+constexpr char cRootNodeName[] = "";
+constexpr int32_t cRootNodeId = -1;
+constexpr char cInternalSubtreeName[] = "";
+constexpr char cLogEventIdxName[] = "log_event_idx";
+
 namespace results_cache::decompression {
 constexpr char cPath[]{"path"};
 constexpr char cOrigFileId[]{"orig_file_id"};
@@ -23,6 +31,14 @@ constexpr char cBeginMsgIx[]{"begin_msg_ix"};
 constexpr char cEndMsgIx[]{"end_msg_ix"};
 constexpr char cIsLastIrChunk[]{"is_last_ir_chunk"};
 }  // namespace results_cache::decompression
+
+namespace results_cache::search {
+constexpr char cOrigFilePath[]{"orig_file_path"};
+constexpr char cLogEventIx[]{"log_event_ix"};
+constexpr char cTimestamp[]{"timestamp"};
+constexpr char cMessage[]{"message"};
+constexpr char cArchiveId[]{"archive_id"};
+}  // namespace results_cache::search
 
 }  // namespace clp_s::constants
 #endif  // CLP_S_ARCHIVE_CONSTANTS_HPP

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -96,6 +96,7 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     option.timestamp_key = command_line_arguments.get_timestamp_key();
     option.print_archive_stats = command_line_arguments.print_archive_stats();
     option.structurize_arrays = command_line_arguments.get_structurize_arrays();
+    option.record_log_order = command_line_arguments.get_record_log_order();
 
     auto const& db_config_container = command_line_arguments.get_metadata_db_config();
     if (db_config_container.has_value()) {

--- a/components/core/src/clp_s/search/ColumnDescriptor.hpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Literal.hpp"
@@ -22,7 +23,7 @@ public:
      * wildcards
      * @param token the string to initialize the token from
      */
-    explicit DescriptorToken(std::string const& token)
+    explicit DescriptorToken(std::string_view const token)
             : m_token(token),
               m_wildcard(false),
               m_regex(false) {

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -138,14 +138,15 @@ void Output::init(
 
     for (auto column_reader : column_readers) {
         auto column_id = column_reader->get_id();
+        if (0 != m_metadata_columns.count(column_id)) {
+            continue;
+        }
+
         if ((0
              != (m_wildcard_type_mask
                  & node_to_literal_type(m_schema_tree->get_node(column_id).get_type())))
             || m_match.schema_searches_against_column(schema_id, column_id))
         {
-            if (0 != m_metadata_columns.count(column_id)) {
-                continue;
-            }
             ClpStringColumnReader* clp_reader = dynamic_cast<ClpStringColumnReader*>(column_reader);
             VariableStringColumnReader* var_reader
                     = dynamic_cast<VariableStringColumnReader*>(column_reader);

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -62,6 +62,7 @@ bool Output::filter() {
         }
     }
 
+    populate_internal_columns();
     populate_string_queries(top_level_expr);
 
     std::string message;
@@ -92,9 +93,10 @@ bool Output::filter() {
         reader.initialize_filter(this);
 
         if (m_output_handler->should_output_metadata()) {
-            epochtime_t timestamp;
-            while (reader.get_next_message_with_timestamp(message, timestamp, this)) {
-                m_output_handler->write(message, timestamp, archive_id);
+            epochtime_t timestamp{};
+            int64_t log_event_idx{};
+            while (reader.get_next_message_with_metadata(message, timestamp, log_event_idx, this)) {
+                m_output_handler->write(message, timestamp, archive_id, log_event_idx);
             }
         } else {
             while (reader.get_next_message(message, this)) {
@@ -136,10 +138,11 @@ void Output::init(
 
     for (auto column_reader : column_readers) {
         auto column_id = column_reader->get_id();
-        if ((0
-             != (m_wildcard_type_mask
-                 & node_to_literal_type(m_schema_tree->get_node(column_id).get_type())))
-            || m_match.schema_searches_against_column(schema_id, column_id))
+        if (((0
+              != (m_wildcard_type_mask
+                  & node_to_literal_type(m_schema_tree->get_node(column_id).get_type())))
+             || m_match.schema_searches_against_column(schema_id, column_id))
+            && 0 == m_internal_columns.count(column_id))
         {
             ClpStringColumnReader* clp_reader = dynamic_cast<ClpStringColumnReader*>(column_reader);
             VariableStringColumnReader* var_reader
@@ -959,6 +962,19 @@ void Output::populate_string_queries(std::shared_ptr<Expression> const& expr) {
     }
 }
 
+void Output::populate_internal_columns() {
+    int32_t internal_subtree_root_node_id = m_schema_tree->get_internal_subtree_node_id();
+    if (-1 == internal_subtree_root_node_id) {
+        return;
+    }
+
+    // This code assumes that the internal subtree contains no nested structures
+    auto& internal_node = m_schema_tree->get_node(internal_subtree_root_node_id);
+    for (auto child_id : internal_node.get_children_ids()) {
+        m_internal_columns.insert(child_id);
+    }
+}
+
 void Output::populate_searched_wildcard_columns(std::shared_ptr<Expression> const& expr) {
     if (expr->has_only_expression_operands()) {
         for (auto const& op : expr->get_op_list()) {
@@ -973,6 +989,9 @@ void Output::populate_searched_wildcard_columns(std::shared_ptr<Expression> cons
         LiteralTypeBitmask matching_types{0};
         for (int32_t node : (*m_schemas)[m_schema]) {
             if (Schema::schema_entry_is_unordered_object(node)) {
+                continue;
+            }
+            if (0 != m_internal_columns.count(node)) {
                 continue;
             }
             auto tree_node_type = m_schema_tree->get_node(node).get_type();

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -89,7 +89,7 @@ private:
     std::vector<ColumnDescriptor*> m_wildcard_columns;
     std::map<ColumnDescriptor*, std::set<int32_t>> m_wildcard_to_searched_basic_columns;
     LiteralTypeBitmask m_wildcard_type_mask{0};
-    std::unordered_set<int32_t> m_internal_columns;
+    std::unordered_set<int32_t> m_metadata_columns;
 
     std::stack<
             std::pair<ExpressionType, OpList::iterator>,

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <stack>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -88,6 +89,7 @@ private:
     std::vector<ColumnDescriptor*> m_wildcard_columns;
     std::map<ColumnDescriptor*, std::set<int32_t>> m_wildcard_to_searched_basic_columns;
     LiteralTypeBitmask m_wildcard_type_mask{0};
+    std::unordered_set<int32_t> m_internal_columns;
 
     std::stack<
             std::pair<ExpressionType, OpList::iterator>,
@@ -341,6 +343,11 @@ private:
      * @param expr
      */
     void populate_string_queries(std::shared_ptr<Expression> const& expr);
+
+    /**
+     * Populates the set of internal columns that get ignored during dynamic wildcard expansion.
+     */
+    void populate_internal_columns();
 
     /**
      * Constant propagates an expression

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -43,9 +43,14 @@ public:
      * @param message The message in the log event.
      * @param timestamp The timestamp of the log event.
      * @param archive_id The archive containing the log event.
+     * @param log_event_idx The index of the log event within an archive.
      */
-    virtual void write(std::string_view message, epochtime_t timestamp, std::string_view archive_id)
-            = 0;
+    virtual void write(
+            std::string_view message,
+            epochtime_t timestamp,
+            std::string_view archive_id,
+            int64_t log_event_idx
+    ) = 0;
 
     /**
      * Writes a message to the output handler.
@@ -84,9 +89,13 @@ public:
             : OutputHandler(should_output_metadata, true) {}
 
     // Methods inherited from OutputHandler
-    void
-    write(std::string_view message, epochtime_t timestamp, std::string_view archive_id) override {
-        std::cout << archive_id << ": " << timestamp << " " << message;
+    void write(
+            std::string_view message,
+            epochtime_t timestamp,
+            std::string_view archive_id,
+            int64_t log_event_idx
+    ) override {
+        std::cout << archive_id << ": " << log_event_idx << ": " << timestamp << " " << message;
     }
 
     void write(std::string_view message) override { std::cout << message; }
@@ -120,10 +129,14 @@ public:
     }
 
     // Methods inherited from OutputHandler
-    void
-    write(std::string_view message, epochtime_t timestamp, std::string_view archive_id) override;
+    void write(
+            std::string_view message,
+            epochtime_t timestamp,
+            std::string_view archive_id,
+            int64_t log_event_idx
+    ) override;
 
-    void write(std::string_view message) override { write(message, 0, {}); }
+    void write(std::string_view message) override { write(message, 0, {}, 0); }
 
 private:
     std::string m_host;
@@ -143,17 +156,20 @@ public:
                 std::string_view original_path,
                 std::string_view message,
                 epochtime_t timestamp,
-                std::string_view archive_id
+                std::string_view archive_id,
+                int64_t log_event_idx
         )
                 : original_path(original_path),
                   message(message),
                   timestamp(timestamp),
-                  archive_id(archive_id) {}
+                  archive_id(archive_id),
+                  log_event_idx(log_event_idx) {}
 
         std::string original_path;
         std::string message;
         epochtime_t timestamp;
         std::string archive_id;
+        int64_t log_event_idx;
     };
 
     struct QueryResultGreaterTimestampComparator {
@@ -189,10 +205,14 @@ public:
      */
     ErrorCode flush() override;
 
-    void
-    write(std::string_view message, epochtime_t timestamp, std::string_view archive_id) override;
+    void write(
+            std::string_view message,
+            epochtime_t timestamp,
+            std::string_view archive_id,
+            int64_t log_event_idx
+    ) override;
 
-    void write(std::string_view message) override { write(message, 0, {}); }
+    void write(std::string_view message) override { write(message, 0, {}, 0); }
 
 private:
     mongocxx::client m_client;
@@ -216,8 +236,12 @@ public:
     CountOutputHandler(int reducer_socket_fd);
 
     // Methods inherited from OutputHandler
-    void
-    write(std::string_view message, epochtime_t timestamp, std::string_view archive_id) override {}
+    void write(
+            std::string_view message,
+            epochtime_t timestamp,
+            std::string_view archive_id,
+            int64_t log_event_idx
+    ) override {}
 
     void write(std::string_view message) override;
 
@@ -246,8 +270,12 @@ public:
               m_count_by_time_bucket_size{count_by_time_bucket_size} {}
 
     // Methods inherited from OutputHandler
-    void
-    write(std::string_view message, epochtime_t timestamp, std::string_view archive_id) override {
+    void write(
+            std::string_view message,
+            epochtime_t timestamp,
+            std::string_view archive_id,
+            int64_t log_event_idx
+    ) override {
         int64_t bucket = (timestamp / m_count_by_time_bucket_size) * m_count_by_time_bucket_size;
         m_bucket_counts[bucket] += 1;
     }

--- a/components/core/src/clp_s/search/Projection.cpp
+++ b/components/core/src/clp_s/search/Projection.cpp
@@ -52,7 +52,7 @@ void Projection::resolve_column(
      * what we need.
      */
 
-    auto cur_node_id = tree->get_root_node_id();
+    auto cur_node_id = tree->get_object_subtree_node_id();
     auto it = column->descriptor_begin();
     while (it != column->descriptor_end()) {
         bool matched_any{false};

--- a/components/core/src/clp_s/search/SchemaMatch.cpp
+++ b/components/core/src/clp_s/search/SchemaMatch.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<Expression> SchemaMatch::populate_column_mapping(std::shared_ptr
                     auto const* node = &m_tree->get_node(node_id);
                     auto literal_type = node_to_literal_type(node->get_type());
                     DescriptorList descriptors;
-                    while (node->get_id() != m_tree->get_root_node_id()) {
+                    while (node->get_id() != m_tree->get_object_subtree_node_id()) {
                         // may have to explicitly mark non-regex
                         descriptors.emplace_back(node->get_key_name());
                         node = &m_tree->get_node(node->get_parent_id());
@@ -111,9 +111,9 @@ bool SchemaMatch::populate_column_mapping(ColumnDescriptor* column) {
         return matched;
     }
 
-    // TODO: once we start supporting multi-rooted MPTs this (and anything that uses
-    // get_root_node_id, or assumes root node id is 0) will have to change
-    auto const& root = m_tree->get_node(m_tree->get_root_node_id());
+    // TODO: Once we start supporting mixing different types of logs we will have to match against
+    // more than just the object subtree.
+    auto const& root = m_tree->get_node(m_tree->get_object_subtree_node_id());
     for (int32_t child_node_id : root.get_children_ids()) {
         matched |= populate_column_mapping(column, child_node_id);
     }

--- a/components/core/src/clp_s/search/SearchUtils.cpp
+++ b/components/core/src/clp_s/search/SearchUtils.cpp
@@ -34,6 +34,7 @@ LiteralType node_to_literal_type(NodeType type) {
             return LiteralType::NullT;
         case NodeType::DateString:
             return LiteralType::EpochDateT;
+        case NodeType::Internal:
         case NodeType::Unknown:
         default:
             return LiteralType::UnknownT;

--- a/components/core/src/clp_s/search/SearchUtils.cpp
+++ b/components/core/src/clp_s/search/SearchUtils.cpp
@@ -34,7 +34,7 @@ LiteralType node_to_literal_type(NodeType type) {
             return LiteralType::NullT;
         case NodeType::DateString:
             return LiteralType::EpochDateT;
-        case NodeType::Internal:
+        case NodeType::Metadata:
         case NodeType::Unknown:
         default:
             return LiteralType::UnknownT;


### PR DESCRIPTION
# Description
This PR adds support for recording log order at compression time and leveraging that information at decompression time to achieve log-order decompression. The `--ordered` flag now performs log-order decompression and timestamp-ordered decompression is no longer supported.

Technically recording log order could be made optional, but per side-discussion it will save trouble down the line to force recording log order now.

Log order is recorded in a new "Internal" subtree in the MPT. Specifically, we add a new "Internal" node type and create a subtree off of the root node which can contain fields internal to the clp-s implementation. These fields are ignored during decompression (i.e. they do not get marshalled), and search (they can not be resolved to). The log event index is recorded in an integer field called "log_event_idx" in this subtree.

This PR also cleans up some code surrounding its changes. In particular the code to insert nodes into the MPT has been improved, and many instances of `std::string const&` have been replaced with `std::string_view const` throughout the codebase.

# Validation performed
* Validated that search results in mongodb contain log_event_ix field as expected when using the package
* Validated that decompression order matches log-order when the --ordered flag is specified
* Validated that recording log order typically has low compression overhead (2-6%) with only a few outliers
* Validated that recording log order has no significant performance overhead during ingestion
* Validated that wildcard keys and precise keys are unable to resolve to nodes in the Internal subtree
* Validated that ordered decompression behaves as expected for the purpose of log viewing (per @haiqi96)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced log event handling with new indexing capabilities in `ArchiveReader` and `ArchiveWriter`.
  - Added methods for retrieving log event indices and improved metadata handling in `SchemaReader`.
  - Introduced internal field management in `JsonParser` and `SchemaTree` for better data structure handling.
  - New method for populating internal columns in the `Output` class to improve filtering capabilities.
  - Added a new command-line option to control log order recording.

- **Improvements**
  - Updated error messages in command-line argument parsing for clearer user guidance.
  - Refined filtering logic in the `Output` class to better manage internal columns.
  - Improved performance in various classes by adopting `std::string_view` for method parameters.

- **Bug Fixes**
  - Enhanced error handling in various components to improve robustness during data processing.

These changes collectively enhance the application's functionality, performance, and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->