### PR TITLE
docs(ffi): Update `ffi::ir_stream::Serializer`'s doc string to remove "work-in-progress".

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -14,7 +14,7 @@
 
 namespace clp::ffi::ir_stream {
 /**
- * A work-in-progress class for serializing log events into the kv-pair IR format.
+ * Class for serializing log events into the kv-pair IR format.
  *
  * This class:
  * - maintains all necessary internal data structures to track serialization state;


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The doc string for `Serializer` is marked as "work-in-progress". Since we formally upgraded our IR format version number to 0.1.0 (kv-pair format), we dropped "work-in-progress" in the doc string in this PR.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure workflows passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified the description of the `Serializer` class to clarify its purpose for serializing log events. 

No new features or changes to functionality were introduced in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->