### PR TITLE
ci: Add GH workflow to validate PR titles follow Conventional Commits.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 <!--
-Set the PR title to a meaningful commit message in imperative form. E.g.:
-
-clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
+Set the PR title to a meaningful commit message that:
+- follows the Conventional Commits specification (https://www.conventionalcommits.org).
+- is in imperative form.
+Example:
+fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
 -->
 
 # Description

--- a/.github/workflows/clp-pr-title-checks.yaml
+++ b/.github/workflows/clp-pr-title-checks.yaml
@@ -6,6 +6,7 @@ on:
     branches: ["main"]
 
 permissions:
+  # For amannn/action-semantic-pull-request
   pull-requests: "read"
 
 concurrency:

--- a/.github/workflows/clp-pr-title-checks.yaml
+++ b/.github/workflows/clp-pr-title-checks.yaml
@@ -1,0 +1,23 @@
+name: "clp-pr-title-checks"
+
+on:
+  pull_request_target:
+    types: ["edited", "opened", "reopened"]
+    branches: ["main"]
+
+permissions:
+  pull-requests: "read"
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  conventional-commits:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "amannn/action-semantic-pull-request@v5"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"

--- a/.github/workflows/clp-pr-title-checks.yaml
+++ b/.github/workflows/clp-pr-title-checks.yaml
@@ -5,10 +5,6 @@ on:
     types: ["edited", "opened", "reopened"]
     branches: ["main"]
 
-permissions:
-  # For amannn/action-semantic-pull-request
-  pull-requests: "read"
-
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
@@ -17,6 +13,9 @@ concurrency:
 
 jobs:
   conventional-commits:
+    permissions:
+      # For amannn/action-semantic-pull-request
+      pull-requests: "read"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "amannn/action-semantic-pull-request@v5"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
[Convention Commits](https://www.conventionalcommits.org) is a specification for writing commit messages (or in our case, PR titles) that makes it easy to see at a glance what change the commit makes which in turn makes it easier to generate release notes.

This PR adds a workflow to check PR titles match the spec.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Merge this PR into my fork and test:
  - PR title check passed: https://github.com/LinZhihao-723/clp/actions/runs/11807084640
  - PR title check failed: https://github.com/LinZhihao-723/clp/actions/runs/11807102816 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the pull request template to include guidelines for following the Conventional Commits specification for titles.
	- Introduced a new GitHub Actions workflow to enforce title formatting on pull requests.

- **Documentation**
	- Improved instructions in the pull request template for setting meaningful titles.

- **Chores**
	- Added a new workflow file to manage pull request title checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->