### PR TITLE
test(core): Update `network_reader_with_valid_http_header_kv_pairs` to verify the return value before parsing the read content into a JSON object.

### DIFF
--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -213,9 +213,10 @@ TEST_CASE("network_reader_with_valid_http_header_kv_pairs", "[NetworkReader]") {
             clp::NetworkReader::cDefaultBufferSize,
             valid_http_header_kv_pairs
     };
-    auto const content = nlohmann::json::parse(get_content(reader));
-    auto const& headers{content.at("headers")};
+    auto const context{get_content(reader)};
     REQUIRE(assert_curl_error_code(CURLE_OK, reader));
+    auto const parsed_content = nlohmann::json::parse(context);
+    auto const& headers{parsed_content.at("headers")};
     for (auto const& [key, value] : valid_http_header_kv_pairs) {
         REQUIRE((value == headers.at(key).get<std::string_view>()));
     }

--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -213,9 +213,9 @@ TEST_CASE("network_reader_with_valid_http_header_kv_pairs", "[NetworkReader]") {
             clp::NetworkReader::cDefaultBufferSize,
             valid_http_header_kv_pairs
     };
-    auto const context{get_content(reader)};
+    auto const content{get_content(reader)};
     REQUIRE(assert_curl_error_code(CURLE_OK, reader));
-    auto const parsed_content = nlohmann::json::parse(context);
+    auto const parsed_content = nlohmann::json::parse(content);
     auto const& headers{parsed_content.at("headers")};
     for (auto const& [key, value] : valid_http_header_kv_pairs) {
         REQUIRE((value == headers.at(key).get<std::string_view>()));


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
We've seen `network_reader_with_valid_http_header_kv_pairs` test failures in recent macOS workflow runs. These runs can be normally resolved by rerunning the workflow jobs. After further investigation, we realized the requested URL returned an error code 502. This is not our fault; however, the current unit test won't give us a straightforward error message. This PR improves error reporting by reordering the test code to check CURL return code before parsing the read content into a JSON object.

The error message before this PR on failure:
```
-------------------------------------------------------------------------------
network_reader_with_valid_http_header_kv_pairs
-------------------------------------------------------------------------------
/Users/lzh/clp/components/core/tests/test-NetworkReader.cpp:195
...............................................................................

/Users/lzh/clp/components/core/tests/test-NetworkReader.cpp:195: FAILED:
  {Unknown expression after the reported line}
due to unexpected exception with message:
  [json.exception.parse_error.101] parse error at line 1, column 1: attempting
  to parse an empty input; check that your input string or stream contains the
  expected JSON
```

The error message after this PR:
```
-------------------------------------------------------------------------------                                                                                                                                    
network_reader_with_valid_http_header_kv_pairs                                                                                                                                                                     
-------------------------------------------------------------------------------                                                                                                                                    
/Users/lzh/clp/components/core/tests/test-NetworkReader.cpp:195                                                                                                                                                    
...............................................................................                                                                                                                                    
                                                                                                                                                                                                                   
/Users/lzh/clp/components/core/tests/test-NetworkReader.cpp:100: warning:                                                                                                                                          
  Unexpected CURL error code: 56; expected: 0                                                                                                                                                                      
  Error message:                                                                                                                                                                                                   
  The requested URL returned error: 502                                                                                                                                                                            
                                                                                                                                                                                                                   
/Users/lzh/clp/components/core/tests/test-NetworkReader.cpp:218: FAILED:                                                                                                                                           
  REQUIRE( assert_curl_error_code(CURLE_OK, reader) )                                                                                                                                                              
with expansion:                                                                                                                                                                                                    
  false                   
```

After the fix, the error message should look more apparent, as if the error is not on our end.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Unit tests all passed locally
- Ensure workflows are all passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Improved clarity in the `network_reader_with_valid_http_header_kv_pairs` test case by renaming variables for better understanding.
	- Updated variable references in assertions to enhance readability without altering test logic.
	- Minor adjustments made to comments and formatting for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->