### PR TITLE
feat(clp-s): Chunk output by size (in bytes) during ordered decompression.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/decompress.py
@@ -260,7 +260,7 @@ def main(argv):
     json_extraction_parser.add_argument(
         "--target-chunk-size",
         type=int,
-        help="Target chunk size (B)",
+        help="Target chunk size (B).",
     )
 
     parsed_args = args_parser.parse_args(argv[1:])

--- a/components/clp-package-utils/clp_package_utils/scripts/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/decompress.py
@@ -258,7 +258,9 @@ def main(argv):
     json_extraction_parser = command_args_parser.add_parser(EXTRACT_JSON_CMD)
     json_extraction_parser.add_argument("archive_id", type=str, help="Archive ID")
     json_extraction_parser.add_argument(
-        "--target-chunk-size", type=int, help="Target chunk size", default=100000
+        "--target-chunk-size",
+        type=int,
+        help="Target chunk size (B)",
     )
 
     parsed_args = args_parser.parse_args(argv[1:])

--- a/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
@@ -299,7 +299,7 @@ def main(argv):
     json_extraction_parser = command_args_parser.add_parser(EXTRACT_JSON_CMD)
     json_extraction_parser.add_argument("archive_id", type=str, help="Archive ID")
     json_extraction_parser.add_argument(
-        "--target-chunk-size", type=int, help="Target chunk size.", required=True
+        "--target-chunk-size", type=int, help="Target chunk size (B)."
     )
 
     parsed_args = args_parser.parse_args(argv[1:])

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -305,7 +305,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "ordered-chunk-size",
                     po::value<size_t>(&m_ordered_chunk_size)
                             ->default_value(m_ordered_chunk_size),
-                    "Number of records to include in each output file when decompressing records "
+                    "Chunk size in bytes to include in each output file when decompressing records "
                     "in log order"
             );
             // clang-format on

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -302,9 +302,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::bool_switch(&m_ordered_decompression),
                     "Enable decompression in log order for this archive"
             )(
-                    "ordered-chunk-size",
-                    po::value<size_t>(&m_ordered_chunk_size)
-                            ->default_value(m_ordered_chunk_size),
+                    "target-ordered-chunk-size",
+                    po::value<size_t>(&m_target_ordered_chunk_size)
+                            ->default_value(m_target_ordered_chunk_size),
                     "Chunk size (B) for each output file when decompressing records in log order."
                     " When set to 0, no chunking is performed."
             );
@@ -369,7 +369,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 throw std::invalid_argument("No output directory specified");
             }
 
-            if (0 != m_ordered_chunk_size && false == m_ordered_decompression) {
+            if (0 != m_target_ordered_chunk_size && false == m_ordered_decompression) {
                 throw std::invalid_argument("ordered-chunk-size must be used with ordered argument"
                 );
             }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -305,7 +305,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "ordered-chunk-size",
                     po::value<size_t>(&m_ordered_chunk_size)
                             ->default_value(m_ordered_chunk_size),
-                    "Chunk size in bytes to include in each output file when decompressing records "
+                    "Chunk size (B) for each output file when decompressing records "
                     "in log order"
             );
             // clang-format on

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -305,8 +305,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "ordered-chunk-size",
                     po::value<size_t>(&m_ordered_chunk_size)
                             ->default_value(m_ordered_chunk_size),
-                    "Chunk size (B) for each output file when decompressing records "
-                    "in log order"
+                    "Chunk size (B) for each output file when decompressing records in log order. "
+                    "No chunking is performed when this argument is set to zero."
             );
             // clang-format on
             extraction_options.add(decompression_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -304,7 +304,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                     "target-ordered-chunk-size",
                     po::value<size_t>(&m_target_ordered_chunk_size)
-                            ->default_value(m_target_ordered_chunk_size),
+                            ->default_value(m_target_ordered_chunk_size)
+                            ->value_name("SIZE"),
                     "Chunk size (B) for each output file when decompressing records in log order."
                     " When set to 0, no chunking is performed."
             );

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -305,8 +305,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "ordered-chunk-size",
                     po::value<size_t>(&m_ordered_chunk_size)
                             ->default_value(m_ordered_chunk_size),
-                    "Chunk size (B) for each output file when decompressing records in log order. "
-                    "No chunking is performed when this argument is set to zero."
+                    "Chunk size (B) for each output file when decompressing records in log order."
+                    " When set to 0, no chunking is performed."
             );
             // clang-format on
             extraction_options.add(decompression_options);

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -371,7 +371,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             }
 
             if (0 != m_target_ordered_chunk_size && false == m_ordered_decompression) {
-                throw std::invalid_argument("ordered-chunk-size must be used with ordered argument"
+                throw std::invalid_argument(
+                        "target-ordered-chunk-size must be used with ordered argument"
                 );
             }
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -178,7 +178,7 @@ private:
     size_t m_max_document_size{512ULL * 1024 * 1024};  // 512 MB
     bool m_structurize_arrays{false};
     bool m_ordered_decompression{false};
-    size_t m_ordered_chunk_size{0};
+    size_t m_ordered_chunk_size{};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -106,7 +106,7 @@ public:
 
     bool get_ordered_decompression() const { return m_ordered_decompression; }
 
-    size_t get_ordered_chunk_size() const { return m_ordered_chunk_size; }
+    size_t get_target_ordered_chunk_size() const { return m_target_ordered_chunk_size; }
 
     size_t get_minimum_table_size() const { return m_minimum_table_size; }
 
@@ -178,7 +178,7 @@ private:
     size_t m_max_document_size{512ULL * 1024 * 1024};  // 512 MB
     bool m_structurize_arrays{false};
     bool m_ordered_decompression{false};
-    size_t m_ordered_chunk_size{};
+    size_t m_target_ordered_chunk_size{};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
 

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -159,7 +159,9 @@ void JsonConstructor::construct_in_order() {
         writer.write(buffer.c_str(), buffer.length());
         chunk_size += buffer.length();
 
-        if (0 != m_option.ordered_chunk_size && chunk_size >= m_option.ordered_chunk_size) {
+        if (0 != m_option.target_ordered_chunk_size
+            && chunk_size >= m_option.target_ordered_chunk_size)
+        {
             finalize_chunk(true);
             chunk_size = 0;
         }

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -83,7 +83,7 @@ void JsonConstructor::construct_in_order() {
 
     int64_t first_idx{0};
     int64_t last_idx{0};
-    size_t num_records_marshalled{0};
+    size_t chunk_size{0};
     auto src_path = std::filesystem::path(m_option.output_dir) / m_option.archive_id;
     FileWriter writer;
     writer.open(src_path, FileWriter::OpenMode::CreateForWriting);
@@ -149,7 +149,7 @@ void JsonConstructor::construct_in_order() {
         ReaderPointer next = record_queue.top();
         record_queue.pop();
         last_idx = next->get_next_log_event_idx();
-        if (0 == num_records_marshalled) {
+        if (0 == chunk_size) {
             first_idx = last_idx;
         }
         next->get_next_message(buffer);
@@ -157,17 +157,15 @@ void JsonConstructor::construct_in_order() {
             record_queue.emplace(std::move(next));
         }
         writer.write(buffer.c_str(), buffer.length());
-        num_records_marshalled += 1;
+        chunk_size += buffer.length();
 
-        if (0 != m_option.ordered_chunk_size
-            && num_records_marshalled >= m_option.ordered_chunk_size)
-        {
+        if (0 != m_option.ordered_chunk_size && chunk_size >= m_option.ordered_chunk_size) {
             finalize_chunk(true);
-            num_records_marshalled = 0;
+            chunk_size = 0;
         }
     }
 
-    if (num_records_marshalled > 0) {
+    if (chunk_size > 0) {
         finalize_chunk(false);
     } else {
         writer.close();

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -81,9 +81,9 @@ void JsonConstructor::construct_in_order() {
     // a given table
     tables.clear();
 
-    int64_t first_idx{0};
-    int64_t last_idx{0};
-    size_t chunk_size{0};
+    int64_t first_idx{};
+    int64_t last_idx{};
+    size_t chunk_size{};
     auto src_path = std::filesystem::path(m_option.output_dir) / m_option.archive_id;
     FileWriter writer;
     writer.open(src_path, FileWriter::OpenMode::CreateForWriting);

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -30,7 +30,7 @@ struct JsonConstructorOption {
     std::string archive_id;
     std::string output_dir;
     bool ordered{false};
-    size_t ordered_chunk_size{0};
+    size_t ordered_chunk_size{};
     std::optional<MetadataDbOption> metadata_db;
 };
 

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -30,7 +30,7 @@ struct JsonConstructorOption {
     std::string archive_id;
     std::string output_dir;
     bool ordered{false};
-    size_t ordered_chunk_size{};
+    size_t target_ordered_chunk_size{};
     std::optional<MetadataDbOption> metadata_db;
 };
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -300,7 +300,7 @@ int main(int argc, char const* argv[]) {
         option.output_dir = command_line_arguments.get_output_dir();
         option.ordered = command_line_arguments.get_ordered_decompression();
         option.archives_dir = archives_dir;
-        option.ordered_chunk_size = command_line_arguments.get_ordered_chunk_size();
+        option.target_ordered_chunk_size = command_line_arguments.get_target_ordered_chunk_size();
         if (false == command_line_arguments.get_mongodb_uri().empty()) {
             option.metadata_db
                     = {command_line_arguments.get_mongodb_uri(),

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -65,7 +65,7 @@ def make_command(
             stream_collection_name,
         ]
         if extract_json_config.target_chunk_size is not None:
-            command.append("--ordered-chunk-size")
+            command.append("--target-ordered-chunk-size")
             command.append(str(extract_json_config.target_chunk_size))
     else:
         logger.error(f"Unsupported storage engine {storage_engine}")


### PR DESCRIPTION

<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
This PR changes the behaviour of chunking during ordered decompression to target a chunk size in bytes instead of number of records. Generating chunks in this way should allow the log viewer to have more consistent memory usage and computation required per chunk.

Chunks are generated by appending records to them until the total chunk size exceeds that specified by the `--ordered-chunk-size` argument. That is, `--ordered-chunk-size` specifies a lower bound for the chunk size which may be slightly exceeded. 

As before, specifying `--ordered-chunk-size 0` (which is also the default) will result in the output *not* being divided into chunks.



# Validation performed
* Validated that all records for an archive are decompressed into a single chunk when using `--ordered-chunk-size 0`
* Validated that generated chunk size closely corresponds to requested size
* Validated that `--target-chunk-size` argument still functions correctly in the package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced command-line argument parsing for improved user experience.
	- Clearer error messages for invalid inputs and specific command requirements.
	- Updated help text for command-line options to clarify their usage, including units for chunk sizes.

- **Bug Fixes**
	- Improved error handling for file reading, including specific messages for file not found and opening errors.

- **Chores**
	- Streamlined variable initialization for better code maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->