### PR TITLE
feat(clp-s): Add temporary output directory support to prepare for cloud integration

### DIFF
--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -312,7 +312,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::value<std::string>(&m_temp_output_dir)
                         ->value_name("DIR")
                         ->default_value(m_temp_output_dir),
-                        "Temporary output directory for output files while they're being written"
+                        "Temporary output directory for ordered output files while they're being "
+                        "written"
             );
             // clang-format on
             extraction_options.add(decompression_options);
@@ -375,13 +376,17 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 throw std::invalid_argument("No output directory specified");
             }
 
-            if (m_temp_output_dir.empty()) {
-                m_temp_output_dir = m_output_dir;
-            }
-
             if (0 != m_ordered_chunk_size && false == m_ordered_decompression) {
                 throw std::invalid_argument("ordered-chunk-size must be used with ordered argument"
                 );
+            }
+
+            if (false == m_temp_output_dir.empty() && false == m_ordered_decompression) {
+                throw std::invalid_argument("temp-output-dir must be used with ordered argument");
+            }
+
+            if (m_temp_output_dir.empty()) {
+                m_temp_output_dir = m_output_dir;
             }
 
             // We use xor to check that these arguments are either both specified or both

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -307,6 +307,12 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                             ->default_value(m_ordered_chunk_size),
                     "Number of records to include in each output file when decompressing records "
                     "in log order"
+            )(
+                    "temp-output-dir",
+                    po::value<std::string>(&m_temp_output_dir)
+                        ->value_name("DIR")
+                        ->default_value(m_temp_output_dir),
+                        "Temporary output directory for output files while they're being written"
             );
             // clang-format on
             extraction_options.add(decompression_options);
@@ -367,6 +373,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             if (m_output_dir.empty()) {
                 throw std::invalid_argument("No output directory specified");
+            }
+
+            if (m_temp_output_dir.empty()) {
+                m_temp_output_dir = m_output_dir;
             }
 
             if (0 != m_ordered_chunk_size && false == m_ordered_decompression) {

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -52,6 +52,8 @@ public:
 
     std::string const& get_output_dir() const { return m_output_dir; }
 
+    std::string const& get_temp_output_dir() const { return m_temp_output_dir; }
+
     std::string const& get_timestamp_key() const { return m_timestamp_key; }
 
     int get_compression_level() const { return m_compression_level; }
@@ -171,6 +173,7 @@ private:
     std::vector<std::string> m_file_paths;
     std::string m_archives_dir;
     std::string m_output_dir;
+    std::string m_temp_output_dir;
     std::string m_timestamp_key;
     int m_compression_level{3};
     size_t m_target_encoded_size{8ULL * 1024 * 1024 * 1024};  // 8 GiB

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -37,10 +37,7 @@ JsonConstructor::JsonConstructor(JsonConstructorOption const& option) : m_option
                 ErrorCodeFailure,
                 __FILENAME__,
                 __LINE__,
-                fmt::format(
-                        "Temporary output directory '{}' doesn't exist",
-                        option.temp_output_dir
-                )
+                fmt::format("Temporary output directory '{}' doesn't exist", option.temp_output_dir)
         );
     }
 

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -32,16 +32,14 @@ JsonConstructor::JsonConstructor(JsonConstructorOption const& option) : m_option
         );
     }
 
-    std::ignore = std::filesystem::create_directory(option.temp_output_dir, error_code);
-    if (error_code) {
+    if (false == std::filesystem::exists(option.temp_output_dir)) {
         throw OperationFailed(
                 ErrorCodeFailure,
                 __FILENAME__,
                 __LINE__,
                 fmt::format(
-                        "Cannot create temporary output directory '{}' - {}",
-                        option.temp_output_dir,
-                        error_code.message()
+                        "Temporary output directory '{}' doesn't exist",
+                        option.temp_output_dir
                 )
         );
     }

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -40,7 +40,7 @@ JsonConstructor::JsonConstructor(JsonConstructorOption const& option) : m_option
                 __LINE__,
                 fmt::format(
                         "Cannot create temporary output directory '{}' - {}",
-                        option.output_dir,
+                        option.temp_output_dir,
                         error_code.message()
                 )
         );

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -29,6 +29,7 @@ struct JsonConstructorOption {
     std::string archives_dir;
     std::string archive_id;
     std::string output_dir;
+    std::string temp_output_dir;
     bool ordered{false};
     size_t ordered_chunk_size{0};
     std::optional<MetadataDbOption> metadata_db;

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -298,6 +298,7 @@ int main(int argc, char const* argv[]) {
 
         clp_s::JsonConstructorOption option{};
         option.output_dir = command_line_arguments.get_output_dir();
+        option.temp_output_dir = command_line_arguments.get_temp_output_dir();
         option.ordered = command_line_arguments.get_ordered_decompression();
         option.archives_dir = archives_dir;
         option.ordered_chunk_size = command_line_arguments.get_ordered_chunk_size();


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The current chunk decompression of CLP-S requires first writting the output as a temporary file in the output directory and rename it. However, this strategy won't work in the cloud with S3 storage because there isn't a "rename" equivalent operation in S3. In order to "rename" a file, the file has to be deleted and uploaded with a new name. In addition, our current fuse layer doesn't support rename either.

In this PR, we implement a temp_output_dir strategy which is also used in CLP. If the temp-output-dir is specified, the output of chunk decompression will be first redirected to a temporary directory. The temporary output files are then renamed and moved to the destination output directory. 

In cloud, we expect the temporary directory to be a directory on the local file system, and the output_directory will be pointing to a mounted path which handles write to S3.


# Validation performed
Manually verified that output chunk files are being written to temporary output directory and then moved to the final output_directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `temp-output-dir` option for decompression, allowing users to specify a temporary output directory for ordered output files.
	- Enhanced error handling for directory creation and argument validation to improve clarity and user experience.

- **Bug Fixes**
	- Improved validation checks to prevent misuse of the `temp-output-dir` option.

- **Documentation**
	- Updated error messages for invalid arguments to provide clearer guidance to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->