### PR TITLE
build(macos): Check if pkg-config is installed before installing it.

### DIFF
--- a/components/core/tools/scripts/lib_install/macos/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos/install-all.sh
@@ -21,5 +21,12 @@ brew install \
   mongo-cxx-driver \
   msgpack-cxx \
   spdlog \
-  pkg-config \
   zstd
+
+# Install pkg-config if it isn't already installed
+# NOTE: We might expect that pkg-config is installed through brew, so trying to install it again
+# would be harmless; however, in certain environments, like the macOS GitHub hosted runner,
+# pkg-config is installed by other means, meaning a brew install would cause conflicts.
+if ! command -v pkg-config ; then
+    brew install pkg-config
+fi


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

To fix #610, this PR only installs pkg-config on macOS if it isn't already installed.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

clp-core-macos-build workflow now succeeds.