### PR TITLE
test: Allow multiple trials when unittesting http headers

### DIFF
--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -193,6 +193,9 @@ TEST_CASE("network_reader_illegal_offset", "[NetworkReader]") {
 }
 
 TEST_CASE("network_reader_with_valid_http_header_kv_pairs", "[NetworkReader]") {
+    // Since the http request sometimes crash due to arbitrary reasons, so we just try it
+    // multiple times to avoid such cases
+    constexpr int cNumMaxTrials{10};
     std::unordered_map<std::string, std::string> valid_http_header_kv_pairs;
     // We use httpbin (https://httpbin.org/) to test the user-specified headers. On success, it is
     // supposed to respond all the user-specified headers as key-value pairs in JSON form.
@@ -203,23 +206,38 @@ TEST_CASE("network_reader_with_valid_http_header_kv_pairs", "[NetworkReader]") {
                 fmt::format("Unit-Test-Value{}", i)
         );
     }
-    clp::NetworkReader reader{
-            "https://httpbin.org/headers",
-            0,
-            false,
-            clp::CurlDownloadHandler::cDefaultOverallTimeout,
-            clp::CurlDownloadHandler::cDefaultConnectionTimeout,
-            clp::NetworkReader::cDefaultBufferPoolSize,
-            clp::NetworkReader::cDefaultBufferSize,
-            valid_http_header_kv_pairs
-    };
-    auto const content{get_content(reader)};
-    REQUIRE(assert_curl_error_code(CURLE_OK, reader));
-    auto const parsed_content = nlohmann::json::parse(content);
-    auto const& headers{parsed_content.at("headers")};
-    for (auto const& [key, value] : valid_http_header_kv_pairs) {
-        REQUIRE((value == headers.at(key).get<std::string_view>()));
+    bool is_pass{false};
+    for (size_t i{0}; i < cNumMaxTrials; ++i) {
+        clp::NetworkReader reader{
+                "https://httpbin.org/headers",
+                0,
+                false,
+                clp::CurlDownloadHandler::cDefaultOverallTimeout,
+                clp::CurlDownloadHandler::cDefaultConnectionTimeout,
+                clp::NetworkReader::cDefaultBufferPoolSize,
+                clp::NetworkReader::cDefaultBufferSize,
+                valid_http_header_kv_pairs
+        };
+        auto const content{get_content(reader)};
+        if (false == assert_curl_error_code(CURLE_OK, reader)) {
+            continue;
+        }
+        auto const parsed_content = nlohmann::json::parse(content);
+        auto const& headers{parsed_content.at("headers")};
+        bool are_headers_same{true};
+        for (auto const& [key, value] : valid_http_header_kv_pairs) {
+            if (value != headers.at(key).get<std::string_view>()) {
+                are_headers_same = false;
+                break;
+            }
+        }
+        if (!are_headers_same) {
+            continue;
+        }
+        is_pass = true;
+        break;
     }
+    REQUIRE(is_pass);
 }
 
 TEST_CASE("network_reader_with_illegal_http_header_kv_pairs", "[NetworkReader]") {


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Allow up to 10 trials when unitesting `network_reader_with_valid_http_header_kv_pairs` and `network_reader_with_illegal_http_header_kv_pairs`


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Run these two unittest cases and get passed.
