### PR TITLE
chore(log-viewer-webui): Update `yscope-log-viewer` to the latest version.

### DIFF
--- a/deps-tasks.yml
+++ b/deps-tasks.yml
@@ -421,8 +421,8 @@ tasks:
         vars:
           DEST: "{{.DEST}}"
           FLAGS: "--extract"
-          SRC_NAME: "yscope-log-viewer-4c69bc11dbe8a5d87b5fbfb0e43a2f2a06f04866"
-          SRC_URL: "https://github.com/y-scope/yscope-log-viewer/archive/4c69bc1.zip"
+          SRC_NAME: "yscope-log-viewer-969ff35b2387bcdc3580b441907e3656640ce16d"
+          SRC_URL: "https://github.com/y-scope/yscope-log-viewer/archive/969ff35.zip"
       # This command must be last
       - task: ":utils:compute-checksum"
         vars:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This updates to the latest version of the log viewer which includes some major user experience improvements for structured log viewing.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Referred to #565 to ensure the `yscope-log-viewer` git ref is updated in all needed places.
2. Sanitize tested unstructured log viewing as instructed by the validation steps at #565 .
3. Tested structured log viewing:
1. Configured `package.storage_engine` as `clp-s` in `<package>/etc/clp-config.yml`.
2. `sbin/start-clp.sh`
3. `sbin/compress.sh --timestamp-key 't.$date' mongod`
4. Cleared browser caches (ensured no `localStorage` content was preserved as the old formatter syntax is not compatible with the current syntax).
5. Loaded http://localhost:4000/search
6. Searched for `1`.
7. Clicked on the file path ("Original File") in one of the search results.
8. Validated that the log viewer was opened with the cursor at the same search result. The logs are displayed as newline-delimited JSON (a.k.a. JSON Lines).
9. Configured format string `{t.$date:timestamp:YYYY-MM-DD HH\:mm\:ss} {s} [{ctx}] {msg}` in the Settings modal, clicked button `Apply & Reload` and observed the application reloaded, and the logs are formatted as desired:
   ![image](https://github.com/user-attachments/assets/97d4c385-646d-4d51-aae0-136a5604a8b0)
