### PR TITLE
docs(clp-json): Update list of characters that requires escaping in queries.

### DIFF
--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -33,8 +33,17 @@ To search for a key or value with multiple words, you must quote the key/value w
 "multi-word key": "multi-word value"
 ```
 
-Queries for keys or values with the following literal characters must escape the characters using a
-`\` (backslash): `\`, `(`, `)`, `:`, `<`, `>`, `"`, `*`, `{`, `}`.
+Keys or values with the following literal characters must escape the characters using a `\`
+ (backslash): `\`, `"`.
+
+Unquoted keys or values must also escape the following characters: `(`, `)`, `:`, `<`, `>`, `{`,
+ `}`. The unquoted keywords `and`, `or`, and `not` can also be escaped with a `\`.
+
+Values containing `?` and `*` can escape these characters with a `\` to differentiate them from the
+ `?` and `*` characters used to specify arbitrary single character match and wildcard match.
+
+Keys containing `.` can escape the `.` with `\` to differentiate from the special `.` character that
+indicates nested keys.
 
 :::{caution}
 Currently, a query that contains spaces is interpreted as a substring search, i.e., it will match

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -37,7 +37,7 @@ Keys or values with the following literal characters must escape the characters 
  (backslash): `\`, `"`.
 
 Unquoted keys or values must also escape the following characters: `(`, `)`, `:`, `<`, `>`, `{`,
- `}`. The unquoted keywords `and`, `or`, and `not` can also be escaped with a `\`.
+ `}`.
 
 Values containing `?` and `*` can escape these characters with a `\` to differentiate them from the
  `?` and `*` characters used to specify arbitrary single character match and wildcard match.

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -33,22 +33,16 @@ To search for a key or value with multiple words, you must quote the key/value w
 "multi-word key": "multi-word value"
 ```
 
-Keys or values with the following literal characters must escape the characters using a `\`
- (backslash): `\`, `"`.
-
-Unquoted keys or values must also escape the following characters: `(`, `)`, `:`, `<`, `>`, `{`,
- `}`.
-
-Values containing `?` and `*` can escape these characters with a `\` to differentiate them from the
- `?` and `*` characters used to specify arbitrary single character match and wildcard match.
-
-Keys containing `.` can escape the `.` with `\` to differentiate from the special `.` character that
-indicates nested keys.
-
 :::{caution}
 Currently, a query that contains spaces is interpreted as a substring search, i.e., it will match
 log events that contain the value as a *substring*. In a future version of CLP, these queries will
 be interpreted as _exact_ searches unless they include [wildcards](#wildcards-in-values).
+:::
+
+:::{note}
+Certain characters have special meanings when used in keys or values, so to search for the
+characters literally, you must escape them. For a list of such characters, see
+[Escaping special characters](#escaping-special-characters).
 :::
 
 ### Querying nested kv-pairs
@@ -169,6 +163,33 @@ There are three supported boolean operators:
 * `NOT` - the expression after the operator must _not_ be true.
 
 You can use parentheses (`()`) to apply an operator to a group of expressions.
+
+### Escaping special characters
+
+Keys containing the following literal characters must escape the characters using a `\` (backslash):
+
+* `\`
+* `"`
+* `.`
+
+Values containing the following literal characters must escape the characters using a `\`
+(backslash):
+
+* `\`
+* `"`
+* `?`
+* `*`
+
+_Unquoted_ keys or values containing the following literal characters must also escape the
+characters using a `\` (backslash):
+
+* `(`
+* `)`
+* `:`
+* `<`
+* `>`
+* `{`
+* `}`
 
 ## Examples
 


### PR DESCRIPTION
# Description
Update docs for JSON search to clarify what characters need to be escaped and when.

# Validation performed
Validated that markdown renders as expected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Revised the CLP JSON search syntax documentation for improved clarity on escaping characters and wildcards.
	- Enhanced cautionary notes regarding the interpretation of spaces in queries and anticipated changes to search behaviour.
	- Clarified the syntax for querying array values and highlighted differences with KQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->