### PR TITLE
feat(clp-s): Add command line options for stubbed out kv-pair-IR ingestion.

### DIFF
--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -106,11 +106,13 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  c - compress" << std::endl;
                 std::cerr << "  x - decompress" << std::endl;
                 std::cerr << "  s - search" << std::endl;
+                std::cerr << "  i - compress IR format" << std::endl;
                 std::cerr << std::endl;
                 std::cerr << "Try "
                           << " c --help OR"
                           << " x --help OR"
-                          << " s --help for command-specific details." << std::endl;
+                          << " s --help OR"
+                          << " i --help for command-specific details." << std::endl;
 
                 po::options_description visible_options;
                 visible_options.add(general_options);
@@ -125,6 +127,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             case (char)Command::Compress:
             case (char)Command::Extract:
             case (char)Command::Search:
+            case (char)Command::IrCompress:
                 m_command = (Command)command_input;
                 break;
             default:
@@ -696,6 +699,147 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                         "The --count-by-time and --count options are mutually exclusive."
                 );
             }
+        } else if (Command::IrCompress == m_command) {
+            po::options_description compression_positional_options;
+            // clang-format off
+             compression_positional_options.add_options()(
+                     "archives-dir",
+                     po::value<std::string>(&m_archives_dir)->value_name("DIR"),
+                     "output directory"
+             )(
+                     "input-paths",
+                     po::value<std::vector<std::string>>(&m_file_paths)->value_name("PATHS"),
+                     "input paths"
+             );
+            // clang-format on
+
+            po::options_description compression_options("Compression options");
+            std::string metadata_db_config_file_path;
+            std::string input_path_list_file_path;
+            // clang-format off
+            compression_options.add_options()(
+                    "compression-level",
+                    po::value<int>(&m_compression_level)->value_name("LEVEL")->
+                        default_value(m_compression_level),
+                    "1 (fast/low compression) to 9 (slow/high compression)."
+            )(
+                    "target-encoded-size",
+                    po::value<size_t>(&m_target_encoded_size)->value_name("TARGET_ENCODED_SIZE")->
+                        default_value(m_target_encoded_size),
+                    "Target size (B) for the dictionaries and encoded messages before a new "
+                    "archive is created."
+            )(
+                    "min-table-size",
+                    po::value<size_t>(&m_minimum_table_size)->value_name("MIN_TABLE_SIZE")->
+                        default_value(m_minimum_table_size),
+                    "Minimum size (B) for a packed table before it gets compressed."
+            )(
+                    "max-document-size",
+                    po::value<size_t>(&m_max_document_size)->value_name("DOC_SIZE")->
+                        default_value(m_max_document_size),
+                    "Maximum allowed size (B) for a single document before compression fails."
+            )(
+                    "timestamp-key",
+                    po::value<std::string>(&m_timestamp_key)->value_name("TIMESTAMP_COLUMN_KEY")->
+                        default_value(m_timestamp_key),
+                    "Path (e.g. x.y) for the field containing the log event's timestamp."
+            )(
+                    "db-config-file",
+                    po::value<std::string>(&metadata_db_config_file_path)->value_name("FILE")->
+                    default_value(metadata_db_config_file_path),
+                    "Global metadata DB YAML config"
+            )(
+                    "files-from,f",
+                    po::value<std::string>(&input_path_list_file_path)
+                            ->value_name("FILE")
+                            ->default_value(input_path_list_file_path),
+                    "Compress files specified in FILE"
+            )(
+                    "print-archive-stats",
+                    po::bool_switch(&m_print_archive_stats),
+                    "Print statistics (json) about the archive after it's compressed."
+            )(
+                    "single-file-archive",
+                    po::bool_switch(&m_single_file_archive),
+                    "Create a single archive file instead of multiple files."
+            )(
+                    "disable-log-order",
+                    po::bool_switch(&m_disable_log_order),
+                    "Do not record log order at ingestion time."
+            );
+            // clang-format on
+
+            po::positional_options_description positional_options;
+            positional_options.add("archives-dir", 1);
+            positional_options.add("input-paths", -1);
+
+            po::options_description all_compression_options;
+            all_compression_options.add(compression_options);
+            all_compression_options.add(compression_positional_options);
+
+            std::vector<std::string> unrecognized_options
+                    = po::collect_unrecognized(parsed.options, po::include_positional);
+            unrecognized_options.erase(unrecognized_options.begin());
+            po::store(
+                    po::command_line_parser(unrecognized_options)
+                            .options(all_compression_options)
+                            .positional(positional_options)
+                            .run(),
+                    parsed_command_line_options
+            );
+            po::notify(parsed_command_line_options);
+
+            if (parsed_command_line_options.count("help")) {
+                print_ir_compression_usage();
+
+                std::cerr << "Examples:\n";
+                std::cerr << "  # Compress file1.ir and dir1 into archives-dir\n";
+                std::cerr << "  " << m_program_name << " i archives-dir file1.ir dir1\n";
+
+                po::options_description visible_options;
+                visible_options.add(general_options);
+                visible_options.add(compression_options);
+                std::cerr << visible_options << '\n';
+                return ParsingResult::InfoCommand;
+            }
+
+            if (m_archives_dir.empty()) {
+                throw std::invalid_argument("No archives directory specified.");
+            }
+
+            if (false == input_path_list_file_path.empty()) {
+                if (false == read_paths_from_file(input_path_list_file_path, m_file_paths)) {
+                    SPDLOG_ERROR("Failed to read paths from {}", input_path_list_file_path);
+                    return ParsingResult::Failure;
+                }
+            }
+
+            if (m_file_paths.empty()) {
+                throw std::invalid_argument("No input paths specified.");
+            }
+
+            // Parse and validate global metadata DB config
+            if (false == metadata_db_config_file_path.empty()) {
+                clp::GlobalMetadataDBConfig metadata_db_config;
+                try {
+                    metadata_db_config.parse_config_file(metadata_db_config_file_path);
+                } catch (std::exception& e) {
+                    SPDLOG_ERROR("Failed to validate metadata database config - {}.", e.what());
+                    return ParsingResult::Failure;
+                }
+
+                if (clp::GlobalMetadataDBConfig::MetadataDBType::MySQL
+                    != metadata_db_config.get_metadata_db_type())
+                {
+                    SPDLOG_ERROR(
+                            "Invalid metadata database type for {}; only supported type is MySQL.",
+                            m_program_name
+                    );
+                    return ParsingResult::Failure;
+                }
+
+                m_metadata_db_config = std::move(metadata_db_config);
+            }
         }
     } catch (std::exception& e) {
         SPDLOG_ERROR("{}", e.what());
@@ -808,5 +952,9 @@ void CommandLineArguments::print_search_usage() const {
               << " s [OPTIONS] ARCHIVES_DIR KQL_QUERY"
                  " [OUTPUT_HANDLER [OUTPUT_HANDLER_OPTIONS]]"
               << std::endl;
+}
+
+void CommandLineArguments::print_ir_compression_usage() const {
+    std::cerr << "Usage: " << m_program_name << " i [OPTIONS] ARCHIVES_DIR [FILE/DIR ...]\n";
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -106,13 +106,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 std::cerr << "  c - compress" << std::endl;
                 std::cerr << "  x - decompress" << std::endl;
                 std::cerr << "  s - search" << std::endl;
-                std::cerr << "  i - compress IR format" << std::endl;
                 std::cerr << std::endl;
                 std::cerr << "Try "
                           << " c --help OR"
                           << " x --help OR"
-                          << " s --help OR"
-                          << " i --help for command-specific details." << std::endl;
+                          << " s --help for command-specific details." << std::endl;
 
                 po::options_description visible_options;
                 visible_options.add(general_options);
@@ -127,7 +125,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             case (char)Command::Compress:
             case (char)Command::Extract:
             case (char)Command::Search:
-            case (char)Command::IrCompress:
                 m_command = (Command)command_input;
                 break;
             default:
@@ -205,6 +202,11 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "disable-log-order",
                     po::bool_switch(&m_disable_log_order),
                     "Do not record log order at ingestion time."
+            )(
+                    "file-type",
+                    po::value<std::string>(&m_file_type)->value_name("FILE_TYPE")->
+                        default_value(m_file_type),
+                    "The type of file that is to be compressed to archive (e.g Json or IR)"
             );
             // clang-format on
 
@@ -699,147 +701,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                         "The --count-by-time and --count options are mutually exclusive."
                 );
             }
-        } else if (Command::IrCompress == m_command) {
-            po::options_description compression_positional_options;
-            // clang-format off
-             compression_positional_options.add_options()(
-                     "archives-dir",
-                     po::value<std::string>(&m_archives_dir)->value_name("DIR"),
-                     "output directory"
-             )(
-                     "input-paths",
-                     po::value<std::vector<std::string>>(&m_file_paths)->value_name("PATHS"),
-                     "input paths"
-             );
-            // clang-format on
-
-            po::options_description compression_options("Compression options");
-            std::string metadata_db_config_file_path;
-            std::string input_path_list_file_path;
-            // clang-format off
-            compression_options.add_options()(
-                    "compression-level",
-                    po::value<int>(&m_compression_level)->value_name("LEVEL")->
-                        default_value(m_compression_level),
-                    "1 (fast/low compression) to 9 (slow/high compression)."
-            )(
-                    "target-encoded-size",
-                    po::value<size_t>(&m_target_encoded_size)->value_name("TARGET_ENCODED_SIZE")->
-                        default_value(m_target_encoded_size),
-                    "Target size (B) for the dictionaries and encoded messages before a new "
-                    "archive is created."
-            )(
-                    "min-table-size",
-                    po::value<size_t>(&m_minimum_table_size)->value_name("MIN_TABLE_SIZE")->
-                        default_value(m_minimum_table_size),
-                    "Minimum size (B) for a packed table before it gets compressed."
-            )(
-                    "max-document-size",
-                    po::value<size_t>(&m_max_document_size)->value_name("DOC_SIZE")->
-                        default_value(m_max_document_size),
-                    "Maximum allowed size (B) for a single document before compression fails."
-            )(
-                    "timestamp-key",
-                    po::value<std::string>(&m_timestamp_key)->value_name("TIMESTAMP_COLUMN_KEY")->
-                        default_value(m_timestamp_key),
-                    "Path (e.g. x.y) for the field containing the log event's timestamp."
-            )(
-                    "db-config-file",
-                    po::value<std::string>(&metadata_db_config_file_path)->value_name("FILE")->
-                    default_value(metadata_db_config_file_path),
-                    "Global metadata DB YAML config"
-            )(
-                    "files-from,f",
-                    po::value<std::string>(&input_path_list_file_path)
-                            ->value_name("FILE")
-                            ->default_value(input_path_list_file_path),
-                    "Compress files specified in FILE"
-            )(
-                    "print-archive-stats",
-                    po::bool_switch(&m_print_archive_stats),
-                    "Print statistics (json) about the archive after it's compressed."
-            )(
-                    "single-file-archive",
-                    po::bool_switch(&m_single_file_archive),
-                    "Create a single archive file instead of multiple files."
-            )(
-                    "disable-log-order",
-                    po::bool_switch(&m_disable_log_order),
-                    "Do not record log order at ingestion time."
-            );
-            // clang-format on
-
-            po::positional_options_description positional_options;
-            positional_options.add("archives-dir", 1);
-            positional_options.add("input-paths", -1);
-
-            po::options_description all_compression_options;
-            all_compression_options.add(compression_options);
-            all_compression_options.add(compression_positional_options);
-
-            std::vector<std::string> unrecognized_options
-                    = po::collect_unrecognized(parsed.options, po::include_positional);
-            unrecognized_options.erase(unrecognized_options.begin());
-            po::store(
-                    po::command_line_parser(unrecognized_options)
-                            .options(all_compression_options)
-                            .positional(positional_options)
-                            .run(),
-                    parsed_command_line_options
-            );
-            po::notify(parsed_command_line_options);
-
-            if (parsed_command_line_options.count("help")) {
-                print_ir_compression_usage();
-
-                std::cerr << "Examples:\n";
-                std::cerr << "  # Compress file1.ir and dir1 into archives-dir\n";
-                std::cerr << "  " << m_program_name << " i archives-dir file1.ir dir1\n";
-
-                po::options_description visible_options;
-                visible_options.add(general_options);
-                visible_options.add(compression_options);
-                std::cerr << visible_options << '\n';
-                return ParsingResult::InfoCommand;
-            }
-
-            if (m_archives_dir.empty()) {
-                throw std::invalid_argument("No archives directory specified.");
-            }
-
-            if (false == input_path_list_file_path.empty()) {
-                if (false == read_paths_from_file(input_path_list_file_path, m_file_paths)) {
-                    SPDLOG_ERROR("Failed to read paths from {}", input_path_list_file_path);
-                    return ParsingResult::Failure;
-                }
-            }
-
-            if (m_file_paths.empty()) {
-                throw std::invalid_argument("No input paths specified.");
-            }
-
-            // Parse and validate global metadata DB config
-            if (false == metadata_db_config_file_path.empty()) {
-                clp::GlobalMetadataDBConfig metadata_db_config;
-                try {
-                    metadata_db_config.parse_config_file(metadata_db_config_file_path);
-                } catch (std::exception& e) {
-                    SPDLOG_ERROR("Failed to validate metadata database config - {}.", e.what());
-                    return ParsingResult::Failure;
-                }
-
-                if (clp::GlobalMetadataDBConfig::MetadataDBType::MySQL
-                    != metadata_db_config.get_metadata_db_type())
-                {
-                    SPDLOG_ERROR(
-                            "Invalid metadata database type for {}; only supported type is MySQL.",
-                            m_program_name
-                    );
-                    return ParsingResult::Failure;
-                }
-
-                m_metadata_db_config = std::move(metadata_db_config);
-            }
         }
     } catch (std::exception& e) {
         SPDLOG_ERROR("{}", e.what());
@@ -954,7 +815,4 @@ void CommandLineArguments::print_search_usage() const {
               << std::endl;
 }
 
-void CommandLineArguments::print_ir_compression_usage() const {
-    std::cerr << "Usage: " << m_program_name << " i [OPTIONS] ARCHIVES_DIR [FILE/DIR ...]\n";
-}
 }  // namespace clp_s

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -262,22 +262,20 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 throw std::invalid_argument("No input paths specified.");
             }
 
-            if (parsed_command_line_options.count("file-type") > 0) {
-                if (cJsonFileType == file_type) {
-                    m_file_type = FileType::Json;
-                } else if (cKeyValueIrFileType == file_type) {
-                    m_file_type = FileType::KeyValueIr;
-                    if (m_structurize_arrays) {
-                        SPDLOG_ERROR(
-                                "Invalid combination of arguments; --file-type {} and "
-                                "--structurize-arrays can't be used together",
-                                cKeyValueIrFileType
-                        );
-                        return ParsingResult::Failure;
-                    }
-                } else {
-                    throw std::invalid_argument("Unknown FILE_TYPE: " + file_type);
+            if (cJsonFileType == file_type) {
+                m_file_type = FileType::Json;
+            } else if (cKeyValueIrFileType == file_type) {
+                m_file_type = FileType::KeyValueIr;
+                if (m_structurize_arrays) {
+                    SPDLOG_ERROR(
+                            "Invalid combination of arguments; --file-type {} and "
+                            "--structurize-arrays can't be used together",
+                            cKeyValueIrFileType
+                    );
+                    return ParsingResult::Failure;
                 }
+            } else {
+                throw std::invalid_argument("Unknown FILE_TYPE: " + file_type);
             }
 
             // Parse and validate global metadata DB config

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -148,7 +148,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             po::options_description compression_options("Compression options");
             std::string metadata_db_config_file_path;
             std::string input_path_list_file_path;
-            std::string file_type;
+            constexpr std::string_view cJsonFileType{"json"};
+            constexpr std::string_view cKeyValueIrFileType{"kv-ir"};
+            std::string file_type{cJsonFileType};
             // clang-format off
             compression_options.add_options()(
                     "compression-level",
@@ -205,8 +207,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "Do not record log order at ingestion time."
             )(
                     "file-type",
-                    po::value<std::string>(&file_type)->value_name("FILE_TYPE"),
-                    "The type of file that is to be compressed to archive (e.g json or kv-ir)"
+                    po::value<std::string>(&file_type)->value_name("FILE_TYPE")->default_value(file_type),
+                    "The type of file being compressed (json or kv-ir)"
             );
             // clang-format on
 
@@ -259,9 +261,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             if (m_file_paths.empty()) {
                 throw std::invalid_argument("No input paths specified.");
             }
-
-            constexpr std::string_view cJsonFileType{"json"};
-            constexpr std::string_view cKeyValueIrFileType{"kv-ir"};
 
             if (parsed_command_line_options.count("file-type") > 0) {
                 if (cJsonFileType == file_type) {

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -36,6 +36,11 @@ public:
         Stdout,
     };
 
+    enum class FileType : uint8_t {
+        Json = 0,
+        KeyValueIr
+    };
+
     // Constructors
     explicit CommandLineArguments(std::string const& program_name) : m_program_name(program_name) {}
 
@@ -116,7 +121,7 @@ public:
 
     bool get_record_log_order() const { return false == m_disable_log_order; }
 
-    [[nodiscard]] auto get_file_type() const -> std::string { return m_file_type; }
+    [[nodiscard]] auto get_file_type() const -> FileType { return m_file_type; }
 
 private:
     // Methods
@@ -186,7 +191,7 @@ private:
     size_t m_target_ordered_chunk_size{};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
-    std::string m_file_type{"Json"};
+    FileType m_file_type{FileType::Json};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -26,8 +26,7 @@ public:
     enum class Command : char {
         Compress = 'c',
         Extract = 'x',
-        Search = 's',
-        IrCompress = 'i'
+        Search = 's'
     };
 
     enum class OutputHandlerType : uint8_t {
@@ -117,6 +116,8 @@ public:
 
     bool get_record_log_order() const { return false == m_disable_log_order; }
 
+    [[nodiscard]] auto get_file_type() const -> std::string { return m_file_type; }
+
 private:
     // Methods
     /**
@@ -164,8 +165,6 @@ private:
 
     void print_decompression_usage() const;
 
-    void print_ir_compression_usage() const;
-
     void print_search_usage() const;
 
     // Variables
@@ -187,6 +186,7 @@ private:
     size_t m_target_ordered_chunk_size{};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
+    std::string m_file_type{"Json"};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -26,7 +26,8 @@ public:
     enum class Command : char {
         Compress = 'c',
         Extract = 'x',
-        Search = 's'
+        Search = 's',
+        IrCompress = 'i'
     };
 
     enum class OutputHandlerType : uint8_t {
@@ -162,6 +163,8 @@ private:
     void print_compression_usage() const;
 
     void print_decompression_usage() const;
+
+    void print_ir_compression_usage() const;
 
     void print_search_usage() const;
 

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -12,6 +12,7 @@
 
 #include "../clp/GlobalMySQLMetadataDB.hpp"
 #include "ArchiveWriter.hpp"
+#include "CommandLineArguments.hpp"
 #include "DictionaryWriter.hpp"
 #include "FileReader.hpp"
 #include "FileWriter.hpp"
@@ -29,6 +30,7 @@ using namespace simdjson;
 namespace clp_s {
 struct JsonParserOption {
     std::vector<std::string> file_paths;
+    CommandLineArguments::FileType input_file_type{CommandLineArguments::FileType::Json};
     std::string timestamp_key;
     std::string archives_dir;
     size_t target_encoded_size{};

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -51,13 +51,6 @@ namespace {
 bool compress(CommandLineArguments const& command_line_arguments);
 
 /**
- * Compresses the input IR files specified by the command line arguments into an archive.
- * @param command_line_arguments
- * @return Whether compression was successful
- */
-auto ir_compress(CommandLineArguments const& command_line_arguments) -> bool;
-
-/**
  * Decompresses the archive specified by the given JsonConstructorOption.
  * @param json_constructor_option
  */

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -118,7 +118,7 @@ bool compress(CommandLineArguments const& command_line_arguments) {
         // Functionality Coming in later PR
         //  -->Call new parsing function in Json Parser to parse IRv2 to archive
         //  -->Check for error from parsing function
-        SPDLOG_ERROR("Compressing Key Valur IR Files is not yet supported");
+        SPDLOG_ERROR("Compressing Key Value IR Files is not yet supported");
         return false;
     } else {
         if (false == parser.parse()) {

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -72,16 +72,6 @@ bool search_archive(
 );
 
 bool compress(CommandLineArguments const& command_line_arguments) {
-    auto file_type = command_line_arguments.get_file_type();
-    if ("IR" != file_type && "Json" != file_type) {
-        SPDLOG_ERROR("File Type specified is Invalid");
-        return false;
-    }
-    if ("IR" == file_type && command_line_arguments.get_structurize_arrays()) {
-        SPDLOG_ERROR("ERROR: structurized arrays are not supported for IR files");
-        return false;
-    }
-
     auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
 
     // Create output directory in case it doesn't exist
@@ -98,6 +88,7 @@ bool compress(CommandLineArguments const& command_line_arguments) {
 
     clp_s::JsonParserOption option{};
     option.file_paths = command_line_arguments.get_file_paths();
+    option.input_file_type = command_line_arguments.get_file_type();
     option.archives_dir = archives_dir.string();
     option.target_encoded_size = command_line_arguments.get_target_encoded_size();
     option.max_document_size = command_line_arguments.get_max_document_size();
@@ -123,7 +114,7 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     }
 
     clp_s::JsonParser parser(option);
-    if ("IR" == file_type) {
+    if (CommandLineArguments::FileType::KeyValueIr == option.input_file_type) {
         // Functionality Coming in later PR
         //  -->Call new parsing function in Json Parser to parse IRv2 to archive
         //  -->Check for error from parsing function

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -118,6 +118,8 @@ bool compress(CommandLineArguments const& command_line_arguments) {
         // Functionality Coming in later PR
         //  -->Call new parsing function in Json Parser to parse IRv2 to archive
         //  -->Check for error from parsing function
+        SPDLOG_ERROR("Compressing Key Valur IR Files is not yet supported");
+        return false;
     } else {
         if (false == parser.parse()) {
             SPDLOG_ERROR("Encountered error while parsing input");

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -79,6 +79,16 @@ bool search_archive(
 );
 
 bool compress(CommandLineArguments const& command_line_arguments) {
+    auto file_type = command_line_arguments.get_file_type();
+    if ("IR" != file_type && "Json" != file_type) {
+        SPDLOG_ERROR("File Type specified is Invalid");
+        return false;
+    }
+    if ("IR" == file_type && command_line_arguments.get_structurize_arrays()) {
+        SPDLOG_ERROR("ERROR: structurized arrays are not supported for IR files");
+        return false;
+    }
+
     auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
 
     // Create output directory in case it doesn't exist
@@ -120,66 +130,17 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     }
 
     clp_s::JsonParser parser(option);
-    if (false == parser.parse()) {
-        SPDLOG_ERROR("Encountered error while parsing input");
-        return false;
+    if ("IR" == file_type) {
+        // Functionality Coming in later PR
+        //  -->Call new parsing function in Json Parser to parse IRv2 to archive
+        //  -->Check for error from parsing function
+    } else {
+        if (false == parser.parse()) {
+            SPDLOG_ERROR("Encountered error while parsing input");
+            return false;
+        }
     }
     parser.store();
-    return true;
-}
-
-auto setup_compression_options(
-        CommandLineArguments const& command_line_arguments,
-        clp_s::JsonParserOption& option
-) -> bool {
-    auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
-    // Create output directory in case it doesn't exist
-    try {
-        std::filesystem::create_directory(archives_dir.string());
-    } catch (std::exception& e) {
-        SPDLOG_ERROR(
-                "Failed to create archives directory {} - {}",
-                archives_dir.string(),
-                e.what()
-        );
-        return false;
-    }
-    option.file_paths = command_line_arguments.get_file_paths();
-    option.archives_dir = archives_dir.string();
-    option.target_encoded_size = command_line_arguments.get_target_encoded_size();
-    option.max_document_size = command_line_arguments.get_max_document_size();
-    option.min_table_size = command_line_arguments.get_minimum_table_size();
-    option.compression_level = command_line_arguments.get_compression_level();
-    option.timestamp_key = command_line_arguments.get_timestamp_key();
-    option.print_archive_stats = command_line_arguments.print_archive_stats();
-    option.single_file_archive = command_line_arguments.get_single_file_archive();
-    option.record_log_order = command_line_arguments.get_record_log_order();
-
-    auto const& db_config_container = command_line_arguments.get_metadata_db_config();
-    if (db_config_container.has_value()) {
-        auto const& db_config = db_config_container.value();
-        option.metadata_db = std::make_shared<clp::GlobalMySQLMetadataDB>(
-                db_config.get_metadata_db_host(),
-                db_config.get_metadata_db_port(),
-                db_config.get_metadata_db_username(),
-                db_config.get_metadata_db_password(),
-                db_config.get_metadata_db_name(),
-                db_config.get_metadata_table_prefix()
-        );
-    }
-    return true;
-}
-
-auto ir_compress(CommandLineArguments const& command_line_arguments) -> bool {
-    clp_s::JsonParserOption option{};
-    if (false == setup_compression_options(command_line_arguments, option)) {
-        return false;
-    }
-
-    // Functionality Coming in later PR
-    //  -->Instantiate Json Parser
-    //  -->Call new parsing function in Json Parser to parse IRv2 to archive
-    //  -->Store Archive
     return true;
 }
 
@@ -350,10 +311,6 @@ int main(int argc, char const* argv[]) {
 
     if (CommandLineArguments::Command::Compress == command_line_arguments.get_command()) {
         if (false == compress(command_line_arguments)) {
-            return 1;
-        }
-    } else if (CommandLineArguments::Command::IrCompress == command_line_arguments.get_command()) {
-        if (false == ir_compress(command_line_arguments)) {
             return 1;
         }
     } else if (CommandLineArguments::Command::Extract == command_line_arguments.get_command()) {


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Added command line interface needed for compressing IRv2 to archive. 
- added the `--file-type` flag to the `c` compression option of the clp-s command line interface
- this new flag determine which parsing function will get called and there is error checking to make sure the `--stucturize-arrrays` isn't used in conjunction with incorrect file types.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Called the corresponding command line options (e.g. `./clp-s c test-archive test_ir.ir --file-type IR` )to see that the command line options called the correct function paths. 

Called `./clp-s c test-archive test_ir.ir --file-type IR --structurize-arrays` to see the an error message is produced. 

Called `./clp-s c test-archive test_json.json` && `./clp-s c test-archive test_json.json --structurize-arrays`  to make sure both of these command result in the expected normal opperation.

Called `./clp-s c --help` to see the  correct usage message was printed including the new flag option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line option for specifying the file type during compression (e.g., Json or KeyValueIr).
  - Added a method to retrieve the specified file type from command-line arguments.
  - Enhanced the `JsonParser` to specify the type of input file it processes.

- **Bug Fixes**
  - Improved error handling for invalid file type combinations in the compression process.

- **Documentation**
  - Updated help messages to include information about the new `file-type` option and its usage in compression commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->