### PR TITLE
revert(core): Remove temporary output directory option from `clp` and `clo`.

### DIFF
--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -181,10 +181,6 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     // clang-format off
     options_ir_extraction
             .add_options()(
-                    "temp-output-dir",
-                    po::value<string>(&m_ir_temp_output_dir)->value_name("DIR"),
-                    "Temporary output directory for IR chunks while they're being written"
-            )(
                     "target-size",
                     po::value<size_t>(&m_ir_target_size)->value_name("SIZE"),
                     "Target size (B) for each IR chunk before a new chunk is created"
@@ -286,10 +282,6 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
 
     if (m_ir_mongodb_collection.empty()) {
         throw invalid_argument("COLLECTION not specified or empty.");
-    }
-
-    if (m_ir_temp_output_dir.empty()) {
-        m_ir_temp_output_dir = m_ir_output_dir;
     }
     return ParsingResult::Success;
 }

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -54,10 +54,6 @@ public:
 
     [[nodiscard]] auto get_ir_output_dir() const -> std::string const& { return m_ir_output_dir; }
 
-    [[nodiscard]] auto get_ir_temp_output_dir() const -> std::string const& {
-        return m_ir_temp_output_dir;
-    }
-
     [[nodiscard]] auto get_ir_mongodb_uri() const -> std::string const& { return m_ir_mongodb_uri; }
 
     [[nodiscard]] auto get_ir_mongodb_collection() const -> std::string const& {
@@ -187,7 +183,6 @@ private:
     std::string m_file_split_id;
     size_t m_ir_target_size{128ULL * 1024 * 1024};
     std::string m_ir_output_dir;
-    std::string m_ir_temp_output_dir;
     std::string m_ir_mongodb_uri;
     std::string m_ir_mongodb_collection;
 

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -224,7 +224,7 @@ bool extract_ir(CommandLineArguments const& command_line_args) {
                     archive_reader,
                     *file_metadata_ix_ptr,
                     command_line_args.get_ir_target_size(),
-                    command_line_args.get_ir_temp_output_dir(),
+                    command_line_args.get_ir_output_dir(),
                     ir_output_handler
             ))
         {

--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -255,13 +255,6 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                             ->default_value(m_ir_target_size),
                     "Target size (B) for each IR chunk before a new chunk is created"
             );
-            options_ir.add_options()(
-                    "temp-output-dir",
-                    po::value<string>(&m_ir_temp_output_dir)
-                            ->value_name("DIR")
-                            ->default_value(m_ir_temp_output_dir),
-                    "Temporary output directory for IR chunks while they're being written"
-            );
 
             po::options_description all_ir_options;
             all_ir_options.add(ir_positional_options);
@@ -310,10 +303,6 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
 
             if (m_orig_file_id.empty()) {
                 throw invalid_argument("ORIG_FILE_ID cannot be empty.");
-            }
-
-            if (m_ir_temp_output_dir.empty()) {
-                m_ir_temp_output_dir = m_output_dir;
             }
         } else if (Command::Compress == m_command) {
             // Define compression hidden positional options

--- a/components/core/src/clp/clp/CommandLineArguments.hpp
+++ b/components/core/src/clp/clp/CommandLineArguments.hpp
@@ -37,8 +37,6 @@ public:
 
     std::string const& get_path_prefix_to_remove() const { return m_path_prefix_to_remove; }
 
-    std::string const& get_ir_temp_output_dir() const { return m_ir_temp_output_dir; }
-
     std::string const& get_output_dir() const { return m_output_dir; }
 
     std::string const& get_schema_file_path() const { return m_schema_file_path; }
@@ -91,7 +89,6 @@ private:
     size_t m_ir_msg_ix{0};
     size_t m_ir_target_size{128ULL * 1024 * 1024};
     bool m_sort_input_files;
-    std::string m_ir_temp_output_dir;
     std::string m_output_dir;
     std::string m_schema_file_path;
     bool m_show_progress;

--- a/components/core/src/clp/clp/decompression.cpp
+++ b/components/core/src/clp/clp/decompression.cpp
@@ -310,7 +310,7 @@ bool decompress_to_ir(CommandLineArguments& command_line_args) {
                     archive_reader,
                     *file_metadata_ix_ptr,
                     command_line_args.get_ir_target_size(),
-                    command_line_args.get_ir_temp_output_dir(),
+                    command_line_args.get_output_dir(),
                     ir_output_handler
             ))
         {


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
The temp_output option was introduced to support cloud with fuse layer. However, it turns out that std::filesystem::rename doesn't support cross device link, and as a result the cloud clp will anyway require its own customization. 
Since temp output directory option does not have any other usage other than supporting cloud, we will remove the temp_output from OSS clp and make it a cloud-only feature in clp-cloud's repo.



# Validation performed
Manually tested `clp i` and confirmed the IR can be extracted.
Manaully Ran clo and clp, ensure that temp_directory_output is no longer an option in cmd.
Locally launched CLP package and confirmed that there's no issue for log-viewing. In other words, exercising the clo ir flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined command-line argument parsing by removing the `temp-output-dir` option for IR extraction.
- **Bug Fixes**
	- Enhanced error handling and logging in the `extract_ir` and `search` functions for clearer feedback during processing.
- **Refactor**
	- Simplified the `CommandLineArguments` class by removing the `get_ir_temp_output_dir()` method and its associated variable.
	- Updated output directory handling in decompression functions to improve clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->