### PR TITLE
feat(clp-s): Unescape string values during ingestion and fix support for search using escape sequences.

### DIFF
--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -23,8 +23,6 @@ set(
         ../clp/ffi/KeyValuePairLogEvent.hpp
         ../clp/ffi/SchemaTree.cpp
         ../clp/ffi/SchemaTree.hpp
-        ../clp/ffi/utils.cpp
-        ../clp/ffi/utils.hpp
         ../clp/ffi/Value.hpp
         ../clp/FileDescriptor.cpp
         ../clp/FileDescriptor.hpp

--- a/components/core/src/clp_s/ColumnReader.cpp
+++ b/components/core/src/clp_s/ColumnReader.cpp
@@ -2,6 +2,7 @@
 
 #include "BufferViewReader.hpp"
 #include "ColumnWriter.hpp"
+#include "Utils.hpp"
 #include "VariableDecoder.hpp"
 
 namespace clp_s {
@@ -88,6 +89,20 @@ void ClpStringColumnReader::extract_string_value_into_buffer(
     VariableDecoder::decode_variables_into_message(entry, *m_var_dict, encoded_vars, buffer);
 }
 
+void ClpStringColumnReader::extract_escaped_string_value_into_buffer(
+        uint64_t cur_message,
+        std::string& buffer
+) {
+    if (false == m_is_array) {
+        // TODO: escape while decoding instead of after.
+        std::string tmp;
+        extract_string_value_into_buffer(cur_message, tmp);
+        StringUtils::escape_json_string(buffer, tmp);
+    } else {
+        extract_string_value_into_buffer(cur_message, buffer);
+    }
+}
+
 int64_t ClpStringColumnReader::get_encoded_id(uint64_t cur_message) {
     auto value = m_logtypes[cur_message];
     return ClpStringColumnWriter::get_encoded_log_dict_id(value);
@@ -123,6 +138,13 @@ void VariableStringColumnReader::extract_string_value_into_buffer(
         std::string& buffer
 ) {
     buffer.append(m_var_dict->get_value(m_variables[cur_message]));
+}
+
+void VariableStringColumnReader::extract_escaped_string_value_into_buffer(
+        uint64_t cur_message,
+        std::string& buffer
+) {
+    StringUtils::escape_json_string(buffer, m_var_dict->get_value(m_variables[cur_message]));
 }
 
 int64_t VariableStringColumnReader::get_variable_id(uint64_t cur_message) {

--- a/components/core/src/clp_s/ColumnReader.hpp
+++ b/components/core/src/clp_s/ColumnReader.hpp
@@ -53,6 +53,17 @@ public:
      */
     virtual void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) = 0;
 
+    /**
+     * Extracts a value from the column, escapes it, and serializes it into a provided buffer as a
+     * string.
+     * @param cur_message
+     * @param buffer
+     */
+    virtual void
+    extract_escaped_string_value_into_buffer(uint64_t cur_message, std::string& buffer) {
+        extract_string_value_into_buffer(cur_message, buffer);
+    }
+
 private:
     int32_t m_id;
 };
@@ -152,6 +163,9 @@ public:
 
     void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
 
+    void
+    extract_escaped_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
+
     /**
      * Gets the encoded id of the variable
      * @param cur_message
@@ -195,6 +209,9 @@ public:
     ) override;
 
     void extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
+
+    void
+    extract_escaped_string_value_into_buffer(uint64_t cur_message, std::string& buffer) override;
 
     /**
      * Gets the encoded id of the variable

--- a/components/core/src/clp_s/JsonSerializer.hpp
+++ b/components/core/src/clp_s/JsonSerializer.hpp
@@ -6,6 +6,9 @@
 #include <vector>
 
 #include "ColumnReader.hpp"
+#include "Utils.hpp"
+
+namespace clp_s {
 
 class JsonSerializer {
 public:
@@ -67,7 +70,11 @@ public:
         return false;
     }
 
-    void add_special_key(std::string_view const key) { m_special_keys.emplace_back(key); }
+    void add_special_key(std::string_view const key) {
+        std::string tmp;
+        StringUtils::escape_json_string(tmp, key);
+        m_special_keys.emplace_back(tmp);
+    }
 
     void begin_object() {
         append_key();
@@ -109,11 +116,11 @@ public:
         m_json_string += "],";
     }
 
-    void append_key() { append_key(m_special_keys[m_special_keys_index++]); }
+    void append_key() { append_escaped_key(m_special_keys[m_special_keys_index++]); }
 
     void append_key(std::string_view const key) {
         m_json_string += "\"";
-        m_json_string += key;
+        StringUtils::escape_json_string(m_json_string, key);
         m_json_string += "\":";
     }
 
@@ -130,11 +137,17 @@ public:
     void
     append_value_from_column_with_quotes(clp_s::BaseColumnReader* column, uint64_t cur_message) {
         m_json_string += "\"";
-        column->extract_string_value_into_buffer(cur_message, m_json_string);
+        column->extract_escaped_string_value_into_buffer(cur_message, m_json_string);
         m_json_string += "\",";
     }
 
 private:
+    void append_escaped_key(std::string_view const key) {
+        m_json_string.push_back('"');
+        m_json_string.append(key);
+        m_json_string.append("\":");
+    }
+
     std::string m_json_string;
     std::vector<Op> m_op_list;
     std::vector<std::string> m_special_keys;
@@ -142,5 +155,7 @@ private:
     size_t m_op_list_index{0};
     size_t m_special_keys_index{0};
 };
+
+}  // namespace clp_s
 
 #endif  // CLP_S_JSONSERIALIZER_HPP

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -540,7 +540,7 @@ void StringUtils::escape_json_string(std::string& destination, std::string_view 
 
 namespace {
 /**
- * Convert a four byte hex sequence to utf8. We perform the conversion in this cumbersome way
+ * Converts a four byte hex sequence to utf8. We perform the conversion in this cumbersome way
  * because c++20 deprecates most of the much more convenient std::codecvt utilities.
  */
 bool convert_four_byte_hex_to_utf8(std::string_view const hex, std::string& destination) {

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -579,11 +579,12 @@ bool StringUtils::unescape_kql_internal(
 ) {
     bool escaped{false};
     for (size_t i = 0; i < value.size(); ++i) {
-        if (false == escaped && '\\' != value[i]) {
-            unescaped.push_back(value[i]);
-            continue;
-        } else if (false == escaped && '\\' == value[i]) {
-            escaped = true;
+        if (false == escaped) {
+            if ('\\' == value[i]) {
+                escaped = true;
+            } else {
+                unescaped.push_back(value[i]);
+            }
             continue;
         }
 

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -300,7 +300,7 @@ private:
     }
 
     /**
-     * Unescape a KQL key or value with special handling for each case and append the unescaped
+     * Unescapes a KQL key or value with special handling for each case and append the unescaped
      * value to the `unescaped` buffer.
      * @param value
      * @param unescaped

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -230,8 +230,8 @@ public:
      * (e.g. \n) and less common control sequences with unicode escape sequences (e.g. \u001f). The
      * '"' and '\' characters are escaped with a backslash.
      *
-     * @param source
      * @param destination
+     * @param source
      */
     static void escape_json_string(std::string& destination, std::string_view const source);
 
@@ -245,7 +245,7 @@ public:
      *
      * @param value
      * @param unescaped
-     * @return true if the value was escaped succesfully and false otherwise.
+     * @return true if the value was unescaped successfully, false otherwise.
      */
     static bool unescape_kql_value(std::string const& value, std::string& unescaped);
 
@@ -280,7 +280,7 @@ private:
             if ('\x00' <= nibble && nibble <= '\x09') {
                 return '0' + (nibble - '\x00');
             } else {
-                return 'a' + (nibble - '\x10');
+                return 'a' + (nibble - '\x0a');
             }
         };
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -206,7 +206,7 @@ bool search_archive(
                 SPDLOG_ERROR("Can not tokenize invalid column: \"{}\"", column);
                 return false;
             }
-            projection->add_column(ColumnDescriptor::create(descriptor_tokens));
+            projection->add_column(ColumnDescriptor::create_from_escaped_tokens(descriptor_tokens));
         }
     } catch (clp_s::TraceableException& e) {
         SPDLOG_ERROR("{}", e.what());

--- a/components/core/src/clp_s/search/AddTimestampConditions.cpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.cpp
@@ -18,7 +18,8 @@ std::shared_ptr<Expression> AddTimestampConditions::run(std::shared_ptr<Expressi
         return EmptyExpr::create();
     }
 
-    auto timestamp_column = ColumnDescriptor::create(m_timestamp_column.value());
+    auto timestamp_column
+            = ColumnDescriptor::create_from_escaped_tokens(m_timestamp_column.value());
 
     auto and_expr = AndExpr::create();
     if (m_begin_ts.has_value()) {

--- a/components/core/src/clp_s/search/ColumnDescriptor.cpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.cpp
@@ -6,7 +6,7 @@ namespace clp_s::search {
 DescriptorList tokenize_descriptor(std::vector<std::string> const& descriptors) {
     DescriptorList list;
     for (std::string const& descriptor : descriptors) {
-        list.push_back(DescriptorToken(descriptor));
+        list.push_back(DescriptorToken::create_descriptor_from_escaped_token(descriptor));
     }
     return list;
 }
@@ -15,7 +15,7 @@ void ColumnDescriptor::check_and_set_unresolved_descriptor_flag() {
     m_unresolved_descriptors = false;
     m_pure_wildcard = m_descriptors.size() == 1 && m_descriptors[0].wildcard();
     for (auto const& token : m_descriptors) {
-        if (token.wildcard() || token.regex()) {
+        if (token.wildcard()) {
             m_unresolved_descriptors = true;
             break;
         }
@@ -24,7 +24,7 @@ void ColumnDescriptor::check_and_set_unresolved_descriptor_flag() {
 
 ColumnDescriptor::ColumnDescriptor(std::string const& descriptor) {
     m_flags = cAllTypes;
-    m_descriptors.emplace_back(descriptor);
+    m_descriptors.emplace_back(DescriptorToken::create_descriptor_from_escaped_token(descriptor));
     check_and_set_unresolved_descriptor_flag();
     if (is_unresolved_descriptor()) {
         simplify_descriptor_wildcards();
@@ -49,17 +49,21 @@ ColumnDescriptor::ColumnDescriptor(DescriptorList const& descriptors) {
     }
 }
 
-std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create(std::string const& descriptor) {
-    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(descriptor));
-}
-
-std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create(
-        std::vector<std::string> const& descriptors
+std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create_from_escaped_token(
+        std::string const& token
 ) {
-    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(descriptors));
+    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(token));
 }
 
-std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create(DescriptorList const& descriptors) {
+std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create_from_escaped_tokens(
+        std::vector<std::string> const& tokens
+) {
+    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(tokens));
+}
+
+std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create_from_descriptors(
+        DescriptorList const& descriptors
+) {
     return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(descriptors));
 }
 

--- a/components/core/src/clp_s/search/ColumnDescriptor.cpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.cpp
@@ -22,18 +22,18 @@ void ColumnDescriptor::check_and_set_unresolved_descriptor_flag() {
     }
 }
 
-ColumnDescriptor::ColumnDescriptor(std::string const& descriptor) {
+ColumnDescriptor::ColumnDescriptor(std::string const& token) {
     m_flags = cAllTypes;
-    m_descriptors.emplace_back(DescriptorToken::create_descriptor_from_escaped_token(descriptor));
+    m_descriptors.emplace_back(DescriptorToken::create_descriptor_from_escaped_token(token));
     check_and_set_unresolved_descriptor_flag();
     if (is_unresolved_descriptor()) {
         simplify_descriptor_wildcards();
     }
 }
 
-ColumnDescriptor::ColumnDescriptor(std::vector<std::string> const& descriptors) {
+ColumnDescriptor::ColumnDescriptor(std::vector<std::string> const& tokens) {
     m_flags = cAllTypes;
-    m_descriptors = std::move(tokenize_descriptor(descriptors));
+    m_descriptors = std::move(tokenize_descriptor(tokens));
     check_and_set_unresolved_descriptor_flag();
     if (is_unresolved_descriptor()) {
         simplify_descriptor_wildcards();

--- a/components/core/src/clp_s/search/ColumnDescriptor.hpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.hpp
@@ -117,22 +117,35 @@ DescriptorList tokenize_descriptor(std::vector<std::string> const& descriptors);
 class ColumnDescriptor : public Literal {
 public:
     /**
-     * Create a ColumnDescriptor literal from an integral value
-     * @param descriptor(s) the token or list of tokens making up the descriptor
-     * @return A ColumnDescriptor
+     * Creates a ColumnDescriptor literal from a list of escaped tokens.
+     *
+     * In particular there are escaping rules for literal '\' and '*':
+     * \\ -> literal \
+     * \* -> literal *
+     *
+     * A '*' that is not escaped is treated as a wildcard descriptor.
+     *
+     * @param token(s) the escaped token or list of escaped tokens making up the descriptor
+     * @return A ColumnDescriptor literal
      */
     static std::shared_ptr<ColumnDescriptor> create_from_escaped_token(std::string const& token);
     static std::shared_ptr<ColumnDescriptor> create_from_escaped_tokens(
             std::vector<std::string> const& tokens
     );
+
+    /**
+     * Create a ColumnDescriptor literal from a list of already-parsed DescriptorToken.
+     * @param descriptors the list of parsed DescriptorToken
+     * @return A ColumnDescriptor literal
+     */
     static std::shared_ptr<ColumnDescriptor> create_from_descriptors(
             DescriptorList const& descriptors
     );
 
     /**
      * Inserts an entire DescriptorList into this ColumnDescriptor before the specified position.
-     * @param an iterator indicating the position in the internal descriptor list before which the new descriptors will be inserted.
-     * before.
+     * @param an iterator indicating the position in the internal descriptor list before which the
+     * new descriptors will be inserted.
      * @param source the list of descriptors to be inserted
      */
     void insert(DescriptorList::iterator pos, DescriptorList const& source) {

--- a/components/core/src/clp_s/search/ColumnDescriptor.hpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.hpp
@@ -63,7 +63,7 @@ public:
 
 private:
     /**
-     * Initialize the token from a string and set flags based on whether the token contains
+     * Initializes the token from a string and sets flags based on whether the token contains
      * wildcards
      * @param token the string to initialize the token from
      * @param bool true if the string should be interpreted as literal, and false
@@ -130,10 +130,10 @@ public:
     );
 
     /**
-     * Insert an entire DescriptorList into this ColumnDescriptor at before given position.
-     * @param pos an iterator to the position inside of the internal descriptor list to insert
+     * Inserts an entire DescriptorList into this ColumnDescriptor before the specified position.
+     * @param an iterator indicating the position in the internal descriptor list before which the new descriptors will be inserted.
      * before.
-     * @param source the list of descriptors to insert
+     * @param source the list of descriptors to be inserted
      */
     void insert(DescriptorList::iterator pos, DescriptorList const& source) {
         m_descriptors.insert(pos, source.begin(), source.end());

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -666,9 +666,7 @@ bool Output::evaluate_array_filter_object(
     }
 
     for (auto field : object) {
-        // Note: field.key() yields the escaped JSON key, so the descriptor tokens passed to search
-        // must likewise be escaped.
-        if (field.key() != unresolved_tokens[cur_idx].get_token()) {
+        if (field.unescaped_key(true).value() != unresolved_tokens[cur_idx].get_token()) {
             continue;
         }
 

--- a/components/core/src/clp_s/search/SchemaMatch.cpp
+++ b/components/core/src/clp_s/search/SchemaMatch.cpp
@@ -77,12 +77,15 @@ std::shared_ptr<Expression> SchemaMatch::populate_column_mapping(std::shared_ptr
                     auto literal_type = node_to_literal_type(node->get_type());
                     DescriptorList descriptors;
                     while (node->get_id() != m_tree->get_object_subtree_node_id()) {
-                        // may have to explicitly mark non-regex
-                        descriptors.emplace_back(node->get_key_name());
+                        descriptors.emplace_back(
+                                DescriptorToken::create_descriptor_from_literal_token(
+                                        node->get_key_name()
+                                )
+                        );
                         node = &m_tree->get_node(node->get_parent_id());
                     }
                     std::reverse(descriptors.begin(), descriptors.end());
-                    auto resolved_column = ColumnDescriptor::create(descriptors);
+                    auto resolved_column = ColumnDescriptor::create_from_descriptors(descriptors);
                     resolved_column->set_matching_type(literal_type);
                     *it = resolved_column;
                     cur->copy_append(possibilities.get());

--- a/components/core/src/clp_s/search/kql/Kql.g4
+++ b/components/core/src/clp_s/search/kql/Kql.g4
@@ -48,35 +48,27 @@ QUOTED_STRING: '"' QUOTED_CHARACTER* '"' ;
 
 UNQUOTED_LITERAL: UNQUOTED_CHARACTER+ ;
 
-// TODO handle unicode
 fragment QUOTED_CHARACTER
     : ESCAPED_SPACE
     | '\\"'
     | ~'"'
     ;
 
-// TODO:  handle unicode
 fragment UNQUOTED_CHARACTER
     : ESCAPED_SPACE
     | ESCAPED_SPECIAL_CHARACTER
-    | ESCAPED_KEYWORD
     | WILDCARD
+    | UNICODE
     |  ~[\\():<>"{} \r\n\t]
     ;
 
 fragment WILDCARD:   '*' | '?';
-
-// TODO: unescape keywords
-fragment ESCAPED_KEYWORD
-    : '\\' KEYWORD
-    ;
 
 fragment KEYWORD
     : AND
     | OR
     | NOT
     ;
-
 
 RANGE_OPERATOR
     : '<='
@@ -99,9 +91,8 @@ fragment SPECIAL_CHARACTER
     : [\\():<>"*?{}.]
     ;
 
-
 // For unicode hex
-//UNICODE: 'u' HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT ;
-//fragment HEXDIGIT: [0-9a-fA-F]+ ;
+fragment UNICODE: '\\u' HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT ;
+fragment HEXDIGIT: [0-9a-fA-F]+ ;
 
 SPACE:  [ \t\r\n] -> skip ;

--- a/components/core/src/clp_s/search/kql/Kql.g4
+++ b/components/core/src/clp_s/search/kql/Kql.g4
@@ -93,6 +93,6 @@ fragment SPECIAL_CHARACTER
 
 // For unicode hex
 fragment UNICODE: '\\u' HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT ;
-fragment HEXDIGIT: [0-9a-fA-F]+ ;
+fragment HEXDIGIT: [0-9a-fA-F] ;
 
 SPACE:  [ \t\r\n] -> skip ;

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -65,7 +65,8 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(false == filter->is_inverted());
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         REQUIRE(1 == filter->get_column()->get_descriptor_list().size());
-        REQUIRE(DescriptorToken{"key"} == *filter->get_column()->descriptor_begin());
+        auto const key_token = DescriptorToken::create_descriptor_from_escaped_token("key");
+        REQUIRE(key_token == *filter->get_column()->descriptor_begin());
         std::string extracted_value;
         REQUIRE(filter->get_operand()->as_var_string(extracted_value, filter->get_operation()));
         REQUIRE("value" == extracted_value);
@@ -82,7 +83,8 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(true == not_filter->is_inverted());
         REQUIRE(FilterOperation::EQ == not_filter->get_operation());
         REQUIRE(1 == not_filter->get_column()->get_descriptor_list().size());
-        REQUIRE(DescriptorToken{"key"} == *not_filter->get_column()->descriptor_begin());
+        auto const key_token = DescriptorToken::create_descriptor_from_escaped_token("key");
+        REQUIRE(key_token == *not_filter->get_column()->descriptor_begin());
         std::string extracted_value;
         REQUIRE(not_filter->get_operand()
                         ->as_var_string(extracted_value, not_filter->get_operation()));
@@ -127,7 +129,8 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
             std::string key = "key" + std::to_string(suffix_number);
             std::string value = "value" + std::to_string(suffix_number);
             REQUIRE(value == extracted_value);
-            REQUIRE(DescriptorToken{key} == *filter->get_column()->descriptor_begin());
+            auto const key_token = DescriptorToken::create_descriptor_from_escaped_token(key);
+            REQUIRE(key_token == *filter->get_column()->descriptor_begin());
             ++suffix_number;
         }
     }
@@ -176,7 +179,8 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
             std::string key = "key" + std::to_string(suffix_number);
             std::string value = "value" + std::to_string(suffix_number);
             REQUIRE(value == extracted_value);
-            REQUIRE(DescriptorToken{key} == *filter->get_column()->descriptor_begin());
+            auto const key_token = DescriptorToken::create_descriptor_from_escaped_token(key);
+            REQUIRE(key_token == *filter->get_column()->descriptor_begin());
             ++suffix_number;
         }
     }
@@ -206,8 +210,10 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         REQUIRE(2 == filter->get_column()->get_descriptor_list().size());
         auto it = filter->get_column()->descriptor_begin();
-        REQUIRE(DescriptorToken{"a.b"} == *it++);
-        REQUIRE(DescriptorToken{"c"} == *it++);
+        auto const a_b_token = DescriptorToken::create_descriptor_from_escaped_token("a.b");
+        REQUIRE(a_b_token == *it++);
+        auto const c_token = DescriptorToken::create_descriptor_from_escaped_token("c");
+        REQUIRE(c_token == *it++);
     }
 
     SECTION("Illegal escape sequences in column name") {

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -245,10 +245,13 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
                 std::pair{"\\\\", "\\\\"},
                 std::pair{"\\??", "\\??"},
                 std::pair{"\\**", "\\**"},
-                std::pair{"\u9999", "香"},
+                std::pair{"\\u9999", "香"},
                 std::pair{"\\r\\n\\t\\b\\f", "\r\n\t\b\f"},
                 std::pair{"\\\"", "\""},
-                std::pair{"\\{\\}\\(\\)\\<\\>", "{}()<>"}
+                std::pair{"\\{\\}\\(\\)\\<\\>", "{}()<>"},
+                std::pair{"\\u003F", "\\?"},
+                std::pair{"\\u002A", "\\*"},
+                std::pair{"\\u005C", "\\\\"}
         );
 
         auto formatted_query = fmt::format("*: \"{}\"", translated_pair.first);

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -205,6 +205,11 @@ Keys and values also support the following escape sequences to represent control
 * `\r`
 * `\t`
 
+:::{note}
+The escape sequences in this section are described verbatim and don't need an extra backslash to
+escape the backslash at the beginning of each sequence.
+:::
+
 ## Examples
 
 **Search for log events that contain a specific key-value pair:**

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -164,7 +164,7 @@ There are three supported boolean operators:
 
 You can use parentheses (`()`) to apply an operator to a group of expressions.
 
-### Escaping special characters
+### Characters that require escaping
 
 Keys containing the following literal characters must escape the characters using a `\` (backslash):
 
@@ -197,11 +197,11 @@ Keys and values can also represent unicode codepoints using the `\uXXXX` escape 
 
 Keys and values also support the following escape sequences to represent control characters:
 
-* `\r`
-* `\n`
-* `\t`
 * `\b`
 * `\f`
+* `\n`
+* `\r`
+* `\t`
 
 ## Examples
 

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -194,8 +194,8 @@ characters using a `\` (backslash):
 
 ### Supported escape sequences
 
-Keys and values can also represent unicode codepoints using the `\uXXXX` escape sequence, where each
-`X` is a hexadecimal character.
+Keys and values can represent Unicode codepoints using the `\uXXXX` escape sequence, where each `X`
+is a hexadecimal character.
 
 Keys and values also support the following escape sequences to represent control characters:
 

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -171,6 +171,7 @@ Keys containing the following literal characters must escape the characters usin
 * `\`
 * `"`
 * `.`
+* `*`
 
 Values containing the following literal characters must escape the characters using a `\`
 (backslash):
@@ -190,6 +191,17 @@ characters using a `\` (backslash):
 * `>`
 * `{`
 * `}`
+
+Keys and values can also represent unicode codepoints using the `\uXXXX` escape sequence, where each
+`X` is a hexadecimal character.
+
+Keys and values also support the following escape sequences to represent control characters:
+
+* `\r`
+* `\n`
+* `\t`
+* `\b`
+* `\f`
 
 ## Examples
 

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -42,7 +42,7 @@ be interpreted as _exact_ searches unless they include [wildcards](#wildcards-in
 :::{note}
 Certain characters have special meanings when used in keys or values, so to search for the
 characters literally, you must escape them. For a list of such characters, see
-[Escaping special characters](#escaping-special-characters).
+[Characters that require escaping](#characters-that-require-escaping).
 :::
 
 ### Querying nested kv-pairs
@@ -191,6 +191,8 @@ characters using a `\` (backslash):
 * `>`
 * `{`
 * `}`
+
+### Supported escape sequences
 
 Keys and values can also represent unicode codepoints using the `\uXXXX` escape sequence, where each
 `X` is a hexadecimal character.


### PR DESCRIPTION
# Description
This PR changes the archive format of clp-s to store the unescaped versions of string values instead of the escaped version of string values, and implements fixes and missing features for search involving escape sequences.

This change to the archive format both makes it more straightforward to support correct search on escape sequences and makes it so that the archive format is consistent between the JSON ingestion path and the soon-to-be-implemented kv-pair IR ingestion path.

| Dataset |  (new compression time / old compression time) |
| ---- | ---- |
| cockroach | 1.01 |
| mongodb | 1.09 |
| elasticsearch | 1.00 |
| spark-event-logs | 0.98 |
| postgresql | 0.97 |
| ---- | ---- |
| Avg | 1.01 |

Compression ratio is effectively unchanged (1.002x improvement in compression ratio on average.

| Dataset | (new decompression time / old decompression time) |
| ---- | ----|
| cockroach | 1.26 |
| mongodb | 1.04 |
| elasticsearch | 1.36 |
| spark-event-logs | 1.15 |
| postgresql | 1.14 |
| ---- | ----|
| Avg | 1.19 |

Overall there is effectively no change in compression performance, and only a moderate decrease in decompression performance. This performance is achieved by getting rid of string copies during compression and implementing escape for JSON strings with a fast path for strings that largely don't have to be escaped.

On the search side the KQL escaping behaviour has been nailed down, support for the \KEYWORD (e.g. \and) escape sequences has been removed, and support for the \u unicode escape sequences has been added.

The full set of escape sequences are:
| sequence | raw | required in quoted string |
| --- | --- | --- |
| \\\ | \ | Y |
| \\" | " | Y |
| \\{ | { | N |
| \\} | } | N |
| \\( | ( | N |
| \\) | ) | N |
| \\< | < | N |
| \\> | > | N |
| \\* | LITERAL * | Y |
| \\? | LITERAL ? | Y (only values) |
| \\. | LITERAL . | Y (only keys) |
| \r | \<cr\> | Y |
| \n | \<nl\> | Y |
| \t | \<tab\> | Y |
| \b | \<bs\> | Y |
| \f | \<ff\> | Y |
| \uXXXX | utf-8 of hex XXXX | Y |

Note that the LITERAL escape sequences are for getting the literal version of a character as opposed to a special character that affects the semantics of search (wildcard "*", match any single character "?", and denote nested keys keys ".").

# Validation performed
* Validated that decompression re-escapes characters 0x00-0x1f, '"', and '\' to generate valid JSON.
* Benchmarked impact on compression and decompression performance.
* Manually validated that this PR fixes every case in the attached github issue (except for 4002 and 4003 which appear to be encountering a CLP search bug).
* Added unit tests for escaping behaviour



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced string extraction capabilities with new methods for escaping string values.
	- Improved handling of Unicode in KQL grammar.
	- Added error handling for invalid literals in KQL parsing.
	- Introduced new methods for creating descriptor tokens from escaped values.
	- Updated methods for adding columns and handling timestamp conditions to utilize escaped token processing.
	- Added comprehensive guidelines for escaping special characters and Unicode in JSON search syntax documentation.

- **Bug Fixes**
	- Streamlined error checks in expression handling to prevent empty expressions.

- **Documentation**
	- Expanded documentation for utility methods related to JSON and KQL string handling.
	- Updated guidelines for escaping special characters in JSON search syntax.

- **Refactor**
	- Updated method signatures across various components to reflect changes in handling escaped tokens.
	- Refined logic for handling unresolved descriptors in schema matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->