### PR TITLE
feat(ffi): Add initial implementation of `IrErrorCode` (using the `ErrorCode` template) which will replace the `IRErrorCode` enum.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -382,6 +382,8 @@ set(SOURCE_FILES_unitTest
         src/clp/ffi/ir_stream/decoding_methods.inc
         src/clp/ffi/ir_stream/encoding_methods.cpp
         src/clp/ffi/ir_stream/encoding_methods.hpp
+        src/clp/ffi/ir_stream/IrErrorCode.cpp
+        src/clp/ffi/ir_stream/IrErrorCode.hpp
         src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp
         src/clp/ffi/ir_stream/IrUnitType.hpp
         src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp

--- a/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
+++ b/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
@@ -14,11 +14,12 @@ template <>
 auto IrErrorCategory::message(IrErrorCodeEnum error_enum) const -> std::string {
     switch (error_enum) {
         case IrErrorCodeEnum::DecodingMethodFailure:
-            return "Decoding method failure.";
+            return "Decoding methods failed.";
         case IrErrorCodeEnum::EndOfStream:
-            return "End-of-stream has been reached.";
+            return "The end-of-stream IR unit was already consumed.";
         case IrErrorCodeEnum::IncompleteStream:
-            return "Incomplete IR stream.";
+            return "The IR stream ended with a truncated IR unit or did not terminate with an "
+                   "end-of-stream IR unit.";
         default:
             return "Unknown error code enum.";
     }

--- a/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
+++ b/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
@@ -14,7 +14,7 @@ template <>
 auto IrErrorCategory::message(IrErrorCodeEnum error_enum) const -> std::string {
     switch (error_enum) {
         case IrErrorCodeEnum::DecodingMethodFailure:
-            return "Decoding methods failed.";
+            return "The decoding method failed.";
         case IrErrorCodeEnum::EndOfStream:
             return "The end-of-stream IR unit has already been consumed.";
         case IrErrorCodeEnum::IncompleteStream:

--- a/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
+++ b/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
@@ -16,7 +16,7 @@ auto IrErrorCategory::message(IrErrorCodeEnum error_enum) const -> std::string {
         case IrErrorCodeEnum::DecodingMethodFailure:
             return "Decoding methods failed.";
         case IrErrorCodeEnum::EndOfStream:
-            return "The end-of-stream IR unit was already consumed.";
+            return "The end-of-stream IR unit has already been consumed.";
         case IrErrorCodeEnum::IncompleteStream:
             return "The IR stream ended with a truncated IR unit or did not terminate with an "
                    "end-of-stream IR unit.";

--- a/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
+++ b/components/core/src/clp/ffi/ir_stream/IrErrorCode.cpp
@@ -1,0 +1,25 @@
+#include "IrErrorCode.hpp"
+
+#include <string>
+
+using IrErrorCategory = clp::error_handling::ErrorCategory<clp::ffi::ir_stream::IrErrorCodeEnum>;
+using clp::ffi::ir_stream::IrErrorCodeEnum;
+
+template <>
+auto IrErrorCategory::name() const noexcept -> char const* {
+    return "clp::ffi::ir_stream::IrErrorCode";
+}
+
+template <>
+auto IrErrorCategory::message(IrErrorCodeEnum error_enum) const -> std::string {
+    switch (error_enum) {
+        case IrErrorCodeEnum::DecodingMethodFailure:
+            return "Decoding method failure.";
+        case IrErrorCodeEnum::EndOfStream:
+            return "End-of-stream has been reached.";
+        case IrErrorCodeEnum::IncompleteStream:
+            return "Incomplete IR stream.";
+        default:
+            return "Unknown error code enum.";
+    }
+}

--- a/components/core/src/clp/ffi/ir_stream/IrErrorCode.hpp
+++ b/components/core/src/clp/ffi/ir_stream/IrErrorCode.hpp
@@ -7,7 +7,8 @@
 
 namespace clp::ffi::ir_stream {
 /**
- * Enums that define all
+ * This enum class represents all possible error codes related to serializing or deserializing CLP
+ * IR streams.
  */
 enum class IrErrorCodeEnum : uint8_t {
     DecodingMethodFailure,

--- a/components/core/src/clp/ffi/ir_stream/IrErrorCode.hpp
+++ b/components/core/src/clp/ffi/ir_stream/IrErrorCode.hpp
@@ -1,0 +1,23 @@
+#ifndef CLP_IRERRORCODE_HPP
+#define CLP_IRERRORCODE_HPP
+
+#include <cstdint>
+
+#include "../../error_handling/ErrorCode.hpp"
+
+namespace clp::ffi::ir_stream {
+/**
+ * Enums that define all
+ */
+enum class IrErrorCodeEnum : uint8_t {
+    DecodingMethodFailure,
+    EndOfStream,
+    IncompleteStream,
+};
+
+using IrErrorCode = clp::error_handling::ErrorCode<IrErrorCodeEnum>;
+}  // namespace clp::ffi::ir_stream
+
+CLP_ERROR_HANDLING_MARK_AS_ERROR_CODE_ENUM(clp::ffi::ir_stream::IrErrorCodeEnum);
+
+#endif  // CLP_IRERRORCODE_HPP

--- a/components/core/tests/test-error_handling.cpp
+++ b/components/core/tests/test-error_handling.cpp
@@ -9,6 +9,7 @@
 #include <Catch2/single_include/catch2/catch.hpp>
 
 #include "../src/clp/error_handling/ErrorCode.hpp"
+#include "../src/clp/ffi/ir_stream/IrErrorCode.hpp"
 
 using clp::error_handling::ErrorCategory;
 using clp::error_handling::ErrorCode;
@@ -138,4 +139,18 @@ TEST_CASE("test_error_code_implementation", "[error_handling][ErrorCode]") {
     REQUIRE((success_error_code != always_success_error_code));
     REQUIRE((AlwaysSuccessErrorCode{AlwaysSuccessErrorCodeEnum::Success} != success_error_code));
     REQUIRE((BinaryErrorCode{BinaryErrorCodeEnum::Success} != always_success_error_code));
+}
+
+TEST_CASE("test_ir_error_code", "[error_handling][ErrorCode][IrErrorCode]") {
+    using clp::ffi::ir_stream::IrErrorCode;
+    using clp::ffi::ir_stream::IrErrorCodeEnum;
+
+    auto assert_error_code_matches_error_code_enum = [](IrErrorCodeEnum error_code_enum) -> bool {
+        std::error_code const error_code{IrErrorCode{error_code_enum}};
+        return error_code == IrErrorCode{error_code_enum};
+    };
+
+    REQUIRE(assert_error_code_matches_error_code_enum(IrErrorCodeEnum::DecodingMethodFailure));
+    REQUIRE(assert_error_code_matches_error_code_enum(IrErrorCodeEnum::EndOfStream));
+    REQUIRE(assert_error_code_matches_error_code_enum(IrErrorCodeEnum::IncompleteStream));
 }


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The existing error handling of CLP IR serialization/deserialization relies on the enum `IRErrorCode`, defined in `decoding_methods.hpp`. However, this enum has many limitations and should be deprecated by the new error-handling system introduced in PR #486.
This PR introduces a boilerplate for the new IR error code, `IrErrorCode,` based on the new error-handling system from #486. So far, we have introduced only three error code enums that are general enough for existing IR errors. More error enums will be added in future PRs when `IrErrorCode` is used inside the current serialization/deserialization code path.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Add unit tests to ensure the new error code can be successfully compiled and used
- Ensure workflows all passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced error handling with new error codes for the IR stream context.
	- Added methods for error category identification and message retrieval.

- **Bug Fixes**
	- Improved clarity in error reporting through specific messages for known error codes.

- **Tests**
	- Added new test cases to validate the functionality of the new error handling mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->