### PR TITLE
feat(clp-s): Add support for kv-pair-IR ingestion.

### DIFF
--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -8,11 +8,35 @@ set(
         ../clp/database_utils.hpp
         ../clp/Defs.h
         ../clp/ErrorCode.hpp
+        ../clp/ffi/ir_stream/decoding_methods.cpp
+        ../clp/ffi/ir_stream/decoding_methods.hpp
+        ../clp/ffi/ir_stream/Deserializer.hpp
+        ../clp/ffi/ir_stream/encoding_methods.cpp
+        ../clp/ffi/ir_stream/encoding_methods.hpp
+        ../clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+        ../clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
+        ../clp/ffi/ir_stream/Serializer.cpp
+        ../clp/ffi/ir_stream/Serializer.hpp
+        ../clp/ffi/ir_stream/utils.cpp
+        ../clp/ffi/ir_stream/utils.hpp
+        ../clp/ffi/KeyValuePairLogEvent.cpp
+        ../clp/ffi/KeyValuePairLogEvent.hpp
+        ../clp/ffi/SchemaTree.cpp
+        ../clp/ffi/SchemaTree.hpp
+        ../clp/ffi/utils.cpp
+        ../clp/ffi/utils.hpp
+        ../clp/ffi/Value.hpp
+        ../clp/FileDescriptor.cpp
+        ../clp/FileDescriptor.hpp
         ../clp/GlobalMetadataDB.hpp
         ../clp/GlobalMetadataDBConfig.cpp
         ../clp/GlobalMetadataDBConfig.hpp
         ../clp/GlobalMySQLMetadataDB.cpp
         ../clp/GlobalMySQLMetadataDB.hpp
+        ../clp/ir/EncodedTextAst.cpp
+        ../clp/ir/EncodedTextAst.hpp
+        ../clp/ir/parsing.cpp
+        ../clp/ir/parsing.hpp
         ../clp/MySQLDB.cpp
         ../clp/MySQLDB.hpp
         ../clp/MySQLParamBindings.cpp
@@ -23,9 +47,16 @@ set(
         ../clp/networking/socket_utils.hpp
         ../clp/ReaderInterface.cpp
         ../clp/ReaderInterface.hpp
+        ../clp/ReadOnlyMemoryMappedFile.cpp
+        ../clp/ReadOnlyMemoryMappedFile.hpp
         ../clp/streaming_archive/ArchiveMetadata.cpp
         ../clp/streaming_archive/ArchiveMetadata.hpp
+        ../clp/streaming_compression/zstd/Decompressor.cpp
+        ../clp/streaming_compression/zstd/Decompressor.hpp
         ../clp/TraceableException.hpp
+        ../clp/time_types.hpp
+        ../clp/utf8_utils.cpp
+        ../clp/utf8_utils.hpp
         ../clp/WriterInterface.cpp
         ../clp/WriterInterface.hpp
 )

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -274,6 +274,14 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     );
                     return ParsingResult::Failure;
                 }
+                if (false == m_timestamp_key.empty()) {
+                    SPDLOG_ERROR(
+                            "Invalid combination of arguments; --file-type {} and "
+                            "--timestamp-key can't be used together",
+                            cKeyValueIrFileType
+                    );
+                    return ParsingResult::Failure;
+                }
             } else {
                 throw std::invalid_argument("Unknown FILE_TYPE: " + file_type);
             }

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -1,15 +1,79 @@
 #include "JsonParser.hpp"
 
+#include <cstdint>
+#include <filesystem>
 #include <iostream>
+#include <optional>
 #include <stack>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <simdjson.h>
 #include <spdlog/spdlog.h>
 
+#include "../clp/ffi/ir_stream/decoding_methods.hpp"
+#include "../clp/ffi/ir_stream/Deserializer.hpp"
+#include "../clp/ffi/ir_stream/IrUnitType.hpp"
+#include "../clp/ffi/KeyValuePairLogEvent.hpp"
+#include "../clp/ffi/SchemaTree.hpp"
+#include "../clp/ffi/utils.hpp"
+#include "../clp/ffi/Value.hpp"
+#include "../clp/ir/EncodedTextAst.hpp"
+#include "../clp/streaming_compression/zstd/Decompressor.hpp"
+#include "../clp/time_types.hpp"
 #include "archive_constants.hpp"
+#include "ErrorCode.hpp"
 #include "JsonFileIterator.hpp"
 
+using clp::ffi::ir_stream::Deserializer;
+using clp::ffi::ir_stream::IRErrorCode;
+using clp::ffi::KeyValuePairLogEvent;
+using clp::UtcOffset;
+
 namespace clp_s {
+/**
+ * Class that implements `clp::ffi::ir_stream::IrUnitHandlerInterface` for Key-Value IR compression.
+ */
+class IrUnitHandler {
+public:
+    [[nodiscard]] auto handle_log_event(KeyValuePairLogEvent&& log_event) -> IRErrorCode {
+        m_deserialized_log_event.emplace(std::move(log_event));
+        return IRErrorCode::IRErrorCode_Success;
+    }
+
+    [[nodiscard]] static auto handle_utc_offset_change(
+            [[maybe_unused]] UtcOffset utc_offset_old,
+            [[maybe_unused]] UtcOffset utc_offset_new
+    ) -> IRErrorCode {
+        return IRErrorCode::IRErrorCode_Success;
+    }
+
+    [[nodiscard]] auto handle_schema_tree_node_insertion(
+            [[maybe_unused]] clp::ffi::SchemaTree::NodeLocator schema_tree_node_locator
+    ) -> IRErrorCode {
+        return IRErrorCode::IRErrorCode_Success;
+    }
+
+    [[nodiscard]] auto handle_end_of_stream() -> IRErrorCode {
+        m_is_complete = true;
+        return IRErrorCode::IRErrorCode_Success;
+    }
+
+    [[nodiscard]] auto get_deserialized_log_event(
+    ) const -> std::optional<KeyValuePairLogEvent> const& {
+        return m_deserialized_log_event;
+    }
+
+    void clear() { m_is_complete = false; }
+
+    [[nodiscard]] auto is_complete() const -> bool { return m_is_complete; }
+
+private:
+    std::optional<KeyValuePairLogEvent> m_deserialized_log_event;
+    bool m_is_complete{false};
+};
+
 JsonParser::JsonParser(JsonParserOption const& option)
         : m_num_messages(0),
           m_target_encoded_size(option.target_encoded_size),
@@ -555,6 +619,292 @@ int32_t JsonParser::add_metadata_field(std::string_view const field_name, NodeTy
             constants::cMetadataSubtreeName
     );
     return m_archive_writer->add_node(metadata_subtree_id, type, field_name);
+}
+
+auto JsonParser::get_archive_node_type(
+        clp::ffi::SchemaTree::Node::Type ir_node_type,
+        bool node_has_value,
+        std::optional<clp::ffi::Value> const& node_value
+) -> NodeType {
+    // figure out what type the node is in archive node type
+    NodeType archive_node_type = NodeType::Unknown;
+    switch (ir_node_type) {
+        case clp::ffi::SchemaTree::Node::Type::Int:
+            archive_node_type = NodeType::Integer;
+            break;
+        case clp::ffi::SchemaTree::Node::Type::Float:
+            archive_node_type = NodeType::Float;
+            break;
+        case clp::ffi::SchemaTree::Node::Type::Bool:
+            archive_node_type = NodeType::Boolean;
+            break;
+        case clp::ffi::SchemaTree::Node::Type::UnstructuredArray:
+            archive_node_type = NodeType::UnstructuredArray;
+            break;
+        case clp::ffi::SchemaTree::Node::Type::Str:
+            if (node_value && node_value->is<std::string>()) {
+                archive_node_type = NodeType::VarString;
+            } else {
+                archive_node_type = NodeType::ClpString;
+            }
+            break;
+        case clp::ffi::SchemaTree::Node::Type::Obj:
+            if (node_has_value) {
+                if (node_value->is_null()) {
+                    archive_node_type = NodeType::NullValue;
+                } else {
+                    archive_node_type = NodeType::Object;
+                }
+            } else {
+                archive_node_type = NodeType::Object;
+            }
+            break;
+        default:
+            break;
+    }
+    return archive_node_type;
+}
+
+auto JsonParser::get_archive_node_id(
+        std::unordered_map<uint32_t, std::vector<std::pair<NodeType, int32_t>>>&
+                ir_node_to_archive_node_unordered_map,
+        uint32_t ir_node_id,
+        NodeType archive_node_type,
+        clp::ffi::SchemaTree const& ir_tree
+) -> int {
+    auto unordered_map_location = ir_node_to_archive_node_unordered_map.find(ir_node_id);
+    if (ir_node_to_archive_node_unordered_map.end() != unordered_map_location) {
+        auto translation_vector = unordered_map_location->second;
+        for (auto& i : translation_vector) {
+            if (i.first == archive_node_type) {
+                return i.second;
+            }
+        }
+    }
+
+    auto const& curr_node = ir_tree.get_node(ir_node_id);
+    int32_t parent_node_id{-1};
+    auto parent_of_curr_node_id = curr_node.get_parent_id();
+    if (parent_of_curr_node_id.has_value()) {
+        parent_node_id = get_archive_node_id(
+                ir_node_to_archive_node_unordered_map,
+                parent_of_curr_node_id.value(),
+                NodeType::Object,
+                ir_tree
+        );
+    }
+    auto validated_escaped_key
+            = clp::ffi::validate_and_escape_utf8_string(curr_node.get_key_name());
+    std::string node_key;
+    if (validated_escaped_key.has_value()) {
+        node_key = validated_escaped_key.value();
+    } else {
+        throw "Key is not UTF-8 compliant";
+    }
+    int const curr_node_archive_id
+            = m_archive_writer->add_node(parent_node_id, archive_node_type, node_key);
+    auto p = std::make_pair(archive_node_type, curr_node_archive_id);
+    if (ir_node_to_archive_node_unordered_map.end() != unordered_map_location) {
+        unordered_map_location->second.push_back(p);
+    } else {
+        std::vector<std::pair<NodeType, int32_t>> v;
+        v.push_back(p);
+        ir_node_to_archive_node_unordered_map.emplace(ir_node_id, v);
+    }
+    return curr_node_archive_id;
+}
+
+void JsonParser::parse_kv_log_event(
+        KeyValuePairLogEvent const& kv,
+        std::unordered_map<uint32_t, std::vector<std::pair<NodeType, int32_t>>>&
+                ir_node_to_archive_node_unordered_map
+) {
+    clp::ffi::SchemaTree const& tree = kv.get_schema_tree();
+    for (auto const& pair : kv.get_node_id_value_pairs()) {
+        clp::ffi::SchemaTree::Node const& tree_node = tree.get_node(pair.first);
+        clp::ffi::SchemaTree::Node::Type const ir_node_type = tree_node.get_type();
+        bool const node_has_value = pair.second.has_value();
+        NodeType archive_node_type = NodeType::Unknown;
+        if (node_has_value) {
+            archive_node_type
+                    = get_archive_node_type(ir_node_type, node_has_value, pair.second.value());
+        } else {
+            archive_node_type = get_archive_node_type(ir_node_type, node_has_value, {});
+        }
+        int node_id{0};
+        try {
+            node_id = get_archive_node_id(
+                    ir_node_to_archive_node_unordered_map,
+                    pair.first,
+                    archive_node_type,
+                    tree
+            );
+        } catch (...) {
+            throw;
+        }
+
+        switch (archive_node_type) {
+            case NodeType::Integer: {
+                int64_t const i64_value
+                        = pair.second.value().get_immutable_view<clp::ffi::value_int_t>();
+                m_current_parsed_message.add_value(node_id, i64_value);
+            } break;
+            case NodeType::Float: {
+                double const d_value
+                        = pair.second.value().get_immutable_view<clp::ffi::value_float_t>();
+                m_current_parsed_message.add_value(node_id, d_value);
+            } break;
+            case NodeType::Boolean: {
+                bool const b_value
+                        = pair.second.value().get_immutable_view<clp::ffi::value_bool_t>();
+                m_current_parsed_message.add_value(node_id, b_value);
+            } break;
+            case NodeType::VarString: {
+                auto validated_escaped_string = clp::ffi::validate_and_escape_utf8_string(
+                        pair.second.value().get_immutable_view<std::string>()
+                );
+                std::string str;
+                if (validated_escaped_string.has_value()) {
+                    str = validated_escaped_string.value();
+                } else {
+                    throw "String is not utf8 compliant";
+                }
+                m_current_parsed_message.add_value(node_id, str);
+            } break;
+            case NodeType::ClpString: {
+                std::string encoded_str;
+                std::string decoded_value;
+                if (pair.second.value().is<clp::ir::EightByteEncodedTextAst>()) {
+                    decoded_value = pair.second.value()
+                                            .get_immutable_view<clp::ir::EightByteEncodedTextAst>()
+                                            .decode_and_unparse()
+                                            .value();
+
+                } else {
+                    decoded_value = pair.second.value()
+                                            .get_immutable_view<clp::ir::FourByteEncodedTextAst>()
+                                            .decode_and_unparse()
+                                            .value();
+                }
+                auto validated_escaped_encoded_string
+                        = clp::ffi::validate_and_escape_utf8_string(decoded_value.c_str());
+                if (validated_escaped_encoded_string.has_value()) {
+                    encoded_str = validated_escaped_encoded_string.value();
+                } else {
+                    throw "Encoded string is not utf8 compliant";
+                }
+                m_current_parsed_message.add_value(node_id, encoded_str);
+            } break;
+            case NodeType::UnstructuredArray: {
+                std::string array_str;
+                if (pair.second.value().is<clp::ir::EightByteEncodedTextAst>()) {
+                    array_str = pair.second.value()
+                                        .get_immutable_view<clp::ir::EightByteEncodedTextAst>()
+                                        .decode_and_unparse()
+                                        .value();
+                } else {
+                    array_str = pair.second.value()
+                                        .get_immutable_view<clp::ir::FourByteEncodedTextAst>()
+                                        .decode_and_unparse()
+                                        .value();
+                }
+                m_current_parsed_message.add_value(node_id, array_str);
+                break;
+            }
+            default:
+                // Don't need to add value for obj or null
+                break;
+        }
+        m_current_schema.insert_ordered(node_id);
+    }
+
+    int32_t const current_schema_id = m_archive_writer->add_schema(m_current_schema);
+    m_current_parsed_message.set_id(current_schema_id);
+    m_archive_writer->append_message(current_schema_id, m_current_schema, m_current_parsed_message);
+}
+
+auto JsonParser::parse_from_ir() -> bool {
+    std::unordered_map<uint32_t, std::vector<std::pair<NodeType, int32_t>>>
+            ir_node_to_archive_node_unordered_map;
+
+    for (auto& file_path : m_file_paths) {
+        auto const fsize = std::filesystem::file_size(file_path);
+        if (0 == fsize) {
+            m_archive_writer->close();
+            return false;
+        }
+        clp::streaming_compression::zstd::Decompressor zd;
+        zd.open(file_path);
+
+        auto deserializer_result{Deserializer<IrUnitHandler>::create(zd, IrUnitHandler{})};
+        if (deserializer_result.has_error()) {
+            zd.close();
+            m_archive_writer->close();
+            return false;
+        }
+        auto& deserializer = deserializer_result.value();
+        auto& ir_unit_handler{deserializer.get_ir_unit_handler()};
+
+        int32_t log_event_idx_node_id{};
+        auto add_log_event_idx_node = [&]() {
+            if (m_record_log_order) {
+                log_event_idx_node_id
+                        = add_metadata_field(constants::cLogEventIdxName, NodeType::Integer);
+            }
+        };
+        add_log_event_idx_node();
+
+        while (true) {
+            auto const kv_log_event_result{deserializer.deserialize_next_ir_unit(zd)};
+
+            if (kv_log_event_result.has_error()) {
+                break;
+            }
+            if (kv_log_event_result.value() == clp::ffi::ir_stream::IrUnitType::EndOfStream) {
+                break;
+            }
+            if (kv_log_event_result.value() == clp::ffi::ir_stream::IrUnitType::LogEvent) {
+                auto const kv_log_event = &(ir_unit_handler.get_deserialized_log_event().value());
+
+                m_current_schema.clear();
+
+                // Add log_event_idx field to metadata for record
+                if (m_record_log_order) {
+                    m_current_parsed_message.add_value(
+                            log_event_idx_node_id,
+                            m_archive_writer->get_next_log_event_id()
+                    );
+                    m_current_schema.insert_ordered(log_event_idx_node_id);
+                }
+
+                try {
+                    parse_kv_log_event(*kv_log_event, ir_node_to_archive_node_unordered_map);
+                } catch (std::string& msg) {
+                    SPDLOG_ERROR("ERROR: {}" + msg);
+                    zd.close();
+                    return false;
+                } catch (...) {
+                    SPDLOG_ERROR("ERROR: Encountered error while parsing a kv log event");
+                    zd.close();
+                    return false;
+                }
+
+                if (m_archive_writer->get_data_size() >= m_target_encoded_size) {
+                    ir_node_to_archive_node_unordered_map.clear();
+                    split_archive();
+                }
+
+                ir_unit_handler.clear();
+                m_current_parsed_message.clear();
+
+            } else {
+                continue;
+            }
+        }
+        ir_node_to_archive_node_unordered_map.clear();
+        zd.close();
+    }
+    return true;
 }
 
 void JsonParser::store() {

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -749,8 +749,8 @@ auto JsonParser::get_archive_node_id(
 }
 
 void JsonParser::parse_kv_log_event(KeyValuePairLogEvent const& kv) {
-    clp::ffi::SchemaTree const& tree = kv.get_schema_tree();
-    for (auto const& pair : kv.get_node_id_value_pairs()) {
+    clp::ffi::SchemaTree const& tree = kv.get_user_gen_keys_schema_tree();
+    for (auto const& pair : kv.get_user_gen_node_id_value_pairs()) {
         NodeType const archive_node_type = get_archive_node_type(tree, pair);
         auto const node_id = get_archive_node_id(pair.first, archive_node_type, tree);
 

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -1,7 +1,6 @@
 #include "JsonParser.hpp"
 
 #include <cstdint>
-#include <filesystem>
 #include <iostream>
 #include <optional>
 #include <stack>
@@ -837,11 +836,6 @@ void JsonParser::parse_kv_log_event(KeyValuePairLogEvent const& kv) {
 
 auto JsonParser::parse_from_ir() -> bool {
     for (auto& file_path : m_file_paths) {
-        auto const fsize = std::filesystem::file_size(file_path);
-        if (0 == fsize) {
-            m_archive_writer->close();
-            return false;
-        }
         clp::streaming_compression::zstd::Decompressor decompressor;
         size_t curr_pos{};
         size_t last_pos{};

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -1,17 +1,23 @@
 #ifndef CLP_S_JSONPARSER_HPP
 #define CLP_S_JSONPARSER_HPP
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
 #include <boost/uuid/random_generator.hpp>
 #include <simdjson.h>
 
+#include "../clp/ffi/KeyValuePairLogEvent.hpp"
+#include "../clp/ffi/SchemaTree.hpp"
+#include "../clp/ffi/Value.hpp"
 #include "../clp/GlobalMySQLMetadataDB.hpp"
 #include "ArchiveWriter.hpp"
+#include "CommandLineArguments.hpp"
 #include "DictionaryWriter.hpp"
 #include "FileReader.hpp"
 #include "FileWriter.hpp"
@@ -25,10 +31,12 @@
 #include "ZstdCompressor.hpp"
 
 using namespace simdjson;
+using clp::ffi::KeyValuePairLogEvent;
 
 namespace clp_s {
 struct JsonParserOption {
     std::vector<std::string> file_paths;
+    CommandLineArguments::FileType input_file_type{CommandLineArguments::FileType::Json};
     std::string timestamp_key;
     std::string archives_dir;
     size_t target_encoded_size{};
@@ -64,6 +72,12 @@ public:
     [[nodiscard]] bool parse();
 
     /**
+     * Parses the Key Value IR Stream and stores the data in the archive.
+     * @return whether the IR Stream was parsed successfully
+     */
+    [[nodiscard]] auto parse_from_ir() -> bool;
+
+    /**
      * Writes the metadata and archive data to disk.
      */
     void store();
@@ -77,6 +91,47 @@ private:
      * @throw simdjson::simdjson_error when encountering invalid fields while parsing line
      */
     void parse_line(ondemand::value line, int32_t parent_node_id, std::string const& key);
+
+    /**
+     * Determines the archive node type based on the IR node type and value.
+     * @param ir_node_type schema node type from the IR stream
+     * @param node_has_value Boolean that says whether or not the node has value.
+     * @param node_value The IR schema node value if the node has value
+     * @return The clp-s archive Node Type that should be used for the archive node
+     */
+    static auto get_archive_node_type(
+            clp::ffi::SchemaTree::Node::Type ir_node_type,
+            bool node_has_value,
+            std::optional<clp::ffi::Value> const& node_value
+    ) -> NodeType;
+
+    /**
+     * Get archive node id for ir node
+     * @param ir_node_to_archive_node_unordered_map cache of node id conversions between
+     * deserializer schema tree nodes and archive schema tree nodes
+     * @param ir_node_id ID of the IR node
+     * @param archive_node_type Type of the archive node
+     * @param ir_tree The IR schema tree
+     */
+    auto get_archive_node_id(
+            std::unordered_map<uint32_t, std::vector<std::pair<NodeType, int32_t>>>&
+                    ir_node_to_archive_node_unordered_map,
+            uint32_t ir_node_id,
+            NodeType archive_node_type,
+            clp::ffi::SchemaTree const& ir_tree
+    ) -> int;
+
+    /**
+     * Parses a Key Value Log Event
+     * @param kv the key value log event
+     * @param ir_node_to_archive_node_unordered_map cache of node id conversions between
+     * deserializer schema tree nodes and archive schema tree nodes
+     */
+    void parse_kv_log_event(
+            KeyValuePairLogEvent const& kv,
+            std::unordered_map<uint32_t, std::vector<std::pair<NodeType, int32_t>>>&
+                    ir_node_to_archive_node_unordered_map
+    );
 
     /**
      * Parses an array within a JSON line

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -99,7 +99,7 @@ private:
      * @param ir_node_type schema node type from the IR stream
      * @param node_has_value Boolean that says whether or not the node has value.
      * @param node_value The IR schema node value if the node has value
-     * @return The clp-s archive Node Type that should be used for the archive node
+     * @return The NodeType that should be used for the archive node
      */
     static auto get_archive_node_type(
             clp::ffi::SchemaTree const& tree,
@@ -108,7 +108,7 @@ private:
     ) -> NodeType;
 
     /**
-     * Get archive node id for ir node
+     * Adds new schema node to archive and adds translation for IR node ID and NodeType to mapping
      * @param ir_node_id ID of the IR node
      * @param ir_node_to_add IR Schema Node that is being translated to archive
      * @param archive_node_type Type of the archive node
@@ -122,7 +122,7 @@ private:
     ) -> int;
 
     /**
-     * Get archive node id for ir node
+     * Gets the archive node ID for an IR node.
      * @param ir_node_id ID of the IR node
      * @param archive_node_type Type of the archive node
      * @param ir_tree The IR schema tree
@@ -134,8 +134,8 @@ private:
     ) -> int;
 
     /**
-     * Parses a Key Value Log Event
-     * @param kv the key value log event
+     * Parses a Key Value Log Event.
+     * @param kv the Key Value Log Event
      */
     void parse_kv_log_event(KeyValuePairLogEvent const& kv);
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -115,11 +115,10 @@ bool compress(CommandLineArguments const& command_line_arguments) {
 
     clp_s::JsonParser parser(option);
     if (CommandLineArguments::FileType::KeyValueIr == option.input_file_type) {
-        // Functionality Coming in later PR
-        //  -->Call new parsing function in Json Parser to parse IRv2 to archive
-        //  -->Check for error from parsing function
-        SPDLOG_ERROR("Compressing Key Value IR Files is not yet supported");
-        return false;
+        if (false == parser.parse_from_ir()) {
+            SPDLOG_ERROR("Encountered error while parsing input");
+            return false;
+        }
     } else {
         if (false == parser.parse()) {
             SPDLOG_ERROR("Encountered error while parsing input");


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This pull request is the continuation or PR #618, adding the functionality promised. This adds the corresponding ingestion functionality to compress IRv2 into archive. 

- Add additional public function to JsonParser to expose parsing from IR; `parse_from_ir()`
- Add an class implementing the `clp::ffi::ir_stream::IrUnitHandlerInterface` for use deserializing IRv2 files; `IrUnitHandler`
- Add function to iterate over pairs in the `KeyValuePairLogEvent` converting the log event into the correct format for archive; `parse_kv_log_event()`
- Add two helper functions to help convert IR schema nodes into archive schema nodes:
    - Find the archive schema node type based on the IR schema node type and the value of the node in the current log event; `get_archive_node_type`
    - Find or add the correct archive schema node id for a given IR schema node id and correct archive schema node type for the value of the node in the current log event; `get_archive_node_id`


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

For our posted JSON Datasets:
- Generated the corresponding IRv2 file
- Compress the IRv2 file to archive 
    - `./clp-s c <archive dir> <ir file or directory w/ ir file> --file-type kv-ir`
- Extract archive back to JSON
    - `./clp-s x <archive dir> <output JSON dir>`
- Sort keys and compare to JSON generated by clp-s from compressing and extracting directly from original JSON (spark, elasticsearch, and postgresql)
    - `jq -S -c '.' <output JSON dir>/original > out.json`
        - You can sort the json order if not using built in log ordering
        - `jq -S -c '.' <output JSON dir>/original | sort > out_sorted.json`
    - `diff -u out.json clp-s_out.json`
        - To generate clp-s_out.json:
            - `./clp-s c <archive dir> <original JSON>`
            - `./clp-s x <archive dir> <output JSON dir>`
            - `jq -S -c '.' <output JSON dir>/original > clp-s_out.json`
- Spot checked match of mongodb and cockroach database

- Notes:
    - I noticed some differences in numbers of significant digits for floats between both clp-s and the IRv2 to archive, and the original JSON.
    - ex.) original: 1.0; clp_s: 1.00000; IRv2: 1.00000
    - ex.) original: 0.9758767; clp_s: 0.9758767; IRv2: 0.975877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `JsonParser` to support parsing of Key Value IR Streams.
	- Introduced new functionalities for handling log events and schema trees.
	- Improved error handling in the `compress` function for parsing Key Value IR files.
	- Added validation checks in command-line argument parsing for better user feedback.

- **Bug Fixes**
	- Enhanced error logging for parsing failures in the `compress` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->