### PR TITLE
ci(pr-title-checks): Remove default GH workflow permissions and document risk of `pull_request_target` workflow trigger.

### DIFF
--- a/.github/workflows/clp-pr-title-checks.yaml
+++ b/.github/workflows/clp-pr-title-checks.yaml
@@ -2,8 +2,15 @@ name: "clp-pr-title-checks"
 
 on:
   pull_request_target:
+    # NOTE: Workflows triggered by this event give the workflow access to secrets and grant the
+    # `GITHUB_TOKEN` read/write repository access by default. So we need to ensure:
+    # - This workflow doesn't inadvertently check out, build, or execute untrusted code from the
+    #   pull request triggered by this event.
+    # - Each job has `permissions` set to only those necessary.
     types: ["edited", "opened", "reopened"]
     branches: ["main"]
+
+permissions: {}
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the PR title says.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

The same code has been validated in [clp-loglib-py](https://github.com/y-scope/clp-loglib-py/blob/6c32c14fb863c0bde4ae02e1d4a35344294c2033/.github/workflows/pr-title-checks.yaml).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

en-CA

- **Documentation**
  - Added a note to the GitHub Actions workflow file explaining the security implications of using the `pull_request_target` event trigger.
- **Chores**
  - Updated the permissions for the GitHub Actions workflow jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->