### PR TITLE
refactor(clp-s): Replace instances of `std::string const&` with `std::string_view` where it would remove unnecessary conversions to and from `std::string`.

### DIFF
--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -122,7 +122,7 @@ public:
      * @return the epoch time corresponding to the string timestamp
      */
     epochtime_t ingest_timestamp_entry(
-            std::string const& key,
+            std::string_view key,
             int32_t node_id,
             std::string_view timestamp,
             uint64_t& pattern_id
@@ -136,11 +136,11 @@ public:
      * @param node_id
      * @param timestamp
      */
-    void ingest_timestamp_entry(std::string const& key, int32_t node_id, double timestamp) {
+    void ingest_timestamp_entry(std::string_view key, int32_t node_id, double timestamp) {
         m_timestamp_dict.ingest_entry(key, node_id, timestamp);
     }
 
-    void ingest_timestamp_entry(std::string const& key, int32_t node_id, int64_t timestamp) {
+    void ingest_timestamp_entry(std::string_view key, int32_t node_id, int64_t timestamp) {
         m_timestamp_dict.ingest_entry(key, node_id, timestamp);
     }
 

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -124,7 +124,7 @@ public:
     epochtime_t ingest_timestamp_entry(
             std::string const& key,
             int32_t node_id,
-            std::string const& timestamp,
+            std::string_view const timestamp,
             uint64_t& pattern_id
     ) {
         return m_timestamp_dict.ingest_entry(key, node_id, timestamp, pattern_id);

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -124,7 +124,7 @@ public:
     epochtime_t ingest_timestamp_entry(
             std::string const& key,
             int32_t node_id,
-            std::string_view const timestamp,
+            std::string_view timestamp,
             uint64_t& pattern_id
     ) {
         return m_timestamp_dict.ingest_entry(key, node_id, timestamp, pattern_id);

--- a/components/core/src/clp_s/ParsedMessage.hpp
+++ b/components/core/src/clp_s/ParsedMessage.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_PARSEDMESSAGE_HPP
 #define CLP_S_PARSEDMESSAGE_HPP
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <string_view>

--- a/components/core/src/clp_s/ParsedMessage.hpp
+++ b/components/core/src/clp_s/ParsedMessage.hpp
@@ -36,7 +36,7 @@ public:
         m_message.emplace(node_id, value);
     }
 
-    inline void add_value(int32_t node_id, std::string_view const value) {
+    inline void add_value(int32_t node_id, std::string_view value) {
         m_message.emplace(node_id, std::string{value});
     }
 
@@ -61,7 +61,7 @@ public:
         m_unordered_message.emplace_back(value);
     }
 
-    inline void add_unordered_value(std::string_view const value) {
+    inline void add_unordered_value(std::string_view value) {
         m_unordered_message.emplace_back(std::string{value});
     }
 

--- a/components/core/src/clp_s/ParsedMessage.hpp
+++ b/components/core/src/clp_s/ParsedMessage.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 
@@ -34,6 +35,10 @@ public:
         m_message.emplace(node_id, value);
     }
 
+    inline void add_value(int32_t node_id, std::string_view const value) {
+        m_message.emplace(node_id, std::string{value});
+    }
+
     /**
      * Adds a timestamp value and its encoding to the message for a given MST node ID.
      * @param node_id
@@ -53,6 +58,10 @@ public:
     template <typename T>
     inline void add_unordered_value(T const& value) {
         m_unordered_message.emplace_back(value);
+    }
+
+    inline void add_unordered_value(std::string_view const value) {
+        m_unordered_message.emplace_back(std::string{value});
     }
 
     /**

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -1,6 +1,8 @@
 #include "TimestampDictionaryWriter.hpp"
 
+#include <cstdint>
 #include <sstream>
+#include <string_view>
 
 #include "Utils.hpp"
 
@@ -42,9 +44,9 @@ uint64_t TimestampDictionaryWriter::get_pattern_id(TimestampPattern const* patte
 }
 
 epochtime_t TimestampDictionaryWriter::ingest_entry(
-        std::string const& key,
+        std::string_view const key,
         int32_t node_id,
-        std::string const& timestamp,
+        std::string_view const timestamp,
         uint64_t& pattern_id
 ) {
     epochtime_t ret;
@@ -88,7 +90,7 @@ epochtime_t TimestampDictionaryWriter::ingest_entry(
 }
 
 void TimestampDictionaryWriter::ingest_entry(
-        std::string const& key,
+        std::string_view const key,
         int32_t node_id,
         double timestamp
 ) {
@@ -103,7 +105,7 @@ void TimestampDictionaryWriter::ingest_entry(
 }
 
 void TimestampDictionaryWriter::ingest_entry(
-        std::string const& key,
+        std::string_view const key,
         int32_t node_id,
         int64_t timestamp
 ) {

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -44,9 +44,9 @@ uint64_t TimestampDictionaryWriter::get_pattern_id(TimestampPattern const* patte
 }
 
 epochtime_t TimestampDictionaryWriter::ingest_entry(
-        std::string_view const key,
+        std::string_view key,
         int32_t node_id,
-        std::string_view const timestamp,
+        std::string_view timestamp,
         uint64_t& pattern_id
 ) {
     epochtime_t ret;
@@ -90,7 +90,7 @@ epochtime_t TimestampDictionaryWriter::ingest_entry(
 }
 
 void TimestampDictionaryWriter::ingest_entry(
-        std::string_view const key,
+        std::string_view key,
         int32_t node_id,
         double timestamp
 ) {
@@ -105,7 +105,7 @@ void TimestampDictionaryWriter::ingest_entry(
 }
 
 void TimestampDictionaryWriter::ingest_entry(
-        std::string_view const key,
+        std::string_view key,
         int32_t node_id,
         int64_t timestamp
 ) {

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -1,9 +1,11 @@
 #ifndef CLP_S_TIMESTAMPDICTIONARYWRITER_HPP
 #define CLP_S_TIMESTAMPDICTIONARYWRITER_HPP
 
+#include <cstdint>
 #include <map>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -47,9 +49,9 @@ public:
      * @return the epoch time corresponding to the string timestamp
      */
     epochtime_t ingest_entry(
-            std::string const& key,
+            std::string_view const key,
             int32_t node_id,
-            std::string const& timestamp,
+            std::string_view const timestamp,
             uint64_t& pattern_id
     );
 
@@ -59,9 +61,9 @@ public:
      * @param node_id
      * @param timestamp
      */
-    void ingest_entry(std::string const& key, int32_t node_id, double timestamp);
+    void ingest_entry(std::string_view const key, int32_t node_id, double timestamp);
 
-    void ingest_entry(std::string const& key, int32_t node_id, int64_t timestamp);
+    void ingest_entry(std::string_view const key, int32_t node_id, int64_t timestamp);
 
     /**
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and

--- a/components/core/src/clp_s/TimestampDictionaryWriter.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.hpp
@@ -49,9 +49,9 @@ public:
      * @return the epoch time corresponding to the string timestamp
      */
     epochtime_t ingest_entry(
-            std::string_view const key,
+            std::string_view key,
             int32_t node_id,
-            std::string_view const timestamp,
+            std::string_view timestamp,
             uint64_t& pattern_id
     );
 
@@ -61,9 +61,9 @@ public:
      * @param node_id
      * @param timestamp
      */
-    void ingest_entry(std::string_view const key, int32_t node_id, double timestamp);
+    void ingest_entry(std::string_view key, int32_t node_id, double timestamp);
 
-    void ingest_entry(std::string_view const key, int32_t node_id, int64_t timestamp);
+    void ingest_entry(std::string_view key, int32_t node_id, int64_t timestamp);
 
     /**
      * TODO: guarantee epoch milliseconds. The current clp-s approach to encoding timestamps and

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -44,7 +44,7 @@ public:
               m_epoch_start(cEpochTimeMax),
               m_epoch_end(cEpochTimeMin) {}
 
-    TimestampEntry(std::string_view const key_name)
+    TimestampEntry(std::string_view key_name)
             : m_encoding(UnkownTimestampEncoding),
               m_epoch_start_double(cDoubleEpochTimeMax),
               m_epoch_end_double(cDoubleEpochTimeMin),

--- a/components/core/src/clp_s/TimestampEntry.hpp
+++ b/components/core/src/clp_s/TimestampEntry.hpp
@@ -3,6 +3,7 @@
 
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <variant>
 
@@ -43,7 +44,7 @@ public:
               m_epoch_start(cEpochTimeMax),
               m_epoch_end(cEpochTimeMin) {}
 
-    TimestampEntry(std::string const& key_name)
+    TimestampEntry(std::string_view const key_name)
             : m_encoding(UnkownTimestampEncoding),
               m_epoch_start_double(cDoubleEpochTimeMax),
               m_epoch_end_double(cDoubleEpochTimeMin),

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <string_view>
 #include <vector>
 
 #include <date/include/date/date.h>
@@ -71,7 +72,7 @@ append_padded_value_notz(int value, char padding_character, size_t max_length, s
  * @return true if conversion succeeds, false otherwise
  */
 static bool convert_string_to_number(
-        string const& str,
+        std::string_view const str,
         size_t begin_ix,
         size_t end_ix,
         char padding_character,
@@ -89,7 +90,7 @@ static bool convert_string_to_number(
  * @return true if conversion succeeds, false otherwise
  */
 static bool convert_string_to_number_notz(
-        string const& str,
+        std::string_view const str,
         size_t max_digits,
         size_t begin_ix,
         size_t& end_ix,
@@ -125,7 +126,7 @@ append_padded_value_notz(int value, char padding_character, size_t max_length, s
 }
 
 static bool convert_string_to_number(
-        string const& str,
+        std::string_view const str,
         size_t begin_ix,
         size_t end_ix,
         char padding_character,
@@ -154,7 +155,7 @@ static bool convert_string_to_number(
 }
 
 static bool convert_string_to_number_notz(
-        string const& str,
+        std::string_view const str,
         size_t max_digits,
         size_t begin_ix,
         size_t& end_ix,
@@ -306,7 +307,7 @@ void TimestampPattern::init() {
 }
 
 TimestampPattern const* TimestampPattern::search_known_ts_patterns(
-        string const& line,
+        std::string_view const line,
         epochtime_t& timestamp,
         size_t& timestamp_begin_pos,
         size_t& timestamp_end_pos
@@ -342,7 +343,7 @@ void TimestampPattern::clear() {
 }
 
 bool TimestampPattern::parse_timestamp(
-        string const& line,
+        std::string_view const line,
         epochtime_t& timestamp,
         size_t& timestamp_begin_pos,
         size_t& timestamp_end_pos

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -73,7 +73,7 @@ append_padded_value_notz(int value, char padding_character, size_t max_length, s
  * @return true if conversion succeeds, false otherwise
  */
 static bool convert_string_to_number(
-        std::string_view const str,
+        std::string_view str,
         size_t begin_ix,
         size_t end_ix,
         char padding_character,
@@ -91,7 +91,7 @@ static bool convert_string_to_number(
  * @return true if conversion succeeds, false otherwise
  */
 static bool convert_string_to_number_notz(
-        std::string_view const str,
+        std::string_view str,
         size_t max_digits,
         size_t begin_ix,
         size_t& end_ix,
@@ -127,7 +127,7 @@ append_padded_value_notz(int value, char padding_character, size_t max_length, s
 }
 
 static bool convert_string_to_number(
-        std::string_view const str,
+        std::string_view str,
         size_t begin_ix,
         size_t end_ix,
         char padding_character,
@@ -156,7 +156,7 @@ static bool convert_string_to_number(
 }
 
 static bool convert_string_to_number_notz(
-        std::string_view const str,
+        std::string_view str,
         size_t max_digits,
         size_t begin_ix,
         size_t& end_ix,
@@ -308,7 +308,7 @@ void TimestampPattern::init() {
 }
 
 TimestampPattern const* TimestampPattern::search_known_ts_patterns(
-        std::string_view const line,
+        std::string_view line,
         epochtime_t& timestamp,
         size_t& timestamp_begin_pos,
         size_t& timestamp_end_pos
@@ -344,7 +344,7 @@ void TimestampPattern::clear() {
 }
 
 bool TimestampPattern::parse_timestamp(
-        std::string_view const line,
+        std::string_view line,
         epochtime_t& timestamp,
         size_t& timestamp_begin_pos,
         size_t& timestamp_end_pos

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -14,6 +14,7 @@
 
 using clp::string_utils::convert_string_to_int;
 using std::string;
+using std::string_view;
 using std::to_string;
 using std::vector;
 
@@ -73,7 +74,7 @@ append_padded_value_notz(int value, char padding_character, size_t max_length, s
  * @return true if conversion succeeds, false otherwise
  */
 static bool convert_string_to_number(
-        std::string_view str,
+        string_view str,
         size_t begin_ix,
         size_t end_ix,
         char padding_character,
@@ -91,7 +92,7 @@ static bool convert_string_to_number(
  * @return true if conversion succeeds, false otherwise
  */
 static bool convert_string_to_number_notz(
-        std::string_view str,
+        string_view str,
         size_t max_digits,
         size_t begin_ix,
         size_t& end_ix,
@@ -127,7 +128,7 @@ append_padded_value_notz(int value, char padding_character, size_t max_length, s
 }
 
 static bool convert_string_to_number(
-        std::string_view str,
+        string_view str,
         size_t begin_ix,
         size_t end_ix,
         char padding_character,
@@ -156,7 +157,7 @@ static bool convert_string_to_number(
 }
 
 static bool convert_string_to_number_notz(
-        std::string_view str,
+        string_view str,
         size_t max_digits,
         size_t begin_ix,
         size_t& end_ix,
@@ -308,7 +309,7 @@ void TimestampPattern::init() {
 }
 
 TimestampPattern const* TimestampPattern::search_known_ts_patterns(
-        std::string_view line,
+        string_view line,
         epochtime_t& timestamp,
         size_t& timestamp_begin_pos,
         size_t& timestamp_end_pos
@@ -344,7 +345,7 @@ void TimestampPattern::clear() {
 }
 
 bool TimestampPattern::parse_timestamp(
-        std::string_view line,
+        string_view line,
         epochtime_t& timestamp,
         size_t& timestamp_begin_pos,
         size_t& timestamp_end_pos
@@ -829,23 +830,20 @@ bool TimestampPattern::parse_timestamp(
                     }
                     auto dot_position = line.find('.');
                     auto nanosecond_start = dot_position + 1;
-                    if (std::string::npos == dot_position || 0 == dot_position
+                    if (string::npos == dot_position || 0 == dot_position
                         || cNanosecondDigits != (line.length() - nanosecond_start))
                     {
                         return false;
                     }
 
-                    auto timestamp_view = std::string_view(line);
-                    if (false
-                        == convert_string_to_int(timestamp_view.substr(0, dot_position), timestamp))
-                    {
+                    if (false == convert_string_to_int(line.substr(0, dot_position), timestamp)) {
                         return false;
                     }
 
                     epochtime_t timestamp_nanoseconds;
                     if (false
                         == convert_string_to_int(
-                                timestamp_view.substr(nanosecond_start, cNanosecondDigits),
+                                line.substr(nanosecond_start, cNanosecondDigits),
                                 timestamp_nanoseconds
                         ))
                     {
@@ -1072,14 +1070,14 @@ void TimestampPattern::insert_formatted_timestamp(epochtime_t timestamp, string&
                 case 'E':  // UNIX epoch milliseconds
                     // Note: this timestamp format is required to make up the entire timestamp, so
                     // this is safe
-                    new_msg = std::to_string(timestamp);
+                    new_msg = to_string(timestamp);
                     break;
 
                 case 'F': {  // Nanosecond precision floating point UNIX epoch timestamp
                     constexpr auto cNanosecondDigits = 9;
                     // Note: this timestamp format is required to make up the entire timestamp, so
                     // this is safe
-                    new_msg = std::to_string(timestamp);
+                    new_msg = to_string(timestamp);
                     new_msg.insert(new_msg.end() - cNanosecondDigits, '.');
                     break;
                 }

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/components/core/src/clp_s/TimestampPattern.hpp
+++ b/components/core/src/clp_s/TimestampPattern.hpp
@@ -85,7 +85,7 @@ public:
      * @return pointer to the timestamp pattern if found, nullptr otherwise
      */
     static TimestampPattern const* search_known_ts_patterns(
-            std::string_view const line,
+            std::string_view line,
             epochtime_t& timestamp,
             size_t& timestamp_begin_pos,
             size_t& timestamp_end_pos
@@ -123,7 +123,7 @@ public:
      * @return true if parsed successfully, false otherwise
      */
     bool parse_timestamp(
-            std::string_view const line,
+            std::string_view line,
             epochtime_t& timestamp,
             size_t& timestamp_begin_pos,
             size_t& timestamp_end_pos

--- a/components/core/src/clp_s/TimestampPattern.hpp
+++ b/components/core/src/clp_s/TimestampPattern.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "Defs.hpp"
@@ -83,7 +84,7 @@ public:
      * @return pointer to the timestamp pattern if found, nullptr otherwise
      */
     static TimestampPattern const* search_known_ts_patterns(
-            std::string const& line,
+            std::string_view const line,
             epochtime_t& timestamp,
             size_t& timestamp_begin_pos,
             size_t& timestamp_end_pos
@@ -121,7 +122,7 @@ public:
      * @return true if parsed successfully, false otherwise
      */
     bool parse_timestamp(
-            std::string const& line,
+            std::string_view const line,
             epochtime_t& timestamp,
             size_t& timestamp_begin_pos,
             size_t& timestamp_end_pos

--- a/components/core/src/clp_s/TimestampPattern.hpp
+++ b/components/core/src/clp_s/TimestampPattern.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <utility>
 

--- a/components/core/src/clp_s/search/StringLiteral.hpp
+++ b/components/core/src/clp_s/search/StringLiteral.hpp
@@ -69,7 +69,6 @@ private:
             m_string_type = LiteralType::VarStringT;
         }
 
-        // If '?' and '*' are not escaped, we add LiteralType::ClpStringT to m_string_type
         if (StringUtils::has_unescaped_wildcards(m_v)) {
             m_string_type |= LiteralType::ClpStringT;
         }

--- a/components/core/src/clp_s/search/StringLiteral.hpp
+++ b/components/core/src/clp_s/search/StringLiteral.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 
+#include "../Utils.hpp"
 #include "Literal.hpp"
 
 namespace clp_s::search {
@@ -69,18 +70,8 @@ private:
         }
 
         // If '?' and '*' are not escaped, we add LiteralType::ClpStringT to m_string_type
-        bool escape = false;
-        for (char const c : m_v) {
-            if ('\\' == c) {
-                escape = !escape;
-            } else if ('?' == c || '*' == c) {
-                if (false == escape) {
-                    m_string_type |= LiteralType::ClpStringT;
-                    break;
-                }
-            } else {
-                escape = false;
-            }
+        if (StringUtils::has_unescaped_wildcards(m_v)) {
+            m_string_type |= LiteralType::ClpStringT;
         }
     }
 };


### PR DESCRIPTION
# Description
This PR splits out some of the refactoring work from the [escape character fix PR](https://github.com/y-scope/clp/pull/622) to ease review.

In particular this PR:
1) Replaces many uses of std::string const& with std::string_view const, which allows us to avoid some expensive string_view -> string -> string_view round trips
2) Removes some duplicated code
3) Adds some previously missing headers

This PR is pure refactoring with no functional changes.

# Validation performed
* Validated that all unit tests pass, and compression/decompression function as normal



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced string handling efficiency by incorporating `std::string_view` across multiple classes and methods.

- **Bug Fixes**
	- Streamlined logic in the `StringLiteral` class for detecting unescaped wildcard characters.

- **Documentation**
	- Updated method signatures to reflect the new parameter types for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->