### PR TITLE
docs(core): Indicate dependency install scripts should be run with elevated privileges.

### DIFF
--- a/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
+++ b/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, To install all dependencies, run with elevated privileges::
+To install all dependencies, To install all dependencies, run with elevated privileges:
 
 :::{note}
 The packages built from source ([install-packages-from-source.sh][src-install-script]) are installed

--- a/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
+++ b/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, To install all dependencies, run with elevated privileges:
+To install all dependencies, run with elevated privileges:
 
 :::{note}
 The packages built from source ([install-packages-from-source.sh][src-install-script]) are installed

--- a/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
+++ b/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, run:
+To install all dependencies, To install all dependencies, run with elevated privileges::
 
 :::{note}
 The packages built from source ([install-packages-from-source.sh][src-install-script]) are installed

--- a/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
+++ b/docs/src/dev-guide/components-core/centos-stream-9-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, run with elevated privileges:
+To install all dependencies, run the following with elevated privileges:
 
 :::{note}
 The packages built from source ([install-packages-from-source.sh][src-install-script]) are installed

--- a/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
+++ b/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, run:
+To install all dependencies, To install all dependencies, run with elevated privileges::
 
 ```shell
 components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh

--- a/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
+++ b/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, run with elevated privileges:
+To install all dependencies, run the following with elevated privileges:
 
 ```shell
 components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh

--- a/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
+++ b/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, To install all dependencies, run with elevated privileges::
+To install all dependencies, To install all dependencies, run with elevated privileges:
 
 ```shell
 components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh

--- a/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
+++ b/docs/src/dev-guide/components-core/ubuntu-focal-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, To install all dependencies, run with elevated privileges:
+To install all dependencies, run with elevated privileges:
 
 ```shell
 components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh

--- a/docs/src/dev-guide/components-core/ubuntu-jammy-deps-install.md
+++ b/docs/src/dev-guide/components-core/ubuntu-jammy-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, run:
+To install all dependencies, run with elevated privileges:
 
 ```shell
 components/core/tools/scripts/lib_install/ubuntu-jammy/install-all.sh

--- a/docs/src/dev-guide/components-core/ubuntu-jammy-deps-install.md
+++ b/docs/src/dev-guide/components-core/ubuntu-jammy-deps-install.md
@@ -10,7 +10,7 @@ Before you run any commands below, you should review the scripts to ensure they 
 any dependencies or apply any configurations that you don't expect.
 :::
 
-To install all dependencies, run with elevated privileges:
+To install all dependencies, run the following with elevated privileges:
 
 ```shell
 components/core/tools/scripts/lib_install/ubuntu-jammy/install-all.sh


### PR DESCRIPTION
# Description
Improve docs for dependency installation for ubuntu and centos by mentioning that elevated privileges is required during installation.


# Validation performed
Tested `components/core/tools/scripts/lib_install/ubuntu-focal/install-all.sh` command with `sudo` prefix and dependency installation worked.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated installation guides for CentOS Stream 9, Ubuntu Focal, and Ubuntu Jammy to clarify the need for elevated privileges when executing installation commands.
	- Retained caution notes emphasising the importance of reviewing scripts before execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->