### PR TITLE
docs: Add log4j2-appenders repo to system overview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ features:
   (intermediate representation) produced by CLP's logging libraries.
 
 - **Real-time Compression with CLP Logging Libraries**: CLP provides logging libraries for
-  [Python][clp-loglib-py] and Java ([Log4j][log4j1-appenders] and [Logback][logback-appenders]). The
-  logging libraries compress logs in real-time, so only compressed logs are written to disk or
-  transmitted over the network. The compressed logs use CLP's intermediate representation (IR)
-  format which achieves a higher compression ratio than general purpose compressors like Zstandard.
-  Compressing IR into archives can further double the compression ratio and enable global search,
-  but this requires more memory usage as it needs to buffer enough logs. More details on IR versus
-  archives can be found in this [Uber Engineering Blog][uber-blog].
+  [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][logj42-appenders] and 
+- [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only compressed
+  logs are written to disk or transmitted over the network. The compressed logs use CLP's intermediate
+  representation (IR) format which achieves a higher compression ratio than general purpose compressors
+  like Zstandard. Compressing IR into archives can further double the compression ratio and enable 
+  global search, but this requires more memory usage as it needs to buffer enough logs. More details
+  on IR versus archives can be found in this [Uber Engineering Blog][uber-blog].
 
 - **[Log Viewer][log-viewer]**: the compressed IR can be viewed in a web-based log viewer. Compared
   to viewing the logs in an editor, CLP's log viewer supports advanced features like filtering logs
@@ -104,6 +104,7 @@ If you would like a feature or want to report a bug, please file an issue and we
 [log-surgeon]: https://github.com/y-scope/log-surgeon
 [log-viewer]: https://github.com/y-scope/yscope-log-viewer
 [log4j1-appenders]: https://github.com/y-scope/log4j1-appenders
+[log4j2-appenders]: https://github.com/y-scope/log4j2-appenders
 [logback-appenders]: https://github.com/y-scope/logback-appenders
 [re2]: https://github.com/google/re2
 [uber-blog]: https://www.uber.com/en-US/blog/reducing-logging-cost-by-two-orders-of-magnitude-using-clp

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ features:
   (intermediate representation) produced by CLP's logging libraries.
 
 - **Real-time Compression with CLP Logging Libraries**: CLP provides logging libraries for
-  [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][logj42-appenders] and 
+  [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][log4j2-appenders] and 
   [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only
   compressed logs are written to disk or transmitted over the network. The compressed logs use 
   CLP's intermediate representation (IR) format which achieves a higher compression ratio than

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ features:
 
 - **Real-time Compression with CLP Logging Libraries**: CLP provides logging libraries for
   [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][logj42-appenders] and 
-- [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only compressed
-  logs are written to disk or transmitted over the network. The compressed logs use CLP's intermediate
-  representation (IR) format which achieves a higher compression ratio than general purpose compressors
-  like Zstandard. Compressing IR into archives can further double the compression ratio and enable 
-  global search, but this requires more memory usage as it needs to buffer enough logs. More details
-  on IR versus archives can be found in this [Uber Engineering Blog][uber-blog].
+  [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only
+  compressed logs are written to disk or transmitted over the network. The compressed logs use 
+  CLP's intermediate representation (IR) format which achieves a higher compression ratio than
+  general purpose compressors like Zstandard. Compressing IR into archives can further double the
+  compression ratio and enable global search, but this requires more memory usage as it needs to
+  buffer enough logs. More details on IR versus archives can be found in this
+  [Uber Engineering Blog][uber-blog].
 
 - **[Log Viewer][log-viewer]**: the compressed IR can be viewed in a web-based log viewer. Compared
   to viewing the logs in an editor, CLP's log viewer supports advanced features like filtering logs

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ features:
 - **Real-time Compression with CLP Logging Libraries**: CLP provides logging libraries for
   [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][log4j2-appenders] and 
   [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only
-  compressed logs are written to disk or transmitted over the network. The compressed logs use 
-  CLP's intermediate representation (IR) format which achieves a higher compression ratio than
-  general purpose compressors like Zstandard. Compressing IR into archives can further double the
+  compressed logs are written to disk or transmitted over the network. The compressed logs use CLP's
+  intermediate representation (IR) format which achieves a higher compression ratio than general
+  purpose compressors like Zstandard. Compressing IR into archives can further double the
   compression ratio and enable global search, but this requires more memory usage as it needs to
   buffer enough logs. More details on IR versus archives can be found in this
   [Uber Engineering Blog][uber-blog].

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,13 +47,13 @@ features:
   (intermediate representation) produced by CLP's logging libraries.
 
 - **Real-time Compression with CLP Logging Libraries**: CLP provides logging libraries for
-  [Python][clp-loglib-py] and Java ([Log4j][log4j1-appenders] and [Logback][logback-appenders]). The
-  logging libraries compress logs in real-time, so only compressed logs are written to disk or
-  transmitted over the network. The compressed logs use CLP's intermediate representation (IR)
-  format which achieves a higher compression ratio than general purpose compressors like Zstandard.
-  Compressing IR into archives can further double the compression ratio and enable global search,
-  but this requires more memory usage as it needs to buffer enough logs. More details on IR versus
-  archives can be found in this [Uber Engineering Blog][uber-blog].
+  [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][log4j2-appenders], and 
+  [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only 
+  compressed logs are written to disk or transmitted over the network. The compressed logs use CLP's
+  intermediate representation (IR) format which achieves a higher compression ratio than general
+  purpose compressors like Zstandard. Compressing IR into archives can further double the compression
+  ratio and enable global search, but this requires more memory usage as it needs to buffer enough
+  logs. More details on IR versus archives can be found in this [Uber Engineering Blog][uber-blog].
 
 - **[Log Viewer][log-viewer]**: the compressed IR can be viewed in a web-based log viewer. Compared
   to viewing the logs in an editor, CLP's log viewer supports advanced features like filtering logs
@@ -113,6 +113,7 @@ dev-guide/index
 [log-surgeon]: https://github.com/y-scope/log-surgeon
 [log-viewer]: https://github.com/y-scope/yscope-log-viewer
 [log4j1-appenders]: https://github.com/y-scope/log4j1-appenders
+[log4j2-appenders]: https://github.com/y-scope/log4j2-appenders
 [logback-appenders]: https://github.com/y-scope/logback-appenders
 [re2]: https://github.com/google/re2
 [uber-blog]: https://www.uber.com/en-US/blog/reducing-logging-cost-by-two-orders-of-magnitude-using-clp

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,9 +49,9 @@ features:
 - **Real-time Compression with CLP Logging Libraries**: CLP provides logging libraries for
   [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][log4j2-appenders], and 
   [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only 
-  compressed logs are written to disk or transmitted over the network. The compressed logs use
-  CLP's intermediate representation (IR) format which achieves a higher compression ratio than
-  general purpose compressors like Zstandard. Compressing IR into archives can further double the
+  compressed logs are written to disk or transmitted over the network. The compressed logs use CLP's
+  intermediate representation (IR) format which achieves a higher compression ratio than general
+  purpose compressors like Zstandard. Compressing IR into archives can further double the
   compression ratio and enable global search, but this requires more memory usage as it needs to
   buffer enough logs. More details on IR versus archives can be found in this
   [Uber Engineering Blog][uber-blog].

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,11 +49,12 @@ features:
 - **Real-time Compression with CLP Logging Libraries**: CLP provides logging libraries for
   [Python][clp-loglib-py] and Java ([Log4j1][log4j1-appenders], [Log4j2][log4j2-appenders], and 
   [Logback][logback-appenders]). The logging libraries compress logs in real-time, so only 
-  compressed logs are written to disk or transmitted over the network. The compressed logs use CLP's
-  intermediate representation (IR) format which achieves a higher compression ratio than general
-  purpose compressors like Zstandard. Compressing IR into archives can further double the compression
-  ratio and enable global search, but this requires more memory usage as it needs to buffer enough
-  logs. More details on IR versus archives can be found in this [Uber Engineering Blog][uber-blog].
+  compressed logs are written to disk or transmitted over the network. The compressed logs use
+  CLP's intermediate representation (IR) format which achieves a higher compression ratio than
+  general purpose compressors like Zstandard. Compressing IR into archives can further double the
+  compression ratio and enable global search, but this requires more memory usage as it needs to
+  buffer enough logs. More details on IR versus archives can be found in this
+  [Uber Engineering Blog][uber-blog].
 
 - **[Log Viewer][log-viewer]**: the compressed IR can be viewed in a web-based log viewer. Compared
   to viewing the logs in an editor, CLP's log viewer supports advanced features like filtering logs


### PR DESCRIPTION
# Description
Incorporated links to log4j2-appender in the documentation.

# Validation Performed
Successfully compiled the documentation locally and confirmed the functionality of the new links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation to include support for Log4j2 alongside Log4j1 and Logback.
	- Improved clarity and consistency in text formatting and structure.
	- Enhanced descriptions in the logging libraries section for better information flow.
	- Added a new link for Log4j2 in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->