### PR TITLE
feat(clp-s): Add support for ingesting logs from S3.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -257,6 +257,8 @@ set(SOURCE_FILES_clp_s_unitTest
     src/clp_s/FileReader.hpp
     src/clp_s/FileWriter.cpp
     src/clp_s/FileWriter.hpp
+    src/clp_s/InputConfig.cpp
+    src/clp_s/InputConfig.hpp
     src/clp_s/JsonConstructor.cpp
     src/clp_s/JsonConstructor.hpp
     src/clp_s/JsonFileIterator.cpp
@@ -592,7 +594,7 @@ target_include_directories(unitTest
 target_link_libraries(unitTest
         PRIVATE
         absl::flat_hash_map
-        Boost::filesystem Boost::iostreams Boost::program_options Boost::regex
+        Boost::filesystem Boost::iostreams Boost::program_options Boost::regex Boost::url
         ${CURL_LIBRARIES}
         fmt::fmt
         kql

--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -208,8 +208,9 @@ BaseColumnReader* ArchiveReader::append_reader_column(SchemaReader& reader, int3
             column_reader = new DateStringColumnReader(column_id, m_timestamp_dict);
             break;
         // No need to push columns without associated object readers into the SchemaReader.
-        case NodeType::Object:
+        case NodeType::Metadata:
         case NodeType::NullValue:
+        case NodeType::Object:
         case NodeType::StructuredArray:
         case NodeType::Unknown:
             break;

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -7,9 +7,8 @@
 #include <string_view>
 #include <utility>
 
-#include <boost/filesystem.hpp>
-
 #include "DictionaryReader.hpp"
+#include "InputConfig.hpp"
 #include "PackedStreamReader.hpp"
 #include "ReaderUtils.hpp"
 #include "SchemaReader.hpp"
@@ -32,10 +31,10 @@ public:
 
     /**
      * Opens an archive for reading.
-     * @param archives_dir
-     * @param archive_id
+     * @param archive_path
+     * @param network_auth
      */
-    void open(std::string_view archives_dir, std::string_view archive_id);
+    void open(Path const& archive_path, NetworkAuthOption const& network_auth);
 
     /**
      * Reads the dictionaries and metadata.

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -270,9 +270,10 @@ void ArchiveWriter::initialize_schema_writer(SchemaWriter* writer, Schema const&
             case NodeType::DateString:
                 writer->append_column(new DateStringColumnWriter(id));
                 break;
-            case NodeType::StructuredArray:
-            case NodeType::Object:
+            case NodeType::Metadata:
             case NodeType::NullValue:
+            case NodeType::Object:
+            case NodeType::StructuredArray:
             case NodeType::Unknown:
                 break;
         }

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -4,7 +4,6 @@
 #include <string_view>
 #include <utility>
 
-#include <boost/filesystem.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -2,30 +2,51 @@ add_subdirectory(search/kql)
 
 set(
         CLP_SOURCES
+        ../clp/aws/AwsAuthenticationSigner.cpp
+        ../clp/aws/AwsAuthenticationSigner.hpp
+        ../clp/BoundedReader.cpp
+        ../clp/BoundedReader.hpp
+        ../clp/CurlDownloadHandler.cpp
+        ../clp/CurlDownloadHandler.hpp
+        ../clp/CurlEasyHandle.hpp
+        ../clp/CurlGlobalInstance.cpp
+        ../clp/CurlGlobalInstance.hpp
+        ../clp/CurlOperationFailed.hpp
+        ../clp/CurlStringList.hpp
         ../clp/cli_utils.cpp
         ../clp/cli_utils.hpp
         ../clp/database_utils.cpp
         ../clp/database_utils.hpp
         ../clp/Defs.h
         ../clp/ErrorCode.hpp
+        ../clp/FileReader.cpp
+        ../clp/FileReader.hpp
         ../clp/GlobalMetadataDB.hpp
         ../clp/GlobalMetadataDBConfig.cpp
         ../clp/GlobalMetadataDBConfig.hpp
         ../clp/GlobalMySQLMetadataDB.cpp
         ../clp/GlobalMySQLMetadataDB.hpp
+        ../clp/hash_utils.cpp
+        ../clp/hash_utils.hpp
         ../clp/MySQLDB.cpp
         ../clp/MySQLDB.hpp
         ../clp/MySQLParamBindings.cpp
         ../clp/MySQLParamBindings.hpp
         ../clp/MySQLPreparedStatement.cpp
         ../clp/MySQLPreparedStatement.hpp
+        ../clp/NetworkReader.cpp
+        ../clp/NetworkReader.hpp
         ../clp/networking/socket_utils.cpp
         ../clp/networking/socket_utils.hpp
         ../clp/ReaderInterface.cpp
         ../clp/ReaderInterface.hpp
+        ../clp/spdlog_with_specializations.hpp
         ../clp/streaming_archive/ArchiveMetadata.cpp
         ../clp/streaming_archive/ArchiveMetadata.hpp
+        ../clp/Thread.cpp
+        ../clp/Thread.hpp
         ../clp/TraceableException.hpp
+        ../clp/type_utils.hpp
         ../clp/WriterInterface.cpp
         ../clp/WriterInterface.hpp
 )
@@ -58,6 +79,8 @@ set(
         FileReader.hpp
         FileWriter.cpp
         FileWriter.hpp
+        InputConfig.cpp
+        InputConfig.hpp
         JsonConstructor.cpp
         JsonConstructor.hpp
         JsonFileIterator.cpp
@@ -195,12 +218,14 @@ target_link_libraries(
         clp-s
         PRIVATE
         absl::flat_hash_map
-        Boost::filesystem Boost::iostreams Boost::program_options
+        Boost::iostreams Boost::program_options Boost::regex Boost::url
+        ${CURL_LIBRARIES}
         clp::string_utils
         kql
         MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
         msgpack-cxx
+        OpenSSL::Crypto
         simdjson
         spdlog::spdlog
         yaml-cpp::yaml-cpp

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -218,7 +218,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                     "auth",
                     po::value<std::string>(&auth)
-                        ->value_name("AUTH_TYPE")
+                        ->value_name("AUTH_METHOD")
                         ->default_value(auth),
                     "Type of authentication required for network requests (s3 | none). Authentication"
                     " with s3 requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment"
@@ -365,7 +365,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                     "auth",
                     po::value<std::string>(&auth)
-                        ->value_name("AUTH_TYPE")
+                        ->value_name("AUTH_METHOD")
                         ->default_value(auth),
                     "Type of authentication required for network requests (s3 | none). Authentication"
                     " with s3 requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment"
@@ -535,7 +535,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             )(
                 "auth",
                 po::value<std::string>(&auth)
-                    ->value_name("AUTH_TYPE")
+                    ->value_name("AUTH_METHOD")
                     ->default_value(auth),
                 "Type of authentication required for network requests (s3 | none). Authentication"
                 " with s3 requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment"

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -12,6 +12,7 @@
 #include "../clp/GlobalMetadataDBConfig.hpp"
 #include "../reducer/types.hpp"
 #include "Defs.hpp"
+#include "InputConfig.hpp"
 
 namespace clp_s {
 class CommandLineArguments {
@@ -51,7 +52,9 @@ public:
 
     Command get_command() const { return m_command; }
 
-    std::vector<std::string> const& get_file_paths() const { return m_file_paths; }
+    std::vector<Path> const& get_input_paths() const { return m_input_paths; }
+
+    NetworkAuthOption const& get_network_auth() const { return m_network_auth; }
 
     std::string const& get_archives_dir() const { return m_archives_dir; }
 
@@ -86,8 +89,6 @@ public:
     std::optional<epochtime_t> get_search_end_ts() const { return m_search_end_ts; }
 
     bool get_ignore_case() const { return m_ignore_case; }
-
-    std::string const& get_archive_id() const { return m_archive_id; }
 
     std::optional<clp::GlobalMetadataDBConfig> const& get_metadata_db_config() const {
         return m_metadata_db_config;
@@ -177,7 +178,8 @@ private:
     Command m_command;
 
     // Compression and decompression variables
-    std::vector<std::string> m_file_paths;
+    std::vector<Path> m_input_paths;
+    NetworkAuthOption m_network_auth{};
     std::string m_archives_dir;
     std::string m_output_dir;
     std::string m_timestamp_key;
@@ -212,9 +214,6 @@ private:
     std::optional<epochtime_t> m_search_end_ts;
     bool m_ignore_case{false};
     std::vector<std::string> m_projection_columns;
-
-    // Decompression and search variables
-    std::string m_archive_id;
 
     // Search aggregation variables
     std::string m_reducer_host;

--- a/components/core/src/clp_s/InputConfig.cpp
+++ b/components/core/src/clp_s/InputConfig.cpp
@@ -17,7 +17,7 @@ auto get_source_for_path(std::string_view const path) -> InputSource {
 }
 
 auto get_path_object_for_raw_path(std::string_view const path) -> Path {
-    return Path{.source{get_source_for_path(path)}, .path{std::string{path}}};
+    return Path{.source = get_source_for_path(path), .path = std::string{path}};
 }
 
 auto get_input_files_for_raw_path(std::string_view const path, std::vector<Path>& files) -> bool {
@@ -41,7 +41,7 @@ auto get_input_files_for_path(Path const& path, std::vector<Path>& files) -> boo
     }
 
     for (auto& file : file_paths) {
-        files.emplace_back(Path{.source{InputSource::Filesystem}, .path{std::move(file)}});
+        files.emplace_back(Path{.source = InputSource::Filesystem, .path = std::move(file)});
     }
     return true;
 }
@@ -68,7 +68,7 @@ auto get_input_archives_for_path(Path const& path, std::vector<Path>& archives) 
     }
 
     for (auto& archive : archive_paths) {
-        archives.emplace_back(Path{.source{InputSource::Filesystem}, .path{std::move(archive)}});
+        archives.emplace_back(Path{.source = InputSource::Filesystem, .path = std::move(archive)});
     }
     return true;
 }

--- a/components/core/src/clp_s/InputConfig.cpp
+++ b/components/core/src/clp_s/InputConfig.cpp
@@ -1,0 +1,88 @@
+#include "InputConfig.hpp"
+
+#include <exception>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "Utils.hpp"
+
+namespace clp_s {
+auto get_source_for_path(std::string_view const path) -> InputSource {
+    try {
+        return std::filesystem::exists(path) ? InputSource::Filesystem : InputSource::Network;
+    } catch (std::exception const& e) {
+        return InputSource::Network;
+    }
+}
+
+auto get_path_object_for_raw_path(std::string_view const path) -> Path {
+    return Path{.source{get_source_for_path(path)}, .path{std::string{path}}};
+}
+
+auto get_input_files_for_raw_path(std::string_view const path, std::vector<Path>& files) -> bool {
+    return get_input_files_for_path(get_path_object_for_raw_path(path), files);
+}
+
+auto get_input_files_for_path(Path const& path, std::vector<Path>& files) -> bool {
+    if (InputSource::Network == path.source) {
+        files.emplace_back(path);
+        return true;
+    }
+
+    if (false == std::filesystem::is_directory(path.path)) {
+        files.emplace_back(path);
+        return true;
+    }
+
+    std::vector<std::string> file_paths;
+    if (false == FileUtils::find_all_files_in_directory(path.path, file_paths)) {
+        return false;
+    }
+
+    for (auto& file : file_paths) {
+        files.emplace_back(Path{.source{InputSource::Filesystem}, .path{std::move(file)}});
+    }
+    return true;
+}
+
+auto get_input_archives_for_raw_path(std::string_view const path, std::vector<Path>& archives)
+        -> bool {
+    return get_input_archives_for_path(get_path_object_for_raw_path(path), archives);
+}
+
+auto get_input_archives_for_path(Path const& path, std::vector<Path>& archives) -> bool {
+    if (InputSource::Network == path.source) {
+        archives.emplace_back(path);
+        return true;
+    }
+
+    if (false == std::filesystem::is_directory(path.path)) {
+        archives.emplace_back(path);
+        return true;
+    }
+
+    std::vector<std::string> archive_paths;
+    if (false == FileUtils::find_all_archives_in_directory(path.path, archive_paths)) {
+        return false;
+    }
+
+    for (auto& archive : archive_paths) {
+        archives.emplace_back(Path{.source{InputSource::Filesystem}, .path{std::move(archive)}});
+    }
+    return true;
+}
+
+auto get_archive_id_from_path(Path const& archive_path, std::string& archive_id) -> bool {
+    switch (archive_path.source) {
+        case InputSource::Network:
+            return UriUtils::get_last_uri_component(archive_path.path, archive_id);
+        case InputSource::Filesystem:
+            return FileUtils::get_last_non_empty_path_component(archive_path.path, archive_id);
+        default:
+            return false;
+    }
+    return true;
+}
+
+}  // namespace clp_s

--- a/components/core/src/clp_s/InputConfig.hpp
+++ b/components/core/src/clp_s/InputConfig.hpp
@@ -1,0 +1,105 @@
+#ifndef CLP_S_INPUTCONFIG_HPP
+#define CLP_S_INPUTCONFIG_HPP
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace clp_s {
+// Constants used for input configuration
+constexpr char cAwsAccessKeyIdEnvVar[] = "AWS_ACCESS_KEY_ID";
+constexpr char cAwsSecretAccessKeyEnvVar[] = "AWS_SECRET_ACCESS_KEY";
+
+/**
+ * Enum class definining the source of some resource.
+ */
+enum class InputSource : uint8_t {
+    Filesystem,
+    Network
+};
+
+/**
+ * Enum class defining the auth that needs to be performed to access some resource.
+ */
+enum class AuthMethod : uint8_t {
+    None,
+    S3PresignedUrlV4
+};
+
+/**
+ * Struct encapsulating information needed to authenticate network requests.
+ */
+struct NetworkAuthOption {
+    AuthMethod method{AuthMethod::None};
+};
+
+/**
+ * Struct describing a path to some resource as well as its source.
+ */
+struct Path {
+    InputSource source{InputSource::Filesystem};
+    std::string path;
+};
+
+/**
+ * Determines the input source for a given raw path or url.
+ * @param path
+ * @return the InputSource for the given path
+ */
+[[nodiscard]] auto get_source_for_path(std::string_view const path) -> InputSource;
+
+/**
+ * Determines the input source for a given raw path or url and converts the path into a Path object.
+ * @param path
+ * @return a Path object representing the raw path or url
+ */
+[[nodiscard]] auto get_path_object_for_raw_path(std::string_view const path) -> Path;
+
+/**
+ * Recursively records all file paths from the given raw path, including the path itself.
+ * @param path
+ * @param files Returned paths
+ * @return true on success, false otherwise
+ */
+auto get_input_files_for_raw_path(std::string_view const path, std::vector<Path>& files) -> bool;
+
+/**
+ * Recursively records all file paths that are children of the the given Path, including the Path
+ * itself.
+ * @param option
+ * @param files Returned paths
+ * @return true on success, false otherwise
+ */
+[[nodiscard]] auto get_input_files_for_path(Path const& path, std::vector<Path>& files) -> bool;
+
+/**
+ * Records all archives that are children of the given raw path, including the path itself.
+ * @param path
+ * @param archives Returned archives
+ * @return true on success, false otherwise
+ */
+[[nodiscard]] auto
+get_input_archives_for_raw_path(std::string_view const path, std::vector<Path>& archives) -> bool;
+
+/**
+ * Records all archives from the given Path, including the Path itself.
+ * @param path
+ * @param archives Returned archives
+ * @return true on success, false otherwise
+ */
+[[nodiscard]] auto
+get_input_archives_for_path(Path const& path, std::vector<Path>& archives) -> bool;
+
+/**
+ * Determines the archive id of a given archive based on a path to that archive.
+ * @param path
+ * @param archive_id Returned archive id
+ * @return true on success, false otherwise
+ */
+[[nodiscard]] auto
+get_archive_id_from_path(Path const& archive_path, std::string& archive_id) -> bool;
+}  // namespace clp_s
+
+#endif  // CLP_S_INPUTCONFIG_HPP

--- a/components/core/src/clp_s/InputConfig.hpp
+++ b/components/core/src/clp_s/InputConfig.hpp
@@ -13,7 +13,7 @@ constexpr char cAwsAccessKeyIdEnvVar[] = "AWS_ACCESS_KEY_ID";
 constexpr char cAwsSecretAccessKeyEnvVar[] = "AWS_SECRET_ACCESS_KEY";
 
 /**
- * Enum class definining the source of some resource.
+ * Enum class defining the source of a resource.
  */
 enum class InputSource : uint8_t {
     Filesystem,
@@ -21,7 +21,7 @@ enum class InputSource : uint8_t {
 };
 
 /**
- * Enum class defining the auth that needs to be performed to access some resource.
+ * Enum class defining the authentication method required for accessing a resource.
  */
 enum class AuthMethod : uint8_t {
     None,
@@ -36,7 +36,7 @@ struct NetworkAuthOption {
 };
 
 /**
- * Struct describing a path to some resource as well as its source.
+ * Struct representing a resource path with its source type.
  */
 struct Path {
     InputSource source{InputSource::Filesystem};
@@ -58,7 +58,7 @@ struct Path {
 [[nodiscard]] auto get_path_object_for_raw_path(std::string_view const path) -> Path;
 
 /**
- * Recursively records all file paths from the given raw path, including the path itself.
+ * Recursively collects all file paths from the given raw path, including the path itself.
  * @param path
  * @param files Returned paths
  * @return true on success, false otherwise
@@ -66,16 +66,16 @@ struct Path {
 auto get_input_files_for_raw_path(std::string_view const path, std::vector<Path>& files) -> bool;
 
 /**
- * Recursively records all file paths that are children of the the given Path, including the Path
+ * Recursively collects all file paths that are children of the the given Path, including the Path
  * itself.
- * @param option
+ * @param path
  * @param files Returned paths
  * @return true on success, false otherwise
  */
 [[nodiscard]] auto get_input_files_for_path(Path const& path, std::vector<Path>& files) -> bool;
 
 /**
- * Records all archives that are children of the given raw path, including the path itself.
+ * Collects all archives that are children of the given raw path, including the path itself.
  * @param path
  * @param archives Returned archives
  * @return true on success, false otherwise
@@ -84,7 +84,7 @@ auto get_input_files_for_raw_path(std::string_view const path, std::vector<Path>
 get_input_archives_for_raw_path(std::string_view const path, std::vector<Path>& archives) -> bool;
 
 /**
- * Records all archives from the given Path, including the Path itself.
+ * Collects all archives from the given Path, including the Path itself.
  * @param path
  * @param archives Returned archives
  * @return true on success, false otherwise
@@ -93,7 +93,7 @@ get_input_archives_for_raw_path(std::string_view const path, std::vector<Path>& 
 get_input_archives_for_path(Path const& path, std::vector<Path>& archives) -> bool;
 
 /**
- * Determines the archive id of a given archive based on a path to that archive.
+ * Determines the archive id of an archive based on the archive path.
  * @param path
  * @param archive_id Returned archive id
  * @return true on success, false otherwise

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -31,22 +31,11 @@ JsonConstructor::JsonConstructor(JsonConstructorOption const& option) : m_option
                 )
         );
     }
-
-    std::filesystem::path archive_path{m_option.archives_dir};
-    archive_path /= m_option.archive_id;
-    if (false == std::filesystem::is_directory(archive_path)) {
-        throw OperationFailed(
-                ErrorCodeFailure,
-                __FILENAME__,
-                __LINE__,
-                fmt::format("'{}' is not a directory", archive_path.c_str())
-        );
-    }
 }
 
 void JsonConstructor::store() {
     m_archive_reader = std::make_unique<ArchiveReader>();
-    m_archive_reader->open(m_option.archives_dir, m_option.archive_id);
+    m_archive_reader->open(m_option.archive_path, m_option.network_auth);
     m_archive_reader->read_dictionaries_and_metadata();
 
     if (m_option.ordered && false == m_archive_reader->has_log_order()) {
@@ -84,7 +73,7 @@ void JsonConstructor::construct_in_order() {
     int64_t first_idx{};
     int64_t last_idx{};
     size_t chunk_size{};
-    auto src_path = std::filesystem::path(m_option.output_dir) / m_option.archive_id;
+    auto src_path = std::filesystem::path(m_option.output_dir) / m_archive_reader->get_archive_id();
     FileWriter writer;
     writer.open(src_path, FileWriter::OpenMode::CreateForWriting);
 
@@ -123,7 +112,7 @@ void JsonConstructor::construct_in_order() {
                     ),
                     bsoncxx::builder::basic::kvp(
                             constants::results_cache::decompression::cStreamId,
-                            m_option.archive_id
+                            std::string{m_archive_reader->get_archive_id()}
                     ),
                     bsoncxx::builder::basic::kvp(
                             constants::results_cache::decompression::cBeginMsgIx,

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -11,6 +11,7 @@
 #include "DictionaryReader.hpp"
 #include "ErrorCode.hpp"
 #include "FileWriter.hpp"
+#include "InputConfig.hpp"
 #include "SchemaReader.hpp"
 #include "SchemaTree.hpp"
 #include "TraceableException.hpp"
@@ -26,12 +27,12 @@ struct MetadataDbOption {
 };
 
 struct JsonConstructorOption {
-    std::string archives_dir;
-    std::string archive_id;
+    Path archive_path{};
+    NetworkAuthOption network_auth{};
     std::string output_dir;
     bool ordered{false};
     size_t target_ordered_chunk_size{};
-    std::optional<MetadataDbOption> metadata_db;
+    std::optional<MetadataDbOption> metadata_db{std::nullopt};
 };
 
 class JsonConstructor {

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -3,6 +3,7 @@
 
 #include <simdjson.h>
 
+#include "../clp/ReaderInterface.hpp"
 #include "FileReader.hpp"
 
 namespace clp_s {
@@ -22,7 +23,7 @@ public:
      * @param buf_size the initial buffer size
      */
     explicit JsonFileIterator(
-            std::string const& file_name,
+            clp::ReaderInterface& reader,
             size_t max_document_size,
             size_t buf_size = 1024 * 1024 /*1MB default*/
     );
@@ -34,12 +35,6 @@ public:
      * @return true if the iterator is valid, false otherwise
      */
     [[nodiscard]] bool get_json(simdjson::ondemand::document_stream::iterator& it);
-
-    /**
-     * Checks if the file is open
-     * @return true if the file opened successfully
-     */
-    [[nodiscard]] bool is_open() const { return m_reader.is_open(); }
 
     /**
      * @return number of truncated bytes after json documents
@@ -86,7 +81,7 @@ private:
     size_t m_buf_occupied{0};
     size_t m_max_document_size{0};
     char* m_buf{nullptr};
-    FileReader m_reader;
+    clp::ReaderInterface& m_reader;
     simdjson::ondemand::parser m_parser;
     simdjson::ondemand::document_stream m_stream;
     bool m_eof{false};

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -4,7 +4,6 @@
 #include <simdjson.h>
 
 #include "../clp/ReaderInterface.hpp"
-#include "FileReader.hpp"
 
 namespace clp_s {
 class JsonFileIterator {

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -10,7 +10,7 @@ namespace clp_s {
 class JsonFileIterator {
 public:
     /**
-     * An iterator over a file containing json objects. JSON is parsed
+     * An iterator over an input stream containing json objects. JSON is parsed
      * using simdjson::parse_many. This allows simdjson to efficiently find
      * delimeters between JSON objects, and if enabled parse JSON ahead of time
      * in another thread while the JSON is being iterated over.
@@ -18,7 +18,7 @@ public:
      * The buffer grows automatically if there are JSON objects larger than the buffer size.
      * The buffer is padded to be SIMDJSON_PADDING bytes larger than the specified size.
 
-     * @param file_name the file containing JSON
+     * @param reader the input stream containing JSON
      * @param max_document_size the maximum allowed size of a single document
      * @param buf_size the initial buffer size
      */

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -557,9 +557,9 @@ bool JsonParser::parse() {
                     error_msg_str = curl_error_message.value();
                 }
                 SPDLOG_ERROR("Encountered curl error during ingestion - {}", error_msg_str);
+                m_archive_writer->close();
+                return false;
             }
-            m_archive_writer->close();
-            return false;
         }
     }
     return true;

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -551,12 +551,13 @@ bool JsonParser::parse() {
             if (auto const rc = network_reader->get_curl_ret_code();
                 rc.has_value() && CURLcode::CURLE_OK != rc.value())
             {
-                auto curl_error_message = network_reader->get_curl_error_msg();
-                std::string error_msg_str;
-                if (curl_error_message.has_value()) {
-                    error_msg_str = curl_error_message.value();
-                }
-                SPDLOG_ERROR("Encountered curl error during ingestion - {}", error_msg_str);
+                auto const curl_error_message = network_reader->get_curl_error_msg();
+                SPDLOG_ERROR(
+                        "Encountered curl error while ingesting {} - Code: {} - Message: {}",
+                        path.path,
+                        rc.value(),
+                        curl_error_message.value_or("Unkown error")
+                );
                 m_archive_writer->close();
                 return false;
             }

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -618,8 +618,8 @@ bool JsonParser::parse() {
                 SPDLOG_ERROR(
                         "Encountered curl error while ingesting {} - Code: {} - Message: {}",
                         path.path,
-                        rc.value(),
-                        curl_error_message.value_or("Unkown error")
+                        static_cast<int64_t>(rc.value()),
+                        curl_error_message.value_or("Unknown error")
                 );
                 m_archive_writer->close();
                 return false;

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_JSONPARSER_HPP
 
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -16,7 +17,9 @@
 #include "DictionaryWriter.hpp"
 #include "FileReader.hpp"
 #include "FileWriter.hpp"
+#include "InputConfig.hpp"
 #include "ParsedMessage.hpp"
+#include "ReaderUtils.hpp"
 #include "Schema.hpp"
 #include "SchemaMap.hpp"
 #include "SchemaTree.hpp"
@@ -29,7 +32,7 @@ using namespace simdjson;
 
 namespace clp_s {
 struct JsonParserOption {
-    std::vector<std::string> file_paths;
+    std::vector<Path> input_paths;
     CommandLineArguments::FileType input_file_type{CommandLineArguments::FileType::Json};
     std::string timestamp_key;
     std::string archives_dir;
@@ -42,6 +45,7 @@ struct JsonParserOption {
     bool record_log_order{true};
     bool single_file_archive{false};
     std::shared_ptr<clp::GlobalMySQLMetadataDB> metadata_db;
+    NetworkAuthOption network_auth{};
 };
 
 class JsonParser {
@@ -108,7 +112,8 @@ private:
     int32_t add_metadata_field(std::string_view const field_name, NodeType type);
 
     int m_num_messages;
-    std::vector<std::string> m_file_paths;
+    std::vector<Path> m_input_paths;
+    NetworkAuthOption m_network_auth{};
 
     Schema m_current_schema;
     ParsedMessage m_current_parsed_message;

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -161,10 +161,18 @@ std::shared_ptr<clp::ReaderInterface> try_create_file_reader(std::string_view co
 }
 
 bool try_sign_url(std::string& url) {
-    clp::aws::AwsAuthenticationSigner signer{
-            std::getenv(cAwsAccessKeyIdEnvVar),
-            std::getenv(cAwsSecretAccessKeyEnvVar)
-    };
+    auto const aws_access_key = std::getenv(cAwsAccessKeyIdEnvVar);
+    auto const aws_secret_access_key = std::getenv(cAwsSecretAccessKeyEnvVar);
+    if (nullptr == aws_access_key || nullptr == aws_secret_access_key) {
+        SPDLOG_ERROR(
+                "{} and {} environment variables not available for presigned url authentication.",
+                cAwsAccessKeyIdEnvVar,
+                cAwsSecretAccessKeyEnvVar
+        );
+        return false;
+    }
+
+    clp::aws::AwsAuthenticationSigner signer{aws_access_key, aws_secret_access_key};
 
     try {
         clp::aws::S3Url s3_url{url};

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -1,6 +1,14 @@
 #include "ReaderUtils.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include "../clp/aws/AwsAuthenticationSigner.hpp"
+#include "../clp/FileReader.hpp"
+#include "../clp/NetworkReader.hpp"
+#include "../clp/ReaderInterface.hpp"
+#include "../clp/spdlog_with_specializations.hpp"
 #include "archive_constants.hpp"
+#include "Utils.hpp"
 
 namespace clp_s {
 std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(std::string const& archives_dir) {
@@ -142,22 +150,67 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
     return schemas_pointer;
 }
 
-std::vector<std::string> ReaderUtils::get_archives(std::string const& archives_dir) {
-    std::vector<std::string> archive_paths;
-
-    if (false == boost::filesystem::is_directory(archives_dir)) {
-        throw OperationFailed(ErrorCodeBadParam, __FILENAME__, __LINE__);
+namespace {
+std::shared_ptr<clp::ReaderInterface> try_create_file_reader(std::string_view const file_path) {
+    try {
+        return std::make_shared<clp::FileReader>(std::string{file_path});
+    } catch (clp::FileReader::OperationFailed const& e) {
+        SPDLOG_ERROR("Failed to open file for reading - {} - {}", file_path, e.what());
+        return nullptr;
     }
-
-    boost::filesystem::directory_iterator iter(archives_dir);
-    boost::filesystem::directory_iterator end;
-    for (; iter != end; ++iter) {
-        if (boost::filesystem::is_directory(iter->path())) {
-            archive_paths.push_back(iter->path().string());
-        }
-    }
-
-    return archive_paths;
 }
 
+bool try_sign_url(std::string& url) {
+    clp::aws::AwsAuthenticationSigner signer{
+            std::getenv(cAwsAccessKeyIdEnvVar),
+            std::getenv(cAwsSecretAccessKeyEnvVar)
+    };
+
+    try {
+        clp::aws::S3Url s3_url{url};
+        if (auto const rc = signer.generate_presigned_url(s3_url, url);
+            clp::ErrorCode::ErrorCode_Success != rc)
+        {
+            return false;
+        }
+    } catch (std::exception const& e) {
+        return false;
+    }
+    return true;
+}
+
+std::shared_ptr<clp::ReaderInterface>
+try_create_network_reader(std::string_view const url, NetworkAuthOption const& auth) {
+    std::string request_url{url};
+    switch (auth.method) {
+        case AuthMethod::S3PresignedUrlV4:
+            if (false == try_sign_url(request_url)) {
+                return nullptr;
+            }
+            break;
+        case AuthMethod::None:
+            break;
+        default:
+            return nullptr;
+    }
+
+    try {
+        return std::make_shared<clp::NetworkReader>(request_url);
+    } catch (clp::NetworkReader::OperationFailed const& e) {
+        SPDLOG_ERROR("Failed to open url for reading - {}", e.what());
+        return nullptr;
+    }
+}
+}  // namespace
+
+std::shared_ptr<clp::ReaderInterface>
+ReaderUtils::try_create_reader(Path const& path, NetworkAuthOption const& network_auth) {
+    if (InputSource::Filesystem == path.source) {
+        return try_create_file_reader(path.path);
+    } else if (InputSource::Network == path.source) {
+        return try_create_network_reader(path.path, network_auth);
+    } else {
+        return nullptr;
+    }
+}
 }  // namespace clp_s

--- a/components/core/src/clp_s/ReaderUtils.hpp
+++ b/components/core/src/clp_s/ReaderUtils.hpp
@@ -70,6 +70,12 @@ public:
             std::string const& archive_path
     );
 
+    /**
+     * Tries to open a clp::ReaderInterface using the given Path and NetworkAuthOption.
+     * @param path
+     * @param network_auth
+     * @return the opened clp::ReaderInterface or nullptr on error
+     */
     static std::shared_ptr<clp::ReaderInterface>
     try_create_reader(Path const& path, NetworkAuthOption const& network_auth);
 

--- a/components/core/src/clp_s/ReaderUtils.hpp
+++ b/components/core/src/clp_s/ReaderUtils.hpp
@@ -1,7 +1,11 @@
 #ifndef CLP_S_READERUTILS_HPP
 #define CLP_S_READERUTILS_HPP
 
+#include <string>
+
+#include "../clp/ReaderInterface.hpp"
 #include "DictionaryReader.hpp"
+#include "InputConfig.hpp"
 #include "Schema.hpp"
 #include "SchemaReader.hpp"
 #include "SchemaTree.hpp"
@@ -66,12 +70,8 @@ public:
             std::string const& archive_path
     );
 
-    /**
-     * Gets the list of archives in the given archive directory
-     * @param archives_dir
-     * @return the list of archives
-     */
-    static std::vector<std::string> get_archives(std::string const& archives_dir);
+    static std::shared_ptr<clp::ReaderInterface>
+    try_create_reader(Path const& path, NetworkAuthOption const& network_auth);
 
 private:
     /**

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -112,7 +112,7 @@ bool FileUtils::find_all_archives_in_directory(
         return false;
     }
 
-    if (directory_is_multi_file_archive(path)) {
+    if (is_multi_file_archive(path)) {
         archive_paths.emplace_back(path);
         return true;
     }

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -65,7 +65,7 @@ namespace {
  * @param path
  * @return true if this directory is a multi-file archive, false otherwise
  */
-bool directory_is_multi_file_archive(std::string_view const path) {
+bool is_multi_file_archive(std::string_view const path) {
     for (auto const& entry : std::filesystem::directory_iterator{path}) {
         if (entry.is_directory()) {
             return false;

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -9,7 +9,6 @@
 #include <spdlog/spdlog.h>
 
 #include "archive_constants.hpp"
-#include "Utils.hpp"
 
 using std::string;
 using std::string_view;

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -5,8 +5,8 @@
 #include <cstring>
 #include <sstream>
 #include <string>
-
-#include <boost/filesystem.hpp>
+#include <string_view>
+#include <vector>
 
 namespace clp_s {
 class FileUtils {
@@ -17,14 +17,48 @@ public:
      * @param file_paths
      * @return true if successful, false otherwise
      */
-    static bool find_all_files(std::string const& path, std::vector<std::string>& file_paths);
+    static bool
+    find_all_files_in_directory(std::string const& path, std::vector<std::string>& file_paths);
 
     /**
-     * Validate if all paths exist
-     * @param paths
-     * @return true if all paths exist, false otherwise
+     * Find all archives in a directory, including the directory itself
+     * @param path
+     * @param archive_paths
+     * @return true if successful, false otherwise
      */
-    static bool validate_path(std::vector<std::string> const& paths);
+    static bool find_all_archives_in_directory(
+            std::string_view const path,
+            std::vector<std::string>& archive_paths
+    );
+
+    /**
+     * Gets the last non-empty component of a path, accounting for trailing forward slashes.
+     *
+     * For example:
+     * ./foo/bar.baz -> bar.baz
+     * ./foo/bar.baz/ -> bar.baz
+     *
+     * @param path
+     * @param name Returned component name
+     * @return true on success, false otherwise
+     */
+    static bool get_last_non_empty_path_component(std::string_view const path, std::string& name);
+};
+
+class UriUtils {
+public:
+    /**
+     * Gets the last component of a uri.
+     *
+     * For example:
+     * https://www.something.org/abc-xyz -> abc-xyz
+     * https://www.something.org/aaa/bbb/abc-xyz?something=something -> abc-xyz
+     *
+     * @param uri
+     * @param name Returned component name
+     * @return true on success, false otherwise
+     */
+    static bool get_last_uri_component(std::string_view const uri, std::string& name);
 };
 
 class StringUtils {

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -21,7 +21,7 @@ public:
     find_all_files_in_directory(std::string const& path, std::vector<std::string>& file_paths);
 
     /**
-     * Find all archives in a directory, including the directory itself
+     * Finds all archives in a directory, including the directory itself
      * @param path
      * @param archive_paths
      * @return true if successful, false otherwise

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -12,7 +12,7 @@ namespace clp_s {
 class FileUtils {
 public:
     /**
-     * Find all files in a directory
+     * Finds all files in a directory
      * @param path
      * @param file_paths
      * @return true if successful, false otherwise

--- a/components/core/src/clp_s/ZstdDecompressor.cpp
+++ b/components/core/src/clp_s/ZstdDecompressor.cpp
@@ -3,8 +3,9 @@
 #include "ZstdDecompressor.hpp"
 
 #include <algorithm>
+#include <filesystem>
 
-#include <boost/filesystem.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
 #include <spdlog/spdlog.h>
 
 namespace clp_s {
@@ -202,14 +203,13 @@ ErrorCode ZstdDecompressor::open(std::string const& compressed_file_path) {
     m_input_type = InputType::MemoryMappedCompressedFile;
 
     // Create memory mapping for compressed_file_path, use boost read only memory mapped file
-    boost::system::error_code boost_error_code;
-    size_t compressed_file_size
-            = boost::filesystem::file_size(compressed_file_path, boost_error_code);
-    if (boost_error_code) {
+    std::error_code error_code;
+    size_t compressed_file_size = std::filesystem::file_size(compressed_file_path, error_code);
+    if (error_code) {
         SPDLOG_ERROR(
                 "ZstdDecompressor: Unable to obtain file size for '{}' - {}.",
                 compressed_file_path.c_str(),
-                boost_error_code.message().c_str()
+                error_code.message().c_str()
         );
         return ErrorCodeFailure;
     }

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -353,7 +353,12 @@ int main(int argc, char const* argv[]) {
 
         auto archive_reader = std::make_shared<clp_s::ArchiveReader>();
         for (auto const& archive_path : command_line_arguments.get_input_paths()) {
-            archive_reader->open(archive_path, command_line_arguments.get_network_auth());
+            try {
+                archive_reader->open(archive_path, command_line_arguments.get_network_auth());
+            } catch (std::exception const& e) {
+                SPDLOG_ERROR("Failed to open archive - {}", e.what());
+                return 1;
+            }
             if (false
                 == search_archive(
                         command_line_arguments,

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <exception>
 #include <filesystem>
 #include <iostream>
@@ -11,6 +12,7 @@
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
 
+#include "../clp/CurlGlobalInstance.hpp"
 #include "../clp/GlobalMySQLMetadataDB.hpp"
 #include "../clp/streaming_archive/ArchiveMetadata.hpp"
 #include "../reducer/network_utils.hpp"
@@ -18,7 +20,6 @@
 #include "Defs.hpp"
 #include "JsonConstructor.hpp"
 #include "JsonParser.hpp"
-#include "ReaderUtils.hpp"
 #include "search/AddTimestampConditions.hpp"
 #include "search/ConvertToExists.hpp"
 #include "search/EmptyExpr.hpp"
@@ -87,7 +88,8 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     }
 
     clp_s::JsonParserOption option{};
-    option.file_paths = command_line_arguments.get_file_paths();
+    option.input_paths = command_line_arguments.get_input_paths();
+    option.network_auth = command_line_arguments.get_network_auth();
     option.input_file_type = command_line_arguments.get_file_type();
     option.archives_dir = archives_dir.string();
     option.target_encoded_size = command_line_arguments.get_target_encoded_size();
@@ -143,7 +145,7 @@ bool search_archive(
 ) {
     auto const& query = command_line_arguments.get_query();
 
-    auto timestamp_dict = archive_reader->read_timestamp_dictionary();
+    auto timestamp_dict = archive_reader->get_timestamp_dictionary();
     AddTimestampConditions add_timestamp_conditions(
             timestamp_dict->get_authoritative_timestamp_tokenized_column(),
             command_line_arguments.get_search_begin_ts(),
@@ -282,6 +284,7 @@ int main(int argc, char const* argv[]) {
 
     clp_s::TimestampPattern::init();
     mongocxx::instance const mongocxx_instance{};
+    clp::CurlGlobalInstance const curl_instance{};
 
     CommandLineArguments command_line_arguments("clp-s");
     auto parsing_result = command_line_arguments.parse_arguments(argc, argv);
@@ -300,37 +303,21 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
     } else if (CommandLineArguments::Command::Extract == command_line_arguments.get_command()) {
-        auto const& archives_dir = command_line_arguments.get_archives_dir();
-        if (false == std::filesystem::is_directory(archives_dir)) {
-            SPDLOG_ERROR("'{}' is not a directory.", archives_dir);
-            return 1;
-        }
-
         clp_s::JsonConstructorOption option{};
         option.output_dir = command_line_arguments.get_output_dir();
         option.ordered = command_line_arguments.get_ordered_decompression();
-        option.archives_dir = archives_dir;
         option.target_ordered_chunk_size = command_line_arguments.get_target_ordered_chunk_size();
+        option.network_auth = command_line_arguments.get_network_auth();
         if (false == command_line_arguments.get_mongodb_uri().empty()) {
             option.metadata_db
                     = {command_line_arguments.get_mongodb_uri(),
                        command_line_arguments.get_mongodb_collection()};
         }
-        try {
-            auto const& archive_id = command_line_arguments.get_archive_id();
-            if (false == archive_id.empty()) {
-                option.archive_id = archive_id;
-                decompress_archive(option);
-            } else {
-                for (auto const& entry : std::filesystem::directory_iterator(archives_dir)) {
-                    if (false == entry.is_directory()) {
-                        // Skip non-directories
-                        continue;
-                    }
 
-                    option.archive_id = entry.path().filename();
-                    decompress_archive(option);
-                }
+        try {
+            for (auto const& archive_path : command_line_arguments.get_input_paths()) {
+                option.archive_path = archive_path;
+                decompress_archive(option);
             }
         } catch (clp_s::TraceableException& e) {
             SPDLOG_ERROR("{}", e.what());
@@ -349,12 +336,6 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
 
-        auto const& archives_dir = command_line_arguments.get_archives_dir();
-        if (false == std::filesystem::is_directory(archives_dir)) {
-            SPDLOG_ERROR("'{}' is not a directory.", archives_dir);
-            return 1;
-        }
-
         int reducer_socket_fd{-1};
         if (command_line_arguments.get_output_handler_type()
             == CommandLineArguments::OutputHandlerType::Reducer)
@@ -370,37 +351,20 @@ int main(int argc, char const* argv[]) {
             }
         }
 
-        auto const& archive_id = command_line_arguments.get_archive_id();
         auto archive_reader = std::make_shared<clp_s::ArchiveReader>();
-        if (false == archive_id.empty()) {
-            archive_reader->open(archives_dir, archive_id);
+        for (auto const& archive_path : command_line_arguments.get_input_paths()) {
+            archive_reader->open(archive_path, command_line_arguments.get_network_auth());
             if (false
-                == search_archive(command_line_arguments, archive_reader, expr, reducer_socket_fd))
+                == search_archive(
+                        command_line_arguments,
+                        archive_reader,
+                        expr->copy(),
+                        reducer_socket_fd
+                ))
             {
                 return 1;
             }
             archive_reader->close();
-        } else {
-            for (auto const& entry : std::filesystem::directory_iterator(archives_dir)) {
-                if (false == entry.is_directory()) {
-                    // Skip non-directories
-                    continue;
-                }
-
-                auto const archive_id = entry.path().filename().string();
-                archive_reader->open(archives_dir, archive_id);
-                if (false
-                    == search_archive(
-                            command_line_arguments,
-                            archive_reader,
-                            expr->copy(),
-                            reducer_socket_fd
-                    ))
-                {
-                    return 1;
-                }
-                archive_reader->close();
-            }
         }
     }
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -145,7 +145,7 @@ bool search_archive(
 ) {
     auto const& query = command_line_arguments.get_query();
 
-    auto timestamp_dict = archive_reader->get_timestamp_dictionary();
+    auto timestamp_dict = archive_reader->read_timestamp_dictionary();
     AddTimestampConditions add_timestamp_conditions(
             timestamp_dict->get_authoritative_timestamp_tokenized_column(),
             command_line_arguments.get_search_begin_ts(),

--- a/components/core/src/clp_s/search/kql/CMakeLists.txt
+++ b/components/core/src/clp_s/search/kql/CMakeLists.txt
@@ -25,4 +25,4 @@ add_library(
 )
 target_compile_features(kql PRIVATE cxx_std_20)
 target_include_directories(kql PRIVATE ${ANTLR_KqlParser_OUTPUT_DIR})
-target_link_libraries(kql PRIVATE antlr4_static Boost::filesystem)
+target_link_libraries(kql PRIVATE antlr4_static)

--- a/components/core/src/clp_s/search/kql/CMakeLists.txt
+++ b/components/core/src/clp_s/search/kql/CMakeLists.txt
@@ -25,4 +25,5 @@ add_library(
 )
 target_compile_features(kql PRIVATE cxx_std_20)
 target_include_directories(kql PRIVATE ${ANTLR_KqlParser_OUTPUT_DIR})
-target_link_libraries(kql PRIVATE antlr4_static spdlog::spdlog)
+target_link_libraries(kql PRIVATE antlr4_static Boost::filesystem spdlog::spdlog)
+

--- a/components/core/src/clp_s/search/kql/CMakeLists.txt
+++ b/components/core/src/clp_s/search/kql/CMakeLists.txt
@@ -25,5 +25,5 @@ add_library(
 )
 target_compile_features(kql PRIVATE cxx_std_20)
 target_include_directories(kql PRIVATE ${ANTLR_KqlParser_OUTPUT_DIR})
-target_link_libraries(kql PRIVATE antlr4_static Boost::filesystem spdlog::spdlog)
+target_link_libraries(kql PRIVATE antlr4_static Boost::filesystem)
 

--- a/components/core/src/clp_s/search/kql/CMakeLists.txt
+++ b/components/core/src/clp_s/search/kql/CMakeLists.txt
@@ -25,4 +25,4 @@ add_library(
 )
 target_compile_features(kql PRIVATE cxx_std_20)
 target_include_directories(kql PRIVATE ${ANTLR_KqlParser_OUTPUT_DIR})
-target_link_libraries(kql PRIVATE antlr4_static)
+target_link_libraries(kql PRIVATE antlr4_static spdlog::spdlog)

--- a/components/core/tests/test-clp_s-end_to_end.cpp
+++ b/components/core/tests/test-clp_s-end_to_end.cpp
@@ -71,9 +71,10 @@ void compress(bool structurize_arrays) {
     REQUIRE((std::filesystem::is_directory(cTestEndToEndArchiveDirectory)));
 
     clp_s::JsonParserOption parser_option{};
-    parser_option.input_paths.emplace_back(
-            clp_s::Path{.source{clp_s::InputSource::Filesystem}, .path{get_test_input_local_path()}}
-    );
+    parser_option.input_paths.emplace_back(clp_s::Path{
+            .source = clp_s::InputSource::Filesystem,
+            .path = get_test_input_local_path()
+    });
     parser_option.archives_dir = cTestEndToEndArchiveDirectory;
     parser_option.target_encoded_size = cDefaultTargetEncodedSize;
     parser_option.max_document_size = cDefaultMaxDocumentSize;


### PR DESCRIPTION
# Description
This PR adds support for ingesting logs from S3, and majorly refactors the command line interface to simplify specifying resources that exist at some network location. A follow-up PR will build on the utilties added by this PR to implement search on archives located on s3, as well as general search on single-file archives.

The major changes are as follows
- Added InputConfig.{hpp,cpp} which introduces new Path and NetworkAuth structs which can be used in combination with new utilties in ReaderUtils to open readers for resources which may exist on the network or local filesystem
- Modified JsonFileIterator and JsonParser to transparently support ingestion from the network or filesystem via new Path and NetworkAuth structs
- Modified ArchiveReader to accept Path and NetworkAuth, and just return an error when the requested archive is a SFA or exists on the network.
- Modified the command line arguments to allow specifying the full path to an archive (the --archive-id option still exists, but is not required). Archive id is also no longer passed around explicitly, but rather determined based on the path to an archive.
- Made CommandLineArguments fully determine the paths to all relevant files/archives based on the command line options to allow simplifying clp-s.cpp
- Removed uses of boost::filesystem

# Validation performed
* Validated that logs from s3 can be ingested succesfully
* Validated that search/extraction correctly error out when trying to interact with S3 or any single file archive
* Validated that compression, decompression, and search function as normal for multi-file archives



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced support for network authentication and input path handling in command-line arguments.
  - Added new functionalities for managing input configurations and creating readers for file and network sources.
  - Enhanced command-line argument parsing with new options for authentication types and input paths.
  - Integrated new source files for improved functionality in the application.

- **Bug Fixes**
  - Enhanced error handling for archive operations and input path validations.

- **Documentation**
  - Updated method signatures and documentation to reflect changes in input path and authentication handling.

- **Refactor**
  - Transitioned from Boost Filesystem to C++17's standard filesystem library for improved maintainability.
  - Streamlined the handling of archive paths and JSON parsing logic for clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->