### PR TITLE
fix(clp-package): Remove faulty error handling for parsing archive compression stats. 

### DIFF
--- a/components/job-orchestration/job_orchestration/executor/compress/fs_compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/fs_compression_task.py
@@ -243,16 +243,13 @@ def run_clp(
     # Handle job metadata update and s3 write if enabled
     s3_error = None
     while not last_line_decoded:
-        line = proc.stdout.readline()
         stats: Optional[Dict[str, Any]] = None
-        if "" == line:
-            # Skip empty lines that could be caused by potential errors in printing archive stats
-            continue
 
-        if line is not None:
-            stats = json.loads(line.decode("ascii"))
-        else:
+        line = proc.stdout.readline()
+        if not line:
             last_line_decoded = True
+        else:
+            stats = json.loads(line.decode("ascii"))
 
         if last_archive_stats is not None and (
             None is stats or stats["id"] != last_archive_stats["id"]


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
Fix a bug introduced by #634.

The previous changed intended to catch empty strings (actually empty lines) in between the clp archive stat output, but made a few mistakes. 
1. The empty line will not be '', it will only be b''.
2. Based on my experiment, the line from stdout.readline() will never be None. Even if the process terminates, stdout.readline() will keep reading b''.
3. The "empty line" we intended to catch should not be '', but '\n' instead.

As a result, the change in #634 will cause the compression worker to stuck in the while-continue loop, causing compression job to hang.

For 3, since it will anyway be a non-empty line, and will be caught by Json decoding, we don;t need to specifically catch "\n" in our code. After all, CLP and CLP-S are not expected to behave in such way.

# Validation performed
Manuall tested CLP and CLP-S compression job and make sure they don't hang.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of output from the compression command, enhancing clarity and efficiency.
	- Refined error handling for subprocess output, streamlining the control flow.

- **New Features**
	- Updated method signatures for better clarity in the compression task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->