### PR TITLE
fix(lib_install): Disable file system translation in `checkinstall` during dependency installation (fixes #642).

### DIFF
--- a/components/core/tools/scripts/lib_install/fmtlib.sh
+++ b/components/core/tools/scripts/lib_install/fmtlib.sh
@@ -38,10 +38,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-privileged_command_prefix=""
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  privileged_command_prefix="${privileged_command_prefix} sudo"
+  install_cmd_args+=("sudo")
 fi
 
 # Get number of cpu cores
@@ -74,11 +74,22 @@ checkinstall_installed=$?
 set -e
 
 # Install
-install_command_prefix="${privileged_command_prefix}"
 if [ $checkinstall_installed -eq 0 ] ; then
-  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+  install_cmd_args+=(
+    checkinstall
+    --default
+    --fstrans=no
+    --nodoc
+    --pkgname "${package_name}"
+    --pkgversion "${version}"
+    --provides "${package_name}"
+    --pakdir "${deb_output_dir}"
+  )
 fi
-${install_command_prefix} make install
+install_cmd_args+=(
+  make install
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/libarchive.sh
+++ b/components/core/tools/scripts/lib_install/libarchive.sh
@@ -37,10 +37,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-privileged_command_prefix=""
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  privileged_command_prefix="${privileged_command_prefix} sudo"
+  install_cmd_args+=("sudo")
 fi
 
 # Get number of cpu cores
@@ -74,11 +74,22 @@ checkinstall_installed=$?
 set -e
 
 # Install
-install_command_prefix="${privileged_command_prefix}"
 if [ $checkinstall_installed -eq 0 ] ; then
-  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+  install_cmd_args+=(
+    checkinstall
+    --default
+    --fstrans=no
+    --nodoc
+    --pkgname "${package_name}"
+    --pkgversion "${version}"
+    --provides "${package_name}"
+    --pakdir "${deb_output_dir}"
+  )
 fi
-${install_command_prefix} make install
+install_cmd_args+=(
+  make install
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/liblzma.sh
+++ b/components/core/tools/scripts/lib_install/liblzma.sh
@@ -96,7 +96,7 @@ if [ $checkinstall_installed -eq 0 ] ; then
   )
 fi
 install_cmd_args+=(
-    make install liblzma
+    make install
 )
 "${install_cmd_args[@]}"
 

--- a/components/core/tools/scripts/lib_install/lz4.sh
+++ b/components/core/tools/scripts/lib_install/lz4.sh
@@ -38,10 +38,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-privileged_command_prefix=""
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  privileged_command_prefix="${privileged_command_prefix} sudo"
+  install_cmd_args+=("sudo")
 fi
 
 # Get number of cpu cores
@@ -71,11 +71,22 @@ checkinstall_installed=$?
 set -e
 
 # Install
-install_command_prefix="${privileged_command_prefix}"
 if [ $checkinstall_installed -eq 0 ] ; then
-  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+  install_cmd_args+=(
+    checkinstall
+    --default
+    --fstrans=no
+    --nodoc
+    --pkgname "${package_name}"
+    --pkgversion "${version}"
+    --provides "${package_name}"
+    --pakdir "${deb_output_dir}"
+  )
 fi
-${install_command_prefix} make install
+install_cmd_args+=(
+  make install
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/mongocxx.sh
+++ b/components/core/tools/scripts/lib_install/mongocxx.sh
@@ -85,11 +85,12 @@ set -e
 if [ $checkinstall_installed -eq 0 ] ; then
   install_cmd_args+=(
     checkinstall
+    --default
+    --fstrans=no
+    --nodoc
     --pkgname "${package_name}"
     --pkgversion "${version}"
     --provides "${package_name}"
-    --nodoc
-    -y
     --pakdir "${deb_output_dir}"
   )
 fi

--- a/components/core/tools/scripts/lib_install/msgpack.sh
+++ b/components/core/tools/scripts/lib_install/msgpack.sh
@@ -36,10 +36,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-privileged_command_prefix=""
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  privileged_command_prefix="${privileged_command_prefix} sudo"
+  install_cmd_args+=("sudo")
 fi
 
 # Download
@@ -66,11 +66,24 @@ checkinstall_installed=$?
 set -e
 
 # Install
-install_command_prefix="${privileged_command_prefix}"
 if [ $checkinstall_installed -eq 0 ] ; then
-  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+  install_cmd_args+=(
+    checkinstall
+    --default
+    --fstrans=no
+    --nodoc
+    --pkgname "${package_name}"
+    --pkgversion "${version}"
+    --provides "${package_name}"
+    --pakdir "${deb_output_dir}"
+  )
 fi
-${install_command_prefix} cmake --build . --target install
+install_cmd_args+=(
+  cmake
+  --build .
+  --target install
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/spdlog.sh
+++ b/components/core/tools/scripts/lib_install/spdlog.sh
@@ -45,10 +45,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-privileged_command_prefix=""
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  privileged_command_prefix="${privileged_command_prefix} sudo"
+  install_cmd_args+=("sudo")
 fi
 
 # Get number of cpu cores
@@ -81,12 +81,22 @@ checkinstall_installed=$?
 set -e
 
 # Install
-install_command_prefix="${privileged_command_prefix}"
 if [ $checkinstall_installed -eq 0 ] ; then
-  # NOTE: We use "1:${version}" to override the version installed by Ubuntu 18.04
-  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '1:${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+  install_cmd_args+=(
+    checkinstall
+    --default
+    --fstrans=no
+    --nodoc
+    --pkgname "${package_name}"
+    --pkgversion "${version}"
+    --provides "${package_name}"
+    --pakdir "${deb_output_dir}"
+  )
 fi
-${install_command_prefix} make install
+install_cmd_args+=(
+  make install
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf $temp_dir

--- a/components/core/tools/scripts/lib_install/zstandard.sh
+++ b/components/core/tools/scripts/lib_install/zstandard.sh
@@ -38,10 +38,10 @@ if [ $installed -eq 0 ] ; then
 fi
 
 echo "Checking for elevated privileges..."
-privileged_command_prefix=""
+install_cmd_args=()
 if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
-  privileged_command_prefix="${privileged_command_prefix} sudo"
+  install_cmd_args+=("sudo")
 fi
 
 # Get number of cpu cores
@@ -74,11 +74,22 @@ checkinstall_installed=$?
 set -e
 
 # Install
-install_command_prefix="${privileged_command_prefix}"
 if [ $checkinstall_installed -eq 0 ] ; then
-  install_command_prefix="${install_command_prefix} checkinstall --pkgname '${package_name}' --pkgversion '${version}' --provides '${package_name}' --nodoc -y --pakdir \"${deb_output_dir}\""
+  install_cmd_args+=(
+    checkinstall
+    --default
+    --fstrans=no
+    --nodoc
+    --pkgname "${package_name}"
+    --pkgversion "${version}"
+    --provides "${package_name}"
+    --pakdir "${deb_output_dir}"
+  )
 fi
-${install_command_prefix} make install
+install_cmd_args+=(
+  make install
+)
+"${install_cmd_args[@]}"
 
 # Clean up
 rm -rf $temp_dir


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Disable file system translation in `checkinstall` during dependency installation.
2. Streamline install commands composition.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Entered an environment where GCC 13 is installed (e.g., Ubuntu 2404)
2. Followed https://docs.yscope.com/clp/main/dev-guide/building-package.html#:~:text=Install%20CLP%20core%E2%80%99s%20dependencies to install CLP's core dependencies.
3. Observed successful installations for all dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command execution structure for installation scripts, improving flexibility and clarity.
	- Added support for `checkinstall` with structured command arguments across multiple scripts.

- **Bug Fixes**
	- Improved error handling and checks for the existence of necessary directories and files during installation.

- **Refactor**
	- Replaced `privileged_command_prefix` with `install_cmd_args` array in multiple scripts for better command management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->