### PR TITLE
feat(ffi): Add support for serializing/deserializing auto-generated key-value pairs in the new IR format (resolves #556).

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -211,18 +211,25 @@ auto Deserializer<IrUnitHandler>::deserialize_next_ir_unit(ReaderInterface& read
                 return result.error();
             }
 
-            auto const node_locator{result.value()};
-            if (m_user_gen_keys_schema_tree->has_node(node_locator)) {
+            auto const& [is_auto_generated, node_locator]{result.value()};
+            auto& schema_tree_to_insert{
+                    is_auto_generated ? m_auto_gen_keys_schema_tree : m_user_gen_keys_schema_tree
+            };
+
+            if (schema_tree_to_insert->has_node(node_locator)) {
                 return std::errc::protocol_error;
             }
 
-            if (auto const err{m_ir_unit_handler.handle_schema_tree_node_insertion(node_locator)};
+            if (auto const err{m_ir_unit_handler.handle_schema_tree_node_insertion(
+                        is_auto_generated,
+                        node_locator
+                )};
                 IRErrorCode::IRErrorCode_Success != err)
             {
                 return ir_error_code_to_errc(err);
             }
 
-            std::ignore = m_user_gen_keys_schema_tree->insert_node(node_locator);
+            std::ignore = schema_tree_to_insert->insert_node(node_locator);
             break;
         }
 

--- a/components/core/src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp
+++ b/components/core/src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp
@@ -17,6 +17,7 @@ template <typename Handler>
 concept IrUnitHandlerInterface = requires(
         Handler handler,
         KeyValuePairLogEvent&& log_event,
+        bool is_auto_generated,
         UtcOffset utc_offset_old,
         UtcOffset utc_offset_new,
         SchemaTree::NodeLocator schema_tree_node_locator
@@ -42,11 +43,12 @@ concept IrUnitHandlerInterface = requires(
 
     /**
      * Handles a schema tree node insertion IR unit.
+     * @param is_auto_generated Whether the node is from auto-gen keys schema tree
      * @param schema_tree_node_locator The locator of the node to insert.
      * @return IRErrorCode::Success on success, user-defined error code on failures.
      */
     {
-        handler.handle_schema_tree_node_insertion(schema_tree_node_locator)
+        handler.handle_schema_tree_node_insertion(is_auto_generated, schema_tree_node_locator)
     } -> std::same_as<IRErrorCode>;
 
     /**

--- a/components/core/src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp
+++ b/components/core/src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp
@@ -43,7 +43,7 @@ concept IrUnitHandlerInterface = requires(
 
     /**
      * Handles a schema tree node insertion IR unit.
-     * @param is_auto_generated Whether the node is from auto-gen keys schema tree
+     * @param is_auto_generated Whether the node is from the auto-gen keys schema tree.
      * @param schema_tree_node_locator The locator of the node to insert.
      * @return IRErrorCode::Success on success, user-defined error code on failures.
      */

--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -1,5 +1,6 @@
 #include "Serializer.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -35,6 +36,56 @@ using clp::ir::four_byte_encoded_variable_t;
 
 namespace clp::ffi::ir_stream {
 namespace {
+/**
+ * Concept that defines the method to serialize a schema tree node identified by the given locator.
+ * @param serialization_method
+ * @param locator
+ * @return Whether serialization succeeded.
+ */
+template <typename SerializationMethod>
+concept SchemaTreeNodeSerializationMethodReq = requires(
+        SerializationMethod serialization_method,
+        SchemaTree::NodeLocator const& locator
+) {
+    {
+        serialization_method(locator)
+    } -> std::same_as<bool>;
+};
+
+/**
+ * Concept that defines the method to serialize a node-ID-value pair.
+ * @param serialization_method
+ * @param node_id
+ * @param val
+ * @param schema_tree_node_type The type of the schema tree node that corresponds to `val`.
+ * @return Whether serialization succeeded.
+ */
+template <typename SerializationMethod>
+concept NodeIdValuePairSerializationMethodReq = requires(
+        SerializationMethod serialization_method,
+        SchemaTree::Node::id_t id,
+        msgpack::object const& val,
+        SchemaTree::Node::Type schema_tree_node_type
+) {
+    {
+        serialization_method(id, val, schema_tree_node_type)
+    } -> std::same_as<bool>;
+};
+
+/**
+ * Concept that defines the method to serialize a node-ID-value pair whose value is an empty map.
+ * @param serialization_method
+ * @param node_id
+ * @return Whether serialization succeeded.
+ */
+template <typename SerializationMethod>
+concept EmptyMapSerializationMethodReq
+        = requires(SerializationMethod serialization_method, SchemaTree::Node::id_t node_id) {
+              {
+                  serialization_method(node_id)
+              } -> std::same_as<bool>;
+          };
+
 /**
  * Class for iterating the kv-pairs of a MessagePack map.
  */
@@ -147,6 +198,23 @@ template <typename encoded_variable_t>
 ) -> bool;
 
 /**
+ * Serializes the given MessagePack value into `output_buf`.
+ * @tparam encoded_variable_t
+ * @param val
+ * @param schema_tree_node_type
+ * @param logtype_buf
+ * @param output_buf
+ * @return Whether serialization succeeded.
+ */
+template <typename encoded_variable_t>
+[[nodiscard]] auto serialize_value(
+        msgpack::object const& val,
+        SchemaTree::Node::Type schema_tree_node_type,
+        string& logtype_buf,
+        vector<int8_t>& output_buf
+) -> bool;
+
+/**
  * Checks whether the given msgpack array can be serialized into the key-value pair IR format.
  * @param array
  * @return true if the array is serializable.
@@ -155,6 +223,30 @@ template <typename encoded_variable_t>
  * - Any value inside the array has type `MAP` and the map has non-string keys.
  */
 [[nodiscard]] auto is_msgpack_array_serializable(msgpack::object const& array) -> bool;
+
+/**
+ * Serializes the given msgpack map using a depth-first search (DFS).
+ * @tparam SchemaTreeNodeSerializationMethod
+ * @tparam NodeIdValuePairSerializationMethod
+ * @tparam EmptyMapSerializationMethod
+ * @param msgpack_map
+ * @param schema_tree
+ * @param schema_tree_node_serialization_method
+ * @param node_id_value_pair_serialization_method
+ * @param empty_map_serialization_method
+ * @return Whether serialization succeeded.
+ */
+template <
+        SchemaTreeNodeSerializationMethodReq SchemaTreeNodeSerializationMethod,
+        NodeIdValuePairSerializationMethodReq NodeIdValuePairSerializationMethod,
+        EmptyMapSerializationMethodReq EmptyMapSerializationMethod>
+[[nodiscard]] auto serialize_msgpack_map_using_dfs(
+        msgpack::object_map const& msgpack_map,
+        SchemaTree& schema_tree,
+        SchemaTreeNodeSerializationMethod schema_tree_node_serialization_method,
+        NodeIdValuePairSerializationMethod node_id_value_pair_serialization_method,
+        EmptyMapSerializationMethod empty_map_serialization_method
+) -> bool;
 
 auto get_schema_tree_node_type_from_msgpack_val(msgpack::object const& val
 ) -> optional<SchemaTree::Node::Type> {
@@ -245,6 +337,63 @@ auto serialize_value_array(
     return serialize_clp_string<encoded_variable_t>(oss.str(), logtype_buf, output_buf);
 }
 
+template <typename encoded_variable_t>
+auto serialize_value(
+        msgpack::object const& val,
+        SchemaTree::Node::Type schema_tree_node_type,
+        string& logtype_buf,
+        vector<int8_t>& output_buf
+) -> bool {
+    switch (schema_tree_node_type) {
+        case SchemaTree::Node::Type::Int:
+            if (msgpack::type::POSITIVE_INTEGER == val.type
+                && static_cast<uint64_t>(INT64_MAX) < val.as<uint64_t>())
+            {
+                return false;
+            }
+            serialize_value_int(val.as<int64_t>(), output_buf);
+            break;
+
+        case SchemaTree::Node::Type::Float:
+            serialize_value_float(val.as<double>(), output_buf);
+            break;
+
+        case SchemaTree::Node::Type::Bool:
+            serialize_value_bool(val.as<bool>(), output_buf);
+            break;
+
+        case SchemaTree::Node::Type::Str:
+            if (false
+                == serialize_value_string<encoded_variable_t>(
+                        val.as<string_view>(),
+                        logtype_buf,
+                        output_buf
+                ))
+            {
+                return false;
+            }
+            break;
+
+        case SchemaTree::Node::Type::Obj:
+            if (msgpack::type::NIL != val.type) {
+                return false;
+            }
+            serialize_value_null(output_buf);
+            break;
+
+        case SchemaTree::Node::Type::UnstructuredArray:
+            if (false == serialize_value_array<encoded_variable_t>(val, logtype_buf, output_buf)) {
+                return false;
+            }
+            break;
+
+        default:
+            // Unknown schema tree node type
+            return false;
+    }
+    return true;
+}
+
 auto is_msgpack_array_serializable(msgpack::object const& array) -> bool {
     vector<msgpack::object const*> validation_stack{&array};
     while (false == validation_stack.empty()) {
@@ -281,6 +430,94 @@ auto is_msgpack_array_serializable(msgpack::object const& array) -> bool {
                 default:
                     break;
             }
+        }
+    }
+
+    return true;
+}
+
+template <
+        SchemaTreeNodeSerializationMethodReq SchemaTreeNodeSerializationMethod,
+        NodeIdValuePairSerializationMethodReq NodeIdValuePairSerializationMethod,
+        EmptyMapSerializationMethodReq EmptyMapSerializationMethod>
+[[nodiscard]] auto serialize_msgpack_map_using_dfs(
+        msgpack::object_map const& msgpack_map,
+        SchemaTree& schema_tree,
+        SchemaTreeNodeSerializationMethod schema_tree_node_serialization_method,
+        NodeIdValuePairSerializationMethod node_id_value_pair_serialization_method,
+        EmptyMapSerializationMethod empty_map_serialization_method
+) -> bool {
+    vector<MsgpackMapIterator> dfs_stack;
+    dfs_stack.emplace_back(
+            SchemaTree::cRootId,
+            span<MsgpackMapIterator::Child>{msgpack_map.ptr, msgpack_map.size}
+    );
+    while (false == dfs_stack.empty()) {
+        auto& curr{dfs_stack.back()};
+        if (false == curr.has_next_child()) {
+            // Visited all children, so pop node
+            dfs_stack.pop_back();
+            continue;
+        }
+
+        // Convert the current value's type to its corresponding schema-tree node type
+        auto const& [key, val]{curr.get_next_child()};
+        if (msgpack::type::STR != key.type) {
+            // A map containing non-string keys is not serializable
+            return false;
+        }
+
+        auto const opt_schema_tree_node_type{get_schema_tree_node_type_from_msgpack_val(val)};
+        if (false == opt_schema_tree_node_type.has_value()) {
+            return false;
+        }
+        auto const schema_tree_node_type{opt_schema_tree_node_type.value()};
+
+        SchemaTree::NodeLocator const locator{
+                curr.get_schema_tree_node_id(),
+                key.as<string_view>(),
+                schema_tree_node_type
+        };
+
+        // Get the schema-tree node that corresponds with the current kv-pair, or add it if it
+        // doesn't exist.
+        auto opt_schema_tree_node_id{schema_tree.try_get_node_id(locator)};
+        if (false == opt_schema_tree_node_id.has_value()) {
+            opt_schema_tree_node_id.emplace(schema_tree.insert_node(locator));
+            if (false == schema_tree_node_serialization_method(locator)) {
+                return false;
+            }
+        }
+        auto const schema_tree_node_id{opt_schema_tree_node_id.value()};
+
+        if (msgpack::type::MAP == val.type) {
+            // Serialize map
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+            auto const& inner_map{val.via.map};
+            auto const inner_map_size(inner_map.size);
+            if (0 != inner_map_size) {
+                // Add map for DFS iteration
+                dfs_stack.emplace_back(
+                        schema_tree_node_id,
+                        span<MsgpackMapIterator::Child>{inner_map.ptr, inner_map_size}
+                );
+            } else {
+                if (false == empty_map_serialization_method(schema_tree_node_id)) {
+                    return false;
+                }
+            }
+            continue;
+        }
+
+        // Serialize primitive
+        if (false
+            == node_id_value_pair_serialization_method(
+                    schema_tree_node_id,
+                    val,
+                    schema_tree_node_type
+            ))
+        {
+            return false;
         }
     }
 
@@ -331,32 +568,180 @@ auto Serializer<encoded_variable_t>::change_utc_offset(UtcOffset utc_offset) -> 
 }
 
 template <typename encoded_variable_t>
-auto Serializer<encoded_variable_t>::serialize_msgpack_map(msgpack::object_map const& msgpack_map
+auto Serializer<encoded_variable_t>::serialize_msgpack_map(
+        msgpack::object_map const& auto_gen_kv_pairs_map,
+        msgpack::object_map const& user_gen_kv_pairs_map
 ) -> bool {
-    if (0 == msgpack_map.size) {
-        serialize_value_empty_object(m_ir_buf);
-        return true;
-    }
+    m_auto_gen_keys_schema_tree.take_snapshot();
+    m_user_gen_keys_schema_tree.take_snapshot();
+    TransactionManager revert_manager{
+            []() noexcept -> void {},
+            [&]() noexcept -> void {
+                m_user_gen_keys_schema_tree.revert();
+                m_auto_gen_keys_schema_tree.revert();
+            }
+    };
 
     m_schema_tree_node_buf.clear();
-    m_key_group_buf.clear();
-    m_value_group_buf.clear();
+    m_sequential_serialization_buf.clear();
+    m_user_gen_val_group_buf.clear();
 
-    if (false == serialize_msgpack_map_using_dfs(msgpack_map)) {
+    // Serialize auto-generated kv pairs
+    auto auto_gen_schema_tree_node_serialization_method
+            = [this](SchemaTree::NodeLocator const& locator) -> bool {
+        return this->serialize_schema_tree_node<true>(locator);
+    };
+
+    auto auto_gen_node_id_value_pairs_serialization_method
+            = [&](SchemaTree::Node::id_t node_id,
+                  msgpack::object const& val,
+                  SchemaTree::Node::Type schema_tree_node_type) -> bool {
+        if (false
+            == encode_and_serialize_schema_tree_node_id<
+                    true,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdByte,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdShort,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdInt>(
+                    node_id,
+                    m_sequential_serialization_buf
+            ))
+        {
+            return false;
+        }
+        if (false
+            == serialize_value<encoded_variable_t>(
+                    val,
+                    schema_tree_node_type,
+                    m_logtype_buf,
+                    m_sequential_serialization_buf
+            ))
+        {
+            return false;
+        }
+        return true;
+    };
+
+    auto auto_gen_empty_map_serialization_method = [&](SchemaTree::Node::id_t node_id) -> bool {
+        if (false
+            == encode_and_serialize_schema_tree_node_id<
+                    true,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdByte,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdShort,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdInt>(
+                    node_id,
+                    m_sequential_serialization_buf
+            ))
+        {
+            return false;
+        }
+        serialize_value_empty_object(m_sequential_serialization_buf);
+        return true;
+    };
+
+    if (0 != auto_gen_kv_pairs_map.size
+        && false
+                   == serialize_msgpack_map_using_dfs(
+                           auto_gen_kv_pairs_map,
+                           m_auto_gen_keys_schema_tree,
+                           auto_gen_schema_tree_node_serialization_method,
+                           auto_gen_node_id_value_pairs_serialization_method,
+                           auto_gen_empty_map_serialization_method
+                   ))
+    {
         return false;
     }
 
+    // Serialize user-generated kv pairs
+    auto user_gen_schema_tree_node_serialization_method
+            = [this](SchemaTree::NodeLocator const& locator) -> bool {
+        return this->serialize_schema_tree_node<false>(locator);
+    };
+
+    auto user_gen_node_id_value_pairs_serialization_method
+            = [&](SchemaTree::Node::id_t node_id,
+                  msgpack::object const& val,
+                  SchemaTree::Node::Type schema_tree_node_type) -> bool {
+        if (false
+            == encode_and_serialize_schema_tree_node_id<
+                    false,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdByte,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdShort,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdInt>(
+                    node_id,
+                    m_sequential_serialization_buf
+            ))
+        {
+            return false;
+        }
+        if (false
+            == serialize_value<encoded_variable_t>(
+                    val,
+                    schema_tree_node_type,
+                    m_logtype_buf,
+                    m_user_gen_val_group_buf
+            ))
+        {
+            return false;
+        }
+        return true;
+    };
+
+    auto user_gen_empty_map_serialization_method = [&](SchemaTree::Node::id_t node_id) -> bool {
+        if (false
+            == encode_and_serialize_schema_tree_node_id<
+                    false,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdByte,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdShort,
+                    cProtocol::Payload::EncodedSchemaTreeNodeIdInt>(
+                    node_id,
+                    m_sequential_serialization_buf
+            ))
+        {
+            return false;
+        }
+        serialize_value_empty_object(m_user_gen_val_group_buf);
+        return true;
+    };
+
+    if (0 == user_gen_kv_pairs_map.size) {
+        serialize_value_empty_object(m_sequential_serialization_buf);
+    } else {
+        if (false
+            == serialize_msgpack_map_using_dfs(
+                    user_gen_kv_pairs_map,
+                    m_user_gen_keys_schema_tree,
+                    user_gen_schema_tree_node_serialization_method,
+                    user_gen_node_id_value_pairs_serialization_method,
+                    user_gen_empty_map_serialization_method
+            ))
+        {
+            return false;
+        }
+    }
+
+    // Copy serialized results into `m_ir_buf`
     m_ir_buf.insert(
             m_ir_buf.cend(),
             m_schema_tree_node_buf.cbegin(),
             m_schema_tree_node_buf.cend()
     );
-    m_ir_buf.insert(m_ir_buf.cend(), m_key_group_buf.cbegin(), m_key_group_buf.cend());
-    m_ir_buf.insert(m_ir_buf.cend(), m_value_group_buf.cbegin(), m_value_group_buf.cend());
+    m_ir_buf.insert(
+            m_ir_buf.cend(),
+            m_sequential_serialization_buf.cbegin(),
+            m_sequential_serialization_buf.cend()
+    );
+    m_ir_buf.insert(
+            m_ir_buf.cend(),
+            m_user_gen_val_group_buf.cbegin(),
+            m_user_gen_val_group_buf.cend()
+    );
+
+    revert_manager.mark_success();
     return true;
 }
 
 template <typename encoded_variable_t>
+template <bool is_auto_generated_node>
 auto Serializer<encoded_variable_t>::serialize_schema_tree_node(
         SchemaTree::NodeLocator const& locator
 ) -> bool {
@@ -386,7 +771,7 @@ auto Serializer<encoded_variable_t>::serialize_schema_tree_node(
 
     if (false
         == encode_and_serialize_schema_tree_node_id<
-                false,
+                is_auto_generated_node,
                 cProtocol::Payload::EncodedSchemaTreeNodeParentIdByte,
                 cProtocol::Payload::EncodedSchemaTreeNodeParentIdShort,
                 cProtocol::Payload::EncodedSchemaTreeNodeParentIdInt>(
@@ -398,158 +783,6 @@ auto Serializer<encoded_variable_t>::serialize_schema_tree_node(
     }
 
     return serialize_string(locator.get_key_name(), m_schema_tree_node_buf);
-}
-
-template <typename encoded_variable_t>
-auto Serializer<encoded_variable_t>::serialize_key(SchemaTree::Node::id_t id) -> bool {
-    return encode_and_serialize_schema_tree_node_id<
-            false,
-            cProtocol::Payload::EncodedSchemaTreeNodeIdByte,
-            cProtocol::Payload::EncodedSchemaTreeNodeIdShort,
-            cProtocol::Payload::EncodedSchemaTreeNodeIdInt>(id, m_key_group_buf);
-}
-
-template <typename encoded_variable_t>
-auto Serializer<encoded_variable_t>::serialize_val(
-        msgpack::object const& val,
-        SchemaTree::Node::Type schema_tree_node_type
-) -> bool {
-    switch (schema_tree_node_type) {
-        case SchemaTree::Node::Type::Int:
-            if (msgpack::type::POSITIVE_INTEGER == val.type
-                && static_cast<uint64_t>(INT64_MAX) < val.as<uint64_t>())
-            {
-                return false;
-            }
-            serialize_value_int(val.as<int64_t>(), m_value_group_buf);
-            break;
-
-        case SchemaTree::Node::Type::Float:
-            serialize_value_float(val.as<double>(), m_value_group_buf);
-            break;
-
-        case SchemaTree::Node::Type::Bool:
-            serialize_value_bool(val.as<bool>(), m_value_group_buf);
-            break;
-
-        case SchemaTree::Node::Type::Str:
-            if (false
-                == serialize_value_string<encoded_variable_t>(
-                        val.as<string_view>(),
-                        m_logtype_buf,
-                        m_value_group_buf
-                ))
-            {
-                return false;
-            }
-            break;
-
-        case SchemaTree::Node::Type::Obj:
-            if (msgpack::type::NIL != val.type) {
-                return false;
-            }
-            serialize_value_null(m_value_group_buf);
-            break;
-
-        case SchemaTree::Node::Type::UnstructuredArray:
-            if (false
-                == serialize_value_array<encoded_variable_t>(val, m_logtype_buf, m_value_group_buf))
-            {
-                return false;
-            }
-            break;
-
-        default:
-            // Unknown schema tree node type
-            return false;
-    }
-    return true;
-}
-
-template <typename encoded_variable_t>
-auto Serializer<encoded_variable_t>::serialize_msgpack_map_using_dfs(
-        msgpack::object_map const& msgpack_map
-) -> bool {
-    m_schema_tree.take_snapshot();
-    TransactionManager revert_manager{
-            []() noexcept -> void {},
-            [&]() noexcept -> void { m_schema_tree.revert(); }
-    };
-
-    vector<MsgpackMapIterator> dfs_stack;
-    dfs_stack.emplace_back(
-            SchemaTree::cRootId,
-            span<MsgpackMapIterator::Child>{msgpack_map.ptr, msgpack_map.size}
-    );
-    while (false == dfs_stack.empty()) {
-        auto& curr{dfs_stack.back()};
-        if (false == curr.has_next_child()) {
-            // Visited all children, so pop node
-            dfs_stack.pop_back();
-            continue;
-        }
-
-        // Convert the current value's type to its corresponding schema-tree node type
-        auto const& [key, val]{curr.get_next_child()};
-        if (msgpack::type::STR != key.type) {
-            // A map containing non-string keys is not serializable
-            return false;
-        }
-
-        auto const opt_schema_tree_node_type{get_schema_tree_node_type_from_msgpack_val(val)};
-        if (false == opt_schema_tree_node_type.has_value()) {
-            return false;
-        }
-        auto const schema_tree_node_type{opt_schema_tree_node_type.value()};
-
-        SchemaTree::NodeLocator const locator{
-                curr.get_schema_tree_node_id(),
-                key.as<string_view>(),
-                schema_tree_node_type
-        };
-
-        // Get the schema-tree node that corresponds with the current kv-pair, or add it if it
-        // doesn't exist.
-        auto opt_schema_tree_node_id{m_schema_tree.try_get_node_id(locator)};
-        if (false == opt_schema_tree_node_id.has_value()) {
-            opt_schema_tree_node_id.emplace(m_schema_tree.insert_node(locator));
-            if (false == serialize_schema_tree_node(locator)) {
-                return false;
-            }
-        }
-        auto const schema_tree_node_id{opt_schema_tree_node_id.value()};
-
-        if (msgpack::type::MAP == val.type) {
-            // Serialize map
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
-            auto const& inner_map{val.via.map};
-            auto const inner_map_size(inner_map.size);
-            if (0 != inner_map_size) {
-                // Add map for DFS iteration
-                dfs_stack.emplace_back(
-                        schema_tree_node_id,
-                        span<MsgpackMapIterator::Child>{inner_map.ptr, inner_map_size}
-                );
-            } else {
-                // Value is an empty map, so we can serialize it immediately
-                if (false == serialize_key(schema_tree_node_id)) {
-                    return false;
-                }
-                serialize_value_empty_object(m_value_group_buf);
-            }
-            continue;
-        }
-
-        // Serialize primitive
-        if (false
-            == (serialize_key(schema_tree_node_id) && serialize_val(val, schema_tree_node_type)))
-        {
-            return false;
-        }
-    }
-
-    revert_manager.mark_success();
-    return true;
 }
 
 // Explicitly declare template specializations so that we can define the template methods in this
@@ -565,37 +798,24 @@ template auto Serializer<four_byte_encoded_variable_t>::change_utc_offset(UtcOff
 ) -> void;
 
 template auto Serializer<eight_byte_encoded_variable_t>::serialize_msgpack_map(
-        msgpack::object_map const& msgpack_map
+        msgpack::object_map const& auto_gen_kv_pairs_map,
+        msgpack::object_map const& user_gen_kv_pairs_map
 ) -> bool;
 template auto Serializer<four_byte_encoded_variable_t>::serialize_msgpack_map(
-        msgpack::object_map const& msgpack_map
+        msgpack::object_map const& auto_gen_kv_pairs_map,
+        msgpack::object_map const& user_gen_kv_pairs_map
 ) -> bool;
 
-template auto Serializer<eight_byte_encoded_variable_t>::serialize_schema_tree_node(
+template auto Serializer<eight_byte_encoded_variable_t>::serialize_schema_tree_node<true>(
         SchemaTree::NodeLocator const& locator
 ) -> bool;
-template auto Serializer<four_byte_encoded_variable_t>::serialize_schema_tree_node(
+template auto Serializer<eight_byte_encoded_variable_t>::serialize_schema_tree_node<false>(
         SchemaTree::NodeLocator const& locator
 ) -> bool;
-
-template auto Serializer<eight_byte_encoded_variable_t>::serialize_key(SchemaTree::Node::id_t id
+template auto Serializer<four_byte_encoded_variable_t>::serialize_schema_tree_node<true>(
+        SchemaTree::NodeLocator const& locator
 ) -> bool;
-template auto Serializer<four_byte_encoded_variable_t>::serialize_key(SchemaTree::Node::id_t id
-) -> bool;
-
-template auto Serializer<eight_byte_encoded_variable_t>::serialize_val(
-        msgpack::object const& val,
-        SchemaTree::Node::Type schema_tree_node_type
-) -> bool;
-template auto Serializer<four_byte_encoded_variable_t>::serialize_val(
-        msgpack::object const& val,
-        SchemaTree::Node::Type schema_tree_node_type
-) -> bool;
-
-template auto Serializer<eight_byte_encoded_variable_t>::serialize_msgpack_map_using_dfs(
-        msgpack::object_map const& msgpack_map
-) -> bool;
-template auto Serializer<four_byte_encoded_variable_t>::serialize_msgpack_map_using_dfs(
-        msgpack::object_map const& msgpack_map
+template auto Serializer<four_byte_encoded_variable_t>::serialize_schema_tree_node<false>(
+        SchemaTree::NodeLocator const& locator
 ) -> bool;
 }  // namespace clp::ffi::ir_stream

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -82,11 +82,15 @@ public:
     auto change_utc_offset(UtcOffset utc_offset) -> void;
 
     /**
-     * Serializes the given msgpack map as a key-value pair log event.
-     * @param msgpack_map
+     * Serializes the given msgpack maps as a key-value pair log event.
+     * @param auto_gen_kv_pairs_map
+     * @param user_gen_kv_pairs_map
      * @return Whether serialization succeeded.
      */
-    [[nodiscard]] auto serialize_msgpack_map(msgpack::object_map const& msgpack_map) -> bool;
+    [[nodiscard]] auto serialize_msgpack_map(
+            msgpack::object_map const& auto_gen_kv_pairs_map,
+            msgpack::object_map const& user_gen_kv_pairs_map
+    ) -> bool;
 
 private:
     // Constructors
@@ -95,43 +99,22 @@ private:
     // Methods
     /**
      * Serializes a schema tree node identified by the given locator into `m_schema_tree_node_buf`.
+     * @tparam is_auto_generated_node
      * @param locator
      * @return Whether serialization succeeded.
      */
+    template <bool is_auto_generated_node>
     [[nodiscard]] auto serialize_schema_tree_node(SchemaTree::NodeLocator const& locator) -> bool;
-
-    /**
-     * Serializes the given key ID into `m_key_group_buf`.
-     * @param id
-     * @return Forwards `encode_and_serialize_schema_tree_node_id`'s return values.
-     */
-    [[nodiscard]] auto serialize_key(SchemaTree::Node::id_t id) -> bool;
-
-    /**
-     * Serializes the given MessagePack value into `m_value_group_buf`.
-     * @param val
-     * @param schema_tree_node_type The type of the schema tree node that corresponds to `val`.
-     * @return Whether serialization succeeded.
-     */
-    [[nodiscard]] auto
-    serialize_val(msgpack::object const& val, SchemaTree::Node::Type schema_tree_node_type) -> bool;
-
-    /**
-     * Serializes the given msgpack map using a depth-first search (DFS).
-     * @param msgpack_map
-     * @return Whether serialization succeeded.
-     */
-    [[nodiscard]] auto serialize_msgpack_map_using_dfs(msgpack::object_map const& msgpack_map
-    ) -> bool;
 
     UtcOffset m_curr_utc_offset{0};
     Buffer m_ir_buf;
-    SchemaTree m_schema_tree;
+    SchemaTree m_auto_gen_keys_schema_tree;
+    SchemaTree m_user_gen_keys_schema_tree;
 
     std::string m_logtype_buf;
     Buffer m_schema_tree_node_buf;
-    Buffer m_key_group_buf;
-    Buffer m_value_group_buf;
+    Buffer m_sequential_serialization_buf;
+    Buffer m_user_gen_val_group_buf;
 };
 }  // namespace clp::ffi::ir_stream
 

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -328,7 +328,7 @@ auto deserialize_auto_gen_node_id_value_pairs_and_user_gen_schema(
 
         auto const [is_auto_generated, node_id]{schema_tree_node_id_result.value()};
         if (false == is_auto_generated) {
-            // User-generated node ID has been deserialized, pushes the node and terminates
+            // User-generated node ID has been deserialized, so push the node and terminate
             // auto-generated node-ID-value pair deserialization.
             user_gen_schema.push_back(node_id);
             break;

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -106,7 +106,7 @@ deserialize_string(ReaderInterface& reader, encoded_tag_t tag, std::string& dese
  * - The possible error codes:
  *   - Forwards `deserialize_tag`'s return values.
  *   - Forwards `deserialize_and_decode_schema_tree_node_id`'s return values.
- *   - std::err::protocol_error if the IR stream contains auto-generated key IDs after at least one
+ *   - std::err::protocol_error if the IR stream contains auto-generated key IDs *after* a
  *     user-generated key ID has been deserialized.
  */
 [[nodiscard]] auto deserialize_auto_gen_node_id_value_pairs_and_user_gen_schema(

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -512,7 +512,7 @@ auto deserialize_ir_unit_schema_tree_node_insertion(
         ReaderInterface& reader,
         encoded_tag_t tag,
         std::string& key_name
-) -> OUTCOME_V2_NAMESPACE::std_result<SchemaTree::NodeLocator> {
+) -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::NodeLocator>> {
     auto const type{schema_tree_node_tag_to_type(tag)};
     if (false == type.has_value()) {
         return ir_error_code_to_errc(IRErrorCode::IRErrorCode_Corrupted_IR);
@@ -523,18 +523,13 @@ auto deserialize_ir_unit_schema_tree_node_insertion(
         return parent_node_id_result.error();
     }
     auto const [is_auto_generated, parent_id]{parent_node_id_result.value()};
-    if (is_auto_generated) {
-        // Currently, we don't support auto-generated keys.
-        return std::errc::protocol_not_supported;
-    }
-
     if (auto const err{deserialize_schema_tree_node_key_name(reader, key_name)};
         IRErrorCode::IRErrorCode_Success != err)
     {
         return ir_error_code_to_errc(err);
     }
 
-    return SchemaTree::NodeLocator{parent_id, key_name, type.value()};
+    return {is_auto_generated, SchemaTree::NodeLocator{parent_id, key_name, type.value()}};
 }
 
 auto deserialize_ir_unit_utc_offset_change(ReaderInterface& reader

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -305,7 +305,7 @@ auto deserialize_auto_gen_node_id_value_pairs_and_user_gen_schema(
     KeyValuePairLogEvent::NodeIdValuePairs auto_gen_node_id_value_pairs;
     Schema user_gen_schema;
 
-    // Deserialize auto generated node id value pairs
+    // Deserialize pairs of auto-generated node IDs and values
     while (true) {
         if (false == is_encoded_key_id_tag(tag)) {
             break;
@@ -327,7 +327,7 @@ auto deserialize_auto_gen_node_id_value_pairs_and_user_gen_schema(
 
         auto const [is_auto_generated, node_id]{schema_tree_node_id_result.value()};
         if (false == is_auto_generated) {
-            // User-generated node ID has been deserialized, so push the node and terminate
+            // User-generated node ID has been deserialized, so save the node ID and terminate
             // auto-generated node-ID-value pair deserialization.
             user_gen_schema.push_back(node_id);
             break;
@@ -349,6 +349,7 @@ auto deserialize_auto_gen_node_id_value_pairs_and_user_gen_schema(
         }
     }
 
+    // Deserialize any remaining user-generated node IDs
     while (true) {
         if (false == is_encoded_key_id_tag(tag)) {
             break;

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
@@ -69,7 +69,7 @@ namespace clp::ffi::ir_stream {
  * - std::errc::protocol_error if the IR stream is corrupted.
  * - std::errc::protocol_not_supported if the IR stream contains an unsupported metadata format
  *   or uses an unsupported version.
- * - Forwards `deserialize_schema`'s return values.
+ * - Forwards `deserialize_auto_gen_node_id_value_pairs_and_user_gen_schema`'s return values.
  * - Forwards `KeyValuePairLogEvent::create`'s return values if the intermediate deserialized result
  *   cannot construct a valid key-value pair log event.
  */

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include <outcome/single-header/outcome.hpp>
 
@@ -28,20 +29,21 @@ namespace clp::ffi::ir_stream {
  * @param tag
  * @param key_name Returns the key name of the deserialized new node. This should be the underlying
  * storage of the returned schema tree node locator.
- * @return A result containing the locator of the inserted schema tree node or an error code
- * indicating the failure:
- * - std::errc::result_out_of_range if the IR stream is truncated.
- * - std::errc::protocol_error if the deserialized node type isn't supported.
- * - std::errc::protocol_not_supported if the IR stream contains auto-generated keys (TODO: Remove
- *   this once auto-generated keys are fully supported).
- * - Forwards `deserialize_schema_tree_node_key_name`'s return values.
- * - Forwards `deserialize_schema_tree_node_parent_id`'s return values.
+ * @return A result containing a pair or an error code indicating the failure:
+ * - The pair:
+ *   - Whether the node is for auto-generated keys schema tree.
+ *   - The locator of the inserted schema tree node.
+ * - The possible error codes:
+ *   - std::errc::result_out_of_range if the IR stream is truncated.
+ *   - std::errc::protocol_error if the deserialized node type isn't supported.
+ *   - Forwards `deserialize_schema_tree_node_key_name`'s return values.
+ *   - Forwards `deserialize_schema_tree_node_parent_id`'s return values.
  */
 [[nodiscard]] auto deserialize_ir_unit_schema_tree_node_insertion(
         ReaderInterface& reader,
         encoded_tag_t tag,
         std::string& key_name
-) -> OUTCOME_V2_NAMESPACE::std_result<SchemaTree::NodeLocator>;
+) -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::NodeLocator>>;
 
 /**
  * Deserializes a UTC offset change IR unit.

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -49,6 +49,7 @@ public:
     }
 
     [[nodiscard]] auto handle_schema_tree_node_insertion(
+            [[maybe_unused]] bool is_auto_generated,
             [[maybe_unused]] clp::ffi::SchemaTree::NodeLocator schema_tree_node_locator
     ) -> IRErrorCode {
         return IRErrorCode::IRErrorCode_Success;

--- a/components/core/tests/test-ffi_IrUnitHandlerInterface.cpp
+++ b/components/core/tests/test-ffi_IrUnitHandlerInterface.cpp
@@ -39,6 +39,7 @@ public:
     }
 
     [[nodiscard]] auto handle_schema_tree_node_insertion(
+            [[maybe_unused]] bool is_auto_generated,
             SchemaTree::NodeLocator schema_tree_node_locator
     ) -> IRErrorCode {
         m_schema_tree_node_locator.emplace(schema_tree_node_locator);
@@ -109,6 +110,7 @@ auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface 
     REQUIRE(
             (IRErrorCode::IRErrorCode_Success
              == handler.handle_schema_tree_node_insertion(
+                     true,
                      {SchemaTree::cRootId, cTestSchemaTreeNodeKeyName, SchemaTree::Node::Type::Obj}
              ))
     );

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -1215,7 +1215,7 @@ TEMPLATE_TEST_CASE(
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEMPLATE_TEST_CASE(
-        "ffi_ir_stream_kv_pair_log_events_serder",
+        "ffi_ir_stream_kv_pair_log_events_serde",
         "[clp][ffi][ir_stream]",
         four_byte_encoded_variable_t,
         eight_byte_encoded_variable_t

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -1215,8 +1215,8 @@ TEMPLATE_TEST_CASE(
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEMPLATE_TEST_CASE(
-        "ffi_ir_stream_Serializer_serialize_msgpack",
-        "[clp][ffi][ir_stream][Serializer]",
+        "ffi_ir_stream_kv_pair_log_events_serder",
+        "[clp][ffi][ir_stream]",
         four_byte_encoded_variable_t,
         eight_byte_encoded_variable_t
 ) {

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -111,6 +111,7 @@ public:
     }
 
     [[nodiscard]] static auto handle_schema_tree_node_insertion(
+            [[maybe_unused]] bool is_auto_generated,
             [[maybe_unused]] clp::ffi::SchemaTree::NodeLocator schema_tree_node_locator
     ) -> IRErrorCode {
         return IRErrorCode::IRErrorCode_Success;

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -1262,7 +1262,7 @@ TEMPLATE_TEST_CASE(
                {"empty_array", empty_array}};
 
     REQUIRE(unpack_and_serialize_msgpack_bytes(
-            nlohmann::json::to_msgpack(empty_obj),
+            nlohmann::json::to_msgpack(basic_obj),
             nlohmann::json::to_msgpack(basic_obj),
             serializer
     ));
@@ -1298,7 +1298,7 @@ TEMPLATE_TEST_CASE(
         recursive_obj.emplace("obj_" + std::to_string(i), recursive_obj);
         recursive_obj.emplace("array_" + std::to_string(i), recursive_array);
         REQUIRE(unpack_and_serialize_msgpack_bytes(
-                nlohmann::json::to_msgpack(empty_obj),
+                nlohmann::json::to_msgpack(recursive_obj),
                 nlohmann::json::to_msgpack(recursive_obj),
                 serializer
         ));
@@ -1341,7 +1341,7 @@ TEMPLATE_TEST_CASE(
         auto const serialized_json_result{deserialized_log_event.serialize_to_json()};
         REQUIRE_FALSE(serialized_json_result.has_error());
         auto const& [auto_generated, user_generated]{serialized_json_result.value()};
-        REQUIRE(auto_generated.empty());
+        REQUIRE((expect == auto_generated));
         REQUIRE((expect == user_generated));
     }
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fully implements #556. It introduces methods to serialize/deserialize auto-generated key-value pairs in KV pair IR format.

Changes to `Serializer`:
- Remove several member functions and make them as local helpers
- Generalize `serialize_msgpack_map_using_dfs` to take lambda functions as serialization callbacks so that auto-gen and user-gen kv pairs can be encoded in different ways (different node ID encoding and different serialization ordering)



# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure workflows all passed.
- Enhanced unit tests to:
  - Ensure log events without auto-generated kv-pairs can be successfully deserialized, providing backward compatibility.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced serialization logic for handling auto-generated and user-generated key-value pairs.
	- Improved MessagePack data processing with more flexible serialization methods.
	- Restructured internal data management for better modularity.

- **New Features**
	- Added advanced serialization capabilities for different data types.
	- Introduced more granular control over data serialization processes.
	- Enhanced deserialization methods to accommodate distinctions between auto-generated and user-generated keys.

- **Tests**
	- Updated test methods to support new serialization approach.
	- Added support for testing empty map serialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->