### PR TITLE
feat(clp-s): Add support for reading and searching single file archives.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -261,6 +261,8 @@ add_subdirectory(src/reducer)
 set(SOURCE_FILES_clp_s_unitTest
     src/clp_s/ArchiveReader.cpp
     src/clp_s/ArchiveReader.hpp
+    src/clp_s/ArchiveReaderAdaptor.cpp
+    src/clp_s/ArchiveReaderAdaptor.hpp
     src/clp_s/ArchiveWriter.cpp
     src/clp_s/ArchiveWriter.hpp
     src/clp_s/ColumnReader.cpp

--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -4,6 +4,7 @@
 #include <string_view>
 
 #include "archive_constants.hpp"
+#include "ArchiveReaderAdaptor.hpp"
 #include "InputConfig.hpp"
 #include "ReaderUtils.hpp"
 
@@ -20,35 +21,28 @@ void ArchiveReader::open(Path const& archive_path, NetworkAuthOption const& netw
         throw OperationFailed(ErrorCodeBadParam, __FILENAME__, __LINE__);
     }
 
-    if (InputSource::Filesystem != archive_path.source) {
-        throw OperationFailed(ErrorCodeBadParam, __FILENAME__, __LINE__);
+    m_archive_reader_adaptor = std::make_shared<ArchiveReaderAdaptor>(archive_path, network_auth);
+
+    if (auto const rc = m_archive_reader_adaptor->load_archive_metadata(); ErrorCodeSuccess != rc) {
+        throw OperationFailed(rc, __FILENAME__, __LINE__);
     }
 
-    if (false == std::filesystem::is_directory(archive_path.path)) {
-        throw OperationFailed(ErrorCodeBadParam, __FILENAME__, __LINE__);
-    }
-    auto const archive_path_str = archive_path.path;
-
-    m_var_dict = ReaderUtils::get_variable_dictionary_reader(archive_path_str);
-    m_log_dict = ReaderUtils::get_log_type_dictionary_reader(archive_path_str);
-    m_array_dict = ReaderUtils::get_array_dictionary_reader(archive_path_str);
-    m_timestamp_dict = ReaderUtils::get_timestamp_dictionary_reader(archive_path_str);
-
-    m_schema_tree = ReaderUtils::read_schema_tree(archive_path_str);
-    m_schema_map = ReaderUtils::read_schemas(archive_path_str);
+    m_schema_tree = ReaderUtils::read_schema_tree(*m_archive_reader_adaptor);
+    m_schema_map = ReaderUtils::read_schemas(*m_archive_reader_adaptor);
 
     m_log_event_idx_column_id = m_schema_tree->get_metadata_field_id(constants::cLogEventIdxName);
 
-    m_table_metadata_file_reader.open(archive_path_str + constants::cArchiveTableMetadataFile);
-    m_stream_reader.open_packed_streams(archive_path_str + constants::cArchiveTablesFile);
+    m_var_dict = ReaderUtils::get_variable_dictionary_reader(*m_archive_reader_adaptor);
+    m_log_dict = ReaderUtils::get_log_type_dictionary_reader(*m_archive_reader_adaptor);
+    m_array_dict = ReaderUtils::get_array_dictionary_reader(*m_archive_reader_adaptor);
 }
 
 void ArchiveReader::read_metadata() {
     constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;  // 64 KB
-    m_table_metadata_decompressor.open(
-            m_table_metadata_file_reader,
-            cDecompressorFileReadBufferCapacity
+    auto table_metadata_reader = m_archive_reader_adaptor->checkout_reader_for_section(
+            constants::cArchiveTableMetadataFile
     );
+    m_table_metadata_decompressor.open(*table_metadata_reader, cDecompressorFileReadBufferCapacity);
 
     m_stream_reader.read_metadata(m_table_metadata_decompressor);
 
@@ -131,14 +125,19 @@ void ArchiveReader::read_metadata() {
               - prev_metadata.stream_offset;
     m_id_to_schema_metadata[prev_schema_id] = prev_metadata;
     m_table_metadata_decompressor.close();
+
+    m_archive_reader_adaptor->checkin_reader_for_section(constants::cArchiveTableMetadataFile);
 }
 
 void ArchiveReader::read_dictionaries_and_metadata() {
-    m_var_dict->read_new_entries();
-    m_log_dict->read_new_entries();
-    m_array_dict->read_new_entries();
-    m_timestamp_dict->read_new_entries();
     read_metadata();
+    m_var_dict->read_entries();
+    m_log_dict->read_entries();
+    m_array_dict->read_entries();
+}
+
+void ArchiveReader::open_packed_streams() {
+    m_stream_reader.open_packed_streams(m_archive_reader_adaptor);
 }
 
 SchemaReader& ArchiveReader::read_schema_table(
@@ -205,7 +204,7 @@ BaseColumnReader* ArchiveReader::append_reader_column(SchemaReader& reader, int3
             column_reader = new ClpStringColumnReader(column_id, m_var_dict, m_array_dict, true);
             break;
         case NodeType::DateString:
-            column_reader = new DateStringColumnReader(column_id, m_timestamp_dict);
+            column_reader = new DateStringColumnReader(column_id, get_timestamp_dictionary());
             break;
         // No need to push columns without associated object readers into the SchemaReader.
         case NodeType::Metadata:
@@ -288,7 +287,8 @@ void ArchiveReader::initialize_schema_reader(
             m_id_to_schema_metadata[schema_id].num_messages,
             should_marshal_records
     );
-    auto timestamp_column_ids = m_timestamp_dict->get_authoritative_timestamp_column_ids();
+    auto timestamp_column_ids
+            = get_timestamp_dictionary()->get_authoritative_timestamp_column_ids();
     for (size_t i = 0; i < schema.size(); ++i) {
         int32_t column_id = schema[i];
         if (Schema::schema_entry_is_unordered_object(column_id)) {
@@ -355,10 +355,9 @@ void ArchiveReader::close() {
     m_var_dict->close();
     m_log_dict->close();
     m_array_dict->close();
-    m_timestamp_dict->close();
 
     m_stream_reader.close();
-    m_table_metadata_file_reader.close();
+    m_archive_reader_adaptor.reset();
 
     m_id_to_schema_metadata.clear();
     m_schema_ids.clear();

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <utility>
 
+#include "ArchiveReaderAdaptor.hpp"
 #include "DictionaryReader.hpp"
 #include "InputConfig.hpp"
 #include "PackedStreamReader.hpp"
@@ -42,12 +43,17 @@ public:
     void read_dictionaries_and_metadata();
 
     /**
+     * Opens packed streams for reading.
+     */
+    void open_packed_streams();
+
+    /**
      * Reads the variable dictionary from the archive.
      * @param lazy
      * @return the variable dictionary reader
      */
     std::shared_ptr<VariableDictionaryReader> read_variable_dictionary(bool lazy = false) {
-        m_var_dict->read_new_entries(lazy);
+        m_var_dict->read_entries(lazy);
         return m_var_dict;
     }
 
@@ -57,7 +63,7 @@ public:
      * @return the log type dictionary reader
      */
     std::shared_ptr<LogTypeDictionaryReader> read_log_type_dictionary(bool lazy = false) {
-        m_log_dict->read_new_entries(lazy);
+        m_log_dict->read_entries(lazy);
         return m_log_dict;
     }
 
@@ -67,7 +73,7 @@ public:
      * @return the array dictionary reader
      */
     std::shared_ptr<LogTypeDictionaryReader> read_array_dictionary(bool lazy = false) {
-        m_array_dict->read_new_entries(lazy);
+        m_array_dict->read_entries(lazy);
         return m_array_dict;
     }
 
@@ -75,15 +81,6 @@ public:
      * Reads the metadata from the archive.
      */
     void read_metadata();
-
-    /**
-     * Reads the local timestamp dictionary from the archive.
-     * @return the timestamp dictionary reader
-     */
-    std::shared_ptr<TimestampDictionaryReader> read_timestamp_dictionary() {
-        m_timestamp_dict->read_new_entries();
-        return m_timestamp_dict;
-    }
 
     /**
      * Reads a table from the archive.
@@ -113,7 +110,7 @@ public:
     std::shared_ptr<LogTypeDictionaryReader> get_array_dictionary() { return m_array_dict; }
 
     std::shared_ptr<TimestampDictionaryReader> get_timestamp_dictionary() {
-        return m_timestamp_dict;
+        return m_archive_reader_adaptor->get_timestamp_dictionary();
     }
 
     std::shared_ptr<SchemaTree> get_schema_tree() { return m_schema_tree; }
@@ -201,7 +198,7 @@ private:
     std::shared_ptr<VariableDictionaryReader> m_var_dict;
     std::shared_ptr<LogTypeDictionaryReader> m_log_dict;
     std::shared_ptr<LogTypeDictionaryReader> m_array_dict;
-    std::shared_ptr<TimestampDictionaryReader> m_timestamp_dict;
+    std::shared_ptr<ArchiveReaderAdaptor> m_archive_reader_adaptor;
 
     std::shared_ptr<SchemaTree> m_schema_tree;
     std::shared_ptr<ReaderUtils::SchemaMap> m_schema_map;
@@ -212,7 +209,6 @@ private:
     };
 
     PackedStreamReader m_stream_reader;
-    FileReader m_table_metadata_file_reader;
     ZstdDecompressor m_table_metadata_decompressor;
     SchemaReader m_schema_reader;
     std::shared_ptr<char[]> m_stream_buffer{};

--- a/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
+++ b/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
@@ -119,7 +119,7 @@ ErrorCode ArchiveReaderAdaptor::load_archive_metadata() {
 }
 
 ErrorCode ArchiveReaderAdaptor::try_read_header(clp::ReaderInterface& reader) {
-    auto const clp_rc = m_reader->try_read_exact_length(
+    auto const clp_rc = reader.try_read_exact_length(
             reinterpret_cast<char*>(&m_archive_header),
             sizeof(m_archive_header)
     );

--- a/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
+++ b/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
@@ -1,0 +1,273 @@
+#include "ArchiveReaderAdaptor.hpp"
+
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <msgpack.hpp>
+#include <spdlog/spdlog.h>
+
+#include "../clp/BoundedReader.hpp"
+#include "../clp/FileReader.hpp"
+#include "archive_constants.hpp"
+#include "InputConfig.hpp"
+#include "ReaderUtils.hpp"
+#include "SingleFileArchiveDefs.hpp"
+
+namespace clp_s {
+
+ArchiveReaderAdaptor::ArchiveReaderAdaptor(
+        Path const& archive_path,
+        NetworkAuthOption const& network_auth
+)
+        : m_archive_path{archive_path},
+          m_network_auth{network_auth},
+          m_timestamp_dictionary{std::make_shared<TimestampDictionaryReader>()},
+          m_single_file_archive{false} {
+    if (InputSource::Filesystem != archive_path.source
+        || std::filesystem::is_regular_file(archive_path.path))
+    {
+        m_single_file_archive = true;
+    }
+}
+
+ArchiveReaderAdaptor::~ArchiveReaderAdaptor() {
+    m_reader.reset();
+}
+
+ErrorCode
+ArchiveReaderAdaptor::try_read_archive_file_info(ZstdDecompressor& decompressor, size_t size) {
+    std::vector<char> buffer(size);
+    auto rc = decompressor.try_read_exact_length(buffer.data(), size);
+    if (ErrorCodeSuccess != rc) {
+        return rc;
+    }
+
+    try {
+        auto obj_handle = msgpack::unpack(buffer.data(), buffer.size());
+        auto obj = obj_handle.get();
+        // m_archive_file_info = obj.as<clp_s::ArchiveFileInfoPacket>();
+        //  FIXME: the above should work, but does not. Hacking around it as below for now.
+        if (obj.is_nil() || msgpack::type::MAP != obj.type) {
+            return ErrorCodeCorrupt;
+        }
+        if (nullptr == obj.via.map.ptr) {
+            return ErrorCodeCorrupt;
+        }
+        auto val = obj.via.map.ptr->val;
+        if (val.is_nil() || msgpack::type::ARRAY != val.type) {
+            return ErrorCodeCorrupt;
+        }
+        if (nullptr == val.via.array.ptr) {
+            return ErrorCodeCorrupt;
+        }
+        auto arr = val.via.array;
+        for (size_t i = 0; i < arr.size; ++i) {
+            auto array_element = arr.ptr[i].as<clp_s::ArchiveFileInfo>();
+            m_archive_file_info.files.push_back(array_element);
+        }
+        return ErrorCodeSuccess;
+    } catch (std::exception const& e) {
+        return ErrorCodeCorrupt;
+    }
+}
+
+ErrorCode
+ArchiveReaderAdaptor::try_read_timestamp_dictionary(ZstdDecompressor& decompressor, size_t size) {
+    return m_timestamp_dictionary->read(decompressor);
+}
+
+ErrorCode ArchiveReaderAdaptor::try_read_archive_info(ZstdDecompressor& decompressor, size_t size) {
+    std::vector<char> buffer(size);
+    auto rc = decompressor.try_read_exact_length(buffer.data(), buffer.size());
+    if (ErrorCodeSuccess != rc) {
+        return rc;
+    }
+
+    try {
+        auto obj_handle = msgpack::unpack(buffer.data(), buffer.size());
+        auto obj = obj_handle.get();
+        m_archive_info = obj.as<ArchiveInfoPacket>();
+    } catch (std::exception const& e) {
+        return ErrorCodeCorrupt;
+    }
+
+    if (1 != m_archive_info.num_segments) {
+        return ErrorCodeUnsupported;
+    }
+    return ErrorCodeSuccess;
+}
+
+ErrorCode ArchiveReaderAdaptor::load_archive_metadata() {
+    constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;
+    m_reader = try_create_reader_at_header();
+    if (nullptr == m_reader) {
+        return ErrorCodeFileNotFound;
+    }
+
+    if (auto const rc = try_read_header(*m_reader); ErrorCodeSuccess != rc) {
+        return rc;
+    }
+
+    m_files_section_offset = sizeof(m_archive_header) + m_archive_header.metadata_section_size;
+    clp::BoundedReader bounded_reader{m_reader.get(), m_files_section_offset};
+    ZstdDecompressor decompressor;
+    decompressor.open(bounded_reader, cDecompressorFileReadBufferCapacity);
+    auto const rc = try_read_archive_metadata(decompressor);
+    decompressor.close();
+    return rc;
+}
+
+ErrorCode ArchiveReaderAdaptor::try_read_header(clp::ReaderInterface& reader) {
+    std::array<char, sizeof(ArchiveHeader)> header_buffer;
+    auto const clp_rc = m_reader->try_read_exact_length(
+            reinterpret_cast<char*>(&m_archive_header),
+            sizeof(m_archive_header)
+    );
+    if (clp::ErrorCode::ErrorCode_Success != clp_rc) {
+        return ErrorCodeErrno;
+    }
+
+    if (0
+        != std::memcmp(
+                m_archive_header.magic_number,
+                cStructuredSFAMagicNumber,
+                sizeof(cStructuredSFAMagicNumber)
+        ))
+    {
+        return ErrorCodeMetadataCorrupted;
+    }
+
+    switch (static_cast<ArchiveCompressionType>(m_archive_header.compression_type)) {
+        case ArchiveCompressionType::Zstd:
+            break;
+        default:
+            return ErrorCodeUnsupported;
+    }
+    return ErrorCodeSuccess;
+}
+
+ErrorCode ArchiveReaderAdaptor::try_read_archive_metadata(ZstdDecompressor& decompressor) {
+    uint8_t num_metadata_packets{};
+    auto rc = decompressor.try_read_numeric_value(num_metadata_packets);
+    if (ErrorCodeSuccess != rc) {
+        return rc;
+    }
+
+    for (size_t i = 0; i < num_metadata_packets; ++i) {
+        ArchiveMetadataPacketType packet_type;
+        uint32_t packet_size;
+        rc = decompressor.try_read_numeric_value(packet_type);
+        if (ErrorCodeSuccess != rc) {
+            return rc;
+        }
+        rc = decompressor.try_read_numeric_value(packet_size);
+        if (ErrorCodeSuccess != rc) {
+            return rc;
+        }
+
+        switch (packet_type) {
+            case ArchiveMetadataPacketType::ArchiveFileInfo:
+                rc = try_read_archive_file_info(decompressor, packet_size);
+                break;
+            case ArchiveMetadataPacketType::TimestampDictionary:
+                rc = try_read_timestamp_dictionary(decompressor, packet_size);
+                break;
+            case ArchiveMetadataPacketType::ArchiveInfo:
+                rc = try_read_archive_info(decompressor, packet_size);
+                break;
+            default:
+                break;
+        }
+        if (ErrorCodeSuccess != rc) {
+            return rc;
+        }
+    }
+    return ErrorCodeSuccess;
+}
+
+std::unique_ptr<clp::ReaderInterface> ArchiveReaderAdaptor::checkout_reader_for_section(
+        std::string_view section
+) {
+    if (m_current_reader_holder.has_value()) {
+        throw OperationFailed(ErrorCodeNotReady, __FILENAME__, __LINE__);
+    }
+
+    m_current_reader_holder.emplace(section);
+    if (m_single_file_archive) {
+        return checkout_reader_for_sfa_section(section);
+    } else {
+        return std::make_unique<clp::FileReader>(m_archive_path.path + std::string{section});
+    }
+}
+
+std::unique_ptr<clp::ReaderInterface> ArchiveReaderAdaptor::checkout_reader_for_sfa_section(
+        std::string_view section
+) {
+    auto it = std::find_if(
+            m_archive_file_info.files.begin(),
+            m_archive_file_info.files.end(),
+            [&](ArchiveFileInfo& info) { return info.n == section; }
+    );
+    if (m_archive_file_info.files.end() == it) {
+        throw OperationFailed(ErrorCodeBadParam, __FILENAME__, __LINE__);
+    }
+
+    size_t curr_pos{};
+    if (auto rc = m_reader->try_get_pos(curr_pos); clp::ErrorCode::ErrorCode_Success != rc) {
+        throw OperationFailed(ErrorCodeFailure, __FILENAME__, __LINE__);
+    }
+
+    size_t file_offset = m_files_section_offset + it->o;
+    ++it;
+    size_t next_file_offset{m_archive_header.compressed_size};
+    if (m_archive_file_info.files.end() != it) {
+        next_file_offset = m_files_section_offset + it->o;
+    }
+
+    if (curr_pos > file_offset) {
+        throw OperationFailed(ErrorCodeCorrupt, __FILENAME__, __LINE__);
+    }
+
+    if (curr_pos != file_offset) {
+        if (auto rc = m_reader->try_seek_from_begin(file_offset);
+            clp::ErrorCode::ErrorCode_Success != rc)
+        {
+            throw OperationFailed(ErrorCodeFailure, __FILENAME__, __LINE__);
+        }
+    }
+
+    return std::make_unique<clp::BoundedReader>(m_reader.get(), next_file_offset);
+}
+
+void ArchiveReaderAdaptor::checkin_reader_for_section(std::string_view section) {
+    if (false == m_current_reader_holder.has_value()) {
+        throw OperationFailed(ErrorCodeNotInit, __FILENAME__, __LINE__);
+    }
+
+    if (m_current_reader_holder.value() != section) {
+        throw OperationFailed(ErrorCodeBadParam, __FILENAME__, __LINE__);
+    }
+
+    m_current_reader_holder.reset();
+}
+
+std::shared_ptr<clp::ReaderInterface> ArchiveReaderAdaptor::try_create_reader_at_header() {
+    if (InputSource::Filesystem == m_archive_path.source && false == m_single_file_archive) {
+        try {
+            return std::make_shared<clp::FileReader>(
+                    m_archive_path.path + constants::cArchiveHeaderFile
+            );
+        } catch (std::exception const& e) {
+            SPDLOG_ERROR("Failed to open archive header for reading - {}", e.what());
+            return nullptr;
+        }
+    } else {
+        return ReaderUtils::try_create_reader(m_archive_path, m_network_auth);
+    }
+}
+}  // namespace clp_s

--- a/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
+++ b/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
@@ -119,7 +119,6 @@ ErrorCode ArchiveReaderAdaptor::load_archive_metadata() {
 }
 
 ErrorCode ArchiveReaderAdaptor::try_read_header(clp::ReaderInterface& reader) {
-    std::array<char, sizeof(ArchiveHeader)> header_buffer;
     auto const clp_rc = m_reader->try_read_exact_length(
             reinterpret_cast<char*>(&m_archive_header),
             sizeof(m_archive_header)

--- a/components/core/src/clp_s/ArchiveReaderAdaptor.hpp
+++ b/components/core/src/clp_s/ArchiveReaderAdaptor.hpp
@@ -30,19 +30,17 @@ public:
 
     explicit ArchiveReaderAdaptor(Path const& archive_path, NetworkAuthOption const& network_auth);
 
-    ~ArchiveReaderAdaptor();
-
     /**
      * Loads metadata for an archive including the header and metadata section. This method must be
      * invoked before checking out any section of an archive, or calling `get_timestamp_dictionary`.
-     * @return ErrorCodeSuccess on success
-     * @return ErrorCode_errno on failure
+     * @return ErrorCodeSuccess on success.
+     * @return relevant ErrorCode on failure.
      */
     ErrorCode load_archive_metadata();
 
     /**
-     * Checks out a reader for a given section of the archive. Reader must be checked back in with the
-     * `checkin_reader_for_section` method.
+     * Checks out a reader for a given section of the archive. Reader must be checked back in with
+     * the `checkin_reader_for_section` method.
      * @param section
      * @return A ReaderInterface opened and pointing to the requested section.
      * @throw OperationFailed if a reader is already checked out, or checking out this section would
@@ -65,19 +63,64 @@ public:
     ArchiveHeader const& get_header() const { return m_archive_header; }
 
 private:
+    /**
+     * Tries to read an ArchiveFileInfo packet from the archive metadata.
+     * @param decompressor
+     * @param size The number of decompressed bytes making up the packet.
+     * @return ErrorCodeSuccess on success.
+     * @return relevant ErrorCode on failure.
+     */
     ErrorCode try_read_archive_file_info(ZstdDecompressor& decompressor, size_t size);
 
+    /**
+     * Tries to read an TimestampDictionary packet from the archive metadata.
+     * @param decompressor
+     * @param size The number of decompressed bytes making up the packet.
+     * @return ErrorCodeSuccess on success.
+     * @return relevant ErrorCode on failure.
+     */
     ErrorCode try_read_timestamp_dictionary(ZstdDecompressor& decompressor, size_t size);
 
+    /**
+     * Tries to read an ArchiveInfo packet from the archive metadata.
+     * @param decompressor
+     * @param size The number of decompressed bytes making up the packet.
+     * @return ErrorCodeSuccess on success.
+     * @return relevant ErrorCode on failure.
+     */
     ErrorCode try_read_archive_info(ZstdDecompressor& decompressor, size_t size);
 
+    /**
+     * Tries to create a reader for the archive header.
+     * @return A ReaderInterface opened and pointing to the archive header on success.
+     * @return nullptr on failure.
+     */
     std::shared_ptr<clp::ReaderInterface> try_create_reader_at_header();
 
+    /**
+     * Checks out a reader for a given section of the single file archive.
+     * @param section
+     * @return A ReaderInterface opened and pointing to the requested section.
+     * @throw OperationFailed if the requested section does not exist in ArchiveFileInfo, if
+     *        checking out the section would force a backward seek, or on any I/O error.
+     */
     std::unique_ptr<clp::ReaderInterface> checkout_reader_for_sfa_section(std::string_view section);
 
+    /**
+     * Tries to read the header for the archive from the given reader.
+     * @param reader
+     * @return ErrorCodeSuccess on success.
+     * @return relevant ErrorCode on failure.
+     */
     ErrorCode try_read_header(clp::ReaderInterface& reader);
 
-    ErrorCode try_read_archive_metadata(ZstdDecompressor& reader);
+    /**
+     * Tries to read the archive metadata from the given decompressor.
+     * @param decompressor
+     * @return ErrorCodeSuccess on success.
+     * @return relevant ErrorCode on failure.
+     */
+    ErrorCode try_read_archive_metadata(ZstdDecompressor& decompressor);
 
     Path m_archive_path{};
     NetworkAuthOption m_network_auth{};

--- a/components/core/src/clp_s/ArchiveReaderAdaptor.hpp
+++ b/components/core/src/clp_s/ArchiveReaderAdaptor.hpp
@@ -1,0 +1,95 @@
+#ifndef CLP_S_ARCHIVEREADERADAPTOR_HPP
+#define CLP_S_ARCHIVEREADERADAPTOR_HPP
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "../clp/BoundedReader.hpp"
+#include "../clp/ReaderInterface.hpp"
+#include "InputConfig.hpp"
+#include "SingleFileArchiveDefs.hpp"
+#include "TimestampDictionaryReader.hpp"
+#include "TraceableException.hpp"
+#include "ZstdDecompressor.hpp"
+
+namespace clp_s {
+/**
+ * ArchiveReaderAdaptor is an adaptor class which helps with reading single and multi-file archives
+ * which exist on either S3 or a locally mounted file system.
+ */
+class ArchiveReaderAdaptor {
+public:
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
+    };
+
+    explicit ArchiveReaderAdaptor(Path const& archive_path, NetworkAuthOption const& network_auth);
+
+    ~ArchiveReaderAdaptor();
+
+    /**
+     * Load metadata for an archive including the header and metadata section. This method must be
+     * invoked before checking out any section of an archive, or calling `get_timestamp_dictionary`.
+     * @return ErrorCodeSuccess on success
+     * @return ErrorCode_errno on failure
+     */
+    ErrorCode load_archive_metadata();
+
+    /**
+     * Checkout a reader for a given section of the archive. Reader must be checked back in with the
+     * `checkin_reader_for_section` method.
+     * @param section
+     * @return A ReaderInterface opened and pointing to the requested section.
+     * @throw OperationFailed if a reader is already checked out, or checking out this section would
+     *        force a backwards seek.
+     */
+    std::unique_ptr<clp::ReaderInterface> checkout_reader_for_section(std::string_view section);
+
+    /**
+     * Checkin a reader for a given section of the archive.
+     * @param section
+     * @throw OperationFailed if no reader is checked out, or if the section being checked in does
+     *        not match the section currently checked out.
+     */
+    void checkin_reader_for_section(std::string_view section);
+
+    std::shared_ptr<TimestampDictionaryReader> get_timestamp_dictionary() {
+        return m_timestamp_dictionary;
+    }
+
+    ArchiveHeader const& get_header() const { return m_archive_header; }
+
+private:
+    ErrorCode try_read_archive_file_info(ZstdDecompressor& decompressor, size_t size);
+
+    ErrorCode try_read_timestamp_dictionary(ZstdDecompressor& decompressor, size_t size);
+
+    ErrorCode try_read_archive_info(ZstdDecompressor& decompressor, size_t size);
+
+    std::shared_ptr<clp::ReaderInterface> try_create_reader_at_header();
+
+    std::unique_ptr<clp::ReaderInterface> checkout_reader_for_sfa_section(std::string_view section);
+
+    ErrorCode try_read_header(clp::ReaderInterface& reader);
+
+    ErrorCode try_read_archive_metadata(ZstdDecompressor& reader);
+
+    Path m_archive_path{};
+    NetworkAuthOption m_network_auth{};
+    bool m_single_file_archive{false};
+    ArchiveFileInfoPacket m_archive_file_info{};
+    ArchiveHeader m_archive_header{};
+    ArchiveInfoPacket m_archive_info{};
+    size_t m_files_section_offset{};
+    std::optional<std::string> m_current_reader_holder;
+    std::shared_ptr<TimestampDictionaryReader> m_timestamp_dictionary;
+    std::shared_ptr<clp::ReaderInterface> m_reader;
+};
+
+}  // namespace clp_s
+#endif  // CLP_S_ARCHIVEREADERADAPTOR_HPP

--- a/components/core/src/clp_s/ArchiveReaderAdaptor.hpp
+++ b/components/core/src/clp_s/ArchiveReaderAdaptor.hpp
@@ -33,7 +33,7 @@ public:
     ~ArchiveReaderAdaptor();
 
     /**
-     * Load metadata for an archive including the header and metadata section. This method must be
+     * Loads metadata for an archive including the header and metadata section. This method must be
      * invoked before checking out any section of an archive, or calling `get_timestamp_dictionary`.
      * @return ErrorCodeSuccess on success
      * @return ErrorCode_errno on failure
@@ -41,7 +41,7 @@ public:
     ErrorCode load_archive_metadata();
 
     /**
-     * Checkout a reader for a given section of the archive. Reader must be checked back in with the
+     * Checks out a reader for a given section of the archive. Reader must be checked back in with the
      * `checkin_reader_for_section` method.
      * @param section
      * @return A ReaderInterface opened and pointing to the requested section.
@@ -51,7 +51,7 @@ public:
     std::unique_ptr<clp::ReaderInterface> checkout_reader_for_section(std::string_view section);
 
     /**
-     * Checkin a reader for a given section of the archive.
+     * Checks in a reader for a given section of the archive.
      * @param section
      * @throw OperationFailed if no reader is checked out, or if the section being checked in does
      *        not match the section currently checked out.

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -180,7 +180,7 @@ private:
     void write_single_file_archive(std::vector<ArchiveFileInfo> const& files);
 
     /**
-     * Writes the metadata section of the single file archive
+     * Writes the metadata section of an archive.
      * @param archive_writer
      * @param files
      */
@@ -210,15 +210,6 @@ private:
      * Prints the archive's statistics (id, uncompressed size, compressed size, etc.)
      */
     void print_archive_stats();
-
-    /**
-     * Write the timestamp dictionary as a dedicated file for multi-file archives.
-     *
-     * Note: the timestamp dictionary will be moved into the metadata region of multi-file archives
-     * in a follow-up PR.
-     * @return the compressed size of the Timestamp Dictionary in bytes
-     */
-    size_t write_timestamp_dict();
 
     static constexpr size_t cReadBlockSize = 4 * 1024;
 

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -88,6 +88,8 @@ set(
         archive_constants.hpp
         ArchiveReader.cpp
         ArchiveReader.hpp
+        ArchiveReaderAdaptor.cpp
+        ArchiveReaderAdaptor.hpp
         ArchiveWriter.cpp
         ArchiveWriter.hpp
         BufferViewReader.hpp

--- a/components/core/src/clp_s/Decompressor.hpp
+++ b/components/core/src/clp_s/Decompressor.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "../clp/ReaderInterface.hpp"
 #include "FileReader.hpp"
 #include "TraceableException.hpp"
 
@@ -49,6 +50,13 @@ public:
      * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time
      */
     virtual void open(FileReader& file_reader, size_t file_read_buffer_capacity) = 0;
+
+    /**
+     * Initializes the decompressor to decompress from an open clp reader
+     * @param reader
+     * @param read_buffer_capacity The maximum amount of data to read at a time
+     */
+    virtual void open(clp::ReaderInterface& reader, size_t read_buffer_capacity) = 0;
 
     /**
      * Closes decompression stream

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -43,6 +43,7 @@ void JsonConstructor::store() {
                     "log order. Falling back to out of order decompression.");
     }
 
+    m_archive_reader->open_packed_streams();
     if (false == m_option.ordered || false == m_archive_reader->has_log_order()) {
         FileWriter writer;
         writer.open(

--- a/components/core/src/clp_s/PackedStreamReader.cpp
+++ b/components/core/src/clp_s/PackedStreamReader.cpp
@@ -1,14 +1,15 @@
 #include "PackedStreamReader.hpp"
 
+#include "../clp/BoundedReader.hpp"
+#include "archive_constants.hpp"
+#include "ArchiveReaderAdaptor.hpp"
+
 namespace clp_s {
 
 void PackedStreamReader::read_metadata(ZstdDecompressor& decompressor) {
     switch (m_state) {
         case PackedStreamReaderState::Uninitialized:
             m_state = PackedStreamReaderState::MetadataRead;
-            break;
-        case PackedStreamReaderState::PackedStreamsOpened:
-            m_state = PackedStreamReaderState::PackedStreamsOpenedAndMetadataRead;
             break;
         default:
             throw OperationFailed(ErrorCodeNotReady, __FILE__, __LINE__);
@@ -40,31 +41,41 @@ void PackedStreamReader::read_metadata(ZstdDecompressor& decompressor) {
     }
 }
 
-void PackedStreamReader::open_packed_streams(std::string const& tables_file_path) {
+void PackedStreamReader::open_packed_streams(std::shared_ptr<ArchiveReaderAdaptor> adaptor) {
     switch (m_state) {
-        case PackedStreamReaderState::Uninitialized:
+        case PackedStreamReaderState::MetadataRead:
             m_state = PackedStreamReaderState::PackedStreamsOpened;
             break;
-        case PackedStreamReaderState::MetadataRead:
-            m_state = PackedStreamReaderState::PackedStreamsOpenedAndMetadataRead;
-            break;
+        case PackedStreamReaderState::Uninitialized:
         default:
             throw OperationFailed(ErrorCodeNotReady, __FILE__, __LINE__);
     }
-    m_packed_stream_reader.open(tables_file_path);
+    m_adaptor = adaptor;
+    m_packed_stream_reader = m_adaptor->checkout_reader_for_section(constants::cArchiveTablesFile);
+    if (auto rc = m_packed_stream_reader->try_get_pos(m_begin_offset);
+        clp::ErrorCode::ErrorCode_Success != rc)
+    {
+        throw OperationFailed(static_cast<ErrorCode>(rc), __FILE__, __LINE__);
+    }
 }
 
 void PackedStreamReader::close() {
+    bool needs_checkin{false};
     switch (m_state) {
         case PackedStreamReaderState::PackedStreamsOpened:
-        case PackedStreamReaderState::PackedStreamsOpenedAndMetadataRead:
         case PackedStreamReaderState::ReadingPackedStreams:
+            needs_checkin = true;
             break;
         default:
-            throw OperationFailed(ErrorCodeNotReady, __FILE__, __LINE__);
+            needs_checkin = false;
+            break;
     }
-    m_packed_stream_reader.close();
-    m_prev_stream_id = 0;
+    if (needs_checkin) {
+        m_adaptor->checkin_reader_for_section(constants::cArchiveTablesFile);
+    }
+    m_adaptor.reset();
+    m_prev_stream_id = 0ULL;
+    m_begin_offset = 0ULL;
     m_stream_metadata.clear();
     m_state = PackedStreamReaderState::Uninitialized;
 }
@@ -80,7 +91,7 @@ void PackedStreamReader::read_stream(
     }
 
     switch (m_state) {
-        case PackedStreamReaderState::PackedStreamsOpenedAndMetadataRead:
+        case PackedStreamReaderState::PackedStreamsOpened:
             m_state = PackedStreamReaderState::ReadingPackedStreams;
             break;
         case PackedStreamReaderState::ReadingPackedStreams:
@@ -94,12 +105,20 @@ void PackedStreamReader::read_stream(
     m_prev_stream_id = stream_id;
 
     auto& [file_offset, uncompressed_size] = m_stream_metadata[stream_id];
-    if (auto error = m_packed_stream_reader.try_seek_from_begin(file_offset);
-        ErrorCodeSuccess != error)
+    size_t adjusted_file_offset = m_begin_offset + file_offset;
+    if (auto error = m_packed_stream_reader->try_seek_from_begin(adjusted_file_offset);
+        clp::ErrorCode::ErrorCode_Success != error)
     {
-        throw OperationFailed(error, __FILE__, __LINE__);
+        throw OperationFailed(static_cast<ErrorCode>(error), __FILE__, __LINE__);
     }
-    m_packed_stream_decompressor.open(m_packed_stream_reader, cDecompressorFileReadBufferCapacity);
+
+    size_t end_pos = m_adaptor->get_header().compressed_size;
+    if ((stream_id + 1) < m_stream_metadata.size()) {
+        end_pos = m_begin_offset + m_stream_metadata[stream_id + 1].file_offset;
+    }
+    clp::BoundedReader bounded_reader{m_packed_stream_reader.get(), end_pos};
+
+    m_packed_stream_decompressor.open(bounded_reader, cDecompressorFileReadBufferCapacity);
     if (buf_size < uncompressed_size) {
         // make_shared is supposed to work here for c++20, but it seems like the compiler version
         // we use doesn't support it, so we convert a unique_ptr to a shared_ptr instead.

--- a/components/core/src/clp_s/PackedStreamReader.hpp
+++ b/components/core/src/clp_s/PackedStreamReader.hpp
@@ -6,7 +6,8 @@
 #include <string>
 #include <vector>
 
-#include "FileReader.hpp"
+#include "../clp/ReaderInterface.hpp"
+#include "ArchiveReaderAdaptor.hpp"
 #include "ZstdDecompressor.hpp"
 
 namespace clp_s {
@@ -43,9 +44,9 @@ public:
 
     /**
      * Opens a file reader for the tables section. Must be invoked before reading packed streams.
-     * @param tables_file_path the path to the tables file for the archive being read
+     * @param adaptor a reader adaptor for the archive
      */
-    void open_packed_streams(std::string const& tables_file_path);
+    void open_packed_streams(std::shared_ptr<ArchiveReaderAdaptor> adaptor);
 
     /**
      * Closes the file reader for the tables section.
@@ -81,14 +82,15 @@ private:
         Uninitialized,
         MetadataRead,
         PackedStreamsOpened,
-        PackedStreamsOpenedAndMetadataRead,
         ReadingPackedStreams
     };
 
     std::vector<PackedStreamMetadata> m_stream_metadata;
-    FileReader m_packed_stream_reader;
+    std::shared_ptr<ArchiveReaderAdaptor> m_adaptor;
+    std::unique_ptr<clp::ReaderInterface> m_packed_stream_reader;
     ZstdDecompressor m_packed_stream_decompressor;
     PackedStreamReaderState m_state{PackedStreamReaderState::Uninitialized};
+    size_t m_begin_offset{};
     size_t m_prev_stream_id{0ULL};
 };
 

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -1,5 +1,8 @@
 #include "ReaderUtils.hpp"
 
+#include <exception>
+#include <string_view>
+
 #include <spdlog/spdlog.h>
 
 #include "../clp/aws/AwsAuthenticationSigner.hpp"
@@ -11,14 +14,13 @@
 #include "Utils.hpp"
 
 namespace clp_s {
-std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(std::string const& archives_dir) {
-    FileReader schema_tree_reader;
+std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(ArchiveReaderAdaptor& adaptor) {
     ZstdDecompressor schema_tree_decompressor;
-
     std::shared_ptr<SchemaTree> tree = std::make_shared<SchemaTree>();
 
-    schema_tree_reader.open(archives_dir + constants::cArchiveSchemaTreeFile);
-    schema_tree_decompressor.open(schema_tree_reader, cDecompressorFileReadBufferCapacity);
+    auto schema_tree_reader
+            = adaptor.checkout_reader_for_section(constants::cArchiveSchemaTreeFile);
+    schema_tree_decompressor.open(*schema_tree_reader, cDecompressorFileReadBufferCapacity);
 
     size_t num_nodes;
     auto error_code = schema_tree_decompressor.try_read_numeric_value(num_nodes);
@@ -56,51 +58,42 @@ std::shared_ptr<SchemaTree> ReaderUtils::read_schema_tree(std::string const& arc
     }
 
     schema_tree_decompressor.close();
-    schema_tree_reader.close();
+    adaptor.checkin_reader_for_section(constants::cArchiveSchemaTreeFile);
 
     return tree;
 }
 
 std::shared_ptr<VariableDictionaryReader> ReaderUtils::get_variable_dictionary_reader(
-        std::string const& archive_path
+        ArchiveReaderAdaptor& adaptor
 ) {
-    auto reader = std::make_shared<VariableDictionaryReader>();
-    reader->open(archive_path + constants::cArchiveVarDictFile);
+    auto reader = std::make_shared<VariableDictionaryReader>(adaptor);
+    reader->open(constants::cArchiveVarDictFile);
     return reader;
 }
 
 std::shared_ptr<LogTypeDictionaryReader> ReaderUtils::get_log_type_dictionary_reader(
-        std::string const& archive_path
+        ArchiveReaderAdaptor& adaptor
 ) {
-    auto reader = std::make_shared<LogTypeDictionaryReader>();
-    reader->open(archive_path + constants::cArchiveLogDictFile);
+    auto reader = std::make_shared<LogTypeDictionaryReader>(adaptor);
+    reader->open(constants::cArchiveLogDictFile);
     return reader;
 }
 
 std::shared_ptr<LogTypeDictionaryReader> ReaderUtils::get_array_dictionary_reader(
-        std::string const& archive_path
+        ArchiveReaderAdaptor& adaptor
 ) {
-    auto reader = std::make_shared<LogTypeDictionaryReader>();
-    reader->open(archive_path + constants::cArchiveArrayDictFile);
+    auto reader = std::make_shared<LogTypeDictionaryReader>(adaptor);
+    reader->open(constants::cArchiveArrayDictFile);
     return reader;
 }
 
-std::shared_ptr<TimestampDictionaryReader> ReaderUtils::get_timestamp_dictionary_reader(
-        std::string const& archive_path
-) {
-    auto reader = std::make_shared<TimestampDictionaryReader>();
-    reader->open(archive_path + constants::cArchiveTimestampDictFile);
-    return reader;
-}
-
-std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string const& archives_dir) {
+std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(ArchiveReaderAdaptor& adaptor) {
     auto schemas_pointer = std::make_unique<SchemaMap>();
     SchemaMap& schemas = *schemas_pointer;
-    FileReader schema_id_reader;
     ZstdDecompressor schema_id_decompressor;
 
-    schema_id_reader.open(archives_dir + constants::cArchiveSchemaMapFile);
-    schema_id_decompressor.open(schema_id_reader, cDecompressorFileReadBufferCapacity);
+    auto schema_id_reader = adaptor.checkout_reader_for_section(constants::cArchiveSchemaMapFile);
+    schema_id_decompressor.open(*schema_id_reader, cDecompressorFileReadBufferCapacity);
 
     size_t schema_size;
     auto error_code = schema_id_decompressor.try_read_numeric_value(schema_size);
@@ -145,7 +138,7 @@ std::shared_ptr<ReaderUtils::SchemaMap> ReaderUtils::read_schemas(std::string co
     }
 
     schema_id_decompressor.close();
-    schema_id_reader.close();
+    adaptor.checkin_reader_for_section(constants::cArchiveSchemaMapFile);
 
     return schemas_pointer;
 }

--- a/components/core/src/clp_s/ReaderUtils.hpp
+++ b/components/core/src/clp_s/ReaderUtils.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "../clp/ReaderInterface.hpp"
+#include "ArchiveReaderAdaptor.hpp"
 #include "DictionaryReader.hpp"
 #include "InputConfig.hpp"
 #include "Schema.hpp"
@@ -26,48 +27,44 @@ public:
     static constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;  // 64 KB
 
     /**
-     * Reads the schema tree from the given archive directory
-     * @param archives_dir
+     * Reads the schema tree from an archive
+     * @param adaptor
      * @return The schema tree
      */
-    static std::shared_ptr<SchemaTree> read_schema_tree(std::string const& archives_dir);
+    static std::shared_ptr<SchemaTree> read_schema_tree(ArchiveReaderAdaptor& adaptor);
 
     /**
-     * Reads the schema map from the given archive directory
-     * @param archive_dir
+     * Reads the schema map from an archive
+     * @param adaptor
      * @return the schema map
      */
-    static std::shared_ptr<SchemaMap> read_schemas(std::string const& archives_dir);
+    static std::shared_ptr<SchemaMap> read_schemas(ArchiveReaderAdaptor& archives_dir);
 
     /**
-     * Opens and gets the variable dictionary reader for the given archive path
-     * @param archive_path
+     * Gets the variable dictionary reader for an archive
+     * @param adaptor
      * @return the variable dictionary reader
      */
     static std::shared_ptr<VariableDictionaryReader> get_variable_dictionary_reader(
-            std::string const& archive_path
+            ArchiveReaderAdaptor& adaptor
     );
 
     /**
-     * Opens and gets the log type dictionary reader for the given archive path
-     * @param archive_path
+     * Gets the log type dictionary reader for an archive
+     * @param adaptor
      * @return the log type dictionary reader
      */
     static std::shared_ptr<LogTypeDictionaryReader> get_log_type_dictionary_reader(
-            std::string const& archive_path
+            ArchiveReaderAdaptor& adaptor
     );
 
     /**
-     * Opens and gets the array dictionary reader for the given archive path
-     * @param archive_path
+     * Gets the array dictionary reader for an archive
+     * @param adaptor
      * @return the array dictionary reader
      */
     static std::shared_ptr<LogTypeDictionaryReader> get_array_dictionary_reader(
-            std::string const& archive_path
-    );
-
-    static std::shared_ptr<TimestampDictionaryReader> get_timestamp_dictionary_reader(
-            std::string const& archive_path
+            ArchiveReaderAdaptor& adaptor
     );
 
     /**

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -16,7 +16,10 @@ ErrorCode TimestampDictionaryReader::read(ZstdDecompressor& decompressor) {
     for (uint64_t i = 0; i < range_index_size; ++i) {
         TimestampEntry entry;
         std::vector<std::string> tokens;
-        entry.try_read_from_file(decompressor);
+        if (auto rc = entry.try_read_from_file(decompressor); ErrorCodeSuccess != rc) {
+            throw OperationFailed(rc, __FILENAME__, __LINE__);
+        }
+
         if (false == StringUtils::tokenize_column_descriptor(entry.get_key_name(), tokens)) {
             throw OperationFailed(ErrorCodeCorrupt, __FILENAME__, __LINE__);
         }

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -42,7 +42,7 @@ ErrorCode TimestampDictionaryReader::read(ZstdDecompressor& decompressor) {
     if (ErrorCodeSuccess != error) {
         return error;
     }
-    for (int i = 0; i < num_patterns; ++i) {
+    for (uint64_t i = 0; i < num_patterns; ++i) {
         uint64_t id, pattern_len;
         std::string pattern;
         error = decompressor.try_read_numeric_value<uint64_t>(id);

--- a/components/core/src/clp_s/TimestampDictionaryReader.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.hpp
@@ -21,25 +21,13 @@ public:
                 : TraceableException(error_code, filename, line_number) {}
     };
 
-    // Constructors
-    TimestampDictionaryReader() : m_is_open(false) {}
-
     // Methods
     /**
-     * Opens dictionary for reading
-     * @param dictionary_path
+     * Reads the timestamp dictionary from a decompressor
+     * @param decompressor
+     * @return ErrorCodeSuccess on success, and the relevant ErrorCode otherwise
      */
-    void open(std::string const& dictionary_path);
-
-    /**
-     * Closes the dictionary
-     */
-    void close();
-
-    /**
-     * Reads any new entries from disk
-     */
-    void read_new_entries();
+    ErrorCode read(ZstdDecompressor& decompressor);
 
     /**
      * Gets the string encoding for a given epoch and format ID
@@ -78,10 +66,6 @@ private:
             = std::vector<std::pair<std::vector<std::string>, TimestampEntry*>>;
 
     // Variables
-    bool m_is_open;
-    FileReader m_dictionary_file_reader;
-    ZstdDecompressor m_dictionary_decompressor;
-
     id_to_pattern_t m_patterns;
     std::vector<TimestampEntry> m_entries;
     tokenized_column_to_range_t m_tokenized_column_to_range;

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -76,7 +76,7 @@ bool is_multi_file_archive(std::string_view const path) {
             return false;
         }
         auto formatted_name = fmt::format("/{}", file_name);
-        if (constants::cArchiveTimestampDictFile == formatted_name
+        if (constants::cArchiveHeaderFile == formatted_name
             || constants::cArchiveSchemaTreeFile == formatted_name
             || constants::cArchiveSchemaMapFile == formatted_name
             || constants::cArchiveVarDictFile == formatted_name

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -1,5 +1,7 @@
 #include "Utils.hpp"
 
+#include <charconv>
+#include <cstdint>
 #include <exception>
 #include <filesystem>
 #include <set>
@@ -87,10 +89,11 @@ bool is_multi_file_archive(std::string_view const path) {
         {
             continue;
         } else {
-            try {
-                auto segment_file_number = std::stoi(file_name);
-                continue;
-            } catch (std::exception const& e) {
+            uint64_t segment_file_number{};
+            auto const* begin = file_name.data();
+            auto const* end = file_name.data() + file_name.size();
+            auto [last, rc] = std::from_chars(begin, end, segment_file_number);
+            if (std::errc{} != rc || last != end) {
                 return false;
             }
         }

--- a/components/core/src/clp_s/ZstdDecompressor.cpp
+++ b/components/core/src/clp_s/ZstdDecompressor.cpp
@@ -287,12 +287,13 @@ ErrorCode ZstdDecompressor::open(std::string const& compressed_file_path) {
 
 void ZstdDecompressor::reset_stream() {
     if (InputType::File == m_input_type) {
-        auto rc = m_file_reader->try_seek_from_begin(m_file_reader_initial_pos);
-        m_file_read_buffer_length = 0;
-        m_compressed_stream_block.size = m_file_read_buffer_length;
-        if (false == (ErrorCodeSuccess == rc || ErrorCodeEndOfFile == rc)) {
+        if (auto rc = m_file_reader->try_seek_from_begin(m_file_reader_initial_pos);
+            ErrorCodeSuccess != rc && ErrorCodeEndOfFile != rc)
+        {
             throw OperationFailed(rc, __FILENAME__, __LINE__);
         }
+        m_file_read_buffer_length = 0;
+        m_compressed_stream_block.size = m_file_read_buffer_length;
     } else if (InputType::ClpReader == m_input_type) {
         auto rc = m_reader->try_seek_from_begin(m_file_reader_initial_pos);
         m_file_read_buffer_length = 0;

--- a/components/core/src/clp_s/ZstdDecompressor.hpp
+++ b/components/core/src/clp_s/ZstdDecompressor.hpp
@@ -9,6 +9,7 @@
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <zstd.h>
 
+#include "../clp/ReaderInterface.hpp"
 #include "Decompressor.hpp"
 #include "TraceableException.hpp"
 
@@ -41,6 +42,8 @@ public:
     void open(char const* compressed_data_buf, size_t compressed_data_buf_size) override;
 
     void open(FileReader& file_reader, size_t file_read_buffer_capacity) override;
+
+    void open(clp::ReaderInterface& reader, size_t file_read_buffer_capacity) override;
 
     void close() override;
 
@@ -109,7 +112,8 @@ private:
                          // parameter is not initialized properly
         CompressedDataBuf,
         MemoryMappedCompressedFile,
-        File
+        File,
+        ClpReader
     };
 
     // Methods
@@ -127,6 +131,7 @@ private:
 
     boost::iostreams::mapped_file_source m_memory_mapped_compressed_file;
     FileReader* m_file_reader;
+    clp::ReaderInterface* m_reader;
     size_t m_file_reader_initial_pos;
     std::unique_ptr<char[]> m_file_read_buffer;
     size_t m_file_read_buffer_length;

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -7,6 +7,9 @@ namespace clp_s::constants {
 // Single file archive
 constexpr char cTmpPostfix[] = ".tmp";
 
+// Header and metadata section
+constexpr char cArchiveHeaderFile[] = "/header";
+
 // Schema files
 constexpr char cArchiveSchemaMapFile[] = "/schema_ids";
 constexpr char cArchiveSchemaTreeFile[] = "/schema_tree";
@@ -18,7 +21,6 @@ constexpr char cArchiveTablesFile[] = "/tables";
 // Dictionary files
 constexpr char cArchiveArrayDictFile[] = "/array.dict";
 constexpr char cArchiveLogDictFile[] = "/log.dict";
-constexpr char cArchiveTimestampDictFile[] = "/timestamp.dict";
 constexpr char cArchiveVarDictFile[] = "/var.dict";
 
 // Schema tree constants

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -144,7 +144,7 @@ bool search_archive(
 ) {
     auto const& query = command_line_arguments.get_query();
 
-    auto timestamp_dict = archive_reader->read_timestamp_dictionary();
+    auto timestamp_dict = archive_reader->get_timestamp_dictionary();
     AddTimestampConditions add_timestamp_conditions(
             timestamp_dict->get_authoritative_timestamp_tokenized_column(),
             command_line_arguments.get_search_begin_ts(),

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -65,6 +65,8 @@ bool Output::filter() {
     populate_internal_columns();
     populate_string_queries(top_level_expr);
 
+    m_archive_reader->open_packed_streams();
+
     std::string message;
     auto const archive_id = m_archive_reader->get_archive_id();
     for (int32_t schema_id : matched_schemas) {


### PR DESCRIPTION
# Description
This PR adds support for reading and searching clp-s single file archives. The general approach is to introduce a new "adaptor" class that allows most of the code to be oblivious as to whether the underlying archive is a single or multi-file archive.

This class is called "ArchiveReaderAdaptor" and makes up the bulk of this change.

Other notable changes include:
* Modifying the multi-file-archive format to:
  * Remove the dedicated timestamp dict file
  * Add a new "header" file which includes header and metadata identical to the multi-file archive
* Allowing ZstdDecompressor to accept a clp::ReaderInterface
* Adapting read-side code to invoke ArchiveReaderAdaptor instead of opening files directly
* Changing when different sections of the archive get opened during the read-side flow to ensure that single-file-archives can be read without seeks

# Benchmarks
Some benchmarking was performed to get an idea of compression, decompression, and search performance with single file archives. All of the following benchmarking results are from averaging over 3-5 tests on the local filesystem clearing the cache between runs.

Compression is slightly slower (~1.2%) when compressing single-file archives (compared to multi-file archives). 

| dataset | sfa compression time / mfa compression time |
| --- | --- |
| cockroach | 0.996 |
| mongodb | 1.040 |
| elasticsearch | 1.013 |
| spark | 0.998 |
| postgresql | 1.011|
| average | 1.012 |

Surprisingly decompression is also slightly slower (~1%). This should be acceptable for now though, and we can work on optimizing bottlenecks later.

| dataset | sfa decompression time / mfa decompression time |
| --- | --- |
| cockroach | 0.996 |
| mongodb | 1.006 |
| elasticsearch | 1.010 |
| spark | 1.038 |
| postgresql | 1.001 |
| average | 1.010 |

Likewise search seems to be slower (~3.7%). Again this is worth optimizing for later, but should be sufficient for now. 

| query (from our paper) | sfa search time / mfa search time |
| --- | --- |
| J | 0.963 |
| M | 1.090 |
| K | 1.060 |
| average | 1.037 |

# Validation performed
* Validated that multi-file-archives on the local filesystem can be decompressed and searched successfully on the command line
* Validated that single-file-archives on s3 can be decompressed and searched succesfully on the command line
* Validated that single-file-archives on the local filesystem can be decompressed and searched successfully on the command line



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `ArchiveReaderAdaptor` to enhance archive reading capabilities.
	- Added support for opening packed streams in the archive reader.
	- New methods for managing archive metadata and file information.

- **Improvements**
	- Streamlined dictionary and stream reading processes.
	- Enhanced error handling for archive operations.
	- Simplified interactions between archive readers and writers.

- **Technical Updates**
	- Updated methods for reading and managing archive metadata.
	- Modified decompression utilities to support new input types.
	- Refactored archive reading and processing workflows.
	- Updated method signatures to improve modularity and clarity.
	- Removed deprecated methods related to timestamp dictionary handling.

These changes improve the overall robustness and flexibility of the archive reading and processing infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->