### PR TITLE
feat(clp-s): json to irv2

### DIFF
--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -824,6 +824,41 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             if (m_file_paths.empty()) {
                 throw std::invalid_argument("No input paths specified.");
             }
+
+            if ((4 != m_encoding_type) && (8 != m_encoding_type)) {
+                SPDLOG_ERROR(
+                        "Invalid encoding type specified; --encoding-type {}",
+                        m_encoding_type
+                );
+                return ParsingResult::Failure;
+            }
+
+            if (0 >= m_max_ir_buffer_size) {
+                SPDLOG_ERROR(
+                        "Invalid max_ir_buffer_size specified; Buffer size must be greater than "
+                        "zero; --max-ir-buffer-size {}",
+                        m_max_ir_buffer_size
+                );
+                return ParsingResult::Failure;
+            }
+
+            if (0 >= m_max_document_size) {
+                SPDLOG_ERROR(
+                        "Invalid max_document_size specified; Document size must be greater than "
+                        "zero; --max-document-size {}",
+                        m_max_document_size
+                );
+                return ParsingResult::Failure;
+            }
+
+            if ((1 > m_compression_level) || (9 < m_compression_level)) {
+                SPDLOG_ERROR(
+                        "Invalid compression level specified; Compression level must be 1-9; "
+                        "--compression-level {}",
+                        m_compression_level
+                );
+                return ParsingResult::Failure;
+            }
         }
     } catch (std::exception& e) {
         SPDLOG_ERROR("{}", e.what());

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -745,7 +745,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             // clang-format on
 
             po::options_description compression_options("Compression options");
-            std::string metadata_db_config_file_path;
             std::string input_path_list_file_path;
             // clang-format off
             compression_options.add_options()(
@@ -768,11 +767,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::value<int>(&m_encoding_type)->value_name("ENCODING_TYPE")->
                         default_value(m_encoding_type),
                     "4 (four byte encoding) or 8 (eight byte encoding)"
-            )(
-                    "db-config-file",
-                    po::value<std::string>(&metadata_db_config_file_path)->value_name("FILE")->
-                    default_value(metadata_db_config_file_path),
-                    "Global metadata DB YAML config"
             )(
                     "files-from,f",
                     po::value<std::string>(&input_path_list_file_path)
@@ -829,29 +823,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
 
             if (m_file_paths.empty()) {
                 throw std::invalid_argument("No input paths specified.");
-            }
-
-            // Parse and validate global metadata DB config
-            if (false == metadata_db_config_file_path.empty()) {
-                clp::GlobalMetadataDBConfig metadata_db_config;
-                try {
-                    metadata_db_config.parse_config_file(metadata_db_config_file_path);
-                } catch (std::exception& e) {
-                    SPDLOG_ERROR("Failed to validate metadata database config - {}.", e.what());
-                    return ParsingResult::Failure;
-                }
-
-                if (clp::GlobalMetadataDBConfig::MetadataDBType::MySQL
-                    != metadata_db_config.get_metadata_db_type())
-                {
-                    SPDLOG_ERROR(
-                            "Invalid metadata database type for {}; only supported type is MySQL.",
-                            m_program_name
-                    );
-                    return ParsingResult::Failure;
-                }
-
-                m_metadata_db_config = std::move(metadata_db_config);
             }
         }
     } catch (std::exception& e) {

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -201,7 +201,7 @@ private:
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
     FileType m_file_type{FileType::Json};
-    int m_encoding_type{8};
+    int m_encoding_type{4};
     size_t m_max_ir_buffer_size{512ULL * 1024 * 1024};
 
     // Metadata db variables

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -26,7 +26,8 @@ public:
     enum class Command : char {
         Compress = 'c',
         Extract = 'x',
-        Search = 's'
+        Search = 's',
+        JsonToIr = 'r'
     };
 
     enum class OutputHandlerType : uint8_t {
@@ -64,6 +65,10 @@ public:
     size_t get_target_encoded_size() const { return m_target_encoded_size; }
 
     size_t get_max_document_size() const { return m_max_document_size; }
+
+    [[nodiscard]] auto get_max_ir_buffer_size() const -> size_t { return m_max_ir_buffer_size; }
+
+    [[nodiscard]] auto get_encoding_type() const -> int { return m_encoding_type; }
 
     [[nodiscard]] bool print_archive_stats() const { return m_print_archive_stats; }
 
@@ -170,6 +175,8 @@ private:
 
     void print_decompression_usage() const;
 
+    void print_json_to_ir_usage() const;
+
     void print_search_usage() const;
 
     // Variables
@@ -192,6 +199,8 @@ private:
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
     FileType m_file_type{FileType::Json};
+    int m_encoding_type{8};
+    size_t m_max_ir_buffer_size{512ULL * 1024 * 1024};
 
     // Metadata db variables
     std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -56,7 +56,7 @@ struct JsonParserOption {
 };
 
 struct JsonToIrParserOption {
-    std::vector<std::string> file_paths;
+    std::vector<Path> input_paths;
     std::string irs_dir;
     size_t max_document_size;
     size_t max_ir_buffer_size;

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -52,6 +52,15 @@ struct JsonParserOption {
     std::shared_ptr<clp::GlobalMySQLMetadataDB> metadata_db;
 };
 
+struct JsonToIrParserOption {
+    std::vector<std::string> file_paths;
+    std::string irs_dir;
+    size_t max_document_size;
+    size_t max_ir_buffer_size;
+    int compression_level;
+    int encoding;
+};
+
 class JsonParser {
 public:
     class OperationFailed : public TraceableException {

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -1,5 +1,6 @@
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -11,6 +12,8 @@
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
 
+#include "../clp/ffi/ir_stream/protocol_constants.hpp"
+#include "../clp/ffi/ir_stream/Serializer.hpp"
 #include "../clp/GlobalMySQLMetadataDB.hpp"
 #include "../clp/streaming_archive/ArchiveMetadata.hpp"
 #include "../reducer/network_utils.hpp"
@@ -36,6 +39,7 @@
 #include "Utils.hpp"
 
 using namespace clp_s::search;
+using clp::ffi::ir_stream::Serializer;
 using clp_s::cArchiveFormatDevelopmentVersionFlag;
 using clp_s::cEpochTimeMax;
 using clp_s::cEpochTimeMin;
@@ -49,6 +53,36 @@ namespace {
  * @return Whether compression was successful
  */
 bool compress(CommandLineArguments const& command_line_arguments);
+
+template <typename encoded_variable_t>
+auto flush_and_clear_serializer_buffer(
+        Serializer<encoded_variable_t>& serializer,
+        std::vector<int8_t>& byte_buf
+) -> void;
+
+template <typename encoded_variable_t>
+auto unpack_and_serialize_msgpack_bytes(
+        std::vector<uint8_t> const& msgpack_bytes,
+        Serializer<encoded_variable_t>& serializer
+) -> bool;
+
+/**
+ * Given user specified options and a file path to a JSON file calls the serailizer one each JSON
+ * entry to serialize into IR
+ * @param option
+ * @param path
+ * @return Whether serialization was successful
+ */
+template <typename T>
+auto run_serializer(clp_s::JsonToIrParserOption const& option, std::string path);
+
+/**
+ * Iterates over the input JSON files specified by the command line arguments to generate and IR
+ * file for each one.
+ * @param command_line_arguments
+ * @return Whether generation was successful
+ */
+auto generate_ir(CommandLineArguments const& command_line_arguments) -> bool;
 
 /**
  * Decompresses the archive specified by the given JsonConstructorOption.
@@ -126,6 +160,162 @@ bool compress(CommandLineArguments const& command_line_arguments) {
         }
     }
     parser.store();
+    return true;
+}
+
+template <typename encoded_variable_t>
+auto flush_and_clear_serializer_buffer(
+        Serializer<encoded_variable_t>& serializer,
+        std::vector<int8_t>& byte_buf
+) -> void {
+    auto const view{serializer.get_ir_buf_view()};
+    byte_buf.insert(byte_buf.cend(), view.begin(), view.end());
+    serializer.clear_ir_buf();
+}
+
+template <typename encoded_variable_t>
+auto unpack_and_serialize_msgpack_bytes(
+        std::vector<uint8_t> const& msgpack_bytes,
+        Serializer<encoded_variable_t>& serializer
+) -> bool {
+    try {
+        auto const msgpack_obj_handle{msgpack::unpack(
+                clp::size_checked_pointer_cast<char const>(msgpack_bytes.data()),
+                msgpack_bytes.size()
+        )};
+        auto const msgpack_obj{msgpack_obj_handle.get()};
+        if (msgpack::type::MAP != msgpack_obj.type) {
+            return false;
+        }
+        return serializer.serialize_msgpack_map(msgpack_obj.via.map);
+    } catch (std::exception const& e) {
+        SPDLOG_ERROR("Failed to unpack msgpack bytes: {}", e.what());
+        return false;
+    }
+}
+
+template <typename T>
+auto run_serializer(clp_s::JsonToIrParserOption const& option, std::string path) {
+    auto result{Serializer<T>::create()};
+    if (result.has_error()) {
+        SPDLOG_ERROR("Failed to create Serializer");
+        return false;
+    }
+    auto& serializer{result.value()};
+    std::vector<int8_t> ir_buf;
+    flush_and_clear_serializer_buffer(serializer, ir_buf);
+
+    std::ifstream in_file;
+    in_file.open(path, std::ifstream::in);
+
+    std::filesystem::path input_path{path};
+    std::string filename = input_path.filename().string();
+    std::string out_path = option.irs_dir + "/" + filename + ".ir";
+
+    clp_s::FileWriter out_file;
+    out_file.open(out_path, clp_s::FileWriter::OpenMode::CreateForWriting);
+    clp_s::ZstdCompressor zc;
+    try {
+        zc.open(out_file, option.compression_level);
+    } catch (clp_s::ZstdCompressor::OperationFailed& error) {
+        SPDLOG_ERROR("Failed to open ZSTDcompressor - {}", error.what());
+        in_file.close();
+        out_file.close();
+        return false;
+    }
+
+    std::string line = "";
+    size_t total_size = 0;
+
+    if (in_file.is_open()) {
+        while (getline(in_file, line)) {
+            try {
+                auto j_obj = nlohmann::json::parse(line);
+                if (false
+                    == unpack_and_serialize_msgpack_bytes(
+                            nlohmann::json::to_msgpack(j_obj),
+                            serializer
+                    ))
+                {
+                    SPDLOG_ERROR("Failed to serialize msgpack bytes for line: {}", line);
+                    in_file.close();
+                    out_file.close();
+                    zc.close();
+                    return false;
+                }
+                flush_and_clear_serializer_buffer(serializer, ir_buf);
+                if (ir_buf.size() >= option.max_ir_buffer_size) {
+                    total_size = total_size + ir_buf.size();
+                    zc.write(reinterpret_cast<char*>(ir_buf.data()), ir_buf.size());
+                    zc.flush();
+                    ir_buf.clear();
+                }
+            } catch (nlohmann::json::parse_error const& e) {
+                SPDLOG_ERROR("JSON parsing error: {}", e.what());
+                in_file.close();
+                out_file.close();
+                zc.close();
+                return false;
+            } catch (std::exception const& e) {
+                SPDLOG_ERROR("Error during serialization: {}", e.what());
+                in_file.close();
+                out_file.close();
+                zc.close();
+                return false;
+            }
+        }
+        total_size = total_size + ir_buf.size();
+        ir_buf.push_back(clp::ffi::ir_stream::cProtocol::Eof);
+        zc.write(reinterpret_cast<char*>(ir_buf.data()), ir_buf.size());
+        zc.flush();
+        ir_buf.clear();
+        in_file.close();
+        zc.close();
+        out_file.close();
+    }
+
+    return true;
+}
+
+auto generate_ir(CommandLineArguments const& command_line_arguments) -> bool {
+    auto irs_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
+
+    // Create output directory in case it doesn't exist
+    try {
+        std::filesystem::create_directory(irs_dir.string());
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("Failed to create archives directory {} - {}", irs_dir.string(), e.what());
+        return false;
+    }
+    clp_s::JsonToIrParserOption option{};
+    option.file_paths = command_line_arguments.get_file_paths();
+    option.irs_dir = irs_dir.string();
+    option.max_document_size = command_line_arguments.get_max_document_size();
+    option.max_ir_buffer_size = command_line_arguments.get_max_ir_buffer_size();
+    option.compression_level = command_line_arguments.get_compression_level();
+    option.encoding = command_line_arguments.get_encoding_type();
+
+    if (false == clp_s::FileUtils::validate_path(option.file_paths)) {
+        SPDLOG_ERROR("Invalid file path(s) provided");
+        return false;
+    }
+
+    std::vector<std::string> all_file_paths;
+    for (auto& file_path : option.file_paths) {
+        clp_s::FileUtils::find_all_files(file_path, all_file_paths);
+    }
+
+    for (auto& path : all_file_paths) {
+        bool success;
+        if (option.encoding == 4) {
+            success = run_serializer<int32_t>(option, path);
+        } else {
+            success = run_serializer<int64_t>(option, path);
+        }
+        if (false == success) {
+            return false;
+        }
+    }
     return true;
 }
 
@@ -296,6 +486,10 @@ int main(int argc, char const* argv[]) {
 
     if (CommandLineArguments::Command::Compress == command_line_arguments.get_command()) {
         if (false == compress(command_line_arguments)) {
+            return 1;
+        }
+    } else if (CommandLineArguments::Command::JsonToIr == command_line_arguments.get_command()) {
+        if (false == generate_ir(command_line_arguments)) {
             return 1;
         }
     } else if (CommandLineArguments::Command::Extract == command_line_arguments.get_command()) {

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -284,21 +284,16 @@ auto generate_ir(CommandLineArguments const& command_line_arguments) -> bool {
         return false;
     }
     clp_s::JsonToIrParserOption option{};
-    option.file_paths = command_line_arguments.get_file_paths();
+    option.input_paths = command_line_arguments.get_input_paths();
     option.irs_dir = irs_dir.string();
     option.max_document_size = command_line_arguments.get_max_document_size();
     option.max_ir_buffer_size = command_line_arguments.get_max_ir_buffer_size();
     option.compression_level = command_line_arguments.get_compression_level();
     option.encoding = command_line_arguments.get_encoding_type();
 
-    if (false == clp_s::FileUtils::validate_path(option.file_paths)) {
-        SPDLOG_ERROR("Invalid file path(s) provided");
-        return false;
-    }
-
     std::vector<std::string> all_file_paths;
-    for (auto& file_path : option.file_paths) {
-        clp_s::FileUtils::find_all_files(file_path, all_file_paths);
+    for (auto const& path : option.input_paths) {
+        all_file_paths.push_back(path.path);
     }
 
     for (auto& path : all_file_paths) {


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR:
- Exposes the JSON to IRV2 parsing to the user through the command line
- Enables users to write the IRV2 format to a file.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Generated IR V2 format for all 5 JSON public datasets
ex) ./clp-s r elasticsearch_ir elasticsearch/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new command-line option for converting JSON files to Intermediate Representation (IR) format.
  - Introduced advanced configuration options for JSON to IR conversion, including:
    - Output directory specification
    - Compression settings
    - Encoding type configuration
  - New help message to guide users on the JSON to IR command usage.

- **Improvements**
  - Enhanced command-line interface with additional parsing capabilities.
  - Improved error handling for new JSON conversion functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212854499678643