### PR TITLE
ci(clang-format): Update to clang-format v19 (and the corresponding yscope-dev-utils) and apply the corresponding formatting changes (fixes #545).

### DIFF
--- a/components/core/src/clp/BoundedReader.hpp
+++ b/components/core/src/clp/BoundedReader.hpp
@@ -61,8 +61,8 @@ public:
      * @return ErrorCode_EndOfFile on EOF or trying to read after hitting checkpoint
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override;
 
     /**
      * This function is unsupported because BoundedReader can not delegate to a potentially

--- a/components/core/src/clp/BufferReader.cpp
+++ b/components/core/src/clp/BufferReader.cpp
@@ -86,12 +86,9 @@ auto BufferReader::try_get_pos(size_t& pos) -> ErrorCode {
     return ErrorCode_Success;
 }
 
-auto BufferReader::try_read_to_delimiter(
-        char delim,
-        bool keep_delimiter,
-        bool append,
-        std::string& str
-) -> ErrorCode {
+auto
+BufferReader::try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
+        -> ErrorCode {
     if (false == append) {
         str.clear();
     }

--- a/components/core/src/clp/BufferReader.hpp
+++ b/components/core/src/clp/BufferReader.hpp
@@ -63,8 +63,8 @@ public:
      * @return ErrorCode_EndOfFile if the buffer doesn't contain any more data
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override;
 
     /**
      * Tries to seek to the given position, relative to the beginning of the buffer
@@ -88,12 +88,9 @@ public:
      * @param str Returns the content read from the buffer
      * @return Same as BufferReader::try_read_to_delimiter(char, bool, std::string&, bool&, size_t&)
      */
-    [[nodiscard]] auto try_read_to_delimiter(
-            char delim,
-            bool keep_delimiter,
-            bool append,
-            std::string& str
-    ) -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
+            -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/clp/BufferedFileReader.cpp
+++ b/components/core/src/clp/BufferedFileReader.cpp
@@ -265,12 +265,9 @@ auto BufferedFileReader::try_read(char* buf, size_t num_bytes_to_read, size_t& n
     return ErrorCode_Success;
 }
 
-auto BufferedFileReader::try_read_to_delimiter(
-        char delim,
-        bool keep_delimiter,
-        bool append,
-        string& str
-) -> ErrorCode {
+auto
+BufferedFileReader::try_read_to_delimiter(char delim, bool keep_delimiter, bool append, string& str)
+        -> ErrorCode {
     if (-1 == m_fd) {
         return ErrorCode_NotInit;
     }

--- a/components/core/src/clp/BufferedFileReader.hpp
+++ b/components/core/src/clp/BufferedFileReader.hpp
@@ -127,8 +127,8 @@ public:
      * @return ErrorCode_NotInit if the file is not opened
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_peek_buffered_data(char const*& buf, size_t& peek_size) const -> ErrorCode;
+    [[nodiscard]] auto try_peek_buffered_data(char const*& buf, size_t& peek_size) const
+            -> ErrorCode;
 
     /**
      * Peeks the remaining buffered content without advancing the read head.
@@ -191,8 +191,8 @@ public:
      * @return ErrorCode_EndOfFile on EOF
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override;
 
     /**
      * Tries to read up to an occurrence of the given delimiter
@@ -206,12 +206,9 @@ public:
      * @return Same as BufferReader::try_read_to_delimiter if it fails
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_read_to_delimiter(
-            char delim,
-            bool keep_delimiter,
-            bool append,
-            std::string& str
-    ) -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
+            -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/clp/FileDescriptor.cpp
+++ b/components/core/src/clp/FileDescriptor.cpp
@@ -48,7 +48,7 @@ FileDescriptor::~FileDescriptor() {
 }
 
 auto FileDescriptor::get_size() const -> size_t {
-    struct stat stat_result {};
+    struct stat stat_result{};
 
     if (ErrorCode_Success != stat(stat_result)) {
         throw OperationFailed(

--- a/components/core/src/clp/FileDescriptorReader.hpp
+++ b/components/core/src/clp/FileDescriptorReader.hpp
@@ -65,8 +65,8 @@ public:
      * @return ErrorCode_EndOfFile on EOF
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override;
 
     /**
      * Tries to seek to the given position, relative to the beginning of the file.

--- a/components/core/src/clp/Grep.cpp
+++ b/components/core/src/clp/Grep.cpp
@@ -890,10 +890,8 @@ bool Grep::get_bounds_of_next_potential_var(
     return (value_length != begin_pos);
 }
 
-void Grep::calculate_sub_queries_relevant_to_file(
-        File const& compressed_file,
-        vector<Query>& queries
-) {
+void
+Grep::calculate_sub_queries_relevant_to_file(File const& compressed_file, vector<Query>& queries) {
     for (auto& query : queries) {
         query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
     }

--- a/components/core/src/clp/NetworkReader.cpp
+++ b/components/core/src/clp/NetworkReader.cpp
@@ -108,8 +108,8 @@ extern "C" auto curl_progress_callback(
  * @return On success, the number of bytes processed. If this is less than `nmemb`, the download
  * will be aborted.
  */
-extern "C" auto
-curl_write_callback(char* ptr, size_t size, size_t nmemb, void* reader_ptr) -> size_t {
+extern "C" auto curl_write_callback(char* ptr, size_t size, size_t nmemb, void* reader_ptr)
+        -> size_t {
     return static_cast<NetworkReader*>(reader_ptr)->buffer_downloaded_data({ptr, size * nmemb});
 }
 }  // namespace
@@ -304,11 +304,9 @@ auto NetworkReader::get_filled_buffer() -> void {
     m_curr_reader_buf.emplace(next_reader_buffer);
 }
 
-auto NetworkReader::read_from_filled_buffers(
-        size_t num_bytes_to_read,
-        size_t& num_bytes_read,
-        char* dst
-) -> ErrorCode {
+auto
+NetworkReader::read_from_filled_buffers(size_t num_bytes_to_read, size_t& num_bytes_read, char* dst)
+        -> ErrorCode {
     num_bytes_read = 0;
     std::optional<BufferView> dst_view;
     if (nullptr != dst) {

--- a/components/core/src/clp/NetworkReader.hpp
+++ b/components/core/src/clp/NetworkReader.hpp
@@ -132,8 +132,8 @@ public:
      * @return ErrorCode_EndOfFile if there is no more buffered data.
      * @return ErrorCode_Success on success.
      */
-    [[nodiscard]] auto
-    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override {
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override {
         return read_from_filled_buffers(num_bytes_to_read, num_bytes_read, buf);
     }
 
@@ -306,11 +306,9 @@ private:
      * @return ErrorCode_EndOfFile if the buffer doesn't contain any more data.
      * @return ErrorCode_Success on success.
      */
-    [[nodiscard]] auto read_from_filled_buffers(
-            size_t num_bytes_to_read,
-            size_t& num_bytes_read,
-            char* dst
-    ) -> ErrorCode;
+    [[nodiscard]] auto
+    read_from_filled_buffers(size_t num_bytes_to_read, size_t& num_bytes_read, char* dst)
+            -> ErrorCode;
 
     /**
      * Sets the download completion status with the return code from curl.

--- a/components/core/src/clp/Thread.hpp
+++ b/components/core/src/clp/Thread.hpp
@@ -28,7 +28,7 @@ public:
     };
 
     // Constructors
-    Thread() : m_thread_running(false) {};
+    Thread() : m_thread_running(false) {}
 
     // Destructor
     virtual ~Thread();

--- a/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
@@ -43,8 +43,8 @@ namespace {
  * @param timestamp
  * @return The formatted date string.
  */
-[[nodiscard]] auto get_formatted_date_string(std::chrono::system_clock::time_point const& timestamp
-) -> string;
+[[nodiscard]] auto get_formatted_date_string(std::chrono::system_clock::time_point const& timestamp)
+        -> string;
 
 /**
  * Gets the string to sign required by AWS Signature Version 4 protocol.
@@ -89,8 +89,8 @@ auto is_unreserved_characters(char c) -> bool {
     return is_alphabet(c) || is_decimal_digit(c) || c == '-' || c == '_' || c == '.' || c == '~';
 }
 
-auto get_formatted_timestamp_string(std::chrono::system_clock::time_point const& timestamp
-) -> string {
+auto get_formatted_timestamp_string(std::chrono::system_clock::time_point const& timestamp)
+        -> string {
     return fmt::format("{:%Y%m%dT%H%M%SZ}", timestamp);
 }
 
@@ -203,10 +203,9 @@ S3Url::S3Url(string const& url) {
     m_host = fmt::format("{}.s3.{}.{}", m_bucket, m_region, m_end_point);
 }
 
-auto AwsAuthenticationSigner::generate_presigned_url(
-        S3Url const& s3_url,
-        string& presigned_url
-) const -> ErrorCode {
+auto
+AwsAuthenticationSigner::generate_presigned_url(S3Url const& s3_url, string& presigned_url) const
+        -> ErrorCode {
     auto const s3_region = s3_url.get_region();
 
     auto const now = std::chrono::system_clock::now();
@@ -245,10 +244,9 @@ auto AwsAuthenticationSigner::generate_presigned_url(
     return ErrorCode_Success;
 }
 
-auto AwsAuthenticationSigner::get_canonical_query_string(
-        string_view scope,
-        string_view timestamp
-) const -> string {
+auto
+AwsAuthenticationSigner::get_canonical_query_string(string_view scope, string_view timestamp) const
+        -> string {
     auto const uri = fmt::format("{}/{}", m_access_key_id, scope);
     return fmt::format(
             "{}={}&{}={}&{}={}&{}={}&{}={}",

--- a/components/core/src/clp/aws/AwsAuthenticationSigner.hpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.hpp
@@ -82,8 +82,8 @@ public:
      * @return ErrorCode_Success on success.
      * @return Same as `get_sha256_hash` and `AwsAuthenticationSigner::get_signature` on failure.
      */
-    [[nodiscard]] auto
-    generate_presigned_url(S3Url const& s3_url, std::string& presigned_url) const -> ErrorCode;
+    [[nodiscard]] auto generate_presigned_url(S3Url const& s3_url, std::string& presigned_url) const
+            -> ErrorCode;
 
 private:
     /**
@@ -92,10 +92,9 @@ private:
      * @param timestamp
      * @return The canonical query string.
      */
-    [[nodiscard]] auto get_canonical_query_string(
-            std::string_view scope,
-            std::string_view timestamp
-    ) const -> std::string;
+    [[nodiscard]] auto
+    get_canonical_query_string(std::string_view scope, std::string_view timestamp) const
+            -> std::string;
 
     /**
      * Gets the signature signing key for the request.

--- a/components/core/src/clp/error_handling/ErrorCode.hpp
+++ b/components/core/src/clp/error_handling/ErrorCode.hpp
@@ -47,10 +47,9 @@ public:
      * @param condition
      * @return Whether the error condition of the given error matches the given condition.
      */
-    [[nodiscard]] auto equivalent(
-            int error_num,
-            std::error_condition const& condition
-    ) const noexcept -> bool override {
+    [[nodiscard]] auto
+    equivalent(int error_num, std::error_condition const& condition) const noexcept
+            -> bool override {
         return equivalent(static_cast<ErrorCodeEnum>(error_num), condition);
     }
 
@@ -69,10 +68,9 @@ public:
      * @param condition
      * @return Whether the error condition of the given error matches the given condition.
      */
-    [[nodiscard]] auto equivalent(
-            ErrorCodeEnum error_enum,
-            std::error_condition const& condition
-    ) const noexcept -> bool;
+    [[nodiscard]] auto
+    equivalent(ErrorCodeEnum error_enum, std::error_condition const& condition) const noexcept
+            -> bool;
 };
 
 /**

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
@@ -119,8 +119,8 @@ private:
  * @param value
  * @return Whether the given schema tree node type matches the given value's type.
  */
-[[nodiscard]] auto
-node_type_matches_value_type(SchemaTree::Node::Type type, Value const& value) -> bool;
+[[nodiscard]] auto node_type_matches_value_type(SchemaTree::Node::Type type, Value const& value)
+        -> bool;
 
 /**
  * Validates whether the given node-ID value pairs are leaf nodes in the `SchemaTree` forming a
@@ -560,18 +560,18 @@ auto KeyValuePairLogEvent::create(
     };
 }
 
-auto KeyValuePairLogEvent::get_auto_gen_keys_schema_subtree_bitmap(
-) const -> OUTCOME_V2_NAMESPACE::std_result<std::vector<bool>> {
+auto KeyValuePairLogEvent::get_auto_gen_keys_schema_subtree_bitmap() const
+        -> OUTCOME_V2_NAMESPACE::std_result<std::vector<bool>> {
     return get_schema_subtree_bitmap(m_auto_gen_node_id_value_pairs, *m_auto_gen_keys_schema_tree);
 }
 
-auto KeyValuePairLogEvent::get_user_gen_keys_schema_subtree_bitmap(
-) const -> outcome_v2::std_result<std::vector<bool>> {
+auto KeyValuePairLogEvent::get_user_gen_keys_schema_subtree_bitmap() const
+        -> outcome_v2::std_result<std::vector<bool>> {
     return get_schema_subtree_bitmap(m_user_gen_node_id_value_pairs, *m_user_gen_keys_schema_tree);
 }
 
-auto KeyValuePairLogEvent::serialize_to_json(
-) const -> OUTCOME_V2_NAMESPACE::std_result<std::pair<nlohmann::json, nlohmann::json>> {
+auto KeyValuePairLogEvent::serialize_to_json() const
+        -> OUTCOME_V2_NAMESPACE::std_result<std::pair<nlohmann::json, nlohmann::json>> {
     auto const auto_gen_keys_schema_subtree_bitmap_result{get_auto_gen_keys_schema_subtree_bitmap()
     };
     if (auto_gen_keys_schema_subtree_bitmap_result.has_error()) {

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
@@ -85,8 +85,8 @@ public:
      * an error code indicating a failure:
      * - Forwards `get_schema_subtree_bitmap`'s return values.
      */
-    [[nodiscard]] auto get_auto_gen_keys_schema_subtree_bitmap(
-    ) const -> OUTCOME_V2_NAMESPACE::std_result<std::vector<bool>>;
+    [[nodiscard]] auto get_auto_gen_keys_schema_subtree_bitmap() const
+            -> OUTCOME_V2_NAMESPACE::std_result<std::vector<bool>>;
 
     /**
      * @return A result containing a bitmap where every bit corresponds to the ID of a node in the
@@ -95,8 +95,8 @@ public:
      * an error code indicating a failure:
      * - Forwards `get_schema_subtree_bitmap`'s return values.
      */
-    [[nodiscard]] auto get_user_gen_keys_schema_subtree_bitmap(
-    ) const -> OUTCOME_V2_NAMESPACE::std_result<std::vector<bool>>;
+    [[nodiscard]] auto get_user_gen_keys_schema_subtree_bitmap() const
+            -> OUTCOME_V2_NAMESPACE::std_result<std::vector<bool>>;
 
     [[nodiscard]] auto get_utc_offset() const -> UtcOffset { return m_utc_offset; }
 
@@ -110,8 +110,8 @@ public:
      *   - Forwards `get_auto_gen_keys_schema_subtree_bitmap`'s return values on failure.
      *   - Forwards `serialize_node_id_value_pairs_to_json`'s return values on failure.
      */
-    [[nodiscard]] auto serialize_to_json(
-    ) const -> OUTCOME_V2_NAMESPACE::std_result<std::pair<nlohmann::json, nlohmann::json>>;
+    [[nodiscard]] auto serialize_to_json() const
+            -> OUTCOME_V2_NAMESPACE::std_result<std::pair<nlohmann::json, nlohmann::json>>;
 
 private:
     // Constructor

--- a/components/core/src/clp/ffi/SchemaTree.hpp
+++ b/components/core/src/clp/ffi/SchemaTree.hpp
@@ -272,8 +272,8 @@ public:
      * @return The node's ID if it exists.
      * @return std::nullopt otherwise.
      */
-    [[nodiscard]] auto try_get_node_id(NodeLocator const& locator
-    ) const -> std::optional<Node::id_t>;
+    [[nodiscard]] auto try_get_node_id(NodeLocator const& locator) const
+            -> std::optional<Node::id_t>;
 
     /**
      * @param locator

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -95,8 +95,8 @@ public:
      * - Forwards `handle_end_of_stream`'s return values from the user-defined IR unit handler on
      *   unit handling failure.
      */
-    [[nodiscard]] auto deserialize_next_ir_unit(ReaderInterface& reader
-    ) -> OUTCOME_V2_NAMESPACE::std_result<IrUnitType>;
+    [[nodiscard]] auto deserialize_next_ir_unit(ReaderInterface& reader)
+            -> OUTCOME_V2_NAMESPACE::std_result<IrUnitType>;
 
     /**
      * @return Whether the stream has completed. A stream is considered completed if an
@@ -165,8 +165,8 @@ auto Deserializer<IrUnitHandler>::create(ReaderInterface& reader, IrUnitHandler 
 
 template <IrUnitHandlerInterface IrUnitHandler>
 requires(std::move_constructible<IrUnitHandler>)
-auto Deserializer<IrUnitHandler>::deserialize_next_ir_unit(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<IrUnitType> {
+auto Deserializer<IrUnitHandler>::deserialize_next_ir_unit(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<IrUnitType> {
     if (is_stream_completed()) {
         return std::errc::operation_not_permitted;
     }

--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -82,8 +82,8 @@ private:
  * @return The corresponding schema-tree node type.
  * @return std::nullopt if the value doesn't match any of the supported schema-tree node types.
  */
-[[nodiscard]] auto get_schema_tree_node_type_from_msgpack_val(msgpack::object const& val
-) -> optional<SchemaTree::Node::Type>;
+[[nodiscard]] auto get_schema_tree_node_type_from_msgpack_val(msgpack::object const& val)
+        -> optional<SchemaTree::Node::Type>;
 
 /**
  * Serializes an empty object.
@@ -140,11 +140,9 @@ serialize_value_string(string_view val, string& logtype_buf, vector<int8_t>& out
  * @return Whether serialization succeeded.
  */
 template <typename encoded_variable_t>
-[[nodiscard]] auto serialize_value_array(
-        msgpack::object const& val,
-        string& logtype_buf,
-        vector<int8_t>& output_buf
-) -> bool;
+[[nodiscard]] auto
+serialize_value_array(msgpack::object const& val, string& logtype_buf, vector<int8_t>& output_buf)
+        -> bool;
 
 /**
  * Checks whether the given msgpack array can be serialized into the key-value pair IR format.
@@ -156,8 +154,8 @@ template <typename encoded_variable_t>
  */
 [[nodiscard]] auto is_msgpack_array_serializable(msgpack::object const& array) -> bool;
 
-auto get_schema_tree_node_type_from_msgpack_val(msgpack::object const& val
-) -> optional<SchemaTree::Node::Type> {
+auto get_schema_tree_node_type_from_msgpack_val(msgpack::object const& val)
+        -> optional<SchemaTree::Node::Type> {
     optional<SchemaTree::Node::Type> ret_val;
     switch (val.type) {
         case msgpack::type::POSITIVE_INTEGER:
@@ -231,11 +229,9 @@ auto serialize_value_string(string_view val, string& logtype_buf, vector<int8_t>
 }
 
 template <typename encoded_variable_t>
-auto serialize_value_array(
-        msgpack::object const& val,
-        string& logtype_buf,
-        vector<int8_t>& output_buf
-) -> bool {
+auto
+serialize_value_array(msgpack::object const& val, string& logtype_buf, vector<int8_t>& output_buf)
+        -> bool {
     if (false == is_msgpack_array_serializable(val)) {
         return false;
     }
@@ -289,8 +285,8 @@ auto is_msgpack_array_serializable(msgpack::object const& array) -> bool {
 }  // namespace
 
 template <typename encoded_variable_t>
-auto Serializer<encoded_variable_t>::create(
-) -> OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>> {
+auto Serializer<encoded_variable_t>::create()
+        -> OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>> {
     static_assert(
             (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
              || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
@@ -331,8 +327,8 @@ auto Serializer<encoded_variable_t>::change_utc_offset(UtcOffset utc_offset) -> 
 }
 
 template <typename encoded_variable_t>
-auto Serializer<encoded_variable_t>::serialize_msgpack_map(msgpack::object_map const& msgpack_map
-) -> bool {
+auto Serializer<encoded_variable_t>::serialize_msgpack_map(msgpack::object_map const& msgpack_map)
+        -> bool {
     if (0 == msgpack_map.size) {
         serialize_value_empty_object(m_ir_buf);
         return true;
@@ -554,15 +550,15 @@ auto Serializer<encoded_variable_t>::serialize_msgpack_map_using_dfs(
 
 // Explicitly declare template specializations so that we can define the template methods in this
 // file
-template auto Serializer<eight_byte_encoded_variable_t>::create(
-) -> OUTCOME_V2_NAMESPACE::std_result<Serializer<eight_byte_encoded_variable_t>>;
-template auto Serializer<four_byte_encoded_variable_t>::create(
-) -> OUTCOME_V2_NAMESPACE::std_result<Serializer<four_byte_encoded_variable_t>>;
+template auto Serializer<eight_byte_encoded_variable_t>::create()
+        -> OUTCOME_V2_NAMESPACE::std_result<Serializer<eight_byte_encoded_variable_t>>;
+template auto Serializer<four_byte_encoded_variable_t>::create()
+        -> OUTCOME_V2_NAMESPACE::std_result<Serializer<four_byte_encoded_variable_t>>;
 
-template auto Serializer<eight_byte_encoded_variable_t>::change_utc_offset(UtcOffset utc_offset
-) -> void;
-template auto Serializer<four_byte_encoded_variable_t>::change_utc_offset(UtcOffset utc_offset
-) -> void;
+template auto Serializer<eight_byte_encoded_variable_t>::change_utc_offset(UtcOffset utc_offset)
+        -> void;
+template auto Serializer<four_byte_encoded_variable_t>::change_utc_offset(UtcOffset utc_offset)
+        -> void;
 
 template auto Serializer<eight_byte_encoded_variable_t>::serialize_msgpack_map(
         msgpack::object_map const& msgpack_map
@@ -578,10 +574,10 @@ template auto Serializer<four_byte_encoded_variable_t>::serialize_schema_tree_no
         SchemaTree::NodeLocator const& locator
 ) -> bool;
 
-template auto Serializer<eight_byte_encoded_variable_t>::serialize_key(SchemaTree::Node::id_t id
-) -> bool;
-template auto Serializer<four_byte_encoded_variable_t>::serialize_key(SchemaTree::Node::id_t id
-) -> bool;
+template auto Serializer<eight_byte_encoded_variable_t>::serialize_key(SchemaTree::Node::id_t id)
+        -> bool;
+template auto Serializer<four_byte_encoded_variable_t>::serialize_key(SchemaTree::Node::id_t id)
+        -> bool;
 
 template auto Serializer<eight_byte_encoded_variable_t>::serialize_val(
         msgpack::object const& val,

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -42,8 +42,8 @@ public:
      * @return A result containing the serializer or an error code indicating the failure:
      * - std::errc::protocol_error on failure to serialize the preamble.
      */
-    [[nodiscard]] static auto create(
-    ) -> OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>>;
+    [[nodiscard]] static auto create()
+            -> OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>>;
 
     // Disable copy constructor/assignment operator
     Serializer(Serializer const&) = delete;
@@ -121,8 +121,8 @@ private:
      * @param msgpack_map
      * @return Whether serialization succeeded.
      */
-    [[nodiscard]] auto serialize_msgpack_map_using_dfs(msgpack::object_map const& msgpack_map
-    ) -> bool;
+    [[nodiscard]] auto serialize_msgpack_map_using_dfs(msgpack::object_map const& msgpack_map)
+            -> bool;
 
     UtcOffset m_curr_utc_offset{0};
     Buffer m_ir_buf;

--- a/components/core/src/clp/ffi/ir_stream/decoding_methods.hpp
+++ b/components/core/src/clp/ffi/ir_stream/decoding_methods.hpp
@@ -205,8 +205,8 @@ IRErrorCode deserialize_utc_offset_change(ReaderInterface& reader, UtcOffset& ut
  * @return IRProtocolErrorCode::Invalid if the protocol version does not follow the SemVer
  * specification.
  */
-[[nodiscard]] auto validate_protocol_version(std::string_view protocol_version
-) -> IRProtocolErrorCode;
+[[nodiscard]] auto validate_protocol_version(std::string_view protocol_version)
+        -> IRProtocolErrorCode;
 
 namespace eight_byte_encoding {
 /**

--- a/components/core/src/clp/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/encoding_methods.cpp
@@ -148,11 +148,8 @@ bool serialize_log_event(
     return true;
 }
 
-bool serialize_message(
-        std::string_view message,
-        std::string& logtype,
-        std::vector<int8_t>& ir_buf
-) {
+bool
+serialize_message(std::string_view message, std::string& logtype, std::vector<int8_t>& ir_buf) {
     auto encoded_var_handler = [&ir_buf](eight_byte_encoded_variable_t encoded_var) {
         ir_buf.push_back(cProtocol::Payload::VarEightByteEncoding);
         serialize_int(encoded_var, ir_buf);

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -139,7 +139,10 @@ deserialize_string(ReaderInterface& reader, encoded_tag_t tag, std::string& dese
  * @return Forwards `deserialize_encoded_text_ast`'s return values on failure.
  */
 template <typename encoded_variable_t>
-requires(std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t> || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
+requires(
+        (std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t>
+         || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
+)
 [[nodiscard]] auto deserialize_encoded_text_ast_and_insert_to_node_id_value_pairs(
         ReaderInterface& reader,
         SchemaTree::Node::id_t node_id,
@@ -394,7 +397,10 @@ auto deserialize_value_and_insert_to_node_id_value_pairs(
 }
 
 template <typename encoded_variable_t>
-requires(std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t> || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
+requires(
+        (std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t>
+         || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
+)
 [[nodiscard]] auto deserialize_encoded_text_ast_and_insert_to_node_id_value_pairs(
         ReaderInterface& reader,
         SchemaTree::Node::id_t node_id,

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -38,8 +38,8 @@ using Schema = std::vector<SchemaTree::Node::id_t>;
  * @return The corresponding schema tree node type on success.
  * @return std::nullopt if the tag doesn't match to any defined schema tree node type.
  */
-[[nodiscard]] auto schema_tree_node_tag_to_type(encoded_tag_t tag
-) -> std::optional<SchemaTree::Node::Type>;
+[[nodiscard]] auto schema_tree_node_tag_to_type(encoded_tag_t tag)
+        -> std::optional<SchemaTree::Node::Type>;
 
 /**
  * Deserializes the parent ID of a schema tree node.
@@ -52,8 +52,8 @@ using Schema = std::vector<SchemaTree::Node::id_t>;
  *   - Forwards `deserialize_tag`'s return values.
  * @return Forwards `deserialize_and_decode_schema_tree_node_id`'s return values.
  */
-[[nodiscard]] auto deserialize_schema_tree_node_parent_id(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::Node::id_t>>;
+[[nodiscard]] auto deserialize_schema_tree_node_parent_id(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::Node::id_t>>;
 
 /**
  * Deserializes the key name of a schema tree node.
@@ -63,10 +63,9 @@ using Schema = std::vector<SchemaTree::Node::id_t>;
  * @return Forwards `deserialize_tag`'s return values on failure.
  * @return Forwards `deserialize_string`'s return values on failure.
  */
-[[nodiscard]] auto deserialize_schema_tree_node_key_name(
-        ReaderInterface& reader,
-        std::string& key_name
-) -> IRErrorCode;
+[[nodiscard]] auto
+deserialize_schema_tree_node_key_name(ReaderInterface& reader, std::string& key_name)
+        -> IRErrorCode;
 
 /**
  * Deserializes an integer value packet.
@@ -78,8 +77,8 @@ using Schema = std::vector<SchemaTree::Node::id_t>;
  * @return IRErrorCode::IRErrorCode_Corrupted_IR if the given tag doesn't correspond to an integer
  * packet.
  */
-[[nodiscard]] auto
-deserialize_int_val(ReaderInterface& reader, encoded_tag_t tag, value_int_t& val) -> IRErrorCode;
+[[nodiscard]] auto deserialize_int_val(ReaderInterface& reader, encoded_tag_t tag, value_int_t& val)
+        -> IRErrorCode;
 
 /**
  * Deserializes a string packet.
@@ -91,11 +90,9 @@ deserialize_int_val(ReaderInterface& reader, encoded_tag_t tag, value_int_t& val
  * @return IRErrorCode::IRErrorCode_Corrupted_IR if the given tag doesn't correspond to a string
  * packet.
  */
-[[nodiscard]] auto deserialize_string(
-        ReaderInterface& reader,
-        encoded_tag_t tag,
-        std::string& deserialized_str
-) -> IRErrorCode;
+[[nodiscard]] auto
+deserialize_string(ReaderInterface& reader, encoded_tag_t tag, std::string& deserialized_str)
+        -> IRErrorCode;
 
 /**
  * Deserializes the IDs of all keys in a log event.
@@ -142,8 +139,7 @@ deserialize_int_val(ReaderInterface& reader, encoded_tag_t tag, value_int_t& val
  * @return Forwards `deserialize_encoded_text_ast`'s return values on failure.
  */
 template <typename encoded_variable_t>
-requires(std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t>
-         || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
+requires(std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t> || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
 [[nodiscard]] auto deserialize_encoded_text_ast_and_insert_to_node_id_value_pairs(
         ReaderInterface& reader,
         SchemaTree::Node::id_t node_id,
@@ -202,8 +198,8 @@ auto schema_tree_node_tag_to_type(encoded_tag_t tag) -> std::optional<SchemaTree
     }
 }
 
-auto deserialize_schema_tree_node_parent_id(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::Node::id_t>> {
+auto deserialize_schema_tree_node_parent_id(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::Node::id_t>> {
     encoded_tag_t tag{};
     if (auto const err{deserialize_tag(reader, tag)}; IRErrorCode::IRErrorCode_Success != err) {
         return ir_error_code_to_errc(err);
@@ -398,8 +394,7 @@ auto deserialize_value_and_insert_to_node_id_value_pairs(
 }
 
 template <typename encoded_variable_t>
-requires(std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t>
-         || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
+requires(std::is_same_v<ir::four_byte_encoded_variable_t, encoded_variable_t> || std::is_same_v<ir::eight_byte_encoded_variable_t, encoded_variable_t>)
 [[nodiscard]] auto deserialize_encoded_text_ast_and_insert_to_node_id_value_pairs(
         ReaderInterface& reader,
         SchemaTree::Node::id_t node_id,
@@ -537,8 +532,8 @@ auto deserialize_ir_unit_schema_tree_node_insertion(
     return SchemaTree::NodeLocator{parent_id, key_name, type.value()};
 }
 
-auto deserialize_ir_unit_utc_offset_change(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<UtcOffset> {
+auto deserialize_ir_unit_utc_offset_change(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<UtcOffset> {
     UtcOffset utc_offset{0};
     if (auto const err{deserialize_utc_offset_change(reader, utc_offset)};
         IRErrorCode::IRErrorCode_Success != err)

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
@@ -50,8 +50,8 @@ namespace clp::ffi::ir_stream {
  * - std::errc::result_out_of_range if the IR stream is truncated.
  * - Forwards `clp::ffi::ir_stream::deserialize_utc_offset_change`'s return values.
  */
-[[nodiscard]] auto deserialize_ir_unit_utc_offset_change(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<UtcOffset>;
+[[nodiscard]] auto deserialize_ir_unit_utc_offset_change(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<UtcOffset>;
 
 /**
  * Deserializes a key-value pair log event IR unit.

--- a/components/core/src/clp/ffi/ir_stream/utils.hpp
+++ b/components/core/src/clp/ffi/ir_stream/utils.hpp
@@ -29,8 +29,8 @@ namespace clp::ffi::ir_stream {
  * @param output_buf
  * @return Whether serialization succeeded.
  */
-[[nodiscard]] auto
-serialize_metadata(nlohmann::json& metadata, std::vector<int8_t>& output_buf) -> bool;
+[[nodiscard]] auto serialize_metadata(nlohmann::json& metadata, std::vector<int8_t>& output_buf)
+        -> bool;
 
 /**
  * Serializes the given integer into the IR stream.
@@ -60,11 +60,9 @@ template <IntegerType integer_t>
  * @return Whether serialization succeeded.
  */
 template <typename encoded_variable_t>
-[[nodiscard]] auto serialize_clp_string(
-        std::string_view str,
-        std::string& logtype,
-        std::vector<int8_t>& output_buf
-) -> bool;
+[[nodiscard]] auto
+serialize_clp_string(std::string_view str, std::string& logtype, std::vector<int8_t>& output_buf)
+        -> bool;
 
 /**
  * Serializes a string.
@@ -173,11 +171,9 @@ auto deserialize_int(ReaderInterface& reader, integer_t& value) -> bool {
 }
 
 template <typename encoded_variable_t>
-[[nodiscard]] auto serialize_clp_string(
-        std::string_view str,
-        std::string& logtype,
-        std::vector<int8_t>& output_buf
-) -> bool {
+[[nodiscard]] auto
+serialize_clp_string(std::string_view str, std::string& logtype, std::vector<int8_t>& output_buf)
+        -> bool {
     static_assert(
             (std::is_same_v<encoded_variable_t, clp::ir::eight_byte_encoded_variable_t>
              || std::is_same_v<encoded_variable_t, clp::ir::four_byte_encoded_variable_t>)

--- a/components/core/src/clp/ffi/search/query_methods.cpp
+++ b/components/core/src/clp/ffi/search/query_methods.cpp
@@ -66,10 +66,8 @@ static void tokenize_query(
 );
 
 template <typename encoded_variable_t>
-void generate_subqueries(
-        string_view wildcard_query,
-        vector<Subquery<encoded_variable_t>>& sub_queries
-) {
+void
+generate_subqueries(string_view wildcard_query, vector<Subquery<encoded_variable_t>>& sub_queries) {
     if (wildcard_query.empty()) {
         throw QueryMethodFailed(
                 ErrorCode_BadParam,

--- a/components/core/src/clp/ffi/utils.hpp
+++ b/components/core/src/clp/ffi/utils.hpp
@@ -13,8 +13,8 @@ namespace clp::ffi {
  * @return The escaped string on success.
  * @return std::nullopt if the string contains any non-UTF-8-encoded byte sequences.
  */
-[[nodiscard]] auto validate_and_escape_utf8_string(std::string_view raw
-) -> std::optional<std::string>;
+[[nodiscard]] auto validate_and_escape_utf8_string(std::string_view raw)
+        -> std::optional<std::string>;
 
 /**
  * Validates whether `src` is UTF-8 encoded, and appends `src` to `dst` while escaping any
@@ -24,8 +24,8 @@ namespace clp::ffi {
  * @return Whether `src` is a valid UTF-8-encoded string. NOTE: Even if `src` is not UTF-8 encoded,
  * `dst` may be modified.
  */
-[[nodiscard]] auto
-validate_and_append_escaped_utf8_string(std::string_view src, std::string& dst) -> bool;
+[[nodiscard]] auto validate_and_append_escaped_utf8_string(std::string_view src, std::string& dst)
+        -> bool;
 }  // namespace clp::ffi
 
 #endif  // CLP_FFI_UTILS_HPP

--- a/components/core/src/clp/hash_utils.hpp
+++ b/components/core/src/clp/hash_utils.hpp
@@ -69,9 +69,8 @@ private:
  * @return Same as `EvpDigestContext::digest_final` if `EvpDigestContext::digest_final` fails.
  * @throw HashUtilsOperationFailed if an OpenSSL EVP digest couldn't be created.
  */
-[[nodiscard]] auto get_sha256_hash(
-        std::span<unsigned char const> input,
-        std::vector<unsigned char>& hash
-) -> ErrorCode;
+[[nodiscard]] auto
+get_sha256_hash(std::span<unsigned char const> input, std::vector<unsigned char>& hash)
+        -> ErrorCode;
 }  // namespace clp
 #endif  // CLP_HASH_UTILS_HPP

--- a/components/core/src/clp/ir/EncodedTextAst.cpp
+++ b/components/core/src/clp/ir/EncodedTextAst.cpp
@@ -50,8 +50,8 @@ auto EncodedTextAst<encoded_variable_t>::decode_and_unparse() const -> optional<
 
 // Explicitly declare template specializations so that we can define the template methods in this
 // file
-template auto EncodedTextAst<eight_byte_encoded_variable_t>::decode_and_unparse(
-) const -> optional<string>;
-template auto EncodedTextAst<four_byte_encoded_variable_t>::decode_and_unparse(
-) const -> optional<string>;
+template auto EncodedTextAst<eight_byte_encoded_variable_t>::decode_and_unparse() const
+        -> optional<string>;
+template auto EncodedTextAst<four_byte_encoded_variable_t>::decode_and_unparse() const
+        -> optional<string>;
 }  // namespace clp::ir

--- a/components/core/src/clp/ir/LogEventDeserializer.cpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.cpp
@@ -13,8 +13,8 @@
 
 namespace clp::ir {
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
     ffi::ir_stream::encoded_tag_t metadata_type{0};
     std::vector<int8_t> metadata;
     auto ir_error_code = ffi::ir_stream::deserialize_preamble(reader, metadata_type, metadata);
@@ -69,8 +69,8 @@ auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader
 }
 
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event(
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event()
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
     // Process any packets before the log event
     ffi::ir_stream::encoded_tag_t tag{};
     while (true) {
@@ -134,12 +134,12 @@ auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event(
 
 // Explicitly declare template specializations so that we can define the template methods in this
 // file
-template auto LogEventDeserializer<eight_byte_encoded_variable_t>::create(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<eight_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<four_byte_encoded_variable_t>::create(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<four_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event(
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event(
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<eight_byte_encoded_variable_t>::create(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<eight_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<four_byte_encoded_variable_t>::create(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<four_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event()
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event()
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
 }  // namespace clp::ir

--- a/components/core/src/clp/ir/LogEventDeserializer.hpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.hpp
@@ -34,8 +34,8 @@ public:
      * - std::errc::protocol_not_supported if the IR stream contains an unsupported metadata format
      *   or uses an unsupported version
      */
-    static auto create(ReaderInterface& reader
-    ) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
+    static auto create(ReaderInterface& reader)
+            -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
 
     // Delete copy constructor and assignment
     LogEventDeserializer(LogEventDeserializer const&) = delete;
@@ -61,8 +61,8 @@ public:
      * - std::errc::result_out_of_range if the IR stream is truncated
      * - std::errc::protocol_error if the IR stream is corrupted
      */
-    [[nodiscard]] auto deserialize_log_event(
-    ) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
+    [[nodiscard]] auto deserialize_log_event()
+            -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
 
 private:
     // Constructors

--- a/components/core/src/clp/ir/LogEventSerializer.cpp
+++ b/components/core/src/clp/ir/LogEventSerializer.cpp
@@ -139,10 +139,10 @@ auto LogEventSerializer<encoded_variable_t>::close_writer() -> void {
 // file
 template LogEventSerializer<eight_byte_encoded_variable_t>::~LogEventSerializer();
 template LogEventSerializer<four_byte_encoded_variable_t>::~LogEventSerializer();
-template auto LogEventSerializer<eight_byte_encoded_variable_t>::open(string const& file_path
-) -> bool;
-template auto LogEventSerializer<four_byte_encoded_variable_t>::open(string const& file_path
-) -> bool;
+template auto LogEventSerializer<eight_byte_encoded_variable_t>::open(string const& file_path)
+        -> bool;
+template auto LogEventSerializer<four_byte_encoded_variable_t>::open(string const& file_path)
+        -> bool;
 template auto LogEventSerializer<eight_byte_encoded_variable_t>::flush() -> void;
 template auto LogEventSerializer<four_byte_encoded_variable_t>::flush() -> void;
 template auto LogEventSerializer<eight_byte_encoded_variable_t>::close() -> void;

--- a/components/core/src/clp/ir/LogEventSerializer.hpp
+++ b/components/core/src/clp/ir/LogEventSerializer.hpp
@@ -87,8 +87,8 @@ public:
      * Serializes the given log event.
      * @return Whether the log event was successfully serialized.
      */
-    [[nodiscard]] auto
-    serialize_log_event(epoch_time_ms_t timestamp, std::string_view message) -> bool;
+    [[nodiscard]] auto serialize_log_event(epoch_time_ms_t timestamp, std::string_view message)
+            -> bool;
 
 private:
     // Constants

--- a/components/core/src/clp/regex_utils/RegexToWildcardTranslatorConfig.hpp
+++ b/components/core/src/clp/regex_utils/RegexToWildcardTranslatorConfig.hpp
@@ -16,7 +16,7 @@ public:
             bool add_prefix_suffix_wildcards
     )
             : m_case_insensitive_wildcard{case_insensitive_wildcard},
-              m_add_prefix_suffix_wildcards{add_prefix_suffix_wildcards} {};
+              m_add_prefix_suffix_wildcards{add_prefix_suffix_wildcards} {}
 
     /**
      * @return True if the final translated wildcard string will be fed into a case-insensitive

--- a/components/core/src/clp/regex_utils/constants.hpp
+++ b/components/core/src/clp/regex_utils/constants.hpp
@@ -14,8 +14,8 @@ constexpr size_t cCharBitarraySize = 128;
  * @param char_str A string that contains the characters to look up.
  * @return The lookup table as bit array.
  */
-[[nodiscard]] constexpr auto create_char_bit_array(std::string_view char_str
-) -> std::array<bool, cCharBitarraySize> {
+[[nodiscard]] constexpr auto create_char_bit_array(std::string_view char_str)
+        -> std::array<bool, cCharBitarraySize> {
     std::array<bool, cCharBitarraySize> bit_array{};
     bit_array.fill(false);
     for (auto const ch : char_str) {

--- a/components/core/src/clp/regex_utils/regex_translation_utils.hpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.hpp
@@ -17,8 +17,8 @@ namespace clp::regex_utils {
  * @param regex_str The regex string to be translated.
  * @return The translated wildcard string.
  */
-[[nodiscard]] auto regex_to_wildcard(std::string_view regex_str
-) -> OUTCOME_V2_NAMESPACE::std_result<std::string>;
+[[nodiscard]] auto regex_to_wildcard(std::string_view regex_str)
+        -> OUTCOME_V2_NAMESPACE::std_result<std::string>;
 
 /**
  * Translate a given regex string to wildcard with a custom configuration.
@@ -26,10 +26,9 @@ namespace clp::regex_utils {
  * @param regex_str The regex string to be translated.
  * @return The translated wildcard string.
  */
-[[nodiscard]] auto regex_to_wildcard(
-        std::string_view regex_str,
-        RegexToWildcardTranslatorConfig const& config
-) -> OUTCOME_V2_NAMESPACE::std_result<std::string>;
+[[nodiscard]] auto
+regex_to_wildcard(std::string_view regex_str, RegexToWildcardTranslatorConfig const& config)
+        -> OUTCOME_V2_NAMESPACE::std_result<std::string>;
 
 }  // namespace clp::regex_utils
 

--- a/components/core/src/clp/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/reader/Archive.cpp
@@ -161,11 +161,8 @@ bool Archive::get_next_message(File& file, Message& msg) {
     return file.get_next_message(msg);
 }
 
-bool Archive::decompress_message(
-        File& file,
-        Message const& compressed_msg,
-        string& decompressed_msg
-) {
+bool
+Archive::decompress_message(File& file, Message const& compressed_msg, string& decompressed_msg) {
     if (false == decompress_message_without_ts(compressed_msg, decompressed_msg)) {
         return false;
     }
@@ -198,10 +195,8 @@ bool Archive::decompress_message(
     return true;
 }
 
-bool Archive::decompress_message_without_ts(
-        Message const& compressed_msg,
-        string& decompressed_msg
-) {
+bool
+Archive::decompress_message_without_ts(Message const& compressed_msg, string& decompressed_msg) {
     decompressed_msg.clear();
 
     // Build original message content

--- a/components/core/src/clp/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/clp/streaming_archive/reader/Segment.hpp
@@ -20,7 +20,7 @@ namespace clp::streaming_archive::reader {
 class Segment {
 public:
     // Constructor
-    Segment() : m_segment_path({}) {};
+    Segment() : m_segment_path({}) {}
 
     // Destructor
     ~Segment();

--- a/components/core/src/clp/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.cpp
@@ -289,11 +289,8 @@ void Archive::change_ts_pattern(TimestampPattern const* pattern) {
     m_file->change_ts_pattern(pattern);
 }
 
-void Archive::write_msg(
-        epochtime_t timestamp,
-        string const& message,
-        size_t num_uncompressed_bytes
-) {
+void
+Archive::write_msg(epochtime_t timestamp, string const& message, size_t num_uncompressed_bytes) {
     // Encode message and add components to dictionaries
     vector<encoded_variable_t> encoded_vars;
     vector<variable_dictionary_id_t> var_ids;

--- a/components/core/src/clp/utf8_utils.hpp
+++ b/components/core/src/clp/utf8_utils.hpp
@@ -89,8 +89,8 @@ namespace utf8_utils_internal {
  * @param continuation_byte
  * @return The updated code point.
  */
-[[nodiscard]] auto
-parse_continuation_byte(uint32_t code_point, uint8_t continuation_byte) -> uint32_t;
+[[nodiscard]] auto parse_continuation_byte(uint32_t code_point, uint8_t continuation_byte)
+        -> uint32_t;
 }  // namespace utf8_utils_internal
 
 template <typename EscapeHandler>

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -218,11 +218,8 @@ void ArchiveWriter::write_archive_header(FileWriter& archive_writer, size_t meta
     archive_writer.write(reinterpret_cast<char const*>(&header), sizeof(header));
 }
 
-void ArchiveWriter::append_message(
-        int32_t schema_id,
-        Schema const& schema,
-        ParsedMessage& message
-) {
+void
+ArchiveWriter::append_message(int32_t schema_id, Schema const& schema, ParsedMessage& message) {
     SchemaWriter* schema_writer;
     auto it = m_id_to_schema_writer.find(schema_id);
     if (it != m_id_to_schema_writer.end()) {

--- a/components/core/src/clp_s/ColumnReader.cpp
+++ b/components/core/src/clp_s/ColumnReader.cpp
@@ -19,10 +19,8 @@ void FloatColumnReader::load(BufferViewReader& reader, uint64_t num_messages) {
     m_values = reader.read_unaligned_span<double>(num_messages);
 }
 
-void Int64ColumnReader::extract_string_value_into_buffer(
-        uint64_t cur_message,
-        std::string& buffer
-) {
+void
+Int64ColumnReader::extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) {
     buffer.append(std::to_string(m_values[cur_message]));
 }
 
@@ -36,10 +34,8 @@ void BooleanColumnReader::load(BufferViewReader& reader, uint64_t num_messages) 
     m_values = reader.read_unaligned_span<uint8_t>(num_messages);
 }
 
-void FloatColumnReader::extract_string_value_into_buffer(
-        uint64_t cur_message,
-        std::string& buffer
-) {
+void
+FloatColumnReader::extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) {
     buffer.append(std::to_string(m_values[cur_message]));
 }
 
@@ -55,10 +51,8 @@ void ClpStringColumnReader::load(BufferViewReader& reader, uint64_t num_messages
     m_encoded_vars = reader.read_unaligned_span<int64_t>(encoded_vars_length);
 }
 
-void BooleanColumnReader::extract_string_value_into_buffer(
-        uint64_t cur_message,
-        std::string& buffer
-) {
+void
+BooleanColumnReader::extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) {
     buffer.append(0 == m_values[cur_message] ? "false" : "true");
 }
 
@@ -70,10 +64,8 @@ std::variant<int64_t, double, std::string, uint8_t> ClpStringColumnReader::extra
     return message;
 }
 
-void ClpStringColumnReader::extract_string_value_into_buffer(
-        uint64_t cur_message,
-        std::string& buffer
-) {
+void
+ClpStringColumnReader::extract_string_value_into_buffer(uint64_t cur_message, std::string& buffer) {
     auto value = m_logtypes[cur_message];
     int64_t logtype_id = ClpStringColumnWriter::get_encoded_log_dict_id(value);
     auto& entry = m_log_dict->get_entry(logtype_id);

--- a/components/core/src/clp_s/DictionaryEntry.cpp
+++ b/components/core/src/clp_s/DictionaryEntry.cpp
@@ -125,11 +125,8 @@ LogTypeDictionaryEntry::try_read_from_file(ZstdDecompressor& decompressor, uint6
     return error_code;
 }
 
-void LogTypeDictionaryEntry::read_from_file(
-        ZstdDecompressor& decompressor,
-        uint64_t id,
-        bool lazy
-) {
+void
+LogTypeDictionaryEntry::read_from_file(ZstdDecompressor& decompressor, uint64_t id, bool lazy) {
     auto error_code = try_read_from_file(decompressor, id, lazy);
     if (ErrorCodeSuccess != error_code) {
         throw OperationFailed(error_code, __FILENAME__, __LINE__);
@@ -244,11 +241,8 @@ ErrorCode VariableDictionaryEntry::try_read_from_file(ZstdDecompressor& decompre
     return error_code;
 }
 
-void VariableDictionaryEntry::read_from_file(
-        ZstdDecompressor& decompressor,
-        uint64_t id,
-        bool lazy
-) {
+void
+VariableDictionaryEntry::read_from_file(ZstdDecompressor& decompressor, uint64_t id, bool lazy) {
     auto error_code = try_read_from_file(decompressor, id);
     if (ErrorCodeSuccess != error_code) {
         throw OperationFailed(error_code, __FILENAME__, __LINE__);

--- a/components/core/src/clp_s/DictionaryWriter.cpp
+++ b/components/core/src/clp_s/DictionaryWriter.cpp
@@ -35,10 +35,8 @@ bool VariableDictionaryWriter::add_entry(std::string const& value, uint64_t& id)
     return new_entry;
 }
 
-bool LogTypeDictionaryWriter::add_entry(
-        LogTypeDictionaryEntry& logtype_entry,
-        uint64_t& logtype_id
-) {
+bool
+LogTypeDictionaryWriter::add_entry(LogTypeDictionaryEntry& logtype_entry, uint64_t& logtype_id) {
     bool is_new_entry = false;
 
     std::string const& value = logtype_entry.get_value();

--- a/components/core/src/clp_s/InputConfig.hpp
+++ b/components/core/src/clp_s/InputConfig.hpp
@@ -89,8 +89,8 @@ get_input_archives_for_raw_path(std::string_view const path, std::vector<Path>& 
  * @param archives Returned archives
  * @return true on success, false otherwise
  */
-[[nodiscard]] auto
-get_input_archives_for_path(Path const& path, std::vector<Path>& archives) -> bool;
+[[nodiscard]] auto get_input_archives_for_path(Path const& path, std::vector<Path>& archives)
+        -> bool;
 
 /**
  * Determines the archive id of an archive based on the archive path.
@@ -98,8 +98,8 @@ get_input_archives_for_path(Path const& path, std::vector<Path>& archives) -> bo
  * @param archive_id Returned archive id
  * @return true on success, false otherwise
  */
-[[nodiscard]] auto
-get_archive_id_from_path(Path const& archive_path, std::string& archive_id) -> bool;
+[[nodiscard]] auto get_archive_id_from_path(Path const& archive_path, std::string& archive_id)
+        -> bool;
 }  // namespace clp_s
 
 #endif  // CLP_S_INPUTCONFIG_HPP

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -64,8 +64,8 @@ public:
         return IRErrorCode::IRErrorCode_Success;
     }
 
-    [[nodiscard]] auto get_deserialized_log_event(
-    ) const -> std::optional<KeyValuePairLogEvent> const& {
+    [[nodiscard]] auto get_deserialized_log_event() const
+            -> std::optional<KeyValuePairLogEvent> const& {
         return m_deserialized_log_event;
     }
 

--- a/components/core/src/clp_s/PackedStreamReader.cpp
+++ b/components/core/src/clp_s/PackedStreamReader.cpp
@@ -69,11 +69,8 @@ void PackedStreamReader::close() {
     m_state = PackedStreamReaderState::Uninitialized;
 }
 
-void PackedStreamReader::read_stream(
-        size_t stream_id,
-        std::shared_ptr<char[]>& buf,
-        size_t& buf_size
-) {
+void
+PackedStreamReader::read_stream(size_t stream_id, std::shared_ptr<char[]>& buf, size_t& buf_size) {
     constexpr size_t cDecompressorFileReadBufferCapacity = 64 * 1024;  // 64 KB
     if (stream_id >= m_stream_metadata.size()) {
         throw OperationFailed(ErrorCodeCorrupt, __FILE__, __LINE__);

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -44,11 +44,8 @@ int64_t SchemaReader::get_next_log_event_idx() const {
     return 0;
 }
 
-void SchemaReader::load(
-        std::shared_ptr<char[]> stream_buffer,
-        size_t offset,
-        size_t uncompressed_size
-) {
+void
+SchemaReader::load(std::shared_ptr<char[]> stream_buffer, size_t offset, size_t uncompressed_size) {
     m_stream_buffer = stream_buffer;
     BufferViewReader buffer_reader{m_stream_buffer.get() + offset, uncompressed_size};
     for (auto& reader : m_columns) {

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -89,11 +89,8 @@ epochtime_t TimestampDictionaryWriter::ingest_entry(
     return ret;
 }
 
-void TimestampDictionaryWriter::ingest_entry(
-        std::string_view key,
-        int32_t node_id,
-        double timestamp
-) {
+void
+TimestampDictionaryWriter::ingest_entry(std::string_view key, int32_t node_id, double timestamp) {
     auto entry = m_column_id_to_range.find(node_id);
     if (entry == m_column_id_to_range.end()) {
         TimestampEntry new_entry(key);
@@ -104,11 +101,8 @@ void TimestampDictionaryWriter::ingest_entry(
     }
 }
 
-void TimestampDictionaryWriter::ingest_entry(
-        std::string_view key,
-        int32_t node_id,
-        int64_t timestamp
-) {
+void
+TimestampDictionaryWriter::ingest_entry(std::string_view key, int32_t node_id, int64_t timestamp) {
     auto entry = m_column_id_to_range.find(node_id);
     if (entry == m_column_id_to_range.end()) {
         TimestampEntry new_entry(key);

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -361,11 +361,8 @@ bool StringUtils::advance_tame_to_next_match(
     return true;
 }
 
-bool StringUtils::wildcard_match_unsafe(
-        string_view tame,
-        string_view wild,
-        bool case_sensitive_match
-) {
+bool
+StringUtils::wildcard_match_unsafe(string_view tame, string_view wild, bool case_sensitive_match) {
     if (case_sensitive_match) {
         return wildcard_match_unsafe_case_sensitive(tame, wild);
     } else {

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -320,7 +320,8 @@ template <typename T>
 class UnalignedMemSpan {
 public:
     UnalignedMemSpan() = default;
-    UnalignedMemSpan(char* begin, size_t size) : m_begin(begin), m_size(size) {};
+
+    UnalignedMemSpan(char* begin, size_t size) : m_begin(begin), m_size(size) {}
 
     size_t size() { return m_size; }
 

--- a/components/core/src/clp_s/search/BooleanLiteral.hpp
+++ b/components/core/src/clp_s/search/BooleanLiteral.hpp
@@ -51,7 +51,7 @@ private:
     // Constructors
     BooleanLiteral() = default;
 
-    explicit BooleanLiteral(bool v) : m_v(v) {};
+    explicit BooleanLiteral(bool v) : m_v(v) {}
 };
 }  // namespace clp_s::search
 

--- a/components/core/src/clp_s/search/OutputHandler.hpp
+++ b/components/core/src/clp_s/search/OutputHandler.hpp
@@ -32,7 +32,7 @@ public:
     // Constructors
     explicit OutputHandler(bool should_output_metadata, bool should_marshal_records)
             : m_should_output_metadata(should_output_metadata),
-              m_should_marshal_records(should_marshal_records) {};
+              m_should_marshal_records(should_marshal_records) {}
 
     // Destructor
     virtual ~OutputHandler() = default;

--- a/components/core/src/glt/BufferReader.cpp
+++ b/components/core/src/glt/BufferReader.cpp
@@ -86,12 +86,9 @@ auto BufferReader::try_get_pos(size_t& pos) -> ErrorCode {
     return ErrorCode_Success;
 }
 
-auto BufferReader::try_read_to_delimiter(
-        char delim,
-        bool keep_delimiter,
-        bool append,
-        std::string& str
-) -> ErrorCode {
+auto
+BufferReader::try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
+        -> ErrorCode {
     if (false == append) {
         str.clear();
     }

--- a/components/core/src/glt/BufferReader.hpp
+++ b/components/core/src/glt/BufferReader.hpp
@@ -63,8 +63,8 @@ public:
      * @return ErrorCode_EndOfFile if the buffer doesn't contain any more data
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override;
 
     /**
      * Tries to seek to the given position, relative to the beginning of the buffer
@@ -88,12 +88,9 @@ public:
      * @param str Returns the content read from the buffer
      * @return Same as BufferReader::try_read_to_delimiter(char, bool, std::string&, bool&, size_t&)
      */
-    [[nodiscard]] auto try_read_to_delimiter(
-            char delim,
-            bool keep_delimiter,
-            bool append,
-            std::string& str
-    ) -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
+            -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/glt/BufferedFileReader.cpp
+++ b/components/core/src/glt/BufferedFileReader.cpp
@@ -265,12 +265,9 @@ auto BufferedFileReader::try_read(char* buf, size_t num_bytes_to_read, size_t& n
     return ErrorCode_Success;
 }
 
-auto BufferedFileReader::try_read_to_delimiter(
-        char delim,
-        bool keep_delimiter,
-        bool append,
-        string& str
-) -> ErrorCode {
+auto
+BufferedFileReader::try_read_to_delimiter(char delim, bool keep_delimiter, bool append, string& str)
+        -> ErrorCode {
     if (-1 == m_fd) {
         return ErrorCode_NotInit;
     }

--- a/components/core/src/glt/BufferedFileReader.hpp
+++ b/components/core/src/glt/BufferedFileReader.hpp
@@ -127,8 +127,8 @@ public:
      * @return ErrorCode_NotInit if the file is not opened
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_peek_buffered_data(char const*& buf, size_t& peek_size) const -> ErrorCode;
+    [[nodiscard]] auto try_peek_buffered_data(char const*& buf, size_t& peek_size) const
+            -> ErrorCode;
 
     /**
      * Peeks the remaining buffered content without advancing the read head.
@@ -191,8 +191,8 @@ public:
      * @return ErrorCode_EndOfFile on EOF
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto
-    try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read) -> ErrorCode override;
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override;
 
     /**
      * Tries to read up to an occurrence of the given delimiter
@@ -206,12 +206,9 @@ public:
      * @return Same as BufferReader::try_read_to_delimiter if it fails
      * @return ErrorCode_Success on success
      */
-    [[nodiscard]] auto try_read_to_delimiter(
-            char delim,
-            bool keep_delimiter,
-            bool append,
-            std::string& str
-    ) -> ErrorCode override;
+    [[nodiscard]] auto
+    try_read_to_delimiter(char delim, bool keep_delimiter, bool append, std::string& str)
+            -> ErrorCode override;
 
 private:
     // Methods

--- a/components/core/src/glt/Grep.cpp
+++ b/components/core/src/glt/Grep.cpp
@@ -716,10 +716,8 @@ bool Grep::get_bounds_of_next_potential_var(
     return (value_length != begin_pos);
 }
 
-void Grep::calculate_sub_queries_relevant_to_file(
-        File const& compressed_file,
-        vector<Query>& queries
-) {
+void
+Grep::calculate_sub_queries_relevant_to_file(File const& compressed_file, vector<Query>& queries) {
     for (auto& query : queries) {
         query.make_sub_queries_relevant_to_segment(compressed_file.get_segment_id());
     }

--- a/components/core/src/glt/ffi/search/query_methods.cpp
+++ b/components/core/src/glt/ffi/search/query_methods.cpp
@@ -66,10 +66,8 @@ static void tokenize_query(
 );
 
 template <typename encoded_variable_t>
-void generate_subqueries(
-        string_view wildcard_query,
-        vector<Subquery<encoded_variable_t>>& sub_queries
-) {
+void
+generate_subqueries(string_view wildcard_query, vector<Subquery<encoded_variable_t>>& sub_queries) {
     if (wildcard_query.empty()) {
         throw QueryMethodFailed(
                 ErrorCode_BadParam,

--- a/components/core/src/glt/ir/LogEventDeserializer.cpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.cpp
@@ -11,8 +11,8 @@
 
 namespace glt::ir {
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>> {
     ffi::ir_stream::encoded_tag_t metadata_type{0};
     std::vector<int8_t> metadata;
     auto ir_error_code = ffi::ir_stream::deserialize_preamble(reader, metadata_type, metadata);
@@ -67,8 +67,8 @@ auto LogEventDeserializer<encoded_variable_t>::create(ReaderInterface& reader
 }
 
 template <typename encoded_variable_t>
-auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event(
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
+auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event()
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>> {
     epoch_time_ms_t timestamp_or_timestamp_delta{};
     std::string logtype;
     std::vector<std::string> dict_vars;
@@ -106,12 +106,12 @@ auto LogEventDeserializer<encoded_variable_t>::deserialize_log_event(
 
 // Explicitly declare template specializations so that we can define the template methods in this
 // file
-template auto LogEventDeserializer<eight_byte_encoded_variable_t>::create(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<eight_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<four_byte_encoded_variable_t>::create(ReaderInterface& reader
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<four_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event(
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
-template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event(
-) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<eight_byte_encoded_variable_t>::create(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<eight_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<four_byte_encoded_variable_t>::create(ReaderInterface& reader)
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<four_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<eight_byte_encoded_variable_t>::deserialize_log_event()
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<eight_byte_encoded_variable_t>>;
+template auto LogEventDeserializer<four_byte_encoded_variable_t>::deserialize_log_event()
+        -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<four_byte_encoded_variable_t>>;
 }  // namespace glt::ir

--- a/components/core/src/glt/ir/LogEventDeserializer.hpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.hpp
@@ -33,8 +33,8 @@ public:
      * - std::errc::protocol_not_supported if the IR stream contains an unsupported metadata format
      *   or uses an unsupported version
      */
-    static auto create(ReaderInterface& reader
-    ) -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
+    static auto create(ReaderInterface& reader)
+            -> OUTCOME_V2_NAMESPACE::std_result<LogEventDeserializer<encoded_variable_t>>;
 
     // Delete copy constructor and assignment
     LogEventDeserializer(LogEventDeserializer const&) = delete;
@@ -58,8 +58,8 @@ public:
      * - std::errc::result_out_of_range if the IR stream is truncated
      * - std::errc::result_out_of_range if the IR stream is corrupted
      */
-    [[nodiscard]] auto deserialize_log_event(
-    ) -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
+    [[nodiscard]] auto deserialize_log_event()
+            -> OUTCOME_V2_NAMESPACE::std_result<LogEvent<encoded_variable_t>>;
 
 private:
     // Constructors

--- a/components/core/src/glt/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/glt/streaming_archive/reader/Archive.cpp
@@ -183,11 +183,8 @@ bool Archive::get_next_message(File& file, Message& msg) {
     return file.get_next_message(msg);
 }
 
-bool Archive::decompress_message(
-        File& file,
-        Message const& compressed_msg,
-        string& decompressed_msg
-) {
+bool
+Archive::decompress_message(File& file, Message const& compressed_msg, string& decompressed_msg) {
     decompressed_msg.clear();
 
     // Build original message content

--- a/components/core/src/glt/streaming_archive/reader/LogtypeTableManager.hpp
+++ b/components/core/src/glt/streaming_archive/reader/LogtypeTableManager.hpp
@@ -25,7 +25,7 @@ public:
         }
     };
 
-    LogtypeTableManager() : m_is_open(false) {};
+    LogtypeTableManager() : m_is_open(false) {}
 
     /**
      * Open the concated variable segment file and metadata associated with the segment

--- a/components/core/src/glt/streaming_archive/reader/Message.cpp
+++ b/components/core/src/glt/streaming_archive/reader/Message.cpp
@@ -54,11 +54,8 @@ void Message::resize_var(size_t var_size) {
     m_vars.resize(var_size);
 }
 
-void Message::load_vars_from(
-        std::vector<encoded_variable_t> const& vars,
-        size_t count,
-        size_t offset
-) {
+void
+Message::load_vars_from(std::vector<encoded_variable_t> const& vars, size_t count, size_t offset) {
     for (size_t var_ix = 0; var_ix < count; var_ix++) {
         m_vars.at(var_ix) = vars.at(var_ix + offset);
     }

--- a/components/core/src/glt/streaming_archive/reader/Segment.hpp
+++ b/components/core/src/glt/streaming_archive/reader/Segment.hpp
@@ -20,7 +20,7 @@ namespace glt::streaming_archive::reader {
 class Segment {
 public:
     // Constructor
-    Segment() : m_segment_path({}) {};
+    Segment() : m_segment_path({}) {}
 
     // Destructor
     ~Segment();

--- a/components/core/src/glt/streaming_archive/reader/SingleLogtypeTableManager.hpp
+++ b/components/core/src/glt/streaming_archive/reader/SingleLogtypeTableManager.hpp
@@ -11,7 +11,8 @@
 namespace glt::streaming_archive::reader {
 class SingleLogtypeTableManager : public streaming_archive::reader::LogtypeTableManager {
 public:
-    SingleLogtypeTableManager() : m_logtype_table_loaded(false) {};
+    SingleLogtypeTableManager() : m_logtype_table_loaded(false) {}
+
     void open_logtype_table(logtype_dictionary_id_t logtype_id);
     void close_logtype_table();
 

--- a/components/core/src/glt/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/glt/streaming_archive/writer/Archive.cpp
@@ -276,11 +276,8 @@ void Archive::change_ts_pattern(TimestampPattern const* pattern) {
     m_file->change_ts_pattern(pattern);
 }
 
-void Archive::write_msg(
-        epochtime_t timestamp,
-        string const& message,
-        size_t num_uncompressed_bytes
-) {
+void
+Archive::write_msg(epochtime_t timestamp, string const& message, size_t num_uncompressed_bytes) {
     // Encode message and add components to dictionaries
     vector<encoded_variable_t> encoded_vars;
     vector<variable_dictionary_id_t> var_ids;

--- a/components/core/src/reducer/Pipeline.hpp
+++ b/components/core/src/reducer/Pipeline.hpp
@@ -21,7 +21,7 @@ enum class PipelineInputMode : uint8_t {
  */
 class Pipeline {
 public:
-    explicit Pipeline(PipelineInputMode input_mode) : m_input_mode{input_mode} {};
+    explicit Pipeline(PipelineInputMode input_mode) : m_input_mode{input_mode} {}
 
     void push_record(Record const& record);
     void push_record_group(GroupTags const& tags, ConstRecordIterator& record_it);

--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -47,8 +47,8 @@ auto get_content(clp::ReaderInterface& reader, size_t read_buf_size = cDefaultRe
  * @param reader
  * @return Whether the the assertion succeeded.
  */
-[[nodiscard]] auto
-assert_curl_error_code(CURLcode expected, clp::NetworkReader const& reader) -> bool;
+[[nodiscard]] auto assert_curl_error_code(CURLcode expected, clp::NetworkReader const& reader)
+        -> bool;
 
 auto get_test_input_local_path() -> std::string {
     std::filesystem::path const current_file_path{__FILE__};

--- a/components/core/tests/test-ffi_IrUnitHandlerInterface.cpp
+++ b/components/core/tests/test-ffi_IrUnitHandlerInterface.cpp
@@ -32,8 +32,8 @@ public:
         return IRErrorCode::IRErrorCode_Success;
     }
 
-    [[nodiscard]] auto
-    handle_utc_offset_change(UtcOffset utc_offset_old, UtcOffset utc_offset_new) -> IRErrorCode {
+    [[nodiscard]] auto handle_utc_offset_change(UtcOffset utc_offset_old, UtcOffset utc_offset_new)
+            -> IRErrorCode {
         m_utc_offset_delta = utc_offset_new - utc_offset_old;
         return IRErrorCode::IRErrorCode_Success;
     }
@@ -55,8 +55,8 @@ public:
 
     [[nodiscard]] auto is_complete() const -> bool { return m_is_complete; }
 
-    [[nodiscard]] auto get_schema_tree_node_locator(
-    ) const -> std::optional<SchemaTree::NodeLocator> const& {
+    [[nodiscard]] auto get_schema_tree_node_locator() const
+            -> std::optional<SchemaTree::NodeLocator> const& {
         return m_schema_tree_node_locator;
     }
 
@@ -82,11 +82,11 @@ class TriviallyInheritedIrUnitHandler : public TrivialIrUnitHandler {};
  * `clp::ffi::ir_stream::IrUnitHandlerInterface` and ensure they don't return errors.
  * @param handler
  */
-auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface auto& handler
-) -> void;
+auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface auto& handler)
+        -> void;
 
-auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface auto& handler
-) -> void {
+auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface auto& handler)
+        -> void {
     auto test_log_event_result{KeyValuePairLogEvent::create(
             std::make_shared<SchemaTree>(),
             std::make_shared<SchemaTree>(),

--- a/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
+++ b/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
@@ -45,10 +45,9 @@ constexpr std::string_view cStringToEncode{"uid=0, CPU usage: 99.99%, \"user_nam
  * @return The encoded result.
  */
 template <typename encoded_variable_t>
-requires(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
-         || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
-[[nodiscard]] auto get_encoded_text_ast(std::string_view text
-) -> clp::ir::EncodedTextAst<encoded_variable_t>;
+requires(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+[[nodiscard]] auto get_encoded_text_ast(std::string_view text)
+        -> clp::ir::EncodedTextAst<encoded_variable_t>;
 
 /**
  * Tests that `Value::is` returns true for the given type and false for all others.
@@ -102,8 +101,7 @@ auto insert_invalid_node_id_value_pairs_with_node_type_errors(
 ) -> bool;
 
 template <typename encoded_variable_t>
-requires(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
-         || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+requires(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
 auto get_encoded_text_ast(std::string_view text) -> clp::ir::EncodedTextAst<encoded_variable_t> {
     string logtype;
     vector<encoded_variable_t> encoded_vars;

--- a/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
+++ b/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
@@ -45,7 +45,10 @@ constexpr std::string_view cStringToEncode{"uid=0, CPU usage: 99.99%, \"user_nam
  * @return The encoded result.
  */
 template <typename encoded_variable_t>
-requires(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+requires(
+        (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+         || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+)
 [[nodiscard]] auto get_encoded_text_ast(std::string_view text)
         -> clp::ir::EncodedTextAst<encoded_variable_t>;
 
@@ -101,7 +104,10 @@ auto insert_invalid_node_id_value_pairs_with_node_type_errors(
 ) -> bool;
 
 template <typename encoded_variable_t>
-requires(std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t> || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+requires(
+        (std::is_same_v<encoded_variable_t, eight_byte_encoded_variable_t>
+         || std::is_same_v<encoded_variable_t, four_byte_encoded_variable_t>)
+)
 auto get_encoded_text_ast(std::string_view text) -> clp::ir::EncodedTextAst<encoded_variable_t> {
     string logtype;
     vector<encoded_variable_t> encoded_vars;

--- a/components/core/tests/test-utf8_utils.cpp
+++ b/components/core/tests/test-utf8_utils.cpp
@@ -31,8 +31,8 @@ namespace {
  * @param num_continuation_bytes
  * @return The encoded UTF-8 byte sequence.
  */
-[[nodiscard]] auto
-generate_utf8_byte_sequence(uint32_t code_point, size_t num_continuation_bytes) -> std::string;
+[[nodiscard]] auto generate_utf8_byte_sequence(uint32_t code_point, size_t num_continuation_bytes)
+        -> std::string;
 
 auto get_expected_escaped_string(std::string_view raw) -> std::string {
     nlohmann::json const json_str = raw;  // Don't use '{}' initializer

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,4 @@
 black>=24.4.2
-# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
-clang-format~=18.1
+clang-format>=19.1.6
 ruff>=0.4.4
 yamllint>=1.35.1


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR updates yscope-dev-utils to the latest commit so that clang-format v19 config can be used. It also updates clang-format version to v19 in the linter dependency to format C++ code using the latest clang-format pypi release.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure workflows all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Style**
    - Standardized method signature formatting across multiple components
    - Removed unnecessary semicolons from constructors
    - Improved code readability by adjusting line breaks in function declarations

- **Dependency Updates**
    - Upgraded `clang-format` version requirement to >=19.1.6

- **Subproject Updates**
    - Updated `tools/yscope-dev-utils` subproject reference

These changes primarily focus on code style consistency and minor dependency management, with no significant functional modifications to the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->