### PR TITLE
fix(core-clp): Advance to the next message when a message has an out-of-range timestamp when searching archives (fixes #659).

### DIFF
--- a/components/core/src/clp/streaming_archive/reader/File.cpp
+++ b/components/core/src/clp/streaming_archive/reader/File.cpp
@@ -258,6 +258,7 @@ SubQuery const* File::find_message_matching_query(Query const& query, Message& m
         // Get number of variables in logtype
         auto const& logtype_dictionary_entry = m_archive_logtype_dict->get_entry(logtype_id);
         auto const num_vars = logtype_dictionary_entry.get_num_variables();
+
         auto const var_begin_ix{m_variables_ix};
         auto const vars_end_ix{m_variables_ix + num_vars};
 

--- a/components/core/src/clp/streaming_archive/reader/File.cpp
+++ b/components/core/src/clp/streaming_archive/reader/File.cpp
@@ -251,7 +251,6 @@ bool File::find_message_in_time_range(
 
 SubQuery const* File::find_message_matching_query(Query const& query, Message& msg) {
     SubQuery const* matching_sub_query = nullptr;
-
     while (m_msgs_ix < m_num_messages && nullptr == matching_sub_query) {
         auto const curr_msg_ix{m_msgs_ix};
         auto logtype_id = m_logtypes[curr_msg_ix];

--- a/components/core/src/clp/streaming_archive/reader/File.cpp
+++ b/components/core/src/clp/streaming_archive/reader/File.cpp
@@ -259,7 +259,7 @@ SubQuery const* File::find_message_matching_query(Query const& query, Message& m
         auto const& logtype_dictionary_entry = m_archive_logtype_dict->get_entry(logtype_id);
         auto const num_vars = logtype_dictionary_entry.get_num_variables();
 
-        auto const var_begin_ix{m_variables_ix};
+        auto const vars_begin_ix{m_variables_ix};
         auto const vars_end_ix{m_variables_ix + num_vars};
 
         // Advance indices
@@ -277,7 +277,7 @@ SubQuery const* File::find_message_matching_query(Query const& query, Message& m
             }
 
             msg.clear_vars();
-            for (auto vars_ix{var_begin_ix}; vars_ix < vars_end_ix; ++vars_ix) {
+            for (auto vars_ix{vars_begin_ix}; vars_ix < vars_end_ix; ++vars_ix) {
                 msg.add_var(m_variables[vars_ix]);
             }
             if (false == sub_query->matches_vars(msg.get_vars())) {

--- a/components/core/src/clp/streaming_archive/reader/File.cpp
+++ b/components/core/src/clp/streaming_archive/reader/File.cpp
@@ -251,15 +251,22 @@ bool File::find_message_in_time_range(
 
 SubQuery const* File::find_message_matching_query(Query const& query, Message& msg) {
     SubQuery const* matching_sub_query = nullptr;
+
     while (m_msgs_ix < m_num_messages && nullptr == matching_sub_query) {
-        auto logtype_id = m_logtypes[m_msgs_ix];
+        auto const curr_msg_ix{m_msgs_ix};
+        auto logtype_id = m_logtypes[curr_msg_ix];
 
         // Get number of variables in logtype
         auto const& logtype_dictionary_entry = m_archive_logtype_dict->get_entry(logtype_id);
         auto const num_vars = logtype_dictionary_entry.get_num_variables();
-
+        auto const var_begin_ix{m_variables_ix};
         auto const vars_end_ix{m_variables_ix + num_vars};
-        auto const timestamp{m_timestamps[m_msgs_ix]};
+
+        // Advance indices
+        ++m_msgs_ix;
+        m_variables_ix = vars_end_ix;
+
+        auto const timestamp{m_timestamps[curr_msg_ix]};
         if (false == query.timestamp_is_in_search_time_range(timestamp)) {
             continue;
         }
@@ -270,7 +277,7 @@ SubQuery const* File::find_message_matching_query(Query const& query, Message& m
             }
 
             msg.clear_vars();
-            for (auto vars_ix{m_variables_ix}; vars_ix < vars_end_ix; ++vars_ix) {
+            for (auto vars_ix{var_begin_ix}; vars_ix < vars_end_ix; ++vars_ix) {
                 msg.add_var(m_variables[vars_ix]);
             }
             if (false == sub_query->matches_vars(msg.get_vars())) {
@@ -279,14 +286,10 @@ SubQuery const* File::find_message_matching_query(Query const& query, Message& m
 
             msg.set_logtype_id(logtype_id);
             msg.set_timestamp(timestamp);
-            msg.set_msg_ix(m_begin_message_ix, m_msgs_ix);
+            msg.set_msg_ix(m_begin_message_ix, curr_msg_ix);
             matching_sub_query = sub_query;
             break;
         }
-
-        // Advance indices
-        ++m_msgs_ix;
-        m_variables_ix += num_vars;
     }
 
     return matching_sub_query;


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
#426 introduced a refactoring for querying messages in archive files. This refactoring has a bug that doesn't increment the message index when the message's timestamp is out of the query's timestamp range.
This PR fixes the issue by incrementing the message indices before any loop branching that could lead to the next loop iteration.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.
- Ensure the bug has been fixed, confirmed with @junhaoliao 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Improved index management in message search functionality.
	- Enhanced tracking of message and variable indices.
	- Clarified index advancement logic in search method.

These changes enhance the clarity and correctness of the message search process, ensuring a more straightforward experience for users without altering the external interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->