### PR TITLE
feat(clp-package): Add support for uploading extracted streams to S3.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -20,7 +20,6 @@ from clp_py_utils.clp_config import (
     REDIS_COMPONENT_NAME,
     REDUCER_COMPONENT_NAME,
     RESULTS_CACHE_COMPONENT_NAME,
-    StorageType,
     WEBUI_COMPONENT_NAME,
     WorkerConfig,
 )
@@ -276,7 +275,7 @@ def generate_worker_config(clp_config: CLPConfig) -> WorkerConfig:
     worker_config.archive_output = clp_config.archive_output.copy(deep=True)
     worker_config.data_directory = clp_config.data_directory
 
-    worker_config.stream_output_dir = clp_config.stream_output.get_directory()
+    worker_config.stream_output = clp_config.stream_output
     worker_config.stream_collection_name = clp_config.results_cache.stream_collection_name
 
     return worker_config

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -254,17 +254,17 @@ def generate_container_config(
             container_clp_config.archive_output.get_directory(),
         )
 
-    container_clp_config.stream_output.directory = pathlib.Path("/") / "mnt" / "stream-output"
+    container_clp_config.stream_output.set_directory(pathlib.Path("/") / "mnt" / "stream-output")
     if not is_path_already_mounted(
         clp_home,
         CONTAINER_CLP_HOME,
-        clp_config.stream_output.directory,
-        container_clp_config.stream_output.directory,
+        clp_config.stream_output.get_directory(),
+        container_clp_config.stream_output.get_directory(),
     ):
         docker_mounts.stream_output_dir = DockerMount(
             DockerMountType.BIND,
-            clp_config.stream_output.directory,
-            container_clp_config.stream_output.directory,
+            clp_config.stream_output.get_directory(),
+            container_clp_config.stream_output.get_directory(),
         )
 
     return container_clp_config, docker_mounts
@@ -276,7 +276,7 @@ def generate_worker_config(clp_config: CLPConfig) -> WorkerConfig:
     worker_config.archive_output = clp_config.archive_output.copy(deep=True)
     worker_config.data_directory = clp_config.data_directory
 
-    worker_config.stream_output_dir = clp_config.stream_output.directory
+    worker_config.stream_output_dir = clp_config.stream_output.get_directory()
     worker_config.stream_collection_name = clp_config.results_cache.stream_collection_name
 
     return worker_config

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -707,6 +707,7 @@ def generic_start_worker(
     clp_config.stream_output.get_directory().mkdir(parents=True, exist_ok=True)
 
     clp_site_packages_dir = CONTAINER_CLP_HOME / "lib" / "python3" / "site-packages"
+    container_worker_log_path = container_logs_dir / "worker.log"
     # fmt: off
     container_start_cmd = [
         "docker", "run",
@@ -729,6 +730,7 @@ def generic_start_worker(
         "-e", f"CLP_CONFIG_PATH={container_clp_config.logs_directory / container_config_filename}",
         "-e", f"CLP_LOGS_DIR={container_logs_dir}",
         "-e", f"CLP_LOGGING_LEVEL={worker_config.logging_level}",
+        "-e", f"WORKER_LOG_PATH={container_worker_log_path}",
         "-u", f"{os.getuid()}:{os.getgid()}",
     ]
     # fmt: on
@@ -760,7 +762,7 @@ def generic_start_worker(
         "--loglevel",
         "WARNING",
         "-f",
-        str(container_logs_dir / "worker.log"),
+        str(container_worker_log_path),
         "-Q",
         celery_route,
         "-n",

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -730,7 +730,7 @@ def generic_start_worker(
         "-e", f"CLP_CONFIG_PATH={container_clp_config.logs_directory / container_config_filename}",
         "-e", f"CLP_LOGS_DIR={container_logs_dir}",
         "-e", f"CLP_LOGGING_LEVEL={worker_config.logging_level}",
-        "-e", f"WORKER_LOG_PATH={container_worker_log_path}",
+        "-e", f"CLP_WORKER_LOG_PATH={container_worker_log_path}",
         "-u", f"{os.getuid()}:{os.getgid()}",
     ]
     # fmt: on

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -704,7 +704,7 @@ def generic_start_worker(
 
     # Create necessary directories
     clp_config.archive_output.get_directory().mkdir(parents=True, exist_ok=True)
-    clp_config.stream_output.directory.mkdir(parents=True, exist_ok=True)
+    clp_config.stream_output.get_directory().mkdir(parents=True, exist_ok=True)
 
     clp_site_packages_dir = CONTAINER_CLP_HOME / "lib" / "python3" / "site-packages"
     # fmt: off
@@ -922,7 +922,7 @@ def start_log_viewer_webui(
         "MongoDbName": clp_config.results_cache.db_name,
         "MongoDbStreamFilesCollectionName": clp_config.results_cache.stream_collection_name,
         "ClientDir": str(container_log_viewer_webui_dir / "client"),
-        "StreamFilesDir": str(container_clp_config.stream_output.directory),
+        "StreamFilesDir": str(container_clp_config.stream_output.get_directory()),
         "StreamTargetUncompressedSize": container_clp_config.stream_output.target_uncompressed_size,
         "LogViewerDir": str(container_log_viewer_webui_dir / "yscope-log-viewer"),
     }

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -391,7 +391,7 @@ class ArchiveS3Storage(S3Storage):
 
 
 class StreamS3Storage(S3Storage):
-    directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged_streams"
+    staging_directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged_streams"
 
 
 def _get_directory_from_storage_config(storage_config: Union[FsStorage, S3Storage]) -> pathlib.Path:

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -388,7 +388,9 @@ def _get_directory_from_storage_config(storage_config: Union[FsStorage, S3Storag
         raise NotImplementedError(f"storage.type {storage_type} is not supported")
 
 
-def _set_directory_for_storage_config(storage_config: Union[FsStorage, S3Storage], directory) -> None:
+def _set_directory_for_storage_config(
+    storage_config: Union[FsStorage, S3Storage], directory
+) -> None:
     storage_type = storage_config.type
     if StorageType.FS == storage_type:
         storage_config.directory = directory
@@ -647,7 +649,7 @@ class WorkerConfig(BaseModel):
     data_directory: pathlib.Path = CLPConfig().data_directory
 
     # Only needed by query workers.
-    stream_output: StreamOutput= StreamOutput()
+    stream_output: StreamOutput = StreamOutput()
     stream_collection_name: str = ResultsCache().stream_collection_name
 
     def dump_to_primitive_dict(self):

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -455,7 +455,6 @@ class ArchiveOutput(BaseModel):
 
     def dump_to_primitive_dict(self):
         d = self.dict()
-        # Turn storage config into primitive string dict
         d["storage"] = self.storage.dump_to_primitive_dict()
         return d
 
@@ -478,7 +477,6 @@ class StreamOutput(BaseModel):
 
     def dump_to_primitive_dict(self):
         d = self.dict()
-        # Turn storage config into primitive string dict
         d["storage"] = self.storage.dump_to_primitive_dict()
         return d
 

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -647,7 +647,7 @@ class WorkerConfig(BaseModel):
     data_directory: pathlib.Path = CLPConfig().data_directory
 
     # Only needed by query workers.
-    stream_output_dir: pathlib.Path = StreamOutput().get_directory()
+    stream_output: StreamOutput= StreamOutput()
     stream_collection_name: str = ResultsCache().stream_collection_name
 
     def dump_to_primitive_dict(self):
@@ -656,6 +656,6 @@ class WorkerConfig(BaseModel):
 
         # Turn paths into primitive strings
         d["data_directory"] = str(self.data_directory)
-        d["stream_output_dir"] = str(self.stream_output_dir)
+        d["stream_output"] = self.stream_output.dump_to_primitive_dict()
 
         return d

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -1,6 +1,6 @@
 import pathlib
 from enum import auto
-from typing import Literal, Optional, Union, Tuple
+from typing import Literal, Optional, Tuple, Union
 
 from dotenv import dotenv_values
 from pydantic import BaseModel, PrivateAttr, validator

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -408,11 +408,11 @@ class StreamFsStorage(FsStorage):
 
 
 class ArchiveS3Storage(S3Storage):
-    staging_directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged_archives"
+    staging_directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged-archives"
 
 
 class StreamS3Storage(S3Storage):
-    staging_directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged_streams"
+    staging_directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged-streams"
 
 
 def _get_directory_from_storage_config(storage_config: Union[FsStorage, S3Storage]) -> pathlib.Path:

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -358,14 +358,6 @@ class FsStorage(BaseModel):
         return d
 
 
-class ArchiveFsStorage(FsStorage):
-    directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "archive"
-
-
-class StreamFsStorage(FsStorage):
-    directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "streams"
-
-
 class S3Storage(BaseModel):
     type: Literal[StorageType.S3.value] = StorageType.S3.value
     staging_directory: pathlib.Path
@@ -386,12 +378,20 @@ class S3Storage(BaseModel):
         return d
 
 
+class ArchiveFsStorage(FsStorage):
+    directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "archives"
+
+
+class StreamFsStorage(FsStorage):
+    directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "streams"
+
+
 class ArchiveS3Storage(S3Storage):
-    staging_directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staging_archives"
+    staging_directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged_archives"
 
 
 class StreamS3Storage(S3Storage):
-    directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staging_streams"
+    directory: pathlib.Path = CLP_DEFAULT_DATA_DIRECTORY_PATH / "staged_streams"
 
 
 def _get_directory_from_storage_config(storage_config: Union[FsStorage, S3Storage]) -> pathlib.Path:

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -417,7 +417,7 @@ class StreamS3Storage(S3Storage):
 
 def _get_directory_from_storage_config(storage_config: Union[FsStorage, S3Storage]) -> pathlib.Path:
     storage_type = storage_config.type
-    if StorageType.FS == storage_config.type:
+    if StorageType.FS == storage_type:
         return storage_config.directory
     elif StorageType.S3 == storage_type:
         return storage_config.staging_directory
@@ -600,7 +600,7 @@ class CLPConfig(BaseModel):
         try:
             validate_path_could_be_dir(self.stream_output.get_directory())
         except ValueError as ex:
-            raise ValueError(f"stream_output.directory is invalid: {ex}")
+            raise ValueError(f"stream_output.storage's directory is invalid: {ex}")
 
     def validate_data_dir(self):
         try:

--- a/components/clp-py-utils/clp_py_utils/s3_utils.py
+++ b/components/clp-py-utils/clp_py_utils/s3_utils.py
@@ -161,12 +161,13 @@ def s3_put(
         )
 
     config = Config(retries=dict(total_max_attempts=total_max_attempts, mode="adaptive"))
+    aws_access_key_id, aws_secret_access_key = s3_config.get_credentials()
 
     my_s3_client = boto3.client(
         "s3",
         region_name=s3_config.region_code,
-        aws_access_key_id=s3_config.access_key_id,
-        aws_secret_access_key=s3_config.secret_access_key,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
         config=config,
     )
 

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -188,7 +188,7 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     )(
             "print-ir-stats",
             po::bool_switch(&m_print_ir_stats),
-            "Print statistics (ndjson) about each IR file as it's extracted"
+            "Print statistics (ndjson) about each IR file after it's extracted"
     );
     // clang-format on
 

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -179,12 +179,15 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     // Define IR extraction options
     po::options_description options_ir_extraction("IR Extraction Options");
     // clang-format off
-    options_ir_extraction
-            .add_options()(
-                    "target-size",
-                    po::value<size_t>(&m_ir_target_size)->value_name("SIZE"),
-                    "Target size (B) for each IR chunk before a new chunk is created"
-            );
+    options_ir_extraction.add_options()(
+            "target-size",
+            po::value<size_t>(&m_ir_target_size)->value_name("SIZE"),
+            "Target size (B) for each IR chunk before a new chunk is created"
+    )(
+            "print-stream-stats",
+            po::bool_switch(&m_print_stream_stats),
+            "Print statistics (ndjson) about each stream as it's extracted"
+    );
     // clang-format on
 
     // Define visible options
@@ -210,9 +213,6 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     )(
             "mongodb-collection",
             po::value<string>(&m_ir_mongodb_collection)
-    )(
-            "print-stream-stats",
-            po::value<bool>(&m_print_stream_stats)
     );
     // clang-format on
     po::positional_options_description positional_options_description;
@@ -221,7 +221,6 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     positional_options_description.add("output-dir", 1);
     positional_options_description.add("mongodb-uri", 1);
     positional_options_description.add("mongodb-collection", 1);
-    positional_options_description.add("print-stream-stats", 1);
 
     // Aggregate all options
     po::options_description all_options;

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -181,12 +181,12 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     // clang-format off
     options_ir_extraction.add_options()(
             "target-size",
-            po::value<size_t>(&m_ir_target_size)->value_name("SIZE"),
+            po::value<size_t>(&m_ir_target_size)->value_name("SIZE")->default_value(m_ir_target_size),
             "Target size (B) for each IR chunk before a new chunk is created"
     )(
-            "print-stream-stats",
-            po::bool_switch(&m_print_stream_stats),
-            "Print statistics (ndjson) about each stream as it's extracted"
+            "print-ir-stats",
+            po::bool_switch(&m_print_ir_stats)->default_value(m_print_ir_stats),
+            "Print statistics (ndjson) about each IR file as it's extracted"
     );
     // clang-format on
 

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -210,6 +210,9 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     )(
             "mongodb-collection",
             po::value<string>(&m_ir_mongodb_collection)
+    )(
+            "print-stream-stats",
+            po::value<bool>(&m_print_stream_stats)
     );
     // clang-format on
     po::positional_options_description positional_options_description;
@@ -218,6 +221,7 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     positional_options_description.add("output-dir", 1);
     positional_options_description.add("mongodb-uri", 1);
     positional_options_description.add("mongodb-collection", 1);
+    positional_options_description.add("print-stream-stats", 1);
 
     // Aggregate all options
     po::options_description all_options;

--- a/components/core/src/clp/clo/CommandLineArguments.cpp
+++ b/components/core/src/clp/clo/CommandLineArguments.cpp
@@ -181,11 +181,13 @@ auto CommandLineArguments::parse_ir_extraction_arguments(
     // clang-format off
     options_ir_extraction.add_options()(
             "target-size",
-            po::value<size_t>(&m_ir_target_size)->value_name("SIZE")->default_value(m_ir_target_size),
+            po::value<size_t>(&m_ir_target_size)
+                    ->value_name("SIZE")
+                    ->default_value(m_ir_target_size),
             "Target size (B) for each IR chunk before a new chunk is created"
     )(
             "print-ir-stats",
-            po::bool_switch(&m_print_ir_stats)->default_value(m_print_ir_stats),
+            po::bool_switch(&m_print_ir_stats),
             "Print statistics (ndjson) about each IR file as it's extracted"
     );
     // clang-format on

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -48,6 +48,8 @@ public:
     [[nodiscard]] auto get_archive_path() const -> std::string_view { return m_archive_path; }
 
     // IR extraction arguments
+    [[nodiscard]] auto print_stream_stats() const -> bool { return m_print_stream_stats; }
+
     [[nodiscard]] auto get_file_split_id() const -> std::string const& { return m_file_split_id; }
 
     [[nodiscard]] size_t get_ir_target_size() const { return m_ir_target_size; }
@@ -180,6 +182,7 @@ private:
     std::string m_archive_path;
 
     // Variables for IR extraction
+    bool m_print_stream_stats{false};
     std::string m_file_split_id;
     size_t m_ir_target_size{128ULL * 1024 * 1024};
     std::string m_ir_output_dir;

--- a/components/core/src/clp/clo/CommandLineArguments.hpp
+++ b/components/core/src/clp/clo/CommandLineArguments.hpp
@@ -48,7 +48,7 @@ public:
     [[nodiscard]] auto get_archive_path() const -> std::string_view { return m_archive_path; }
 
     // IR extraction arguments
-    [[nodiscard]] auto print_stream_stats() const -> bool { return m_print_stream_stats; }
+    [[nodiscard]] auto print_ir_stats() const -> bool { return m_print_ir_stats; }
 
     [[nodiscard]] auto get_file_split_id() const -> std::string const& { return m_file_split_id; }
 
@@ -182,7 +182,7 @@ private:
     std::string m_archive_path;
 
     // Variables for IR extraction
-    bool m_print_stream_stats{false};
+    bool m_print_ir_stats{false};
     std::string m_file_split_id;
     size_t m_ir_target_size{128ULL * 1024 * 1024};
     std::string m_ir_output_dir;

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -213,9 +213,9 @@ bool extract_ir(CommandLineArguments const& command_line_args) {
                     )
             )));
 
-            if (command_line_args.print_stream_stats()) {
+            if (command_line_args.print_ir_stats()) {
                 nlohmann::json json_msg;
-                json_msg["stream_path"] = dest_ir_path;
+                json_msg["path"] = dest_ir_path;
                 std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
                           << std::endl;
             }

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -5,6 +5,7 @@
 
 #include <mongocxx/instance.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
+#include <json/single_include/nlohmann/json.hpp>
 
 #include "../../reducer/network_utils.hpp"
 #include "../clp/FileDecompressor.hpp"
@@ -211,6 +212,15 @@ bool extract_ir(CommandLineArguments const& command_line_args) {
                             is_last_chunk
                     )
             )));
+
+            if (command_line_args.print_stream_stats()) {
+                nlohmann::json json_msg;
+                json_msg["stream_path"] = dest_ir_path;
+                json_msg["id"] = orig_file_id;
+                std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
+                          << std::endl;
+            }
+
             return true;
         };
 

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -3,9 +3,9 @@
 #include <memory>
 #include <string>
 
+#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/instance.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
-#include <json/single_include/nlohmann/json.hpp>
 
 #include "../../reducer/network_utils.hpp"
 #include "../clp/FileDecompressor.hpp"

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -216,7 +216,6 @@ bool extract_ir(CommandLineArguments const& command_line_args) {
             if (command_line_args.print_stream_stats()) {
                 nlohmann::json json_msg;
                 json_msg["stream_path"] = dest_ir_path;
-                json_msg["id"] = orig_file_id;
                 std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
                           << std::endl;
             }

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -416,7 +416,8 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             }
 
             if (m_print_ordered_stream_stats && false == m_ordered_decompression) {
-                throw std::invalid_argument("print-stream-stats must be used with ordered argument"
+                throw std::invalid_argument(
+                        "print-ordered-stream-stats must be used with ordered argument"
                 );
             }
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -490,16 +490,23 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 throw std::invalid_argument("No output directory specified");
             }
 
-            if (0 != m_target_ordered_chunk_size && false == m_ordered_decompression) {
-                throw std::invalid_argument(
-                        "target-ordered-chunk-size must be used with ordered argument"
-                );
-            }
+            if (m_ordered_decompression) {
+                if (0 != m_target_ordered_chunk_size) {
+                    throw std::invalid_argument(
+                            "target-ordered-chunk-size must be used with ordered argument"
+                    );
+                }
 
-            if (m_print_ordered_chunk_stats && false == m_ordered_decompression) {
-                throw std::invalid_argument(
-                        "print-ordered-chunk-stats must be used with ordered argument"
-                );
+                if (m_print_ordered_chunk_stats) {
+                    throw std::invalid_argument(
+                            "print-ordered-chunk-stats must be used with ordered argument"
+                    );
+                }
+
+                if (false == m_mongodb_uri.empty()) {
+                    throw std::invalid_argument("Recording decompression metadata only supported"
+                                                " for ordered decompression");
+                }
             }
 
             // We use xor to check that these arguments are either both specified or both
@@ -510,11 +517,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
-            if (false == m_mongodb_uri.empty() && false == m_ordered_decompression) {
-                throw std::invalid_argument(
-                        "Recording decompression metadata only supported for ordered decompression"
-                );
-            }
         } else if ((char)Command::Search == command_input) {
             std::string archives_dir;
             std::string query;

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -408,8 +408,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             }
 
             if (m_print_ordered_stream_stats && false == m_ordered_decompression) {
-                throw std::invalid_argument(
-                        "print-stream-stats must be used with ordered argument"
+                throw std::invalid_argument("print-stream-stats must be used with ordered argument"
                 );
             }
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -335,6 +335,10 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                             ->value_name("SIZE"),
                     "Chunk size (B) for each output file when decompressing records in log order."
                     " When set to 0, no chunking is performed."
+            )(
+                    "print-ordered-stream-stats",
+                    po::bool_switch(&m_print_ordered_stream_stats),
+                    "Print statistics (json) about the stream after it's extracted."
             );
             // clang-format on
             extraction_options.add(decompression_options);
@@ -400,6 +404,12 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             if (0 != m_target_ordered_chunk_size && false == m_ordered_decompression) {
                 throw std::invalid_argument(
                         "target-ordered-chunk-size must be used with ordered argument"
+                );
+            }
+
+            if (m_print_ordered_stream_stats && false == m_ordered_decompression) {
+                throw std::invalid_argument(
+                        "print-stream-stats must be used with ordered argument"
                 );
             }
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -490,7 +490,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 throw std::invalid_argument("No output directory specified");
             }
 
-            if (m_ordered_decompression) {
+            if (false == m_ordered_decompression) {
                 if (0 != m_target_ordered_chunk_size) {
                     throw std::invalid_argument(
                             "target-ordered-chunk-size must be used with ordered argument"

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -413,9 +413,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "Chunk size (B) for each output file when decompressing records in log order."
                     " When set to 0, no chunking is performed."
             )(
-                    "print-ordered-stream-stats",
-                    po::bool_switch(&m_print_ordered_stream_stats),
-                    "Print statistics (json) about the stream after it's extracted."
+                    "print-ordered-chunk-stats",
+                    po::bool_switch(&m_print_ordered_chunk_stats),
+                    "Print statistics (ndjson) about each chunk file after it's extracted."
             )(
                     "archive-id",
                     po::value<std::string>(&archive_id)->value_name("ID"),
@@ -496,9 +496,9 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                 );
             }
 
-            if (m_print_ordered_stream_stats && false == m_ordered_decompression) {
+            if (m_print_ordered_chunk_stats && false == m_ordered_decompression) {
                 throw std::invalid_argument(
-                        "print-ordered-stream-stats must be used with ordered argument"
+                        "print-ordered-chunk-stats must be used with ordered argument"
                 );
             }
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -67,7 +67,9 @@ public:
 
     [[nodiscard]] bool print_archive_stats() const { return m_print_archive_stats; }
 
-    [[nodiscard]] auto print_ordered_stream_stats() const -> bool { return m_print_ordered_stream_stats; }
+    [[nodiscard]] auto print_ordered_stream_stats() const -> bool {
+        return m_print_ordered_stream_stats;
+    }
 
     std::string const& get_mongodb_uri() const { return m_mongodb_uri; }
 

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -67,6 +67,8 @@ public:
 
     [[nodiscard]] bool print_archive_stats() const { return m_print_archive_stats; }
 
+    [[nodiscard]] auto print_ordered_stream_stats() const -> bool { return m_print_ordered_stream_stats; }
+
     std::string const& get_mongodb_uri() const { return m_mongodb_uri; }
 
     std::string const& get_mongodb_collection() const { return m_mongodb_collection; }
@@ -189,6 +191,7 @@ private:
     bool m_structurize_arrays{false};
     bool m_ordered_decompression{false};
     size_t m_target_ordered_chunk_size{};
+    bool m_print_ordered_stream_stats{false};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
     FileType m_file_type{FileType::Json};

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -70,8 +70,8 @@ public:
 
     [[nodiscard]] bool print_archive_stats() const { return m_print_archive_stats; }
 
-    [[nodiscard]] auto print_ordered_stream_stats() const -> bool {
-        return m_print_ordered_stream_stats;
+    [[nodiscard]] auto print_ordered_chunk_stats() const -> bool {
+        return m_print_ordered_chunk_stats;
     }
 
     std::string const& get_mongodb_uri() const { return m_mongodb_uri; }
@@ -195,7 +195,7 @@ private:
     bool m_structurize_arrays{false};
     bool m_ordered_decompression{false};
     size_t m_target_ordered_chunk_size{};
-    bool m_print_ordered_stream_stats{false};
+    bool m_print_ordered_chunk_stats{false};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
     FileType m_file_type{FileType::Json};

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -3,9 +3,9 @@
 #include <filesystem>
 #include <queue>
 #include <system_error>
-#include <json/single_include/nlohmann/json.hpp>
 
 #include <fmt/core.h>
+#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/exception.hpp>

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <queue>
 #include <system_error>
+#include <json/single_include/nlohmann/json.hpp>
 
 #include <fmt/core.h>
 #include <mongocxx/client.hpp>
@@ -138,6 +139,14 @@ void JsonConstructor::construct_in_order() {
                             false == open_new_writer
                     )
             )));
+        }
+
+        if (m_option.print_ordered_stream_stats) {
+            nlohmann::json json_msg;
+            json_msg["stream_path"] = new_file_path.string();
+            json_msg["id"] = m_option.archive_id;
+            std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
+                      << std::endl;
         }
 
         if (open_new_writer) {

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -133,7 +133,6 @@ void JsonConstructor::construct_in_order() {
         if (m_option.print_ordered_stream_stats) {
             nlohmann::json json_msg;
             json_msg["stream_path"] = new_file_path.string();
-            json_msg["id"] = m_option.archive_id;
             std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
                       << std::endl;
         }

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -130,9 +130,9 @@ void JsonConstructor::construct_in_order() {
             )));
         }
 
-        if (m_option.print_ordered_stream_stats) {
+        if (m_option.print_ordered_chunk_stats) {
             nlohmann::json json_msg;
-            json_msg["stream_path"] = new_file_path.string();
+            json_msg["path"] = new_file_path.string();
             std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore)
                       << std::endl;
         }

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -31,7 +31,7 @@ struct JsonConstructorOption {
     NetworkAuthOption network_auth{};
     std::string output_dir;
     bool ordered{false};
-    bool print_ordered_stream_stats{false};
+    bool print_ordered_chunk_stats{false};
     size_t target_ordered_chunk_size{};
     std::optional<MetadataDbOption> metadata_db{std::nullopt};
 };

--- a/components/core/src/clp_s/JsonConstructor.hpp
+++ b/components/core/src/clp_s/JsonConstructor.hpp
@@ -30,6 +30,7 @@ struct JsonConstructorOption {
     std::string archive_id;
     std::string output_dir;
     bool ordered{false};
+    bool print_ordered_stream_stats{false};
     size_t target_ordered_chunk_size{};
     std::optional<MetadataDbOption> metadata_db;
 };

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -311,6 +311,7 @@ int main(int argc, char const* argv[]) {
         option.ordered = command_line_arguments.get_ordered_decompression();
         option.archives_dir = archives_dir;
         option.target_ordered_chunk_size = command_line_arguments.get_target_ordered_chunk_size();
+        option.print_ordered_stream_stats = command_line_arguments.print_ordered_stream_stats();
         if (false == command_line_arguments.get_mongodb_uri().empty()) {
             option.metadata_db
                     = {command_line_arguments.get_mongodb_uri(),

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -306,7 +306,7 @@ int main(int argc, char const* argv[]) {
         option.output_dir = command_line_arguments.get_output_dir();
         option.ordered = command_line_arguments.get_ordered_decompression();
         option.target_ordered_chunk_size = command_line_arguments.get_target_ordered_chunk_size();
-        option.print_ordered_stream_stats = command_line_arguments.print_ordered_stream_stats();
+        option.print_ordered_chunk_stats = command_line_arguments.print_ordered_chunk_stats();
         option.network_auth = command_line_arguments.get_network_auth();
         if (false == command_line_arguments.get_mongodb_uri().empty()) {
             option.metadata_db

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -201,7 +201,7 @@ def extract_stream(
 
         if upload_error:
             task_results.status = QueryTaskStatus.FAILED
-            task_results.error_log_path = str(os.getenv("WORKER_LOG_PATH"))
+            task_results.error_log_path = str(os.getenv("CLP_WORKER_LOG_PATH"))
         else:
             logger.info(f"Finished uploading streams.")
 

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -186,13 +186,13 @@ def extract_stream(
             if not upload_error:
                 stream_name = stream_path.name
                 logger.info(f"Uploading stream {stream_name} to S3...")
-                result = s3_put(s3_config, stream_path, stream_name)
 
-                if result.is_err():
-                    logger.error(f"Failed to upload stream {stream_name}: {result.err_value}")
-                    upload_error = True
-                else:
+                try:
+                    s3_put(s3_config, stream_path, stream_name)
                     logger.info(f"Finished uploading stream {stream_name} to S3.")
+                except Exception as err:
+                    logger.error(f"Failed to upload stream {stream_name}: {err}")
+                    upload_error = True
 
             stream_path.unlink()
 

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -30,7 +30,7 @@ def make_command(
 ) -> Optional[List[str]]:
     storage_engine = worker_config.package.storage_engine
     archives_dir = worker_config.archive_output.get_directory()
-    stream_output_dir = worker_config.stream_output_dir
+    stream_output_dir = worker_config.stream_output.get_directory()
     stream_collection_name = worker_config.stream_collection_name
 
     if StorageEngine.CLP == storage_engine:

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -55,7 +55,7 @@ def make_command(
             command.append("--target-size")
             command.append(str(extract_ir_config.target_uncompressed_size))
         if print_stream_stats:
-            command.append("--print-stream-stats")
+            command.append("--print-ir-stats")
     elif StorageEngine.CLP_S == storage_engine:
         logger.info("Starting JSON extraction")
         extract_json_config = ExtractJsonJobConfig.parse_obj(job_config)
@@ -76,7 +76,7 @@ def make_command(
             command.append("--target-ordered-chunk-size")
             command.append(str(extract_json_config.target_chunk_size))
         if print_stream_stats:
-            command.append("--print-ordered-stream-stats")
+            command.append("--print-ordered-chunk-stats")
     else:
         logger.error(f"Unsupported storage engine {storage_engine}")
         return None
@@ -169,7 +169,7 @@ def extract_stream(
         s3_error = None
         for line in task_stdout_as_str.splitlines():
             stream_stats = json.loads(line)
-            stream_path = Path(stream_stats["stream_path"])
+            stream_path = Path(stream_stats["path"])
 
             if s3_error is None:
                 stream_name = stream_path.name

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -152,7 +152,7 @@ def extract_stream(
             start_time=start_time,
         )
 
-    task_results, task_stdout_as_str = run_query_task(
+    task_results, task_stdout_str = run_query_task(
         sql_adapter=sql_adapter,
         logger=logger,
         clp_logs_dir=clp_logs_dir,
@@ -167,7 +167,7 @@ def extract_stream(
         logger.info(f"Uploading streams to S3...")
 
         upload_error = False
-        for line in task_stdout_as_str.splitlines():
+        for line in task_stdout_str.splitlines():
             try:
                 stream_stats = json.loads(line)
             except json.decoder.JSONDecodeError:

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -183,6 +183,9 @@ def extract_stream(
 
             stream_path = Path(stream_path_str)
 
+            # If we've had a single upload error, we don't want to try uploading any other streams
+            # since that may unnecessarily slow down the task and generate a lot of extraneous
+            # output.
             if not upload_error:
                 stream_name = stream_path.name
                 logger.info(f"Uploading stream {stream_name} to S3...")

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -131,8 +131,8 @@ def extract_stream(
     # Get s3 config
     s3_config: S3Config
     enable_s3_write = False
-    storage_config = worker_config.stream_output.storage
 
+    storage_config = worker_config.stream_output.storage
     if StorageType.S3 == storage_config.type:
         s3_config = storage_config.s3_config
         enable_s3_write = True
@@ -170,9 +170,9 @@ def extract_stream(
         for line in task_stdout_as_str.splitlines():
             stream_stats = json.loads(line)
             stream_path = Path(stream_stats["stream_path"])
-            stream_name = stream_path.name
 
             if s3_error is None:
+                stream_name = stream_path.name
                 logger.info(f"Uploading stream {stream_name} to S3...")
                 result = s3_put(s3_config, stream_path, stream_name)
 

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -157,7 +157,7 @@ def search(
             start_time=start_time,
         )
 
-    return run_query_task(
+    task_results, _ = run_query_task(
         sql_adapter=sql_adapter,
         logger=logger,
         clp_logs_dir=clp_logs_dir,
@@ -167,3 +167,5 @@ def search(
         task_id=task_id,
         start_time=start_time,
     )
+
+    return task_results.dict()

--- a/components/job-orchestration/job_orchestration/executor/query/utils.py
+++ b/components/job-orchestration/job_orchestration/executor/query/utils.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import closing
 from logging import Logger
 from pathlib import Path
-from typing import Any, Dict, IO, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from clp_py_utils.clp_config import QUERY_TASKS_TABLE_NAME
 from clp_py_utils.sql_adapter import SQL_Adapter

--- a/components/job-orchestration/job_orchestration/executor/query/utils.py
+++ b/components/job-orchestration/job_orchestration/executor/query/utils.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import closing
 from logging import Logger
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, IO, List, Optional, Tuple
 
 from clp_py_utils.clp_config import QUERY_TASKS_TABLE_NAME
 from clp_py_utils.sql_adapter import SQL_Adapter
@@ -47,7 +47,7 @@ def run_query_task(
     job_id: str,
     task_id: int,
     start_time: datetime.datetime,
-):
+) -> Tuple[QueryTaskResult, str]:
     clo_log_path = get_task_log_file_path(clp_logs_dir, job_id, task_id)
     clo_log_file = open(clo_log_path, "w")
 
@@ -61,7 +61,7 @@ def run_query_task(
         task_command,
         preexec_fn=os.setpgrp,
         close_fds=True,
-        stdout=clo_log_file,
+        stdout=subprocess.PIPE,
         stderr=clo_log_file,
     )
 
@@ -83,7 +83,7 @@ def run_query_task(
     logger.info(f"Waiting for {task_name} to finish")
     # `communicate` is equivalent to `wait` in this case, but avoids deadlocks if we switch to
     # piping stdout/stderr in the future.
-    task_proc.communicate()
+    stdout_data, _ = task_proc.communicate()
     return_code = task_proc.returncode
     if 0 != return_code:
         task_status = QueryTaskStatus.FAILED
@@ -110,7 +110,7 @@ def run_query_task(
     if QueryTaskStatus.FAILED == task_status:
         task_result.error_log_path = str(clo_log_path)
 
-    return task_result.dict()
+    return task_result, stdout_data.decode("ascii")
 
 
 def update_query_task_metadata(

--- a/components/job-orchestration/job_orchestration/executor/query/utils.py
+++ b/components/job-orchestration/job_orchestration/executor/query/utils.py
@@ -81,8 +81,8 @@ def run_query_task(
     signal.signal(signal.SIGTERM, sigterm_handler)
 
     logger.info(f"Waiting for {task_name} to finish")
-    # `communicate` is equivalent to `wait` in this case, but avoids deadlocks if we switch to
-    # piping stdout/stderr in the future.
+    # `communicate` is equivalent to `wait` in this case, but avoids deadlocks when piping to
+    # stdout/stderr.
     stdout_data, _ = task_proc.communicate()
     return_code = task_proc.returncode
     if 0 != return_code:
@@ -110,7 +110,7 @@ def run_query_task(
     if QueryTaskStatus.FAILED == task_status:
         task_result.error_log_path = str(clo_log_path)
 
-    return task_result, stdout_data.decode("ascii")
+    return task_result, stdout_data.decode("utf-8")
 
 
 def update_query_task_metadata(

--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -86,7 +86,9 @@
 #
 ## Where CLP stream files (e.g., IR streams) should be output
 #stream_output:
-#  directory: "var/data/streams"
+#  storage:
+#    type: "fs"
+#    directory: "var/data/streams"
 #
 #  # How large each stream file should be before being split into a new stream file
 #  target_uncompressed_size: 134217728  # 128 MB


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
This PR adds support for uploading JSON chunks and IR streams to S3.

The proposed flow is as follow:
1. While extraction, clo and clp-s binaries writes streams to the disk, and prints a list of extracted streams to stdout.
2. After the binary execution finishes, the stdout is decoded and processed by extraction_worker (in python)
3. Extraction_worker uploads each streams to S3. Only if all streams are upload will extraction_worker return success.

A limitation of the current implementation:
1. The mongodb is directly updated by the clo and clp-s binaries. Even if S3 upload fails, webui will still see streams as available. The plan is to move the mongodb update from binaries into extraction_worker script.
2. Stream viewing is not yet supported in webui.

The PR includes the following changes:
1. Updated stream_output config to accept either a FsStorage or S3Storage config.
2. Updated clp-s and clo to print out the streams stats
3. Updated the extraction worker to upload s3 stream.

# Validation performed
Trigger a stream extraction job from webui. verified that streams are properly written into S3.

Also validated different configuration input and confirmed that type of storage and value of directory are expected:
Case:
1. Default config: 
    - Type=FS, directory = var/data/[streams|archives]
2. Explicitly specifying FsStorage config, without specifying directory
    -  Type=FS, directory = var/data/[streams|archives]
3. Explicitly specifying FsStorage config and directory
    -  Type=FS, directory = [User specified value]
4. Explicitly specifying S3Storage config, without specifying staging_directory
    -  Type=S3, staging_directory = var/data/[staged_streams|staged_archives]
5. Explicitly specifying S3Storage config and directory
    -  Type=S3, staging_directory = [User specified value]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added command-line options to print stream statistics during extraction.
  - Enhanced JSON output capabilities for stream processing.
  - Improved S3 storage integration for stream extraction tasks.
  - Introduced new classes for advanced storage configurations.

- **Improvements**
  - Refined configuration management for storage directories.
  - Updated command-line argument parsing for more flexible options.
  - Improved error handling and configuration validation.

- **Technical Enhancements**
  - Refactored storage configuration classes.
  - Updated method signatures for better encapsulation.
  - Added support for dynamic directory path management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->