### PR TITLE
fix(core-clp): Resolve lost wake-up issue in `NetworkReader` after a download is aborted.

### DIFF
--- a/components/core/src/clp/NetworkReader.cpp
+++ b/components/core/src/clp/NetworkReader.cpp
@@ -252,10 +252,10 @@ auto NetworkReader::acquire_empty_buffer() -> void {
     }
     std::unique_lock<std::mutex> buffer_resource_lock{m_buffer_resource_mutex};
     while (m_filled_buffer_queue.size() == m_buffer_pool_size) {
-        m_downloader_cv.wait(buffer_resource_lock);
         if (is_abort_download_requested()) {
             return;
         }
+        m_downloader_cv.wait(buffer_resource_lock);
     }
     m_curr_downloader_buf.emplace(
             m_buffer_pool.at(m_curr_downloader_buf_idx).data(),


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The current implementation of `NewworkReader` has a "lost wake-up" bug during download abortion: The wait [here](https://github.com/y-scope/clp/blob/57bc265587839a3ac23d7476ee33edbd92847cd1/components/core/src/clp/NetworkReader.cpp#L254) skips the check of abortion status in the first iteration of the while loop, causing that even if the download has already been aborted, it still gets blocked and no one will wake it up. This PR fixes the issue by reordering the abortion check and wait statement and ensuring that the abortion status is checked in every loop iteration.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensured all workflows passed.
- Applied this PR to the private working branch and ensured the bug stopped appearing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined synchronization mechanism in network buffer acquisition process
	- Improved waiting behaviour for network resource management

The changes ensure more consistent and reliable network buffer handling without altering core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->