### PR TITLE
fix(clp-s): Rename tables section to use segment numbering scheme.

### DIFF
--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -85,8 +85,7 @@ bool is_multi_file_archive(std::string_view const path) {
             || constants::cArchiveVarDictFile == formatted_name
             || constants::cArchiveLogDictFile == formatted_name
             || constants::cArchiveArrayDictFile == formatted_name
-            || constants::cArchiveTableMetadataFile == formatted_name
-            || constants::cArchiveTablesFile == formatted_name)
+            || constants::cArchiveTableMetadataFile == formatted_name)
         {
             continue;
         } else {

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -16,7 +16,7 @@ constexpr char cArchiveSchemaTreeFile[] = "/schema_tree";
 
 // Encoded record table files
 constexpr char cArchiveTableMetadataFile[] = "/table_metadata";
-constexpr char cArchiveTablesFile[] = "/tables";
+constexpr char cArchiveTablesFile[] = "/0";
 
 // Dictionary files
 constexpr char cArchiveArrayDictFile[] = "/array.dict";


### PR DESCRIPTION
# Description
This PR implements a small missing change for single-file archive support. In order to match clp behaviour and potentially allow us to implement segments for clp-s while remaining backwards compatible we rename the "/tables" section to "/0" (which holds tables for segment number 0).

This is a breaking change, so ideally it should be merged before the first release containing single-file archives.

# Validation performed
* Validated that compression, decompression, and search still function as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated the archive tables file path constant from "/tables" to "/0"

- **Code Maintenance**
	- Simplified multi-file archive identification logic by removing a specific file path check

<!-- end of auto-generated comment: release notes by coderabbit.ai -->