### PR TITLE
fix: Add missing `libcurl4` dependency to clp-core and package execution containers.

### DIFF
--- a/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-focal/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:focal AS BASE
 # TODO: Investigate why libssl-dev is a hidden dependency of clp-s
 RUN apt-get update \
     && apt-get install -y \
+    libcurl4 \
     libmariadb-dev \
     libssl-dev
 

--- a/tools/docker-images/clp-execution-base-ubuntu-focal/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-ubuntu-focal/setup-scripts/install-prebuilt-packages.sh
@@ -11,6 +11,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   ca-certificates \
   checkinstall \
   curl \
+  libcurl4 \
   libmariadb-dev \
   libssl-dev \
   python3 \

--- a/tools/docker-images/clp-execution-base-ubuntu-jammy/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-execution-base-ubuntu-jammy/setup-scripts/install-prebuilt-packages.sh
@@ -11,6 +11,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   ca-certificates \
   checkinstall \
   curl \
+  libcurl4 \
   libmariadb-dev \
   libssl-dev \
   python3 \


### PR DESCRIPTION
# Description
As pointed out in #669 the core container for the package is missing the libcurl4 dependency. This PR adds libcurl4 to the core container (and explicitly pulls libcurl4 into the execution containers).

# Validation performed
* Locally built core container and confirmed that it can now run clp-s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
	- Added `libcurl4` package to Docker image setup scripts for Ubuntu Focal and Jammy distributions
	- Ensures consistent library availability across different Ubuntu versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->