### PR TITLE
fix(clp-s): Improve error reporting for directory-creation failure during compression.

### DIFF
--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -32,7 +32,13 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
 
     m_archive_path = archive_path.string();
     if (false == std::filesystem::create_directory(m_archive_path, ec)) {
-        throw OperationFailed(ErrorCodeErrno, __FILENAME__, __LINE__);
+        SPDLOG_ERROR(
+                "Failed to create archive directory \"{}\" - {} - {}",
+                m_archive_path,
+                ec.message(),
+                ec.value()
+        );
+        throw OperationFailed(ErrorCodeFailure, __FILENAME__, __LINE__);
     }
 
     std::string var_dict_path = m_archive_path + constants::cArchiveVarDictFile;

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -33,7 +33,7 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
     m_archive_path = archive_path.string();
     if (false == std::filesystem::create_directory(m_archive_path, ec)) {
         SPDLOG_ERROR(
-                "Failed to create archive directory: \"{}\" - {} - {}",
+                "Failed to create archive directory \"{}\" - ({}) {}",
                 m_archive_path,
                 ec.message(),
                 ec.value()

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -33,7 +33,7 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
     m_archive_path = archive_path.string();
     if (false == std::filesystem::create_directory(m_archive_path, ec)) {
         SPDLOG_ERROR(
-                "Failed to create archive directory \"{}\" - {} - {}",
+                "Failed to create archive directory: \"{}\" - {} - {}",
                 m_archive_path,
                 ec.message(),
                 ec.value()

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -298,7 +298,12 @@ int main(int argc, char const* argv[]) {
     }
 
     if (CommandLineArguments::Command::Compress == command_line_arguments.get_command()) {
-        if (false == compress(command_line_arguments)) {
+        try {
+            if (false == compress(command_line_arguments)) {
+                return 1;
+            }
+        } catch (std::exception const& e) {
+            SPDLOG_ERROR("Encountered error during compression - {}", e.what());
             return 1;
         }
     } else if (CommandLineArguments::Command::Extract == command_line_arguments.get_command()) {


### PR DESCRIPTION
# Description
This PR improves error reporting when failing to create a directory during compression (this issue was encountered in #669). Previously we were using the no-throw version of std::filesystem::create_directory, but were not bothering to log the specific system error.

We also wrap the whole compression flow in try/catch so that we can exit gracefully on otherwise uncaught exceptions.

# Validation performed
* Attempted to create archives in directory without correct permissions and verified that expected error log was produced



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
  - Improved error handling during archive creation and compression processes.
  - Enhanced logging for directory creation and compression failures.

- **Improvements**
  - More detailed error reporting with context-specific log messages.
  - Refined exception handling to provide clearer feedback on operational issues.

These updates improve the system's error reporting and diagnostic capabilities, making it easier to identify and troubleshoot potential problems during archive and compression operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->