### PR TITLE
fix(clp-package): Remove transitive boto3 dependency from package compression script.

### DIFF
--- a/components/clp-py-utils/clp_py_utils/s3_utils.py
+++ b/components/clp-py-utils/clp_py_utils/s3_utils.py
@@ -1,4 +1,3 @@
-import configparser
 import re
 from pathlib import Path
 from typing import List, Tuple
@@ -12,42 +11,6 @@ from clp_py_utils.compression import FileMetadata
 
 # Constants
 AWS_ENDPOINT = "amazonaws.com"
-
-
-def parse_aws_credentials_file(
-    credentials_file_path: Path, user: str = "default"
-) -> Tuple[str, str]:
-    """
-    Parses the `aws_access_key_id` and `aws_secret_access_key` of `user` from the given
-    credentials_file_path.
-    :param credentials_file_path:
-    :param user:
-    :return: A tuple of (aws_access_key_id, aws_secret_access_key)
-    :raises: ValueError if the file doesn't exist, or doesn't contain valid aws credentials.
-    """
-
-    if not credentials_file_path.exists():
-        raise ValueError(f"'{credentials_file_path}' doesn't exist.")
-
-    config_reader = configparser.ConfigParser()
-    config_reader.read(credentials_file_path)
-
-    if not config_reader.has_section(user):
-        raise ValueError(f"User '{user}' doesn't exist.")
-
-    user_credentials = config_reader[user]
-    if "aws_session_token" in user_credentials:
-        raise ValueError(f"Session tokens (short-term credentials) are not supported.")
-
-    aws_access_key_id = user_credentials.get("aws_access_key_id")
-    aws_secret_access_key = user_credentials.get("aws_secret_access_key")
-
-    if aws_access_key_id is None or aws_secret_access_key is None:
-        raise ValueError(
-            "The credentials file must contain both aws_access_key_id and aws_secret_access_key."
-        )
-
-    return aws_access_key_id, aws_secret_access_key
 
 
 def parse_s3_url(s3_url: str) -> Tuple[str, str, str]:


### PR DESCRIPTION
# Description
The non-native compress.py script was pulling parse_aws_credentials from s3_utils, which resulted in unintentially adding a boto3 dependency to the package scripts. This PR moves parse_aws_credentials directly into compress.py in order to remove the transitive boto3 dependency.

# Validation performed
* Validated that compression script now runs successfully in environment without boto3
* Validated that ingestion form fs and s3 sources still works

