### PR TITLE
feat(ffi): Add support for serializing/deserializing user-defined stream-level metadata in the new IR format.

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -110,13 +110,21 @@ public:
 
     [[nodiscard]] auto get_ir_unit_handler() -> IrUnitHandler& { return m_ir_unit_handler; }
 
+    /**
+     * @return The metadata associated with the deserialized stream.
+     */
+    [[nodiscard]] auto get_metadata() const -> nlohmann::json const& { return m_metadata; }
+
 private:
     // Constructor
-    Deserializer(IrUnitHandler ir_unit_handler) : m_ir_unit_handler{std::move(ir_unit_handler)} {}
+    Deserializer(IrUnitHandler ir_unit_handler, nlohmann::json metadata)
+            : m_ir_unit_handler{std::move(ir_unit_handler)},
+              m_metadata(std::move(metadata)) {}
 
     // Variables
     std::shared_ptr<SchemaTree> m_auto_gen_keys_schema_tree{std::make_shared<SchemaTree>()};
     std::shared_ptr<SchemaTree> m_user_gen_keys_schema_tree{std::make_shared<SchemaTree>()};
+    nlohmann::json m_metadata;
     UtcOffset m_utc_offset{0};
     IrUnitHandler m_ir_unit_handler;
     bool m_is_complete{false};
@@ -160,7 +168,7 @@ auto Deserializer<IrUnitHandler>::create(ReaderInterface& reader, IrUnitHandler 
         return std::errc::protocol_not_supported;
     }
 
-    return Deserializer{std::move(ir_unit_handler)};
+    return Deserializer{std::move(ir_unit_handler), std::move(metadata_json)};
 }
 
 template <IrUnitHandlerInterface IrUnitHandler>

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -2,10 +2,12 @@
 #define CLP_FFI_IR_STREAM_SERIALIZER_HPP
 
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <string>
 #include <vector>
 
+#include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
 #include <outcome/single-header/outcome.hpp>
 
@@ -39,11 +41,13 @@ public:
     // Factory functions
     /**
      * Creates an IR serializer and serializes the stream's preamble.
+     * @param optional_user_defined_metadata Stream-level user-defined metadata.
      * @return A result containing the serializer or an error code indicating the failure:
      * - std::errc::protocol_error on failure to serialize the preamble.
      */
-    [[nodiscard]] static auto create()
-            -> OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>>;
+    [[nodiscard]] static auto create(
+            std::optional<nlohmann::json> optional_user_defined_metadata = std::nullopt
+    ) -> OUTCOME_V2_NAMESPACE::std_result<Serializer<encoded_variable_t>>;
 
     // Disable copy constructor/assignment operator
     Serializer(Serializer const&) = delete;

--- a/components/core/src/clp/ffi/ir_stream/protocol_constants.hpp
+++ b/components/core/src/clp/ffi/ir_stream/protocol_constants.hpp
@@ -32,6 +32,8 @@ constexpr char ReferenceTimestampKey[] = "REFERENCE_TIMESTAMP";
 
 constexpr char VariablesSchemaIdKey[] = "VARIABLES_SCHEMA_ID";
 constexpr char VariableEncodingMethodsIdKey[] = "VARIABLE_ENCODING_METHODS_ID";
+
+constexpr std::string_view UserDefinedMetadataKey{"USER_DEFINED_METADATA"};
 }  // namespace Metadata
 
 namespace Payload {

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -1223,7 +1223,9 @@ TEMPLATE_TEST_CASE(
     vector<int8_t> ir_buf;
     vector<std::pair<nlohmann::json, nlohmann::json>> expected_auto_gen_and_user_gen_object_pairs;
 
-    auto result{Serializer<TestType>::create()};
+    nlohmann::json const user_defined_metadata
+            = {{"map", {{"int", 0}, {"str", "STRING"}}}, {"array", {0, 0.0, true, "String"}}};
+    auto result{Serializer<TestType>::create(user_defined_metadata)};
     REQUIRE((false == result.has_error()));
 
     auto& serializer{result.value()};
@@ -1308,6 +1310,14 @@ TEMPLATE_TEST_CASE(
     auto deserializer_result{Deserializer<IrUnitHandler>::create(reader, IrUnitHandler{})};
     REQUIRE_FALSE(deserializer_result.has_error());
     auto& deserializer = deserializer_result.value();
+
+    auto const& deserialized_metadata = deserializer.get_metadata();
+    string const user_defined_metadata_key{
+            clp::ffi::ir_stream::cProtocol::Metadata::UserDefinedMetadataKey
+    };
+    REQUIRE(deserialized_metadata.contains(user_defined_metadata_key));
+    REQUIRE((deserialized_metadata.at(user_defined_metadata_key) == user_defined_metadata));
+
     while (true) {
         auto const result{deserializer.deserialize_next_ir_unit(reader)};
         REQUIRE_FALSE(result.has_error());


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds support for serializing and deserializing user-defined stream-level metadata.
To support user-defined metadata serialization, we update serializer's factory function to allow users to give the metadata as an optional JSON object.
We already have stream-level deserialization support before this PR. However, we don't store the deserialized metadata. This PR updates the deserializer to store the stream-level metadata as a private member and exposes APIs to get an immutable view of the metadata through the deserializer.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.
- Update unit tests to test metadata serder.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for user-defined metadata in serialization and deserialization processes
	- Introduced a new method to retrieve metadata from deserialized streams

- **Improvements**
	- Enhanced serializer to optionally include custom metadata
	- Added a new constant for user-defined metadata key

- **Technical Updates**
	- Updated method signatures in serializer and deserializer classes to accommodate metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->