### PR TITLE
feat(clp-json): Add session token support for presigned URL authentication.

### DIFF
--- a/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
@@ -248,16 +248,8 @@ auto
 AwsAuthenticationSigner::get_canonical_query_string(string_view scope, string_view timestamp) const
         -> string {
     auto const uri = fmt::format("{}/{}", m_access_key_id, scope);
-    std::string session_token_parameter;
-    if (m_session_token.has_value()) {
-        session_token_parameter = fmt::format(
-                "&{}={}",
-                cXAmzSecurityToken,
-                encode_uri(m_session_token.value(), false)
-        );
-    }
-    return fmt::format(
-            "{}={}&{}={}&{}={}&{}={}{}&{}={}",
+    auto canonical_query_string = fmt::format(
+            "{}={}&{}={}&{}={}&{}={}",
             cXAmzAlgorithm,
             cAws4HmacSha256,
             cXAmzCredential,
@@ -265,11 +257,17 @@ AwsAuthenticationSigner::get_canonical_query_string(string_view scope, string_vi
             cXAmzDate,
             timestamp,
             cXAmzExpires,
-            cDefaultExpireTime.count(),
-            session_token_parameter,
-            cXAmzSignedHeaders,
-            cDefaultSignedHeaders
+            cDefaultExpireTime.count()
     );
+    if (m_session_token.has_value()) {
+        canonical_query_string.append(fmt::format(
+                "&{}={}",
+                cXAmzSecurityToken,
+                encode_uri(m_session_token.value(), false)
+        ));
+    }
+    canonical_query_string.append(fmt::format("&{}={}", cXAmzSignedHeaders, cDefaultSignedHeaders));
+    return canonical_query_string;
 }
 
 auto AwsAuthenticationSigner::get_signing_key(

--- a/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
@@ -252,7 +252,7 @@ AwsAuthenticationSigner::get_canonical_query_string(string_view scope, string_vi
     if (m_session_token.has_value()) {
         session_token_parameter = fmt::format(
                 "&{}={}",
-                "X-Amz-Security-Token",
+                cAmzSecurityToken,
                 encode_uri(m_session_token.value(), false)
         );
     }

--- a/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
@@ -252,7 +252,7 @@ AwsAuthenticationSigner::get_canonical_query_string(string_view scope, string_vi
     if (m_session_token.has_value()) {
         session_token_parameter = fmt::format(
                 "&{}={}",
-                cAmzSecurityToken,
+                cXAmzSecurityToken,
                 encode_uri(m_session_token.value(), false)
         );
     }

--- a/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
@@ -248,8 +248,16 @@ auto
 AwsAuthenticationSigner::get_canonical_query_string(string_view scope, string_view timestamp) const
         -> string {
     auto const uri = fmt::format("{}/{}", m_access_key_id, scope);
+    std::string session_token_parameter;
+    if (m_session_token.has_value()) {
+        session_token_parameter = fmt::format(
+                "&{}={}",
+                "X-Amz-Security-Token",
+                encode_uri(m_session_token.value(), false)
+        );
+    }
     return fmt::format(
-            "{}={}&{}={}&{}={}&{}={}&{}={}",
+            "{}={}&{}={}&{}={}&{}={}{}&{}={}",
             cXAmzAlgorithm,
             cAws4HmacSha256,
             cXAmzCredential,
@@ -258,6 +266,7 @@ AwsAuthenticationSigner::get_canonical_query_string(string_view scope, string_vi
             timestamp,
             cXAmzExpires,
             cDefaultExpireTime.count(),
+            session_token_parameter,
             cXAmzSignedHeaders,
             cDefaultSignedHeaders
     );

--- a/components/core/src/clp/aws/AwsAuthenticationSigner.hpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.hpp
@@ -2,6 +2,7 @@
 #define CLP_AWS_AWSAUTHENTICATIONSIGNER_HPP
 
 #include <chrono>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -69,9 +70,14 @@ public:
     static constexpr std::string_view cHttpGetMethod{"GET"};
 
     // Constructors
-    AwsAuthenticationSigner(std::string access_key_id, std::string secret_access_key)
+    AwsAuthenticationSigner(
+            std::string access_key_id,
+            std::string secret_access_key,
+            std::optional<std::string> session_token
+    )
             : m_access_key_id{std::move(access_key_id)},
-              m_secret_access_key{std::move(secret_access_key)} {}
+              m_secret_access_key{std::move(secret_access_key)},
+              m_session_token{std::move(session_token)} {}
 
     // Methods
     /**
@@ -129,6 +135,7 @@ private:
     // Variables
     std::string m_access_key_id;
     std::string m_secret_access_key;
+    std::optional<std::string> m_session_token;
 };
 }  // namespace clp::aws
 

--- a/components/core/src/clp/aws/constants.hpp
+++ b/components/core/src/clp/aws/constants.hpp
@@ -12,6 +12,7 @@ constexpr std::string_view cXAmzAlgorithm{"X-Amz-Algorithm"};
 constexpr std::string_view cXAmzCredential{"X-Amz-Credential"};
 constexpr std::string_view cXAmzDate{"X-Amz-Date"};
 constexpr std::string_view cXAmzExpires{"X-Amz-Expires"};
+constexpr std::string_view cAmzSecurityToken{"X-Amz-Security-Token"};
 constexpr std::string_view cXAmzSignature{"X-Amz-Signature"};
 constexpr std::string_view cXAmzSignedHeaders{"X-Amz-SignedHeaders"};
 

--- a/components/core/src/clp/aws/constants.hpp
+++ b/components/core/src/clp/aws/constants.hpp
@@ -12,7 +12,7 @@ constexpr std::string_view cXAmzAlgorithm{"X-Amz-Algorithm"};
 constexpr std::string_view cXAmzCredential{"X-Amz-Credential"};
 constexpr std::string_view cXAmzDate{"X-Amz-Date"};
 constexpr std::string_view cXAmzExpires{"X-Amz-Expires"};
-constexpr std::string_view cAmzSecurityToken{"X-Amz-Security-Token"};
+constexpr std::string_view cXAmzSecurityToken{"X-Amz-Security-Token"};
 constexpr std::string_view cXAmzSignature{"X-Amz-Signature"};
 constexpr std::string_view cXAmzSignedHeaders{"X-Amz-SignedHeaders"};
 

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -274,7 +274,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                         ->default_value(auth),
                     "Type of authentication required for network requests (s3 | none). Authentication"
                     " with s3 requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment"
-                    " variables."
+                    " variables, and optionally the AWS_SESSION_TOKEN environment variable."
             );
             // clang-format on
 
@@ -428,7 +428,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                         ->default_value(auth),
                     "Type of authentication required for network requests (s3 | none). Authentication"
                     " with s3 requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment"
-                    " variables."
+                    " variables, and optionally the AWS_SESSION_TOKEN environment variable."
             );
             // clang-format on
             extraction_options.add(decompression_options);
@@ -582,7 +582,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     ->default_value(auth),
                 "Type of authentication required for network requests (s3 | none). Authentication"
                 " with s3 requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment"
-                " variables."
+                " variables, and optionally the AWS_SESSION_TOKEN environment variable."
             );
             // clang-format on
             search_options.add(match_options);

--- a/components/core/src/clp_s/InputConfig.hpp
+++ b/components/core/src/clp_s/InputConfig.hpp
@@ -11,6 +11,7 @@ namespace clp_s {
 // Constants used for input configuration
 constexpr char cAwsAccessKeyIdEnvVar[] = "AWS_ACCESS_KEY_ID";
 constexpr char cAwsSecretAccessKeyEnvVar[] = "AWS_SECRET_ACCESS_KEY";
+constexpr char cAwsSessionTokenEnvVar[] = "AWS_SESSION_TOKEN";
 
 /**
  * Enum class defining the source of a resource.

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -3,12 +3,10 @@
 #include <exception>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
 #include <spdlog/spdlog.h>
 
 #include "../clp/aws/AwsAuthenticationSigner.hpp"
-#include "../clp/CurlDownloadHandler.hpp"
 #include "../clp/FileReader.hpp"
 #include "../clp/NetworkReader.hpp"
 #include "../clp/ReaderInterface.hpp"

--- a/components/core/src/clp_s/ReaderUtils.cpp
+++ b/components/core/src/clp_s/ReaderUtils.cpp
@@ -1,11 +1,14 @@
 #include "ReaderUtils.hpp"
 
 #include <exception>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include <spdlog/spdlog.h>
 
 #include "../clp/aws/AwsAuthenticationSigner.hpp"
+#include "../clp/CurlDownloadHandler.hpp"
 #include "../clp/FileReader.hpp"
 #include "../clp/NetworkReader.hpp"
 #include "../clp/ReaderInterface.hpp"
@@ -164,8 +167,17 @@ bool try_sign_url(std::string& url) {
         );
         return false;
     }
+    std::optional<std::string> optional_aws_session_token{std::nullopt};
+    auto const aws_session_token = std::getenv(cAwsSessionTokenEnvVar);
+    if (nullptr != aws_session_token) {
+        optional_aws_session_token = std::string{aws_session_token};
+    }
 
-    clp::aws::AwsAuthenticationSigner signer{aws_access_key, aws_secret_access_key};
+    clp::aws::AwsAuthenticationSigner signer{
+            aws_access_key,
+            aws_secret_access_key,
+            optional_aws_session_token
+    };
 
     try {
         clp::aws::S3Url s3_url{url};


### PR DESCRIPTION
# Description
This PR adds support for using an aws session token (the X-Amz-Security-Token request parameter) to authenticate requests against S3 in combination with the access key ID and secret access key.

We add an std::optional<> option to AwsAuthenticationSigner to represent this new optional argument, and conditionally use it to generate the canonical query string.

Inside of clp-s we now look for the `AWS_SESSION_TOKEN` environment variable, and pass it to AwsAuthenticationSigner when it exists.

Note that we chose to pass the session token as a url parameter instead of as an http header, because passing the session token as a url parameter is required for some configurations per the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html).

# Validation performed
* Validated that GET using a presigned url that contains a valid session token completes succesfully



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for optional AWS session token in authentication.
	- Enhanced AWS authentication flexibility for S3 operations.

- **Documentation**
	- Updated help text to clarify optional AWS session token requirements.

- **Improvements**
	- Introduced new constants for AWS session token handling.
	- Modified authentication signer to support session token parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->