### PR TITLE
fix(clp-package): Add support for loading credentials from boto3 session.

### DIFF
--- a/components/clp-py-utils/clp_py_utils/s3_utils.py
+++ b/components/clp-py-utils/clp_py_utils/s3_utils.py
@@ -1,9 +1,10 @@
 import re
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import boto3
 from botocore.config import Config
+from botocore.credentials import ReadOnlyCredentials
 from job_orchestration.scheduler.job_config import S3InputConfig
 
 from clp_py_utils.clp_config import S3Config
@@ -59,6 +60,15 @@ def generate_s3_virtual_hosted_style_url(
         raise ValueError("Object key is not specified")
 
     return f"https://{bucket_name}.s3.{region_code}.{AWS_ENDPOINT}/{object_key}"
+
+
+def s3_get_frozen_credentials() -> Optional[ReadOnlyCredentials]:
+    session = boto3.Session()
+    credentials = session.get_credentials()
+    if credentials is None:
+        return None
+    frozen_credentials = credentials.get_frozen_credentials()
+    return frozen_credentials
 
 
 def s3_get_object_metadata(s3_input_config: S3InputConfig) -> List[FileMetadata]:

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -14,7 +14,7 @@ from job_orchestration.executor.query.utils import (
     report_task_failure,
     run_query_task,
 )
-from job_orchestration.executor.utils import load_worker_config
+from job_orchestration.executor.utils import load_session_credentials, load_worker_config
 from job_orchestration.scheduler.job_config import SearchJobConfig
 
 # Setup logging
@@ -73,8 +73,10 @@ def _make_core_clp_s_command_and_env_vars(
         # fmt: on
         aws_access_key_id, aws_secret_access_key = s3_config.get_credentials()
         if aws_access_key_id is None or aws_secret_access_key is None:
-            logger.error("Missing credentials for accessing archives on S3")
-            return None, None
+            aws_access_key_id, aws_access_key_id = load_session_credentials(logger)
+            if aws_access_key_id is None or aws_secret_access_key is None:
+                return None, None
+
         env_vars = {
             **os.environ,
             "AWS_ACCESS_KEY_ID": aws_access_key_id,

--- a/components/job-orchestration/job_orchestration/executor/utils.py
+++ b/components/job-orchestration/job_orchestration/executor/utils.py
@@ -1,9 +1,10 @@
 from logging import Logger
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 from clp_py_utils.clp_config import WorkerConfig
 from clp_py_utils.core import read_yaml_config_file
+from clp_py_utils.s3_utils import s3_get_frozen_credentials
 
 
 def load_worker_config(
@@ -21,3 +22,14 @@ def load_worker_config(
     except Exception:
         logger.exception("Failed to load worker config")
         return None
+
+
+def load_session_credentials(logger: Logger) -> Tuple[Optional[str], Optional[str]]:
+    s3_frozen_credentials = s3_get_frozen_credentials()
+    if s3_frozen_credentials is None:
+        logger.error("Failed to get s3 credentials from local session")
+        return None, None
+    if s3_frozen_credentials.token is not None:
+        logger.error("Not supporting session token at the moment")
+        return None, None
+    return s3_frozen_credentials.access_key, s3_frozen_credentials.secret_key


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Validation performed
<!-- Describe what tests and validation you performed on the change. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new function to retrieve frozen AWS credentials
  - Enhanced credential management for S3 access across multiple components

- **Improvements**
  - Improved error handling for AWS credential retrieval
  - Added more robust session credential loading mechanism
  - Updated command generation processes to handle missing credentials gracefully

- **Bug Fixes**
  - Resolved potential issues with AWS authentication in various tasks
  - Added fallback mechanisms for credential retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->