### PR TITLE
chore(clp-s): Adjust directory creation failure log message during compression.

### DIFF
--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -33,10 +33,10 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
     m_archive_path = archive_path.string();
     if (false == std::filesystem::create_directory(m_archive_path, ec)) {
         SPDLOG_ERROR(
-                "Failed to create archive directory \"{}\" - ({}) {}",
+                "Failed to create archive directory \"{}\" - {} ({})",
                 m_archive_path,
-                ec.message(),
-                ec.value()
+                ec.value(),
+                ec.message()
         );
         throw OperationFailed(ErrorCodeFailure, __FILENAME__, __LINE__);
     }

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -33,7 +33,7 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
     m_archive_path = archive_path.string();
     if (false == std::filesystem::create_directory(m_archive_path, ec)) {
         SPDLOG_ERROR(
-                "Failed to create archive directory \"{}\" - {} ({})",
+                "Failed to create archive directory \"{}\" - ({}) {}",
                 m_archive_path,
                 ec.value(),
                 ec.message()


### PR DESCRIPTION
# Description
This PR slightly changes the directory creation failure log message during compression in clp-s to print the error code before the error message in order to match common conventions for error logs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error logging format for archive directory creation to improve readability of error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->