### PR TITLE
fix(core-clp): Handle 0-byte reads when `BufferReader`'s underlying buffer is fully consumed.

### DIFF
--- a/components/core/src/clp/BufferReader.cpp
+++ b/components/core/src/clp/BufferReader.cpp
@@ -60,13 +60,12 @@ auto BufferReader::try_read(char* buf, size_t num_bytes_to_read, size_t& num_byt
         throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
     }
 
-    if (0 == num_bytes_to_read) {
-        num_bytes_read = 0;
-        return ErrorCode_Success;
-    }
-
     auto remaining_data_size = get_remaining_data_size();
     if (0 == remaining_data_size) {
+        if (0 == num_bytes_to_read) {
+            num_bytes_read = 0;
+            return ErrorCode_Success;
+        }
         return ErrorCode_EndOfFile;
     }
 

--- a/components/core/src/clp/BufferReader.cpp
+++ b/components/core/src/clp/BufferReader.cpp
@@ -60,6 +60,11 @@ auto BufferReader::try_read(char* buf, size_t num_bytes_to_read, size_t& num_byt
         throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
     }
 
+    if (0 == num_bytes_to_read) {
+        num_bytes_read = 0;
+        return ErrorCode_Success;
+    }
+
     auto remaining_data_size = get_remaining_data_size();
     if (0 == remaining_data_size) {
         return ErrorCode_EndOfFile;


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The current `BufferReader` implementation doesn't handle cases when reading 0-byte from a fully consumed buffer. This error was triggered when using it in Python ffi library to deserialize an empty string value at the end of the buffer. The size of string is zero, meaning that we don't have to read any bytes from the underlying buffer, but the buffer still returns EndOfFile, and thus causing an incomplete IR exception.
This PR fixes this problem by adding a check for 0-byte reads.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.
- Ensure the problem in Python ffi has been solved after applying this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of zero-byte read operations in the buffer reading mechanism.
	- Prevents unnecessary processing when no bytes are requested for reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->