### PR TITLE
feat(ffi): Add type checking to only accept JSON objects as user-defined stream-level metadata for the new IR format.

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -550,6 +550,9 @@ auto Serializer<encoded_variable_t>::create(
             cVariableEncodingMethodsVersion
     );
     if (optional_user_defined_metadata.has_value()) {
+        if (false == optional_user_defined_metadata.value().is_object()) {
+            return std::errc::protocol_not_supported;
+        }
         metadata.emplace(
                 string{cProtocol::Metadata::UserDefinedMetadataKey},
                 std::move(optional_user_defined_metadata.value())

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -44,7 +44,7 @@ public:
      * @param optional_user_defined_metadata Stream-level user-defined metadata, given as a JSON
      * object.
      * @return A result containing the serializer or an error code indicating the failure:
-     * - std::errc::protocol_error if failed to serialize the preamble.
+     * - std::errc::protocol_error if the stream's metadata couldn't be serialized.
      * - std::errc::protocol_not_supported if the given user-defined metadata is not a JSON object.
      */
     [[nodiscard]] static auto create(

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -41,9 +41,11 @@ public:
     // Factory functions
     /**
      * Creates an IR serializer and serializes the stream's preamble.
-     * @param optional_user_defined_metadata Stream-level user-defined metadata.
+     * @param optional_user_defined_metadata Stream-level user-defined metadata, given as a JSON
+     * object.
      * @return A result containing the serializer or an error code indicating the failure:
-     * - std::errc::protocol_error on failure to serialize the preamble.
+     * - std::errc::protocol_error if failed to serialize the preamble.
+     * - std::errc::protocol_not_supported if the given user-defined metadata is not a JSON object.
      */
     [[nodiscard]] static auto create(
             std::optional<nlohmann::json> optional_user_defined_metadata = std::nullopt

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -1494,3 +1494,23 @@ TEMPLATE_TEST_CASE(
     };
     REQUIRE(assert_invalid_serialization(array_with_invalid_submap));
 }
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEMPLATE_TEST_CASE(
+        "ffi_ir_stream_Serializer_serialize_invalid_user_defined_metadata",
+        "[clp][ffi][ir_stream][Serializer]",
+        four_byte_encoded_variable_t,
+        eight_byte_encoded_variable_t
+) {
+    auto invalid_user_defined_metadata = GENERATE(
+            nlohmann::json(std::string{"str"}),
+            nlohmann::json(int{0}),
+            nlohmann::json(double{0.0}),
+            nlohmann::json(true),
+            nlohmann::json(nullptr),
+            nlohmann::json(vector<int>{0, 1, 2})
+    );
+    auto const serializer_result{Serializer<TestType>::create(invalid_user_defined_metadata)};
+    REQUIRE(serializer_result.has_error());
+    REQUIRE((std::errc::protocol_not_supported == serializer_result.error()));
+}


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
As introduced in #677, we added support for serializing/deserializing user-defined stream-level metadata. However, we didn't add any type checking in this implementation, meaning that user can give any valid `nlohmann::json` instances, including arrays and primitive type values.

After an offline discussion with @kirkrodrigues, we decided to constrain the metadata type to only accept JSON objects (key-value pair dictionaries) to avoid undefined behaviors in our ffi libraries. This PR implements this new requirement.

Ideally, the way to implement this PR is to constrain the type of the input to be `nlohmann::json::object_t`, so that other types of inputs can't be compiled. However, after testing I realized the compiler doesn't prevent an implicit conversion from `nlohmann::json` to `nlohmann::json::object_t`, meaning that you could still pass in any `nlohmann::json` object to a `nlohmann::json::object_t` typed parameter, and the error will be raised happens during the runtime through a nlohmann::json exception. To prevent the use of exceptions, we add explicit type checking before serializing the user-defined metadata, and return `std::errc::protocol_not_supported` when seeing a non-JSON-object input.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.
- Added new unit tests to ensure invalid types of values can't be serialized.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced metadata validation for serialization process.

- **Bug Fixes**
  - Added robust error handling for invalid user-defined metadata inputs.

- **Tests**
  - Introduced comprehensive test coverage for invalid user-defined metadata scenarios.

The update improves the reliability of metadata processing by ensuring only valid JSON objects are accepted during serialization, preventing potential data integrity issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->