### PR TITLE
fix(clp-py-utils): Replace typing `tuple` with `Tuple` for Python 3.8 compatibility (fixes #693).

### DIFF
--- a/components/clp-py-utils/clp_py_utils/initialize-results-cache.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-results-cache.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import sys
+from typing import Tuple
 from urllib.parse import urlparse
 
 from pymongo import IndexModel, MongoClient
@@ -17,7 +18,7 @@ logging_console_handler.setFormatter(logging_formatter)
 logger.addHandler(logging_console_handler)
 
 
-def check_replica_set_status(client: MongoClient, netloc: str) -> tuple[bool, bool]:
+def check_replica_set_status(client: MongoClient, netloc: str) -> Tuple[bool, bool]:
     """
     Checks the current replica set status of the MongoDB server and determines whether it needs to
     be configured (or reconfigured).


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. fix(py-utils): Replace typing `tuple` with `Tuple` for Python 3.8 compatibility.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Follow the reproduction steps specified in #693
1. Tested on Ubuntu 20.04 Focal and the CLP package was able to start successfully.
2. Tested on Ubuntu 22.04 Jammy and the CLP package was able to start successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated type hint for `check_replica_set_status` function to use `Tuple` from typing module
	- Improved type annotation consistency in the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->