### PR TITLE
feat(ffi): Validate the type of user-defined metadata when deserializing the new IR format.

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -44,10 +44,10 @@ public:
      * @return A result containing the deserializer or an error code indicating the failure:
      * - std::errc::result_out_of_range if the IR stream is truncated
      * - std::errc::protocol_error if the IR stream is corrupted
-     * - std::errc::protocol_not_supported if:
-     *   - The IR stream contains an unsupported metadata format
-     *   - The IR stream's version is unsupported
-     *   - The IR stream's user-defined metadata is not a JSON object
+     * - std::errc::protocol_not_supported if either:
+     *   - the IR stream contains an unsupported metadata format;
+     *   - the IR stream's version is unsupported;
+     *   - or the IR stream's user-defined metadata is not a JSON object.
      */
     [[nodiscard]] static auto create(ReaderInterface& reader, IrUnitHandler ir_unit_handler)
             -> OUTCOME_V2_NAMESPACE::std_result<Deserializer>;


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
feat(ffi): Add type checking for the user-defined metadata in deserialization for the new IR format.
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
We've added type checking in #691 to ensure only JSON objects can be serialized as user-defined metadata.
As discussed in clp-ffi-py implementation [here](https://github.com/y-scope/clp-ffi-py/pull/133#discussion_r1929667022), we realized we should also add type checking in the deserialization end to raise invalid typed user-defined metadata.
This PR adds the check to return an error if the user-defined metadata is not a JSON object.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for metadata deserialization.
  - Added validation to ensure user-defined metadata is a JSON object.

- **Documentation**
  - Clarified error conditions for metadata processing in method documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->