### PR TITLE
feat(clp::streaming_compression): Update compressors/decompressors to accept generic `WriterInterface`/`ReaderInterface` for improved flexibility over `FileWriter`/`FileReader`.

### DIFF
--- a/components/core/src/clp/streaming_archive/writer/Segment.hpp
+++ b/components/core/src/clp/streaming_archive/writer/Segment.hpp
@@ -6,6 +6,7 @@
 
 #include "../../Defs.h"
 #include "../../ErrorCode.hpp"
+#include "../../FileWriter.hpp"
 #include "../../streaming_compression/passthrough/Compressor.hpp"
 #include "../../streaming_compression/zstd/Compressor.hpp"
 #include "../../TraceableException.hpp"

--- a/components/core/src/clp/streaming_compression/Compressor.hpp
+++ b/components/core/src/clp/streaming_compression/Compressor.hpp
@@ -6,7 +6,6 @@
 #include <cstddef>
 
 #include "../ErrorCode.hpp"
-#include "../FileWriter.hpp"
 #include "../TraceableException.hpp"
 #include "../WriterInterface.hpp"
 
@@ -70,9 +69,9 @@ public:
 
     /**
      * Initializes the compression stream
-     * @param file_writer
+     * @param writer
      */
-    virtual auto open(FileWriter& file_writer) -> void = 0;
+    virtual auto open(WriterInterface& writer) -> void = 0;
 };
 }  // namespace clp::streaming_compression
 

--- a/components/core/src/clp/streaming_compression/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/Decompressor.hpp
@@ -41,7 +41,7 @@ public:
      */
     virtual void open(char const* compressed_data_buffer, size_t compressed_data_buffer_size) = 0;
     /**
-     * Initializes the decompressor to decompress from an open reader
+     * Initializes the decompressor to decompress from a reader interface
      * @param reader
      * @param read_buffer_capacity The maximum amount of data to read from a reader at a time
      */

--- a/components/core/src/clp/streaming_compression/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/Decompressor.hpp
@@ -3,7 +3,6 @@
 
 #include <string>
 
-#include "../FileReader.hpp"
 #include "../ReaderInterface.hpp"
 #include "../TraceableException.hpp"
 #include "Constants.hpp"
@@ -42,11 +41,11 @@ public:
      */
     virtual void open(char const* compressed_data_buffer, size_t compressed_data_buffer_size) = 0;
     /**
-     * Initializes the decompressor to decompress from an open file
-     * @param file_reader
-     * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time
+     * Initializes the decompressor to decompress from an open reader
+     * @param reader
+     * @param read_buffer_capacity The maximum amount of data to read from a reader at a time
      */
-    virtual void open(FileReader& file_reader, size_t file_read_buffer_capacity) = 0;
+    virtual void open(ReaderInterface& reader, size_t read_buffer_capacity) = 0;
     /**
      * Closes decompression stream
      */

--- a/components/core/src/clp/streaming_compression/lzma/Compressor.hpp
+++ b/components/core/src/clp/streaming_compression/lzma/Compressor.hpp
@@ -15,7 +15,8 @@
 
 namespace clp::streaming_compression::lzma {
 /**
- * Implements a LZMA compressor that compresses byte input data to a clp::WriterInterface.
+ * Implements a LZMA compressor that compresses byte input data to a `clp::WriterInterface`
+ * instance.
  */
 class Compressor : public ::clp::streaming_compression::Compressor {
 public:
@@ -58,7 +59,8 @@ public:
     auto write(char const* data, size_t data_length) -> void override;
 
     /**
-     * Writes any internally buffered data to the clp::WriterInterface and ends the current frame
+     * Writes any internally buffered data to the underlying `clp::WriterInterface` instance and
+     * ends the current frame.
      *
      * Forces all the encoded data buffered by LZMA to be available at output
      */
@@ -79,7 +81,7 @@ public:
     auto close() -> void override;
 
     /**
-     * Open the compression stream for encoding to the writer.
+     * Opens the compression stream for encoding to the writer.
      *
      * @param writer
      */
@@ -211,7 +213,8 @@ private:
     auto flush_lzma(lzma_action flush_action) -> void;
 
     /**
-     * Flushes the current compressed data in the output block buffer to the clp::WriterInterface.
+     * Flushes the current compressed data in the output block buffer to the underlying
+     * `clp::WriterInterface` instance.
      *
      * Also resets the output block buffer to receive new data.
      */

--- a/components/core/src/clp/streaming_compression/lzma/Compressor.hpp
+++ b/components/core/src/clp/streaming_compression/lzma/Compressor.hpp
@@ -8,14 +8,14 @@
 
 #include "../../Array.hpp"
 #include "../../ErrorCode.hpp"
-#include "../../FileWriter.hpp"
 #include "../../TraceableException.hpp"
+#include "../../WriterInterface.hpp"
 #include "../Compressor.hpp"
 #include "Constants.hpp"
 
 namespace clp::streaming_compression::lzma {
 /**
- * Implements a LZMA compressor that compresses byte input data to a file.
+ * Implements a LZMA compressor that compresses byte input data to a clp::WriterInterface.
  */
 class Compressor : public ::clp::streaming_compression::Compressor {
 public:
@@ -58,7 +58,7 @@ public:
     auto write(char const* data, size_t data_length) -> void override;
 
     /**
-     * Writes any internally buffered data to file and ends the current frame
+     * Writes any internally buffered data to the clp::WriterInterface and ends the current frame
      *
      * Forces all the encoded data buffered by LZMA to be available at output
      */
@@ -79,11 +79,11 @@ public:
     auto close() -> void override;
 
     /**
-     * Open the compression stream for encoding to the file_writer.
+     * Open the compression stream for encoding to the writer.
      *
-     * @param file_writer
+     * @param writer
      */
-    auto open(FileWriter& file_writer) -> void override;
+    auto open(WriterInterface& writer) -> void override;
 
 private:
     /**
@@ -211,14 +211,14 @@ private:
     auto flush_lzma(lzma_action flush_action) -> void;
 
     /**
-     * Flushes the current compressed data in the output block buffer to the output file handler.
+     * Flushes the current compressed data in the output block buffer to the clp::WriterInterface.
      *
      * Also resets the output block buffer to receive new data.
      */
     auto flush_stream_output_block_buffer() -> void;
 
     // Variables
-    FileWriter* m_compressed_stream_file_writer{nullptr};
+    WriterInterface* m_compressed_stream_writer{nullptr};
 
     // Compressed stream variables
     Array<uint8_t> m_compressed_stream_block_buffer{cCompressedStreamBlockBufferSize};

--- a/components/core/src/clp/streaming_compression/passthrough/Compressor.cpp
+++ b/components/core/src/clp/streaming_compression/passthrough/Compressor.cpp
@@ -4,10 +4,11 @@
 
 #include "../../ErrorCode.hpp"
 #include "../../TraceableException.hpp"
+#include "../../WriterInterface.hpp"
 
 namespace clp::streaming_compression::passthrough {
 auto Compressor::write(char const* data, size_t const data_length) -> void {
-    if (nullptr == m_compressed_stream_file_writer) {
+    if (nullptr == m_compressed_stream_writer) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
@@ -19,30 +20,30 @@ auto Compressor::write(char const* data, size_t const data_length) -> void {
         throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
     }
 
-    m_compressed_stream_file_writer->write(data, data_length);
+    m_compressed_stream_writer->write(data, data_length);
 }
 
 auto Compressor::flush() -> void {
-    if (nullptr == m_compressed_stream_file_writer) {
+    if (nullptr == m_compressed_stream_writer) {
         throw OperationFailed(ErrorCode_NotInit, __FILENAME__, __LINE__);
     }
 
-    m_compressed_stream_file_writer->flush();
+    m_compressed_stream_writer->flush();
 }
 
 auto Compressor::try_get_pos(size_t& pos) const -> ErrorCode {
-    if (nullptr == m_compressed_stream_file_writer) {
+    if (nullptr == m_compressed_stream_writer) {
         return ErrorCode_NotInit;
     }
 
-    return m_compressed_stream_file_writer->try_get_pos(pos);
+    return m_compressed_stream_writer->try_get_pos(pos);
 }
 
 auto Compressor::close() -> void {
-    m_compressed_stream_file_writer = nullptr;
+    m_compressed_stream_writer = nullptr;
 }
 
-auto Compressor::open(FileWriter& file_writer) -> void {
-    m_compressed_stream_file_writer = &file_writer;
+auto Compressor::open(WriterInterface& writer) -> void {
+    m_compressed_stream_writer = &writer;
 }
 }  // namespace clp::streaming_compression::passthrough

--- a/components/core/src/clp/streaming_compression/passthrough/Compressor.hpp
+++ b/components/core/src/clp/streaming_compression/passthrough/Compressor.hpp
@@ -4,8 +4,8 @@
 #include <cstddef>
 
 #include "../../ErrorCode.hpp"
-#include "../../FileWriter.hpp"
 #include "../../TraceableException.hpp"
+#include "../../WriterInterface.hpp"
 #include "../Compressor.hpp"
 
 namespace clp::streaming_compression::passthrough {
@@ -70,13 +70,13 @@ public:
 
     /**
      * Initializes the compression stream
-     * @param file_writer
+     * @param writer
      */
-    auto open(FileWriter& file_writer) -> void override;
+    auto open(WriterInterface& writer) -> void override;
 
 private:
     // Variables
-    FileWriter* m_compressed_stream_file_writer{nullptr};
+    WriterInterface* m_compressed_stream_writer{nullptr};
 };
 }  // namespace clp::streaming_compression::passthrough
 

--- a/components/core/src/clp/streaming_compression/passthrough/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/passthrough/Decompressor.cpp
@@ -23,8 +23,8 @@ ErrorCode Decompressor::try_read(char* buf, size_t num_bytes_to_read, size_t& nu
             );
             memcpy(buf, &m_compressed_data_buf[m_decompressed_stream_pos], num_bytes_read);
             break;
-        case InputType::File: {
-            auto error_code = m_file_reader->try_read(buf, num_bytes_to_read, num_bytes_read);
+        case InputType::ReaderInterface: {
+            auto error_code = m_reader->try_read(buf, num_bytes_to_read, num_bytes_read);
             if (ErrorCode_Success != error_code) {
                 return error_code;
             }
@@ -49,8 +49,8 @@ ErrorCode Decompressor::try_seek_from_begin(size_t pos) {
                 return ErrorCode_Truncated;
             }
             break;
-        case InputType::File: {
-            auto error_code = m_file_reader->try_seek_from_begin(pos);
+        case InputType::ReaderInterface: {
+            auto error_code = m_reader->try_seek_from_begin(pos);
             if (ErrorCode_Success != error_code) {
                 return error_code;
             }
@@ -85,14 +85,14 @@ void Decompressor::open(char const* compressed_data_buf, size_t compressed_data_
     m_input_type = InputType::CompressedDataBuf;
 }
 
-void Decompressor::open(FileReader& file_reader, size_t file_read_buffer_capacity) {
+void Decompressor::open(ReaderInterface& reader, size_t read_buffer_capacity) {
     if (InputType::NotInitialized != m_input_type) {
         throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
     }
 
-    m_file_reader = &file_reader;
+    m_reader = &reader;
     m_decompressed_stream_pos = 0;
-    m_input_type = InputType::File;
+    m_input_type = InputType::ReaderInterface;
 }
 
 void Decompressor::close() {
@@ -101,8 +101,8 @@ void Decompressor::close() {
             m_compressed_data_buf = nullptr;
             m_compressed_data_buf_len = 0;
             break;
-        case InputType::File:
-            m_file_reader = nullptr;
+        case InputType::ReaderInterface:
+            m_reader = nullptr;
             break;
         case InputType::NotInitialized:
             // Do nothing

--- a/components/core/src/clp/streaming_compression/passthrough/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/passthrough/Decompressor.hpp
@@ -1,7 +1,7 @@
 #ifndef CLP_STREAMING_COMPRESSION_PASSTHROUGH_DECOMPRESSOR_HPP
 #define CLP_STREAMING_COMPRESSION_PASSTHROUGH_DECOMPRESSOR_HPP
 
-#include "../../FileReader.hpp"
+#include "../../ReaderInterface.hpp"
 #include "../../TraceableException.hpp"
 #include "../Decompressor.hpp"
 
@@ -69,7 +69,7 @@ public:
 
     // Methods implementing the Decompressor interface
     void open(char const* compressed_data_buf, size_t compressed_data_buf_size) override;
-    void open(FileReader& file_reader, size_t file_read_buffer_capacity) override;
+    void open(ReaderInterface& reader, size_t read_buffer_capacity) override;
     void close() override;
     /**
      * Decompresses and copies the range of uncompressed data described by
@@ -90,13 +90,13 @@ private:
     enum class InputType {
         NotInitialized,
         CompressedDataBuf,
-        File
+        ReaderInterface
     };
 
     // Variables
     InputType m_input_type;
 
-    FileReader* m_file_reader;
+    ReaderInterface* m_reader;
     char const* m_compressed_data_buf;
     size_t m_compressed_data_buf_len;
 

--- a/components/core/src/clp/streaming_compression/zstd/Compressor.hpp
+++ b/components/core/src/clp/streaming_compression/zstd/Compressor.hpp
@@ -7,8 +7,8 @@
 
 #include "../../Array.hpp"
 #include "../../ErrorCode.hpp"
-#include "../../FileWriter.hpp"
 #include "../../TraceableException.hpp"
+#include "../../WriterInterface.hpp"
 #include "../Compressor.hpp"
 #include "Constants.hpp"
 
@@ -72,18 +72,18 @@ public:
 
     /**
      * Initializes the compression stream with the default compression level
-     * @param file_writer
+     * @param writer
      */
-    auto open(FileWriter& file_writer) -> void override {
-        this->open(file_writer, cDefaultCompressionLevel);
+    auto open(WriterInterface& writer) -> void override {
+        this->open(writer, cDefaultCompressionLevel);
     }
 
     /**
      * Initializes the compression stream with the given compression level
-     * @param file_writer
+     * @param writer
      * @param compression_level
      */
-    auto open(FileWriter& file_writer, int compression_level) -> void;
+    auto open(WriterInterface& writer, int compression_level) -> void;
 
     /**
      * Flushes the stream without ending the current frame
@@ -92,7 +92,7 @@ public:
 
 private:
     // Variables
-    FileWriter* m_compressed_stream_file_writer{nullptr};
+    WriterInterface* m_compressed_stream_writer{nullptr};
 
     // Compressed stream variables
     ZSTD_CStream* m_compression_stream{ZSTD_createCStream()};

--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
@@ -8,15 +8,15 @@
 
 namespace clp::streaming_compression::zstd {
 Decompressor::Decompressor()
-        : ::clp::streaming_compression::Decompressor(CompressorType::ZSTD),
-          m_input_type(InputType::NotInitialized),
-          m_decompression_stream(nullptr),
-          m_file_reader(nullptr),
-          m_file_reader_initial_pos(0),
-          m_file_read_buffer_length(0),
-          m_file_read_buffer_capacity(0),
-          m_decompressed_stream_pos(0),
-          m_unused_decompressed_stream_block_size(0) {
+        : ::clp::streaming_compression::Decompressor{CompressorType::ZSTD},
+          m_input_type{InputType::NotInitialized},
+          m_decompression_stream{nullptr},
+          m_reader{nullptr},
+          m_reader_initial_pos{0},
+          m_read_buffer_length{0},
+          m_read_buffer_capacity{0},
+          m_decompressed_stream_pos{0},
+          m_unused_decompressed_stream_block_size{0} {
     m_decompression_stream = ZSTD_createDStream();
     if (nullptr == m_decompression_stream) {
         SPDLOG_ERROR("streaming_compression::zstd::Decompressor: ZSTD_createDStream() error");
@@ -58,11 +58,11 @@ ErrorCode Decompressor::try_read(char* buf, size_t num_bytes_to_read, size_t& nu
                         return ErrorCode_Success;
                     }
                     break;
-                case InputType::File: {
-                    auto error_code = m_file_reader->try_read(
-                            reinterpret_cast<char*>(m_file_read_buffer.get()),
-                            m_file_read_buffer_capacity,
-                            m_file_read_buffer_length
+                case InputType::ReaderInterface: {
+                    auto error_code = m_reader->try_read(
+                            reinterpret_cast<char*>(m_read_buffer.get()),
+                            m_read_buffer_capacity,
+                            m_read_buffer_length
                     );
                     if (ErrorCode_Success != error_code) {
                         if (ErrorCode_EndOfFile == error_code) {
@@ -78,7 +78,7 @@ ErrorCode Decompressor::try_read(char* buf, size_t num_bytes_to_read, size_t& nu
                     }
 
                     m_compressed_stream_block.pos = 0;
-                    m_compressed_stream_block.size = m_file_read_buffer_length;
+                    m_compressed_stream_block.size = m_read_buffer_length;
                     break;
                 }
                 default:
@@ -160,20 +160,24 @@ void Decompressor::open(char const* compressed_data_buf, size_t compressed_data_
     reset_stream();
 }
 
-void Decompressor::open(FileReader& file_reader, size_t file_read_buffer_capacity) {
+void Decompressor::open(ReaderInterface& reader, size_t read_buffer_capacity) {
     if (InputType::NotInitialized != m_input_type) {
         throw OperationFailed(ErrorCode_NotReady, __FILENAME__, __LINE__);
     }
-    m_input_type = InputType::File;
+    m_input_type = InputType::ReaderInterface;
 
-    m_file_reader = &file_reader;
-    m_file_reader_initial_pos = m_file_reader->get_pos();
+    m_reader = &reader;
+    if (auto rc = m_reader->try_get_pos(m_reader_initial_pos);
+        false == (ErrorCode_Success == rc || ErrorCode_EndOfFile == rc))
+    {
+        throw OperationFailed(rc, __FILENAME__, __LINE__);
+    }
 
-    m_file_read_buffer_capacity = file_read_buffer_capacity;
-    m_file_read_buffer = std::make_unique<char[]>(m_file_read_buffer_capacity);
-    m_file_read_buffer_length = 0;
+    m_read_buffer_capacity = read_buffer_capacity;
+    m_read_buffer = std::make_unique<char[]>(m_read_buffer_capacity);
+    m_read_buffer_length = 0;
 
-    m_compressed_stream_block = {m_file_read_buffer.get(), m_file_read_buffer_length, 0};
+    m_compressed_stream_block = {m_read_buffer.get(), m_read_buffer_length, 0};
 
     reset_stream();
 }
@@ -183,11 +187,11 @@ void Decompressor::close() {
         case InputType::MemoryMappedCompressedFile:
             m_memory_mapped_file.reset();
             break;
-        case InputType::File:
-            m_file_read_buffer.reset();
-            m_file_read_buffer_capacity = 0;
-            m_file_read_buffer_length = 0;
-            m_file_reader = nullptr;
+        case InputType::ReaderInterface:
+            m_read_buffer.reset();
+            m_read_buffer_capacity = 0;
+            m_read_buffer_length = 0;
+            m_reader = nullptr;
             break;
         case InputType::CompressedDataBuf:
         case InputType::NotInitialized:
@@ -232,10 +236,14 @@ ErrorCode Decompressor::get_decompressed_stream_region(
 }
 
 void Decompressor::reset_stream() {
-    if (InputType::File == m_input_type) {
-        m_file_reader->seek_from_begin(m_file_reader_initial_pos);
-        m_file_read_buffer_length = 0;
-        m_compressed_stream_block.size = m_file_read_buffer_length;
+    if (InputType::ReaderInterface == m_input_type) {
+        if (auto rc = m_reader->try_seek_from_begin(m_reader_initial_pos);
+            false == (ErrorCode_Success == rc || ErrorCode_EndOfFile == rc))
+        {
+            throw OperationFailed(rc, __FILENAME__, __LINE__);
+        }
+        m_read_buffer_length = 0;
+        m_compressed_stream_block.size = m_read_buffer_length;
     }
 
     ZSTD_initDStream(m_decompression_stream);

--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
@@ -7,16 +7,7 @@
 #include "../../spdlog_with_specializations.hpp"
 
 namespace clp::streaming_compression::zstd {
-Decompressor::Decompressor()
-        : ::clp::streaming_compression::Decompressor{CompressorType::ZSTD},
-          m_input_type{InputType::NotInitialized},
-          m_decompression_stream{nullptr},
-          m_reader{nullptr},
-          m_reader_initial_pos{0},
-          m_read_buffer_length{0},
-          m_read_buffer_capacity{0},
-          m_decompressed_stream_pos{0},
-          m_unused_decompressed_stream_block_size{0} {
+Decompressor::Decompressor() : ::clp::streaming_compression::Decompressor{CompressorType::ZSTD} {
     m_decompression_stream = ZSTD_createDStream();
     if (nullptr == m_decompression_stream) {
         SPDLOG_ERROR("streaming_compression::zstd::Decompressor: ZSTD_createDStream() error");

--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
@@ -167,7 +167,7 @@ void Decompressor::open(ReaderInterface& reader, size_t read_buffer_capacity) {
     m_input_type = InputType::ReaderInterface;
 
     m_reader = &reader;
-    if (auto rc = m_reader->try_get_pos(m_reader_initial_pos);
+    if (auto const rc = m_reader->try_get_pos(m_reader_initial_pos);
         false == (ErrorCode_Success == rc || ErrorCode_EndOfFile == rc))
     {
         throw OperationFailed(rc, __FILENAME__, __LINE__);
@@ -237,7 +237,7 @@ ErrorCode Decompressor::get_decompressed_stream_region(
 
 void Decompressor::reset_stream() {
     if (InputType::ReaderInterface == m_input_type) {
-        if (auto rc = m_reader->try_seek_from_begin(m_reader_initial_pos);
+        if (auto const rc = m_reader->try_seek_from_begin(m_reader_initial_pos);
             false == (ErrorCode_Success == rc || ErrorCode_EndOfFile == rc))
         {
             throw OperationFailed(rc, __FILENAME__, __LINE__);

--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
@@ -120,22 +120,22 @@ private:
     void reset_stream();
 
     // Variables
-    InputType m_input_type;
+    InputType m_input_type{InputType::NotInitialized};
 
     // Compressed stream variables
-    ZSTD_DStream* m_decompression_stream;
+    ZSTD_DStream* m_decompression_stream{nullptr};
 
     std::unique_ptr<ReadOnlyMemoryMappedFile> m_memory_mapped_file;
-    ReaderInterface* m_reader;
-    size_t m_reader_initial_pos;
+    ReaderInterface* m_reader{nullptr};
+    size_t m_reader_initial_pos{0ULL};
     std::unique_ptr<char[]> m_read_buffer;
-    size_t m_read_buffer_length;
-    size_t m_read_buffer_capacity;
+    size_t m_read_buffer_length{0ULL};
+    size_t m_read_buffer_capacity{0ULL};
 
-    ZSTD_inBuffer m_compressed_stream_block;
+    ZSTD_inBuffer m_compressed_stream_block{};
 
-    size_t m_decompressed_stream_pos;
-    size_t m_unused_decompressed_stream_block_size;
+    size_t m_decompressed_stream_pos{0ULL};
+    size_t m_unused_decompressed_stream_block_size{0ULL};
     std::unique_ptr<char[]> m_unused_decompressed_stream_block_buffer;
 };
 }  // namespace clp::streaming_compression::zstd

--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
@@ -6,7 +6,7 @@
 
 #include <zstd.h>
 
-#include "../../FileReader.hpp"
+#include "../../ReaderInterface.hpp"
 #include "../../ReadOnlyMemoryMappedFile.hpp"
 #include "../../TraceableException.hpp"
 #include "../Decompressor.hpp"
@@ -73,7 +73,7 @@ public:
 
     // Methods implementing the Decompressor interface
     void open(char const* compressed_data_buf, size_t compressed_data_buf_size) override;
-    void open(FileReader& file_reader, size_t file_read_buffer_capacity) override;
+    void open(ReaderInterface& reader, size_t read_buffer_capacity) override;
     void close() override;
     /**
      * Decompresses and copies the range of uncompressed data described by
@@ -109,7 +109,7 @@ private:
         NotInitialized,
         CompressedDataBuf,
         MemoryMappedCompressedFile,
-        File
+        ReaderInterface
     };
 
     // Methods
@@ -126,11 +126,11 @@ private:
     ZSTD_DStream* m_decompression_stream;
 
     std::unique_ptr<ReadOnlyMemoryMappedFile> m_memory_mapped_file;
-    FileReader* m_file_reader;
-    size_t m_file_reader_initial_pos;
-    std::unique_ptr<char[]> m_file_read_buffer;
-    size_t m_file_read_buffer_length;
-    size_t m_file_read_buffer_capacity;
+    ReaderInterface* m_reader;
+    size_t m_reader_initial_pos;
+    std::unique_ptr<char[]> m_read_buffer;
+    size_t m_read_buffer_length;
+    size_t m_read_buffer_capacity;
 
     ZSTD_inBuffer m_compressed_stream_block;
 


### PR DESCRIPTION
# Description
This PR modifies all of the clp::Decompressor classes to accept a generic clp::ReaderInterface instead of only clp::FileReader. This change is necessary to allow use-cases like directly decompressing the output of a clp::NetworkReader. Likewise we modify the clp::Compressor classes to accept a generic clp::WriterInterface.

We also make some small modifications to zstd::Decompressor to avoid throwing on `open` when the passed clp::ReaderInterface is already at EOF. This allows open followed by no reads or reads of size zero to succeed as they should.


# Validation performed
* Validated that tests pass
* Validated that zstd::Decompressor can be used to decompress output from a clp::NetworkReader or clp::FileReader



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a more flexible reader interface for decompression, allowing for compatibility with various input sources.
	- Updated the compression interfaces to utilize a generalized writer interface, enhancing output handling flexibility.

- **Refactor**
	- Streamlined decompression and compression processes by replacing file-specific methods with more abstract interfaces.
	- Improved input and output handling across multiple components, enhancing overall system versatility.
	- Enhanced error handling in the `close()` method for file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->