### PR TITLE
feat(clp-package): Add package support for the indexer process.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -92,6 +92,7 @@ tasks:
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/indexer"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/reducer-server"
       - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/package.json"
       - "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/server/package-lock.json"
@@ -137,6 +138,7 @@ tasks:
         "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"
         "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp"
         "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+        "{{.G_CORE_COMPONENT_BUILD_DIR}}/indexer"
         "{{.G_CORE_COMPONENT_BUILD_DIR}}/reducer-server"
         "{{.OUTPUT_DIR}}/bin/"
       - >-
@@ -191,6 +193,7 @@ tasks:
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+      - "{{.G_CORE_COMPONENT_BUILD_DIR}}/indexer"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/reducer-server"
     deps: ["deps:core", "init"]
     cmds:
@@ -200,7 +203,7 @@ tasks:
         cmake
         --build "{{.G_CORE_COMPONENT_BUILD_DIR}}"
         --parallel
-        --target clg clo clp clp-s reducer-server
+        --target clg clo clp clp-s indexer reducer-server
 
   clp-package-utils:
     - task: "python-component"

--- a/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
@@ -99,7 +99,7 @@ def main(argv):
                 f"""
                 CREATE TABLE IF NOT EXISTS `{table_prefix}column_metadata_default` (
                     `name` VARCHAR(512) NOT NULL,
-                    `type` INT NOT NULL,
+                    `type` TINYINT NOT NULL,
                     PRIMARY KEY (`name`, `type`)
                 )
                 """

--- a/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
@@ -95,6 +95,17 @@ def main(argv):
                 """
             )
 
+            metadata_db_cursor.execute(
+                f"""
+            CREATE TABLE IF NOT EXISTS `{table_prefix}column_metadata_default` (
+                `name` VARCHAR(512) NOT NULL,
+                `type` BIGINT NOT NULL,
+                PRIMARY KEY (`name`, `type`)
+                PRIMARY KEY (`file_id`,`tag_id`)
+            )
+            """
+            )
+
             metadata_db.commit()
     except:
         logger.exception("Failed to create clp metadata tables.")

--- a/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
@@ -97,13 +97,12 @@ def main(argv):
 
             metadata_db_cursor.execute(
                 f"""
-            CREATE TABLE IF NOT EXISTS `{table_prefix}column_metadata_default` (
-                `name` VARCHAR(512) NOT NULL,
-                `type` BIGINT NOT NULL,
-                PRIMARY KEY (`name`, `type`)
-                PRIMARY KEY (`file_id`,`tag_id`)
-            )
-            """
+                CREATE TABLE IF NOT EXISTS `{table_prefix}column_metadata_default` (
+                    `name` VARCHAR(512) NOT NULL,
+                    `type` BIGINT NOT NULL,
+                    PRIMARY KEY (`name`, `type`)
+                )
+                """
             )
 
             metadata_db.commit()

--- a/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
@@ -99,7 +99,7 @@ def main(argv):
                 f"""
                 CREATE TABLE IF NOT EXISTS `{table_prefix}column_metadata_default` (
                     `name` VARCHAR(512) NOT NULL,
-                    `type` BIGINT NOT NULL,
+                    `type` INT NOT NULL,
                     PRIMARY KEY (`name`, `type`)
                 )
                 """

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -353,15 +353,27 @@ def run_clp(
                         last_archive_stats,
                     )
                     db_conn.commit()
+
                 if StorageEngine.CLP_S == clp_storage_engine:
+                    # TODO: Since CLP doesn't currently support datasets but users of the index
+                    # require a dataset name, we hardcode a name for now.
+                    dataset_name = "default"
                     indexer_cmd = [
                         str(clp_home / "bin" / "indexer"),
                         "--db-config-file",
                         str(db_config_file_path),
-                        "default",  # hardcode the table name for now
+                        dataset_name,
                         archive_path,
                     ]
-                    subprocess.run(indexer_cmd, stdout=subprocess.DEVNULL, stderr=stderr_log_file)
+                    try:
+                        subprocess.run(
+                            indexer_cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=stderr_log_file,
+                            check=True,
+                        )
+                    except subprocess.CalledProcessError:
+                        logger.exception("Failed to index archive.")
 
             if enable_s3_write:
                 archive_path.unlink()

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -327,8 +327,6 @@ def run_clp(
             if StorageEngine.CLP_S == clp_storage_engine:
                 metadata_uploader_cmd = [
                     str(clp_home / "bin" / "indexer"),
-                    "c",
-                    str(archive_output_dir),
                     "--db-config-file",
                     str(db_config_file_path),
                     "default",  # hardcode the table name for now

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -322,10 +322,20 @@ def run_clp(
         if last_archive_stats is not None and (
             None is stats or stats["id"] != last_archive_stats["id"]
         ):
+            archive_id = last_archive_stats["id"]
+            archive_path = archive_output_dir / archive_id
+            if StorageEngine.CLP_S == clp_storage_engine:
+                metadata_uploader_cmd = [
+                    str(clp_home / "bin" / "indexer"),
+                    "c", str(archive_output_dir),
+                    "--db-config-file", str(db_config_file_path),
+                    "default", # hardcode the table name for now
+                    archive_path
+                ]
+                proc = subprocess.Popen(metadata_uploader_cmd, stdout=subprocess.DEVNULL,
+                                        stderr=stderr_log_file)
+                proc.wait()
             if enable_s3_write:
-                archive_id = last_archive_stats["id"]
-                archive_path = archive_output_dir / archive_id
-
                 if s3_error is None:
                     logger.info(f"Uploading archive {archive_id} to S3...")
                     try:

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -327,13 +327,16 @@ def run_clp(
             if StorageEngine.CLP_S == clp_storage_engine:
                 metadata_uploader_cmd = [
                     str(clp_home / "bin" / "indexer"),
-                    "c", str(archive_output_dir),
-                    "--db-config-file", str(db_config_file_path),
-                    "default", # hardcode the table name for now
-                    archive_path
+                    "c",
+                    str(archive_output_dir),
+                    "--db-config-file",
+                    str(db_config_file_path),
+                    "default",  # hardcode the table name for now
+                    archive_path,
                 ]
-                proc = subprocess.Popen(metadata_uploader_cmd, stdout=subprocess.DEVNULL,
-                                        stderr=stderr_log_file)
+                proc = subprocess.Popen(
+                    metadata_uploader_cmd, stdout=subprocess.DEVNULL, stderr=stderr_log_file
+                )
                 proc.wait()
             if enable_s3_write:
                 if s3_error is None:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds the indexer process as a step for compressing JSON logs using the package. After compression, it runs the indexer process to populate all json paths and corresponding types into a mysql table. This table can then be used by any SQL query engine to resolve metadata for CLP archives.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
+ Built and package
+ Modified `clp_config.yml` to output archives to a test S3 bucket
+ Compressed part of [MongoDB logs](https://zenodo.org/records/11075361) using the package
+ Archives were successfully uploaded to S3
+ Verified that the rows in the clp_column_metadata_default table match the JSON paths and types from the logs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The build and packaging process now integrates a new component, streamlining overall workflows.
	- A new SQL table, `column_metadata_default`, has been added to enhance metadata management.
	- Enhanced metadata handling with an additional storage mechanism to support improved data management.
	- Updated the file compression workflow with an optimized metadata upload step for smoother performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->