### PR TITLE
refactor(clp::streaming_compression): Use `clp::Array` in zstd decompressor to replace C-style arrays.

### DIFF
--- a/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/zstd/Decompressor.hpp
@@ -2,10 +2,12 @@
 #define CLP_STREAMING_COMPRESSION_ZSTD_DECOMPRESSOR_HPP
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <zstd.h>
 
+#include "../../Array.hpp"
 #include "../../ReaderInterface.hpp"
 #include "../../ReadOnlyMemoryMappedFile.hpp"
 #include "../../TraceableException.hpp"
@@ -128,15 +130,15 @@ private:
     std::unique_ptr<ReadOnlyMemoryMappedFile> m_memory_mapped_file;
     ReaderInterface* m_reader{nullptr};
     size_t m_reader_initial_pos{0ULL};
-    std::unique_ptr<char[]> m_read_buffer;
+
+    std::optional<Array<char>> m_read_buffer;
     size_t m_read_buffer_length{0ULL};
-    size_t m_read_buffer_capacity{0ULL};
 
     ZSTD_inBuffer m_compressed_stream_block{};
 
     size_t m_decompressed_stream_pos{0ULL};
-    size_t m_unused_decompressed_stream_block_size{0ULL};
-    std::unique_ptr<char[]> m_unused_decompressed_stream_block_buffer;
+
+    Array<char> m_unused_decompressed_stream_block_buffer;
 };
 }  // namespace clp::streaming_compression::zstd
 #endif  // CLP_STREAMING_COMPRESSION_ZSTD_DECOMPRESSOR_HPP


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).

refactor(clp::streaming_compression): Use `clp::Array` in zstd decompressor to replace C-style arrays.
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR uses `clp::Array` to replace C-style array (backed using a unique pointer) to modernize the implementation so that it matches our latest coding standard.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.
- Unfortunately, we don't have unit tests to test the touched code path. I tested locally to ensure that:
  - Decompression by reading from a file works -> the decompressed results matched the original input before compression
  - Seeking from the beginning works as expected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated memory management for decompression buffers
	- Modernized buffer handling using standard library types
	- Improved error checking and initialization processes

- **Bug Fixes**
	- Enhanced validation for read buffer operations
	- Simplified buffer management to reduce potential memory-related issues

The changes focus on improving the internal implementation of the Zstandard decompression mechanism, making the code more robust and maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->