### PR TITLE
feat(core): Add boilerplate for LZMA decompressor.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -540,6 +540,8 @@ set(SOURCE_FILES_unitTest
         src/clp/streaming_compression/Decompressor.hpp
         src/clp/streaming_compression/lzma/Compressor.cpp
         src/clp/streaming_compression/lzma/Compressor.hpp
+        src/clp/streaming_compression/lzma/Decompressor.cpp
+        src/clp/streaming_compression/lzma/Decompressor.hpp
         src/clp/streaming_compression/lzma/Constants.hpp
         src/clp/streaming_compression/passthrough/Compressor.cpp
         src/clp/streaming_compression/passthrough/Compressor.hpp

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.cpp
@@ -7,7 +7,7 @@
 #include "../../TraceableException.hpp"
 
 namespace clp::streaming_compression::lzma {
-[[nodiscard]] auto Decompressor::try_read(
+auto Decompressor::try_read(
         [[maybe_unused]] char* buf,
         [[maybe_unused]] size_t num_bytes_to_read,
         [[maybe_unused]] size_t& num_bytes_read
@@ -15,11 +15,11 @@ namespace clp::streaming_compression::lzma {
     return ErrorCode_Unsupported;
 }
 
-[[nodiscard]] auto Decompressor::try_seek_from_begin([[maybe_unused]] size_t pos) -> ErrorCode {
+auto Decompressor::try_seek_from_begin([[maybe_unused]] size_t pos) -> ErrorCode {
     return ErrorCode_Unsupported;
 }
 
-[[nodiscard]] auto Decompressor::try_get_pos([[maybe_unused]] size_t& pos) -> ErrorCode {
+auto Decompressor::try_get_pos([[maybe_unused]] size_t& pos) -> ErrorCode {
     return ErrorCode_Unsupported;
 }
 
@@ -41,7 +41,7 @@ auto Decompressor::close() -> void {
     throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
 }
 
-[[nodiscard]] auto Decompressor::get_decompressed_stream_region(
+auto Decompressor::get_decompressed_stream_region(
         [[maybe_unused]] size_t decompressed_stream_pos,
         [[maybe_unused]] char* extraction_buf,
         [[maybe_unused]] size_t extraction_len

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.cpp
@@ -1,0 +1,51 @@
+#include "Decompressor.hpp"
+
+#include <cstddef>
+
+#include "../../ErrorCode.hpp"
+#include "../../ReaderInterface.hpp"
+#include "../../TraceableException.hpp"
+
+namespace clp::streaming_compression::lzma {
+[[nodiscard]] auto Decompressor::try_read(
+        [[maybe_unused]] char* buf,
+        [[maybe_unused]] size_t num_bytes_to_read,
+        [[maybe_unused]] size_t& num_bytes_read
+) -> ErrorCode {
+    return ErrorCode_Unsupported;
+}
+
+[[nodiscard]] auto Decompressor::try_seek_from_begin([[maybe_unused]] size_t pos) -> ErrorCode {
+    return ErrorCode_Unsupported;
+}
+
+[[nodiscard]] auto Decompressor::try_get_pos([[maybe_unused]] size_t& pos) -> ErrorCode {
+    return ErrorCode_Unsupported;
+}
+
+auto Decompressor::open(
+        [[maybe_unused]] char const* compressed_data_buf,
+        [[maybe_unused]] size_t compressed_data_buf_size
+) -> void {
+    throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+}
+
+auto Decompressor::open(
+        [[maybe_unused]] ReaderInterface& file_reader,
+        [[maybe_unused]] size_t file_read_buffer_capacity
+) -> void {
+    throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+}
+
+auto Decompressor::close() -> void {
+    throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
+}
+
+[[nodiscard]] auto Decompressor::get_decompressed_stream_region(
+        [[maybe_unused]] size_t decompressed_stream_pos,
+        [[maybe_unused]] char* extraction_buf,
+        [[maybe_unused]] size_t extraction_len
+) -> ErrorCode {
+    return ErrorCode_Unsupported;
+}
+}  // namespace clp::streaming_compression::lzma

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.cpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.cpp
@@ -24,15 +24,15 @@ auto Decompressor::try_get_pos([[maybe_unused]] size_t& pos) -> ErrorCode {
 }
 
 auto Decompressor::open(
-        [[maybe_unused]] char const* compressed_data_buf,
-        [[maybe_unused]] size_t compressed_data_buf_size
+        [[maybe_unused]] char const* compressed_data_buffer,
+        [[maybe_unused]] size_t compressed_data_buffer_size
 ) -> void {
     throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
 }
 
 auto Decompressor::open(
-        [[maybe_unused]] ReaderInterface& file_reader,
-        [[maybe_unused]] size_t file_read_buffer_capacity
+        [[maybe_unused]] ReaderInterface& reader,
+        [[maybe_unused]] size_t read_buffer_capacity
 ) -> void {
     throw OperationFailed(ErrorCode_Unsupported, __FILENAME__, __LINE__);
 }

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
@@ -68,28 +68,29 @@ public:
     // Methods implementing the Decompressor interface
     /***
      * Initialize streaming decompressor to decompress from the specified compressed data buffer.
-     * @param compressed_data_buf
-     * @param compressed_data_buf_size
+     * @param compressed_data_buffer
+     * @param compressed_data_buffer_size
      * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported.
      */
-    auto open(char const* compressed_data_buf, size_t compressed_data_buf_size) -> void override;
+    auto open(char const* compressed_data_buffer, size_t compressed_data_buffer_size)
+            -> void override;
 
     /**
-     * Initializes the decompressor to decompress from an open file.
-     * @param file_reader
-     * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time.
+     * Initializes the decompressor to decompress from a reader interface.
+     * @param reader
+     * @param read_buffer_capacity The maximum amount of data to read from a reader at a time.
      * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported.
      */
-    auto open(ReaderInterface& file_reader, size_t file_read_buffer_capacity) -> void override;
+    auto open(ReaderInterface& reader, size_t read_buffer_capacity) -> void override;
 
-    /*
+    /**
      * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported.
      */
     auto close() -> void override;
 
     /**
-     * Decompresses and copies the range of uncompressed data described by decompressed_stream_pos
-     * and extraction_len into extraction_buf.
+     * Decompresses and copies the range of uncompressed data described by `decompressed_stream_pos`
+     * and `extraction_len` into `extraction_buf`.
      * @param decompressed_stream_pos
      * @param extraction_buf
      * @param extraction_len

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
@@ -36,7 +36,7 @@ public:
     auto operator=(Decompressor const&) -> Decompressor& = delete;
 
     // Delete move constructor and assignment operator
-    // TODO: change to default when the base decompressor class has been updated.
+    // TODO: Change to default when the base decompressor class has been updated.
     Decompressor(Decompressor&&) noexcept = delete;
     auto operator=(Decompressor&&) noexcept -> Decompressor& = delete;
 

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
@@ -1,0 +1,105 @@
+#ifndef CLP_STREAMING_COMPRESSION_LZMA_DECOMPRESSOR_HPP
+#define CLP_STREAMING_COMPRESSION_LZMA_DECOMPRESSOR_HPP
+
+#include <cstddef>
+
+#include "../../ErrorCode.hpp"
+#include "../../ReaderInterface.hpp"
+#include "../../TraceableException.hpp"
+#include "../Constants.hpp"
+#include "../Decompressor.hpp"
+
+namespace clp::streaming_compression::lzma {
+class Decompressor : public ::clp::streaming_compression::Decompressor {
+public:
+    // Types
+    class OperationFailed : public TraceableException {
+    public:
+        // Constructors
+        OperationFailed(ErrorCode error_code, char const* const filename, int line_number)
+                : TraceableException(error_code, filename, line_number) {}
+
+        // Methods
+        [[nodiscard]] auto what() const noexcept -> char const* override {
+            return "streaming_compression::lzma::Decompressor operation failed";
+        }
+    };
+
+    // Constructor
+    Decompressor() : clp::streaming_compression::Decompressor(CompressorType::LZMA) {}
+
+    // Destructor
+    ~Decompressor() override = default;
+
+    // Delete copy constructor and assignment operator
+    Decompressor(Decompressor const&) = delete;
+    auto operator=(Decompressor const&) -> Decompressor& = delete;
+
+    // Delete move constructor and assignment operator
+    // TODO: change to default when the base decompressor class has been updated
+    Decompressor(Decompressor&&) noexcept = delete;
+    auto operator=(Decompressor&&) noexcept -> Decompressor& = delete;
+
+    // Methods implementing the ReaderInterface
+    /**
+     * Tries to read up to a given number of bytes from the decompressor.
+     * @param buf
+     * @param num_bytes_to_read The number of bytes to try reading
+     * @param num_bytes_read The actual number of bytes read
+     * @return ErrorCode_Unsupported
+     */
+    [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
+            -> ErrorCode override;
+
+    /**
+     * Tries to seek from the beginning to the given position.
+     * @param pos
+     * @return ErrorCode_Unsupported
+     */
+    [[nodiscard]] auto try_seek_from_begin(size_t pos) -> ErrorCode override;
+
+    /**
+     * Tries to get the current position of the read head.
+     * @param pos Position of the read head in the file
+     * @return ErrorCode_Unsupported
+     */
+    [[nodiscard]] auto try_get_pos(size_t& pos) -> ErrorCode override;
+
+    // Methods implementing the Decompressor interface
+    /***
+     * Initialize streaming decompressor to decompress from the specified compressed data buffer
+     * @param compressed_data_buf
+     * @param compressed_data_buf_size
+     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported
+     */
+    auto open(char const* compressed_data_buf, size_t compressed_data_buf_size) -> void override;
+
+    /**
+     * Initializes the decompressor to decompress from an open file
+     * @param file_reader
+     * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time
+     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported
+     */
+    auto open(ReaderInterface& file_reader, size_t file_read_buffer_capacity) -> void override;
+
+    /*
+     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported
+     */
+    auto close() -> void override;
+
+    /**
+     * Decompresses and copies the range of uncompressed data described by decompressed_stream_pos
+     * and extraction_len into extraction_buf.
+     * @param decompressed_stream_pos
+     * @param extraction_buf
+     * @param extraction_len
+     * @return ErrorCode_Unsupported
+     */
+    [[nodiscard]] auto get_decompressed_stream_region(
+            size_t decompressed_stream_pos,
+            char* extraction_buf,
+            size_t extraction_len
+    ) -> ErrorCode override;
+};
+}  // namespace clp::streaming_compression::lzma
+#endif  // CLP_STREAMING_COMPRESSION_LZMA_DECOMPRESSOR_HPP

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
@@ -45,7 +45,7 @@ public:
      * Tries to read up to a given number of bytes from the decompressor.
      * @param buf
      * @param num_bytes_to_read The number of bytes to try reading.
-     * @param num_bytes_read The actual number of bytes read.
+     * @param num_bytes_read Returns the actual number of bytes read.
      * @return ErrorCode_Unsupported
      */
     [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
@@ -60,7 +60,7 @@ public:
 
     /**
      * Tries to get the current position of the read head.
-     * @param pos Position of the read head in the file.
+     * @param pos Returns the position of the read head in the file.
      * @return ErrorCode_Unsupported
      */
     [[nodiscard]] auto try_get_pos(size_t& pos) -> ErrorCode override;

--- a/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
+++ b/components/core/src/clp/streaming_compression/lzma/Decompressor.hpp
@@ -26,7 +26,7 @@ public:
     };
 
     // Constructor
-    Decompressor() : clp::streaming_compression::Decompressor(CompressorType::LZMA) {}
+    Decompressor() : clp::streaming_compression::Decompressor{CompressorType::LZMA} {}
 
     // Destructor
     ~Decompressor() override = default;
@@ -36,7 +36,7 @@ public:
     auto operator=(Decompressor const&) -> Decompressor& = delete;
 
     // Delete move constructor and assignment operator
-    // TODO: change to default when the base decompressor class has been updated
+    // TODO: change to default when the base decompressor class has been updated.
     Decompressor(Decompressor&&) noexcept = delete;
     auto operator=(Decompressor&&) noexcept -> Decompressor& = delete;
 
@@ -44,8 +44,8 @@ public:
     /**
      * Tries to read up to a given number of bytes from the decompressor.
      * @param buf
-     * @param num_bytes_to_read The number of bytes to try reading
-     * @param num_bytes_read The actual number of bytes read
+     * @param num_bytes_to_read The number of bytes to try reading.
+     * @param num_bytes_read The actual number of bytes read.
      * @return ErrorCode_Unsupported
      */
     [[nodiscard]] auto try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)
@@ -60,30 +60,30 @@ public:
 
     /**
      * Tries to get the current position of the read head.
-     * @param pos Position of the read head in the file
+     * @param pos Position of the read head in the file.
      * @return ErrorCode_Unsupported
      */
     [[nodiscard]] auto try_get_pos(size_t& pos) -> ErrorCode override;
 
     // Methods implementing the Decompressor interface
     /***
-     * Initialize streaming decompressor to decompress from the specified compressed data buffer
+     * Initialize streaming decompressor to decompress from the specified compressed data buffer.
      * @param compressed_data_buf
      * @param compressed_data_buf_size
-     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported
+     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported.
      */
     auto open(char const* compressed_data_buf, size_t compressed_data_buf_size) -> void override;
 
     /**
-     * Initializes the decompressor to decompress from an open file
+     * Initializes the decompressor to decompress from an open file.
      * @param file_reader
-     * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time
-     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported
+     * @param file_read_buffer_capacity The maximum amount of data to read from a file at a time.
+     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported.
      */
     auto open(ReaderInterface& file_reader, size_t file_read_buffer_capacity) -> void override;
 
     /*
-     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported
+     * @throw clp::streaming_compression::lzma::Decompressor::OperationFailed if unsupported.
      */
     auto close() -> void override;
 

--- a/components/core/tests/test-StreamingCompression.cpp
+++ b/components/core/tests/test-StreamingCompression.cpp
@@ -18,6 +18,7 @@
 #include "../src/clp/streaming_compression/Compressor.hpp"
 #include "../src/clp/streaming_compression/Decompressor.hpp"
 #include "../src/clp/streaming_compression/lzma/Compressor.hpp"
+#include "../src/clp/streaming_compression/lzma/Decompressor.hpp"
 #include "../src/clp/streaming_compression/passthrough/Compressor.hpp"
 #include "../src/clp/streaming_compression/passthrough/Decompressor.hpp"
 #include "../src/clp/streaming_compression/zstd/Compressor.hpp"
@@ -133,6 +134,7 @@ TEST_CASE("StreamingCompression", "[StreamingCompression]") {
     SECTION("LZMA compression") {
         compressor = std::make_unique<clp::streaming_compression::lzma::Compressor>();
         compress(std::move(compressor), uncompressed_buffer.data());
+        decompressor = std::make_unique<clp::streaming_compression::lzma::Decompressor>();
     }
 
     boost::filesystem::remove(string(cCompressedFilePath));


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

- Introduces the LZMA decompressor interface, inheriting from the base `Decompressor` class, with only the essential functions that require overriding.
- All functions are currently unimplemented and default to returning or throwing `ErrorCode_Unsupported`.
- Updates `CMakeLists.txt` to include the new files.
- Ensures the new files have been checked with `clang-tidy`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This isn't a breaking change.
* [x] No docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Successfully instantiated the new LZMA decompressor in a unit test, bypassing any operations.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added LZMA decompression support to the streaming compression functionality.
	- Introduced a new `Decompressor` class for handling LZMA decompression operations.

- **Tests**
	- Updated test suite to include LZMA decompressor testing.

The changes enhance the project's compression capabilities by integrating LZMA decompression, improving data handling flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->