### PR TITLE
fix(clp-json): Use correct indexer program name

### DIFF
--- a/components/core/src/clp_s/indexer/indexer.cpp
+++ b/components/core/src/clp_s/indexer/indexer.cpp
@@ -19,7 +19,7 @@ int main(int argc, char const* argv[]) {
         return 1;
     }
 
-    CommandLineArguments command_line_arguments("metadata-uploader");
+    CommandLineArguments command_line_arguments("index");
     auto parsing_result = command_line_arguments.parse_arguments(argc, argv);
     switch (parsing_result) {
         case CommandLineArguments::ParsingResult::Failure:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fixes the indexer program name.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Adjusted the command line input settings to align with the updated application behaviour for processing user-provided options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->