### PR TITLE
feat(clp-s): Add a method to SchemaReader to get the number of messages in a schema.

### DIFF
--- a/components/core/src/clp_s/SchemaReader.hpp
+++ b/components/core/src/clp_s/SchemaReader.hpp
@@ -158,6 +158,11 @@ public:
     void load(std::shared_ptr<char[]> stream_buffer, size_t offset, size_t uncompressed_size);
 
     /**
+     * @return the number of messages in the schema
+     */
+    uint64_t get_num_messages() const { return m_num_messages; }
+
+    /**
      * Gets next message
      * @param message
      * @return true if there is a next message


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds a method in `SchemaReader` to get number of messages of a schema, which can be used by custom `FilterClass` to implement related methods.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new capability for retrieving the total number of messages in a data set for easier reference by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->