### PR TITLE
feat: Add script to generate minimal clp-core Debian package.

### DIFF
--- a/components/core/tools/scripts/utils/README.md
+++ b/components/core/tools/scripts/utils/README.md
@@ -9,3 +9,6 @@ This directory contains uncategorized utility scripts.
   * This is useful if, for instance, you're developing on Ubuntu 18.04 but the
     package uses Ubuntu 20.04; you can build in the Ubuntu 20.04 container to
     avoid compatibility issues.
+* `create-debian-package.py` can be used to generate a minimal Debian package
+  containing CLP core package. Sample command:
+  `python3 create-debian-package.py --version 0.0 --revision 1 --build-dir ../../../build`

--- a/components/core/tools/scripts/utils/create-debian-package.py
+++ b/components/core/tools/scripts/utils/create-debian-package.py
@@ -1,0 +1,104 @@
+import argparse
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+
+
+def get_architecture() -> str:
+    """
+    Detect the system architecture using `dpkg`.
+
+    Returns:
+        str: The system architecture (e.g., 'amd64', 'arm64').
+
+    Raises:
+        RuntimeError: If the architecture cannot be detected.
+    """
+    try:
+        result = subprocess.run(
+            ["dpkg", "--print-architecture"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to detect architecture: {e.stderr}") from e
+
+
+def create_debian_package(args):
+    """
+    Create a Debian package for CLP core.
+
+    Args:
+        args: Command-line arguments containing build directory, version, revision, and output directory.
+    """
+
+    # Package configuration
+    package_name = "clp-core"
+    maintainer = "YScope <admin@yscope.com>"
+    description = "A minimal CLP core Debian package"
+    full_version = f"{args.version}-{args.revision}"
+    package_dependencies = ["libmariadb-dev", "libssl-dev"]
+
+    # Get system architecture (e.g., `amd64`, `arm64`)
+    architecture = get_architecture()
+
+    # Define package directory structure
+    package_dir = pathlib.Path(args.output_dir) / f"{package_name}-{full_version}"
+    debian_dir = package_dir / "DEBIAN"
+    bin_dir = package_dir / "usr" / "local" / "bin"
+
+    # Clean up existing directory if it exists
+    if package_dir.is_dir():
+        shutil.rmtree(package_dir, ignore_errors=True)
+
+    # Create debian package directory structure
+    debian_dir.mkdir(parents=True, exist_ok=False)
+    bin_dir.mkdir(parents=True, exist_ok=False)
+
+    # Create the Debian control file
+    control_file_lines = []
+    control_file_lines.append(f"Package: {package_name}")
+    control_file_lines.append(f"Maintainer: {maintainer}")
+    control_file_lines.append(f"Version: {full_version}")
+    control_file_lines.append(f"Architecture: {architecture}")
+    control_file_lines.append(f"Depends: {', '.join(package_dependencies)}")
+    control_file_lines.append(f"Description: {description}")
+    control_file_lines.append(os.linesep)
+    (debian_dir / "control").write_text(os.linesep.join(control_file_lines))
+
+    # Copy CLP core binaries from the build directory to the package's binary directory
+    print("\n=========================================================================\n")
+    build_dir = pathlib.Path(args.build_dir)
+    binaries = ["clg", "clo", "clp", "clp-s", "glt", "indexer", "make-dictionaries-readable"]
+    for binary in binaries:
+        print(f"Copying clp-core binary `{binary}` to {bin_dir.relative_to(package_dir)}")
+        shutil.copy(build_dir / binary, bin_dir)
+
+    # Make all binaries executable
+    for path in bin_dir.glob("*"):  # Non-recursive iteration
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Build the package
+    print("\n=========================================================================\n")
+    deb_file = pathlib.Path(args.output_dir) / f"{package_name}_{full_version}_{architecture}.deb"
+    subprocess.check_call(["dpkg-deb", "--build", str(package_dir), str(deb_file)])
+
+    # Print success message
+    print(f"\nPackage created: {deb_file}")
+    print(f"\nInstall with: sudo dpkg -i {deb_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create a minimal CLP core Debian package")
+    parser.add_argument("-b", "--build-dir", required=True, help="The CLP core CMake build directory")
+    parser.add_argument("-v", "--version", required=True, help="The Debian package upstream version")
+    parser.add_argument("-r", "--revision", default="1", help="The Debian package revision")
+    parser.add_argument("-o", "--output-dir", default=os.getcwd(), help="The debian package output dir")
+
+    args = parser.parse_args()
+
+    create_debian_package(args)

--- a/components/core/tools/scripts/utils/create-debian-package.py
+++ b/components/core/tools/scripts/utils/create-debian-package.py
@@ -73,7 +73,7 @@ def create_debian_package(args):
     build_dir = pathlib.Path(args.build_dir)
     if not build_dir.is_dir():
         raise ValueError(f"Build directory does not exist: {build_dir}")
-    
+
     binaries = ["clg", "clo", "clp", "clp-s", "glt", "indexer", "make-dictionaries-readable"]
     for binary in binaries:
         binary_path = build_dir / binary
@@ -94,7 +94,7 @@ def create_debian_package(args):
             ["dpkg-deb", "--build", str(package_dir), str(deb_file)],
             check=True,
             capture_output=True,
-            text=True
+            text=True,
         )
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to build Debian package: {e.stderr}") from e

--- a/components/core/tools/scripts/utils/create-debian-package.py
+++ b/components/core/tools/scripts/utils/create-debian-package.py
@@ -89,8 +89,15 @@ def create_debian_package(args):
     # Build the package
     print("\n=========================================================================\n")
     deb_file = pathlib.Path(args.output_dir) / f"{package_name}_{full_version}_{architecture}.deb"
-    subprocess.check_call(["dpkg-deb", "--build", str(package_dir), str(deb_file)])
-
+    try:
+        subprocess.run(
+            ["dpkg-deb", "--build", str(package_dir), str(deb_file)],
+            check=True,
+            capture_output=True,
+            text=True
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to build Debian package: {e.stderr}") from e
     # Print success message
     print(f"\nPackage created: {deb_file}")
     print(f"\nInstall with: sudo dpkg -i {deb_file}")

--- a/components/core/tools/scripts/utils/create-debian-package.py
+++ b/components/core/tools/scripts/utils/create-debian-package.py
@@ -71,8 +71,14 @@ def create_debian_package(args):
     # Copy CLP core binaries from the build directory to the package's binary directory
     print("\n=========================================================================\n")
     build_dir = pathlib.Path(args.build_dir)
+    if not build_dir.is_dir():
+        raise ValueError(f"Build directory does not exist: {build_dir}")
+    
     binaries = ["clg", "clo", "clp", "clp-s", "glt", "indexer", "make-dictionaries-readable"]
     for binary in binaries:
+        binary_path = build_dir / binary
+        if not binary_path.is_file():
+            raise ValueError(f"Required binary not found: {binary_path}")
         print(f"Copying clp-core binary `{binary}` to {bin_dir.relative_to(package_dir)}")
         shutil.copy(build_dir / binary, bin_dir)
 

--- a/components/core/tools/scripts/utils/create-debian-package.py
+++ b/components/core/tools/scripts/utils/create-debian-package.py
@@ -18,10 +18,7 @@ def get_architecture() -> str:
     """
     try:
         result = subprocess.run(
-            ["dpkg", "--print-architecture"],
-            capture_output=True,
-            text=True,
-            check=True
+            ["dpkg", "--print-architecture"], capture_output=True, text=True, check=True
         )
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
@@ -33,7 +30,8 @@ def create_debian_package(args):
     Create a Debian package for CLP core.
 
     Args:
-        args: Command-line arguments containing build directory, version, revision, and output directory.
+        args: Command-line arguments containing build directory, version, revision,
+              and output directory.
     """
 
     # Package configuration
@@ -94,10 +92,16 @@ def create_debian_package(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Create a minimal CLP core Debian package")
-    parser.add_argument("-b", "--build-dir", required=True, help="The CLP core CMake build directory")
-    parser.add_argument("-v", "--version", required=True, help="The Debian package upstream version")
+    parser.add_argument(
+        "-b", "--build-dir", required=True, help="The CLP core CMake build directory"
+    )
+    parser.add_argument(
+        "-v", "--version", required=True, help="The Debian package upstream version"
+    )
     parser.add_argument("-r", "--revision", default="1", help="The Debian package revision")
-    parser.add_argument("-o", "--output-dir", default=os.getcwd(), help="The debian package output dir")
+    parser.add_argument(
+        "-o", "--output-dir", default=os.getcwd(), help="The debian package output dir"
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
# Description

This PR adds a python script to automatically generate a minimal clp-core Debian package. The available options are:

```
$ python3 create-debian-package.py --help
usage: create-debian-package.py [-h] -b BUILD_DIR -v VERSION [-r REVISION] [-o OUTPUT_DIR]

Create a minimal CLP core Debian package

options:
  -h, --help            show this help message and exit
  -b BUILD_DIR, --build-dir BUILD_DIR
                        The CLP core CMake build directory
  -v VERSION, --version VERSION
                        The Debian package upstream version
  -r REVISION, --revision REVISION
                        The Debian package revision
  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                        The debian package output dir
 ```

Simple description and usage is also added to `components/core/tools/scripts/utils/README.md`

# Validation
3 commands are executed on an Ubuntu machine to build the Debian package, check the content of the package and install the package. The logs of the command line executions are shown below: 

```
$  python3 create-debian-package.py --version 0.0 --revision 1 --build-dir ../../../build

=========================================================================

Copying clp-core binary `clg` to usr/local/bin
Copying clp-core binary `clo` to usr/local/bin
Copying clp-core binary `clp` to usr/local/bin
Copying clp-core binary `clp-s` to usr/local/bin
Copying clp-core binary `glt` to usr/local/bin
Copying clp-core binary `indexer` to usr/local/bin
Copying clp-core binary `make-dictionaries-readable` to usr/local/bin

=========================================================================

dpkg-deb: building package 'clp-core' in '/home/jack/projects/jackluo923/clp/components/core/tools/scripts/utils/clp-core_0.0-1_amd64.deb'.

Package created: /home/jack/projects/jackluo923/clp/components/core/tools/scripts/utils/clp-core_0.0-1_amd64.deb

Install with: sudo dpkg -i /home/jack/projects/jackluo923/clp/components/core/tools/scripts/utils/clp-core_0.0-1_amd64.deb

$ dpkg -c clp-core_0.0-1_amd64.deb
drwxr-xr-x jack/jack         0 2025-02-13 05:31 ./
drwxr-xr-x jack/jack         0 2025-02-13 05:31 ./usr/
drwxr-xr-x jack/jack         0 2025-02-13 05:31 ./usr/local/
drwxr-xr-x jack/jack         0 2025-02-13 05:31 ./usr/local/bin/
-rwxr-xr-x jack/jack   4480440 2025-02-13 05:31 ./usr/local/bin/clg
-rwxr-xr-x jack/jack   6907752 2025-02-13 05:31 ./usr/local/bin/clo
-rwxr-xr-x jack/jack  10247608 2025-02-13 05:31 ./usr/local/bin/clp
-rwxr-xr-x jack/jack   8337536 2025-02-13 05:31 ./usr/local/bin/clp-s
-rwxr-xr-x jack/jack   9890200 2025-02-13 05:31 ./usr/local/bin/glt
-rwxr-xr-x jack/jack   3136320 2025-02-13 05:31 ./usr/local/bin/indexer
-rwxr-xr-x jack/jack   1399096 2025-02-13 05:31 ./usr/local/bin/make-dictionaries-readable

$ sudo dpkg -i /home/jack/projects/jackluo923/clp/components/core/tools/scripts/utils/clp-core_0.0-1_amd64.deb
(Reading database ... 80606 files and directories currently installed.)
Preparing to unpack .../utils/clp-core_0.0-1_amd64.deb ...
Unpacking clp-core (0.0-1) over (0.0-1) ...
Setting up clp-core (0.0-1) ...
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a utility script that simplifies creating a minimal Debian package for the CLP core, allowing users to specify parameters like version and build directory.
- **Documentation**
	- Enhanced documentation with a detailed description and sample usage to guide users through the new package creation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888482205566