### PR TITLE
feat(core): Add ValidatingUtf8Parser to string_utils.

### DIFF
--- a/components/core/src/clp/string_utils/CMakeLists.txt
+++ b/components/core/src/clp/string_utils/CMakeLists.txt
@@ -8,5 +8,6 @@ add_library(
         ${STRING_UTILS_HEADER_LIST}
 )
 add_library(clp::string_utils ALIAS string_utils)
-target_include_directories(string_utils PUBLIC ../)
+target_include_directories(string_utils PUBLIC ../ PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
+target_link_libraries(string_utils PRIVATE simdjson)
 target_compile_features(string_utils PRIVATE cxx_std_20)

--- a/components/core/src/clp/string_utils/string_utils.cpp
+++ b/components/core/src/clp/string_utils/string_utils.cpp
@@ -302,12 +302,12 @@ bool wildcard_match_unsafe_case_sensitive(string_view tame, string_view wild) {
     }
 }
 
-auto ValidatingUtf8Parser::validate(std::string_view raw)
+auto ValidatingUtf8Parser::validate(std::string_view raw, InvalidUtf8Policy policy)
         -> OUTCOME_V2_NAMESPACE::std_result<std::string_view> {
     if (simdjson::validate_utf8(raw.data(), raw.size())) {
         return raw;
     }
-    switch (m_policy) {
+    switch (policy) {
         case InvalidUtf8Policy::SubstituteReplacementCharacter:
             m_buffer.clear();
             utf8::replace_invalid(raw.begin(), raw.end(), std::back_inserter(m_buffer));
@@ -317,5 +317,28 @@ auto ValidatingUtf8Parser::validate(std::string_view raw)
         default:
             return std::errc::invalid_argument;
     }
+}
+
+template <>
+auto ValidatingUtf8Parser::validate<ValidatingUtf8Parser::InvalidUtf8Policy::ReturnError>(
+        std::string_view raw
+) -> OUTCOME_V2_NAMESPACE::std_result<std::string_view> {
+    if (simdjson::validate_utf8(raw.data(), raw.size())) {
+        return raw;
+    }
+    return std::errc::illegal_byte_sequence;
+}
+
+template <>
+auto ValidatingUtf8Parser::validate<
+        ValidatingUtf8Parser::InvalidUtf8Policy::SubstituteReplacementCharacter>(
+        std::string_view raw
+) -> OUTCOME_V2_NAMESPACE::std_result<std::string_view> {
+    if (simdjson::validate_utf8(raw.data(), raw.size())) {
+        return raw;
+    }
+    m_buffer.clear();
+    utf8::replace_invalid(raw.begin(), raw.end(), std::back_inserter(m_buffer));
+    return m_buffer;
 }
 }  // namespace clp::string_utils

--- a/components/core/src/clp/string_utils/string_utils.hpp
+++ b/components/core/src/clp/string_utils/string_utils.hpp
@@ -2,6 +2,7 @@
 #define CLP_STRING_UTILS_STRING_UTILS_HPP
 
 #include <charconv>
+#include <cstdint>
 #include <string>
 #include <string_view>
 
@@ -150,7 +151,7 @@ bool convert_string_to_int(std::string_view raw, integer_t& converted) {
  */
 class ValidatingUtf8Parser {
 public:
-    enum class InvalidUtf8Policy {
+    enum class InvalidUtf8Policy : uint8_t {
         SubstituteReplacementCharacter,
         ReturnError
     };
@@ -162,7 +163,7 @@ public:
      * or until the input string_view passed to this function becomes invalid, whichever is sooner.
      *
      * @param raw
-     * @param policy
+     * @param policy The error handling policy to apply when encountering invalid UTF-8 characters.
      * @return A result containing a valid UTF-8 string or an error code indicating the failure:
      * - std::errc::illegal_byte_sequence if the input contains invalid UTF-8 and the policy is
      *   ReturnError.
@@ -178,13 +179,13 @@ public:
      * or until the input string_view passed to this function becomes invalid, whichever is sooner.
      *
      * @param raw
-     * @tparam Policy the error handling policy to apply when encountering invalid UTF-8 characters.
+     * @tparam policy The error handling policy to apply when encountering invalid UTF-8 characters.
      * @return A result containing a valid UTF-8 string or an error code indicating the failure:
      * - std::errc::illegal_byte_sequence if the input contains invalid UTF-8 and the policy is
      *   ReturnError.
      * - std::errc::invalid_argument if the configured policy is unknown.
      */
-    template <InvalidUtf8Policy Policy>
+    template <InvalidUtf8Policy policy>
     auto validate(std::string_view raw) -> OUTCOME_V2_NAMESPACE::std_result<std::string_view>;
 
 private:

--- a/components/core/src/clp/string_utils/string_utils.hpp
+++ b/components/core/src/clp/string_utils/string_utils.hpp
@@ -3,6 +3,9 @@
 
 #include <charconv>
 #include <string>
+#include <string_view>
+
+#include <outcome/single-header/outcome.hpp>
 
 namespace clp::string_utils {
 /**
@@ -140,6 +143,41 @@ bool convert_string_to_int(std::string_view raw, integer_t& converted) {
         return result.ec == std::errc();
     }
 }
+
+/**
+ * This class implements a validating UTF-8 parser which takes as input valid or nearly-valid UTF-8
+ * and outputs valid UTF-8, handling invalid UTF-8 characters according to some policy.
+ */
+class ValidatingUtf8Parser {
+public:
+    enum class InvalidUtf8Policy {
+        SubstituteReplacementCharacter,
+        ReturnError
+    };
+
+    // Constructors
+    ValidatingUtf8Parser() {}
+
+    ValidatingUtf8Parser(InvalidUtf8Policy policy) : m_policy{policy} {}
+
+    /**
+     * Validates a UTF-8 input string and returns a valid UTF-8 output string or an error.
+     *
+     * The returned string_view is guaranteed to be valid until either the next call to `validate`
+     * or until the input string_view passed to this function becomes invalid, whichever is sooner.
+     *
+     * @param raw
+     * @return A result containing a valid UTF-8 string or an error code indicating the failure:
+     * - std::errc::illegal_byte_sequence if the input contains invalid UTF-8 and the policy is
+     *   ReturnError.
+     * - std::errc::invalid_argument if the configured policy is unknown.
+     */
+    auto validate(std::string_view raw) -> OUTCOME_V2_NAMESPACE::std_result<std::string_view>;
+
+private:
+    std::string m_buffer;
+    InvalidUtf8Policy m_policy{InvalidUtf8Policy::SubstituteReplacementCharacter};
+};
 }  // namespace clp::string_utils
 
 #endif  // CLP_STRING_UTILS_STRING_UTILS_HPP

--- a/components/core/src/clp/string_utils/string_utils.hpp
+++ b/components/core/src/clp/string_utils/string_utils.hpp
@@ -155,10 +155,21 @@ public:
         ReturnError
     };
 
-    // Constructors
-    ValidatingUtf8Parser() {}
-
-    ValidatingUtf8Parser(InvalidUtf8Policy policy) : m_policy{policy} {}
+    /**
+     * Validates a UTF-8 input string and returns a valid UTF-8 output string or an error.
+     *
+     * The returned string_view is guaranteed to be valid until either the next call to `validate`
+     * or until the input string_view passed to this function becomes invalid, whichever is sooner.
+     *
+     * @param raw
+     * @param policy
+     * @return A result containing a valid UTF-8 string or an error code indicating the failure:
+     * - std::errc::illegal_byte_sequence if the input contains invalid UTF-8 and the policy is
+     *   ReturnError.
+     * - std::errc::invalid_argument if the configured policy is unknown.
+     */
+    auto validate(std::string_view raw, InvalidUtf8Policy policy)
+            -> OUTCOME_V2_NAMESPACE::std_result<std::string_view>;
 
     /**
      * Validates a UTF-8 input string and returns a valid UTF-8 output string or an error.
@@ -167,16 +178,17 @@ public:
      * or until the input string_view passed to this function becomes invalid, whichever is sooner.
      *
      * @param raw
+     * @tparam Policy the error handling policy to apply when encountering invalid UTF-8 characters.
      * @return A result containing a valid UTF-8 string or an error code indicating the failure:
      * - std::errc::illegal_byte_sequence if the input contains invalid UTF-8 and the policy is
      *   ReturnError.
      * - std::errc::invalid_argument if the configured policy is unknown.
      */
+    template <InvalidUtf8Policy Policy>
     auto validate(std::string_view raw) -> OUTCOME_V2_NAMESPACE::std_result<std::string_view>;
 
 private:
     std::string m_buffer;
-    InvalidUtf8Policy m_policy{InvalidUtf8Policy::SubstituteReplacementCharacter};
 };
 }  // namespace clp::string_utils
 

--- a/components/core/tests/test-string_utils.cpp
+++ b/components/core/tests/test-string_utils.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <system_error>
 
 #include <boost/foreach.hpp>
 #include <boost/range/combine.hpp>
@@ -7,6 +8,7 @@
 
 using clp::string_utils::clean_up_wildcard_search_string;
 using clp::string_utils::convert_string_to_int;
+using clp::string_utils::ValidatingUtf8Parser;
 using clp::string_utils::wildcard_match_unsafe;
 using clp::string_utils::wildcard_match_unsafe_case_sensitive;
 using std::chrono::duration;
@@ -559,4 +561,51 @@ TEST_CASE("convert_string_to_int", "[convert_string_to_int]") {
     raw = "98340";
     REQUIRE(convert_string_to_int(raw, converted));
     REQUIRE(98'340 == converted);
+}
+
+TEST_CASE("Validate UTF-8 strings", "[validate_utf8]") {
+    constexpr std::string_view cValidString{"abcd1234\u1234"};
+    constexpr std::string_view cInvalidString1{"abcd123"
+                                               "\xFF"
+                                               "4\u1234"};
+    constexpr std::string_view cExpectedReplacementForInvalidString1{"abcd123\uFFFD4\u1234"};
+    constexpr std::string_view cInvalidString2{"abcd123"
+                                               "\xF0"
+                                               "\x80"
+                                               "\x80"
+                                               "\xC0"
+                                               "4\u1234"};
+    constexpr std::string_view cExpectedReplacementForInvalidString2{"abcd123\uFFFD\uFFFD4\u1234"};
+
+    SECTION("Error on invalid UTF-8 policy") {
+        ValidatingUtf8Parser parser{ValidatingUtf8Parser::InvalidUtf8Policy::ReturnError};
+        auto outcome = parser.validate(cValidString);
+        REQUIRE(false == outcome.has_error());
+        REQUIRE(cValidString == outcome.value());
+
+        outcome = parser.validate(cInvalidString1);
+        REQUIRE(true == outcome.has_error());
+        REQUIRE(std::errc::illegal_byte_sequence == outcome.error());
+
+        outcome = parser.validate(cInvalidString2);
+        REQUIRE(true == outcome.has_error());
+        REQUIRE(std::errc::illegal_byte_sequence == outcome.error());
+    }
+
+    SECTION("Replacement character on invalid UTF-8 policy") {
+        ValidatingUtf8Parser parser{
+                ValidatingUtf8Parser::InvalidUtf8Policy::SubstituteReplacementCharacter
+        };
+        auto outcome = parser.validate(cValidString);
+        REQUIRE(false == outcome.has_error());
+        REQUIRE(cValidString == outcome.value());
+
+        outcome = parser.validate(cInvalidString1);
+        REQUIRE(false == outcome.has_error());
+        REQUIRE(cExpectedReplacementForInvalidString1 == outcome.value());
+
+        outcome = parser.validate(cInvalidString2);
+        REQUIRE(false == outcome.has_error());
+        REQUIRE(cExpectedReplacementForInvalidString2 == outcome.value());
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

This PR adds the `ValidatingUtf8Parser` class to string_utils. This class accepts raw, potentially corrupted, UTF-8 strings and returns valid UTF-8 strings or an error according to a configurable invalid UTF-8 handling policy. The return signature of the validate method is `outcome<std::string_view>`, and the `ValidatingUtf8Parser` class maintains an internal buffer so that we can support error handling policies that require copying and manipulating the original string. Note that as a result of this choice the lifetime of the returned  `string_view` is up to the next call to `validate` or the end of the lifetime of the `string_view `passed as input, whichever is lesser.

`ValidatingUtf8Parser` currently has two flavours of validate signatures `validate(raw, policy)` and templated `validate<policy>(raw)`. It should be trivial to add another family of policies that accept a lambda to handle invalid UTF-8 if needed.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* Added appropriate unit tests for all `validate` signatures and error handling policies



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a robust UTF-8 validation capability that allows configurable error handling—either substituting replacement characters or returning clear error notifications for invalid strings.
  - Integrated improvements to external dependency management to enhance overall string processing performance.

- **Tests**
  - Added comprehensive test cases to verify the accuracy of UTF-8 validation under various scenarios, ensuring reliable handling of both valid and invalid string inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888452014173