### PR TITLE
feat(clp-s): Add support for specifying authoritative timestamp in kv-ir ingestion flow; Refactor timestamp matching for JSON ingestion flow.

### DIFF
--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -18,6 +18,7 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
     m_single_file_archive = option.single_file_archive;
     m_min_table_size = option.min_table_size;
     m_archives_dir = option.archives_dir;
+    m_authoritative_timestamp = option.authoritative_timestamp;
     std::string working_dir_name = m_id;
     if (option.single_file_archive) {
         working_dir_name += constants::cTmpPostfix;
@@ -114,6 +115,9 @@ void ArchiveWriter::close() {
     m_uncompressed_size = 0UL;
     m_compressed_size = 0UL;
     m_next_log_event_id = 0;
+    m_authoritative_timestamp.clear();
+    m_matched_timestamp_prefix_length = 0ULL;
+    m_matched_timestamp_prefix_node_id = constants::cRootNodeId;
 }
 
 void ArchiveWriter::write_single_file_archive(std::vector<ArchiveFileInfo> const& files) {

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -237,6 +237,38 @@ ArchiveWriter::append_message(int32_t schema_id, Schema const& schema, ParsedMes
     ++m_next_log_event_id;
 }
 
+int32_t ArchiveWriter::add_node(int parent_node_id, NodeType type, std::string_view key) {
+    auto const node_id{m_schema_tree.add_node(parent_node_id, type, key)};
+    if (m_matched_timestamp_prefix_node_id == parent_node_id
+        && m_authoritative_timestamp.size() > 0)
+    {
+        if (constants::cRootNodeId == parent_node_id) {
+            if (NodeType::Object == type) {
+                m_matched_timestamp_prefix_node_id = node_id;
+            }
+        } else if (m_authoritative_timestamp.size() - m_matched_timestamp_prefix_length > 1) {
+            if (NodeType::Object == type
+                && m_authoritative_timestamp.at(m_matched_timestamp_prefix_length) == key)
+            {
+                m_matched_timestamp_prefix_length += 1;
+                m_matched_timestamp_prefix_node_id = node_id;
+            }
+        }
+    }
+    return node_id;
+}
+
+bool ArchiveWriter::matches_timestamp(int parent_node_id, std::string_view key) {
+    if (m_matched_timestamp_prefix_node_id == parent_node_id) {
+        if (1 == (m_authoritative_timestamp.size() - m_matched_timestamp_prefix_length)
+            && m_authoritative_timestamp.back() == key)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 size_t ArchiveWriter::get_data_size() {
     return m_log_dict->get_data_size() + m_var_dict->get_data_size() + m_array_dict->get_data_size()
            + m_encoded_message_size;

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -91,32 +91,14 @@ public:
     void append_message(int32_t schema_id, Schema const& schema, ParsedMessage& message);
 
     /**
-     * Adds a node to the schema tree
+     * Adds a node to the schema tree and attempts to resolve the node against the authoritative
+     * timestamp key.
      * @param parent_node_id
      * @param type
      * @param key
      * @return the node id
      */
-    int32_t add_node(int parent_node_id, NodeType type, std::string_view key) {
-        auto const node_id{m_schema_tree.add_node(parent_node_id, type, key)};
-        if (m_matched_timestamp_prefix_node_id == parent_node_id
-            && m_authoritative_timestamp.size() > 0)
-        {
-            if (constants::cRootNodeId == parent_node_id) {
-                if (NodeType::Object == type) {
-                    m_matched_timestamp_prefix_node_id = node_id;
-                }
-            } else if ((m_authoritative_timestamp.size() - m_matched_timestamp_prefix_length) > 1) {
-                if (NodeType::Object == type
-                    && m_authoritative_timestamp.at(m_matched_timestamp_prefix_length) == key)
-                {
-                    m_matched_timestamp_prefix_length += 1;
-                    m_matched_timestamp_prefix_node_id = node_id;
-                }
-            }
-        }
-        return node_id;
-    }
+    int32_t add_node(int parent_node_id, NodeType type, std::string_view key);
 
     /**
      * Checks if a leaf key with a given parent node id matches the authoritative timestamp column.
@@ -124,16 +106,7 @@ public:
      * @param key
      * @return true if this leaf node would match the authoritative timestamp and false otherwise
      */
-    bool matches_timestamp(int parent_node_id, std::string_view key) {
-        if (m_matched_timestamp_prefix_node_id == parent_node_id) {
-            if (1 == (m_authoritative_timestamp.size() - m_matched_timestamp_prefix_length)
-                && m_authoritative_timestamp.back() == key)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
+    bool matches_timestamp(int parent_node_id, std::string_view key);
 
     /**
      * @return The Id that will be assigned to the next log event when appended to the archive.

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -346,14 +346,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     );
                     return ParsingResult::Failure;
                 }
-                if (false == m_timestamp_key.empty()) {
-                    SPDLOG_ERROR(
-                            "Invalid combination of arguments; --file-type {} and "
-                            "--timestamp-key can't be used together",
-                            cKeyValueIrFileType
-                    );
-                    return ParsingResult::Failure;
-                }
             } else {
                 throw std::invalid_argument("Unknown FILE_TYPE: " + file_type);
             }

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -802,7 +802,6 @@ void JsonParser::parse_kv_log_event(KeyValuePairLogEvent const& kv) {
                             encoding_id
                     );
                     m_current_parsed_message.add_value(node_id, encoding_id, timestamp);
-
                 } else {
                     m_current_parsed_message.add_value(node_id, decoded_value);
                 }

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -112,30 +112,44 @@ private:
     ) -> NodeType;
 
     /**
+     * Adjusts the node type used to represent an IR node in an archive based on whether it is a
+     * timestamp as well as its original type.
+     * @param node_type
+     * @param is_timestamp
+     * @return The NodeType that should be used to represent the original IR node in the archive.
+     */
+    static auto adjust_archive_node_type(NodeType node_type, bool is_timestamp) -> NodeType;
+
+    /**
      * Adds new schema node to archive and adds translation for IR node ID and NodeType to mapping
      * @param ir_node_id ID of the IR node
      * @param ir_node_to_add IR Schema Node that is being translated to archive
      * @param archive_node_type Type of the archive node
      * @param parent_node_id ID of the parent of the IR node
+     * @param is_timestamp
+     * @return The ID of the node added to the archive's Schema Tree
      */
     auto add_node_to_archive_and_translations(
             uint32_t ir_node_id,
             clp::ffi::SchemaTree::Node const& ir_node_to_add,
             NodeType archive_node_type,
-            int32_t parent_node_id
-    ) -> int;
+            int32_t parent_node_id,
+            bool is_timestamp
+    ) -> int32_t;
 
     /**
      * Gets the archive node ID for an IR node.
      * @param ir_node_id ID of the IR node
      * @param archive_node_type Type of the archive node
      * @param ir_tree The IR schema tree
+     * @return The ID of the corresponding node in the archive's schema tree and a flag indicating
+     * whether the field should be treated as a timestamp.
      */
-    auto get_archive_node_id(
+    auto get_archive_node_id_and_check_timestamp(
             uint32_t ir_node_id,
             NodeType archive_node_type,
             clp::ffi::SchemaTree const& ir_tree
-    ) -> int;
+    ) -> std::pair<int32_t, bool>;
 
     /**
      * Parses a Key Value Log Event.
@@ -198,7 +212,7 @@ private:
     bool m_structurize_arrays{false};
     bool m_record_log_order{true};
 
-    absl::flat_hash_map<std::pair<uint32_t, NodeType>, int32_t>
+    absl::flat_hash_map<std::pair<uint32_t, NodeType>, std::pair<int32_t, bool>>
             m_ir_node_to_archive_node_id_mapping;
 };
 }  // namespace clp_s

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -115,10 +115,11 @@ private:
      * Adjusts the node type used to represent an IR node in an archive based on whether it is a
      * timestamp as well as its original type.
      * @param node_type
-     * @param is_timestamp
+     * @param matches_timestamp
      * @return The NodeType that should be used to represent the original IR node in the archive.
      */
-    static auto adjust_archive_node_type(NodeType node_type, bool is_timestamp) -> NodeType;
+    static auto adjust_archive_node_type_for_timestamp(NodeType node_type, bool matches_timestamp)
+            -> NodeType;
 
     /**
      * Adds new schema node to archive and adds translation for IR node ID and NodeType to mapping
@@ -126,7 +127,7 @@ private:
      * @param ir_node_to_add IR Schema Node that is being translated to archive
      * @param archive_node_type Type of the archive node
      * @param parent_node_id ID of the parent of the IR node
-     * @param is_timestamp
+     * @param matches_timestamp
      * @return The ID of the node added to the archive's Schema Tree
      */
     auto add_node_to_archive_and_translations(
@@ -134,7 +135,7 @@ private:
             clp::ffi::SchemaTree::Node const& ir_node_to_add,
             NodeType archive_node_type,
             int32_t parent_node_id,
-            bool is_timestamp
+            bool matches_timestamp
     ) -> int32_t;
 
     /**


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

This PR adds support for specifying authoritative timestamps in the kv-ir ingestion flow while refactoring authoritative timestamp extraction in the JSON ingestion flow. Logic to match against authoritative timestamps has been moved into ArchiveWriter so that each ingestion pathway wrapping ArchiveWriter doesn't have to implement as much timestamp matching logic on its own. In particular `add_node` now executes some hooks to progressively match the authoritative timestamp column as the SchemaTree is constructed and a new `matches_timestamp` function has been added to check if a leaf node matches the authoritative timestamp column.


This implementation is slightly slower than the previous one.  Results for all of the open source datasets with timestamp keys are as follows:
| Dataset | (ingestion time new / ingestion time old) |
| ------ | ------ |
| cockroach | 1.044 |
| mongodb | 1.011 |
| elasticsearch | 1.041 |
| postgresql | 0.974 |

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* Manually validated that timestamp column matching functions as expected for a variety of nested columns and types for both the kv-ir and JSON ingestion flows



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Archival operations now feature enhanced timestamp management for improved tracking and data integrity.
  - JSON data processing has been refined with more accurate timestamp matching and node adjustment for consistent results.
- **Bug Fixes**
  - Removed restrictions on using both `--file-type` and `--timestamp-key` command-line arguments, simplifying user input.
- **Refactor**
  - Command-line argument parsing has been streamlined, allowing a more flexible combination of options to better suit user requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->