### PR TITLE
fix(clp-s): Update column metadata 'type' field from BIGINT to TINYINT in the indexer process and add MySQL parameter binding

### DIFF
--- a/components/core/src/clp/MySQLParamBindings.cpp
+++ b/components/core/src/clp/MySQLParamBindings.cpp
@@ -20,6 +20,19 @@ void MySQLParamBindings::resize(size_t num_fields) {
     }
 }
 
+void MySQLParamBindings::bind_uint8(size_t field_index, uint8_t& value) {
+    if (field_index >= m_statement_bindings.size()) {
+        throw OperationFailed(ErrorCode_OutOfBounds, __FILENAME__, __LINE__);
+    }
+
+    auto& binding = m_statement_bindings[field_index];
+    binding.buffer_type = MYSQL_TYPE_TINY;
+    binding.buffer = &value;
+    binding.is_unsigned = true;
+    m_statement_binding_lengths[field_index] = sizeof(value);
+}
+
+
 void MySQLParamBindings::bind_int64(size_t field_index, int64_t& value) {
     if (field_index >= m_statement_bindings.size()) {
         throw OperationFailed(ErrorCode_OutOfBounds, __FILENAME__, __LINE__);

--- a/components/core/src/clp/MySQLParamBindings.hpp
+++ b/components/core/src/clp/MySQLParamBindings.hpp
@@ -37,6 +37,7 @@ public:
      */
     void resize(size_t num_fields);
 
+    void bind_uint8(size_t field_index, uint8_t& value);
     void bind_int64(size_t field_index, int64_t& value);
     void bind_uint64(size_t field_index, uint64_t& value);
     void bind_varchar(size_t field_index, char const* value, size_t value_length);

--- a/components/core/src/clp_s/indexer/MySQLIndexStorage.cpp
+++ b/components/core/src/clp_s/indexer/MySQLIndexStorage.cpp
@@ -31,7 +31,7 @@ void MySQLIndexStorage::init(std::string const& table_name, bool should_create_t
         m_db.execute_query(fmt::format(
                 "CREATE TABLE IF NOT EXISTS {}{} ("
                 "name VARCHAR(512) NOT NULL, "
-                "type INT NOT NULL,"
+                "type TINYINT NOT NULL,"
                 "PRIMARY KEY (name, type)"
                 ")",
                 m_table_prefix,
@@ -78,11 +78,9 @@ void MySQLIndexStorage::add_field(std::string const& field_name, NodeType field_
             field_name.c_str(),
             field_name.length()
     );
-
-    uint64_t field_type_value = static_cast<uint64_t>(field_type);
-    statement_bindings.bind_uint64(
+    statement_bindings.bind_uint8(
             clp::enum_to_underlying_type(TableMetadataFieldIndexes::Type),
-            field_type_value
+            field_type
     );
 
     if (false == m_insert_field_statement->execute()) {

--- a/components/core/src/clp_s/indexer/MySQLIndexStorage.cpp
+++ b/components/core/src/clp_s/indexer/MySQLIndexStorage.cpp
@@ -31,7 +31,7 @@ void MySQLIndexStorage::init(std::string const& table_name, bool should_create_t
         m_db.execute_query(fmt::format(
                 "CREATE TABLE IF NOT EXISTS {}{} ("
                 "name VARCHAR(512) NOT NULL, "
-                "type BIGINT NOT NULL,"
+                "type INT NOT NULL,"
                 "PRIMARY KEY (name, type)"
                 ")",
                 m_table_prefix,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As suggested in #697, the type field in column metadata only requires a `TINYINT`. This PR updates the field from `BIGINT` to `TINYINT` and introduces the corresponding MySQL binding (`bind_uint8`).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
+ Successfully compiled the indexer binary.
<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
