### PR TITLE
feat(clp-s)!: Add support for ingesting auto-generated kv-pairs from kv-ir; Add support for searching auto-generated kv-pairs.

### DIFF
--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -19,6 +19,7 @@ void ArchiveWriter::open(ArchiveWriterOption const& option) {
     m_min_table_size = option.min_table_size;
     m_archives_dir = option.archives_dir;
     m_authoritative_timestamp = option.authoritative_timestamp;
+    m_authoritative_timestamp_namespace = option.authoritative_timestamp_namespace;
     std::string working_dir_name = m_id;
     if (option.single_file_archive) {
         working_dir_name += constants::cTmpPostfix;
@@ -116,6 +117,7 @@ void ArchiveWriter::close() {
     m_compressed_size = 0UL;
     m_next_log_event_id = 0;
     m_authoritative_timestamp.clear();
+    m_authoritative_timestamp_namespace.clear();
     m_matched_timestamp_prefix_length = 0ULL;
     m_matched_timestamp_prefix_node_id = constants::cRootNodeId;
 }
@@ -243,7 +245,7 @@ int32_t ArchiveWriter::add_node(int parent_node_id, NodeType type, std::string_v
         && m_authoritative_timestamp.size() > 0)
     {
         if (constants::cRootNodeId == parent_node_id) {
-            if (NodeType::Object == type) {
+            if (NodeType::Object == type && m_authoritative_timestamp_namespace == key) {
                 m_matched_timestamp_prefix_node_id = node_id;
             }
         } else if (m_authoritative_timestamp.size() - m_matched_timestamp_prefix_length > 1) {

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -241,20 +241,16 @@ ArchiveWriter::append_message(int32_t schema_id, Schema const& schema, ParsedMes
 
 int32_t ArchiveWriter::add_node(int parent_node_id, NodeType type, std::string_view key) {
     auto const node_id{m_schema_tree.add_node(parent_node_id, type, key)};
-    if (m_matched_timestamp_prefix_node_id == parent_node_id
-        && m_authoritative_timestamp.size() > 0)
+    if (NodeType::Object == type && m_matched_timestamp_prefix_node_id == parent_node_id
+        && m_authoritative_timestamp.size() > (m_matched_timestamp_prefix_length + 1))
     {
         if (constants::cRootNodeId == parent_node_id) {
-            if (NodeType::Object == type && m_authoritative_timestamp_namespace == key) {
+            if (m_authoritative_timestamp_namespace == key) {
                 m_matched_timestamp_prefix_node_id = node_id;
             }
-        } else if (m_authoritative_timestamp.size() - m_matched_timestamp_prefix_length > 1) {
-            if (NodeType::Object == type
-                && m_authoritative_timestamp.at(m_matched_timestamp_prefix_length) == key)
-            {
-                m_matched_timestamp_prefix_length += 1;
-                m_matched_timestamp_prefix_node_id = node_id;
-            }
+        } else if (m_authoritative_timestamp.at(m_matched_timestamp_prefix_length) == key) {
+            m_matched_timestamp_prefix_length += 1;
+            m_matched_timestamp_prefix_node_id = node_id;
         }
     }
     return node_id;

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -26,6 +26,7 @@ struct ArchiveWriterOption {
     bool single_file_archive;
     size_t min_table_size;
     std::vector<std::string> authoritative_timestamp;
+    std::string authoritative_timestamp_namespace;
 };
 
 class ArchiveWriter {
@@ -244,6 +245,7 @@ private:
     size_t m_min_table_size{};
 
     std::vector<std::string> m_authoritative_timestamp;
+    std::string m_authoritative_timestamp_namespace;
     size_t m_matched_timestamp_prefix_length{0ULL};
     int32_t m_matched_timestamp_prefix_node_id{constants::cRootNodeId};
 

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -89,8 +89,13 @@ JsonParser::JsonParser(JsonParserOption const& option)
           m_input_paths(option.input_paths),
           m_network_auth(option.network_auth) {
     if (false == m_timestamp_key.empty()) {
+        // FIXME: should probably convert to ColumnDescriptor and validate that no '*'
         if (false
-            == clp_s::StringUtils::tokenize_column_descriptor(m_timestamp_key, m_timestamp_column))
+            == clp_s::StringUtils::tokenize_column_descriptor(
+                    m_timestamp_key,
+                    m_timestamp_column,
+                    m_timestamp_namespace
+            ))
         {
             SPDLOG_ERROR("Can not parse invalid timestamp key: \"{}\"", m_timestamp_key);
             throw OperationFailed(ErrorCodeBadParam, __FILENAME__, __LINE__);

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -36,7 +36,6 @@
 #include "ZstdCompressor.hpp"
 
 using namespace simdjson;
-using clp::ffi::KeyValuePairLogEvent;
 
 namespace clp_s {
 struct JsonParserOption {
@@ -128,8 +127,10 @@ private:
      * @param archive_node_type Type of the archive node
      * @param parent_node_id ID of the parent of the IR node
      * @param matches_timestamp
+     * @tparam autogen whether this node is being added in the auto-generated subtree or not
      * @return The ID of the node added to the archive's Schema Tree
      */
+    template <bool autogen>
     auto add_node_to_archive_and_translations(
             uint32_t ir_node_id,
             clp::ffi::SchemaTree::Node const& ir_node_to_add,
@@ -143,9 +144,11 @@ private:
      * @param ir_node_id ID of the IR node
      * @param archive_node_type Type of the archive node
      * @param ir_tree The IR schema tree
+     * @tparam autogen whether this node is being added in the auto-generated subtree or not
      * @return The ID of the corresponding node in the archive's schema tree and a flag indicating
      * whether the field should be treated as a timestamp.
      */
+    template <bool autogen>
     auto get_archive_node_id_and_check_timestamp(
             uint32_t ir_node_id,
             NodeType archive_node_type,
@@ -153,10 +156,22 @@ private:
     ) -> std::pair<int32_t, bool>;
 
     /**
+     * Parses a subtree (user-gen or auto-gen) of a Key Value Log Event.
+     * @param kv_pairs
+     * @param tree
+     * @tparam autogen whether this node is being added in the auto-generated subtree or not
+     */
+    template <bool autogen>
+    void parse_kv_log_event_subtree(
+            clp::ffi::KeyValuePairLogEvent::NodeIdValuePairs const& kv_pairs,
+            clp::ffi::SchemaTree const& tree
+    );
+
+    /**
      * Parses a Key Value Log Event.
      * @param kv the Key Value Log Event
      */
-    void parse_kv_log_event(KeyValuePairLogEvent const& kv);
+    void parse_kv_log_event(clp::ffi::KeyValuePairLogEvent const& kv);
 
     /**
      * Parses an array within a JSON line

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -231,6 +231,8 @@ private:
 
     absl::flat_hash_map<std::pair<uint32_t, NodeType>, std::pair<int32_t, bool>>
             m_ir_node_to_archive_node_id_mapping;
+    absl::flat_hash_map<std::pair<uint32_t, NodeType>, std::pair<int32_t, bool>>
+            m_autogen_ir_node_to_archive_node_id_mapping;
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -219,6 +219,7 @@ private:
 
     std::string m_timestamp_key;
     std::vector<std::string> m_timestamp_column;
+    std::string m_timestamp_namespace;
 
     boost::uuids::random_generator m_generator;
     std::unique_ptr<ArchiveWriter> m_archive_writer;

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -572,10 +572,12 @@ void SchemaReader::initialize_serializer() {
 
     // TODO: this code will have to change once we allow mixing log lines parsed by different
     // parsers and if we add support for serializing auto-generated keys in regular JSON.
-    if (false == m_local_schema_tree.get_nodes().empty()) {
-        generate_json_template(m_local_schema_tree.get_object_subtree_node_id_for_namespace(
+    if (auto subtree_root = m_local_schema_tree.get_object_subtree_node_id_for_namespace(
                 std::string{constants::cDefaultNamespace}
-        ));
+        );
+        -1 != subtree_root)
+    {
+        generate_json_template(subtree_root);
     }
 }
 

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -572,8 +572,8 @@ void SchemaReader::initialize_serializer() {
 
     // TODO: this code will have to change once we allow mixing log lines parsed by different
     // parsers and if we add support for serializing auto-generated keys in regular JSON.
-    if (auto subtree_root = m_local_schema_tree.get_object_subtree_node_id_for_namespace(
-                std::string{constants::cDefaultNamespace}
+    if (auto subtree_root
+        = m_local_schema_tree.get_object_subtree_node_id_for_namespace(constants::cDefaultNamespace
         );
         -1 != subtree_root)
     {

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -1,7 +1,9 @@
 #include "SchemaReader.hpp"
 
 #include <stack>
+#include <string>
 
+#include "archive_constants.hpp"
 #include "BufferViewReader.hpp"
 #include "Schema.hpp"
 
@@ -569,9 +571,11 @@ void SchemaReader::initialize_serializer() {
     }
 
     // TODO: this code will have to change once we allow mixing log lines parsed by different
-    // parsers.
+    // parsers and if we add support for serializing auto-generated keys in regular JSON.
     if (false == m_local_schema_tree.get_nodes().empty()) {
-        generate_json_template(m_local_schema_tree.get_object_subtree_node_id());
+        generate_json_template(m_local_schema_tree.get_object_subtree_node_id_for_namespace(
+                std::string{constants::cDefaultNamespace}
+        ));
     }
 }
 

--- a/components/core/src/clp_s/SchemaTree.cpp
+++ b/components/core/src/clp_s/SchemaTree.cpp
@@ -18,7 +18,7 @@ int32_t SchemaTree::add_node(int32_t parent_node_id, NodeType type, std::string_
     node.increase_count();
     if (constants::cRootNodeId == parent_node_id) {
         if (NodeType::Object == type) {
-            m_object_subtree_id = node_id;
+            m_namespace_to_object_subtree_id.emplace(node.get_key_name(), node_id);
         } else if (NodeType::Metadata == type) {
             m_metadata_subtree_id = node_id;
         }

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -172,6 +172,8 @@ public:
     void clear() {
         m_nodes.clear();
         m_node_map.clear();
+        m_metadata_subtree_id = -1;
+        m_namespace_to_object_subtree_id.clear();
     }
 
     /**

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
 
 namespace clp_s {
@@ -133,7 +134,7 @@ public:
      * @return the Id of the root of the Object sub-tree for the given namespace.
      * @return -1 if the Object sub-tree does not exist.
      */
-    int32_t get_object_subtree_node_id_for_namespace(std::string const& subtree_namespace) const {
+    int32_t get_object_subtree_node_id_for_namespace(std::string_view subtree_namespace) const {
         if (auto it = m_namespace_to_object_subtree_id.find(subtree_namespace);
             it != m_namespace_to_object_subtree_id.end())
         {
@@ -193,7 +194,7 @@ public:
 private:
     std::vector<SchemaNode> m_nodes;
     absl::flat_hash_map<std::tuple<int32_t, std::string_view const, NodeType>, int32_t> m_node_map;
-    std::map<std::string, int32_t> m_namespace_to_object_subtree_id;
+    absl::btree_map<std::string, int32_t> m_namespace_to_object_subtree_id;
     int32_t m_metadata_subtree_id{-1};
 };
 }  // namespace clp_s

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_SCHEMATREE_HPP
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -127,13 +128,22 @@ public:
     }
 
     /**
-     * @return the Id of the root of the Object sub-tree that records the structure of JSON data.
+     * Gets the root of the object sub-tree within a namespace.
+     * @param subtree_namespace
+     * @return the Id of the root of the Object sub-tree for the given namespace.
      * @return -1 if the Object sub-tree does not exist.
      */
-    int32_t get_object_subtree_node_id() const { return m_object_subtree_id; }
+    int32_t get_object_subtree_node_id_for_namespace(std::string const& subtree_namespace) const {
+        if (auto it = m_namespace_to_object_subtree_id.find(subtree_namespace);
+            it != m_namespace_to_object_subtree_id.end())
+        {
+            return it->second;
+        }
+        return -1;
+    }
 
     /**
-     * Get the field Id for a specified field within the Metadata subtree.
+     * Gets the field Id for a specified field within the Metadata subtree.
      * @param field_name
      *
      * @return the field Id if the field exists within the Metadata sub-tree, -1 otherwise.
@@ -181,7 +191,7 @@ public:
 private:
     std::vector<SchemaNode> m_nodes;
     absl::flat_hash_map<std::tuple<int32_t, std::string_view const, NodeType>, int32_t> m_node_map;
-    int32_t m_object_subtree_id{-1};
+    std::map<std::string, int32_t> m_namespace_to_object_subtree_id;
     int32_t m_metadata_subtree_id{-1};
 };
 }  // namespace clp_s

--- a/components/core/src/clp_s/SingleFileArchiveDefs.hpp
+++ b/components/core/src/clp_s/SingleFileArchiveDefs.hpp
@@ -9,7 +9,7 @@ namespace clp_s {
 // define the version
 constexpr uint8_t cArchiveMajorVersion = 0;
 constexpr uint8_t cArchiveMinorVersion = 2;
-constexpr uint16_t cArchivePatchVersion = 0;
+constexpr uint16_t cArchivePatchVersion = 1;
 
 // define the magic number
 constexpr uint8_t cStructuredSFAMagicNumber[] = {0xFD, 0x2F, 0xC5, 0x30};

--- a/components/core/src/clp_s/SingleFileArchiveDefs.hpp
+++ b/components/core/src/clp_s/SingleFileArchiveDefs.hpp
@@ -8,8 +8,8 @@
 namespace clp_s {
 // define the version
 constexpr uint8_t cArchiveMajorVersion = 0;
-constexpr uint8_t cArchiveMinorVersion = 2;
-constexpr uint16_t cArchivePatchVersion = 1;
+constexpr uint8_t cArchiveMinorVersion = 3;
+constexpr uint16_t cArchivePatchVersion = 0;
 
 // define the magic number
 constexpr uint8_t cStructuredSFAMagicNumber[] = {0xFD, 0x2F, 0xC5, 0x30};

--- a/components/core/src/clp_s/TimestampDictionaryReader.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.cpp
@@ -16,11 +16,18 @@ ErrorCode TimestampDictionaryReader::read(ZstdDecompressor& decompressor) {
     for (uint64_t i = 0; i < range_index_size; ++i) {
         TimestampEntry entry;
         std::vector<std::string> tokens;
+        std::string descriptor_namespace;
         if (auto rc = entry.try_read_from_file(decompressor); ErrorCodeSuccess != rc) {
             throw OperationFailed(rc, __FILENAME__, __LINE__);
         }
 
-        if (false == StringUtils::tokenize_column_descriptor(entry.get_key_name(), tokens)) {
+        if (false
+            == StringUtils::tokenize_column_descriptor(
+                    entry.get_key_name(),
+                    tokens,
+                    descriptor_namespace
+            ))
+        {
             throw OperationFailed(ErrorCodeCorrupt, __FILENAME__, __LINE__);
         }
         m_entries.emplace_back(std::move(entry));
@@ -31,7 +38,7 @@ ErrorCode TimestampDictionaryReader::read(ZstdDecompressor& decompressor) {
         // corresponds to the "authoritative" timestamp column for the dataset.
         if (i == 0) {
             m_authoritative_timestamp_column_ids = m_entries.back().get_column_ids();
-            m_authoritative_timestamp_tokenized_column = tokens;
+            m_authoritative_timestamp_tokenized_column = {tokens, descriptor_namespace};
         }
 
         m_tokenized_column_to_range.emplace_back(std::move(tokens), &m_entries.back());

--- a/components/core/src/clp_s/TimestampDictionaryReader.hpp
+++ b/components/core/src/clp_s/TimestampDictionaryReader.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <optional>
+#include <utility>
 
 #include "FileReader.hpp"
 #include "search/FilterOperation.hpp"
@@ -52,7 +53,8 @@ public:
 
     auto tokenized_column_to_range_end() const { return m_tokenized_column_to_range.end(); }
 
-    std::optional<std::vector<std::string>>& get_authoritative_timestamp_tokenized_column() {
+    std::optional<std::pair<std::vector<std::string>, std::string>>&
+    get_authoritative_timestamp_tokenized_column() {
         return m_authoritative_timestamp_tokenized_column;
     }
 
@@ -70,7 +72,8 @@ private:
     std::vector<TimestampEntry> m_entries;
     tokenized_column_to_range_t m_tokenized_column_to_range;
 
-    std::optional<std::vector<std::string>> m_authoritative_timestamp_tokenized_column;
+    std::optional<std::pair<std::vector<std::string>, std::string>>
+            m_authoritative_timestamp_tokenized_column;
     std::unordered_set<int32_t> m_authoritative_timestamp_column_ids;
 };
 }  // namespace clp_s

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -529,11 +529,24 @@ bool StringUtils::convert_string_to_double(std::string const& raw, double& conve
 
 bool StringUtils::tokenize_column_descriptor(
         std::string const& descriptor,
-        std::vector<std::string>& tokens
+        std::vector<std::string>& tokens,
+        std::string& descriptor_namespace
 ) {
     std::string cur_tok;
     bool escaped{false};
-    for (size_t i = 0; i < descriptor.size(); ++i) {
+    descriptor_namespace.clear();
+    size_t start_index = 0;
+    if (descriptor.size() > 0
+        && std::string_view{descriptor.data(), 1} == constants::cAutogenNamespace)
+    {
+        descriptor_namespace = constants::cAutogenNamespace;
+        start_index += 1;
+
+        if (descriptor.size() <= descriptor_namespace.size()) {
+            return false;
+        }
+    }
+    for (size_t i = start_index; i < descriptor.size(); ++i) {
         if (false == escaped) {
             if ('\\' == descriptor[i]) {
                 escaped = true;
@@ -763,6 +776,9 @@ bool StringUtils::unescape_kql_internal(
                 } else {
                     unescaped.push_back('?');
                 }
+                break;
+            case '@':
+                unescaped.push_back('@');
                 break;
             default:
                 return false;

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -248,10 +248,14 @@ public:
      * descriptor is tokenized and unescaped per the escaping rules for KQL columns.
      * @param descriptor
      * @param tokens
+     * @param descriptor_namespace
      * @return true if the descriptor was tokenized successfully, false otherwise
      */
-    [[nodiscard]] static bool
-    tokenize_column_descriptor(std::string const& descriptor, std::vector<std::string>& tokens);
+    [[nodiscard]] static bool tokenize_column_descriptor(
+            std::string const& descriptor,
+            std::vector<std::string>& tokens,
+            std::string& descriptor_namespace
+    );
 
     /**
      * Escapes a string according to JSON string escaping rules and appends the escaped string to

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_ARCHIVE_CONSTANTS_HPP
 
 #include <cstdint>
+#include <string_view>
 
 namespace clp_s::constants {
 // Single file archive
@@ -28,6 +29,7 @@ constexpr char cRootNodeName[] = "";
 constexpr int32_t cRootNodeId = -1;
 constexpr char cMetadataSubtreeName[] = "";
 constexpr char cLogEventIdxName[] = "log_event_idx";
+constexpr std::string_view cAutogenNamespace{"@"};
 
 namespace results_cache::decompression {
 constexpr char cPath[]{"path"};

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -30,6 +30,7 @@ constexpr int32_t cRootNodeId = -1;
 constexpr char cMetadataSubtreeName[] = "";
 constexpr char cLogEventIdxName[] = "log_event_idx";
 constexpr std::string_view cAutogenNamespace{"@"};
+constexpr std::string_view cDefaultNamespace{""};
 
 namespace results_cache::decompression {
 constexpr char cPath[]{"path"};

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -202,11 +202,21 @@ bool search_archive(
     try {
         for (auto const& column : command_line_arguments.get_projection_columns()) {
             std::vector<std::string> descriptor_tokens;
-            if (false == StringUtils::tokenize_column_descriptor(column, descriptor_tokens)) {
+            std::string descriptor_namespace;
+            if (false
+                == StringUtils::tokenize_column_descriptor(
+                        column,
+                        descriptor_tokens,
+                        descriptor_namespace
+                ))
+            {
                 SPDLOG_ERROR("Can not tokenize invalid column: \"{}\"", column);
                 return false;
             }
-            projection->add_column(ColumnDescriptor::create_from_escaped_tokens(descriptor_tokens));
+            projection->add_column(ColumnDescriptor::create_from_escaped_tokens(
+                    descriptor_tokens,
+                    descriptor_namespace
+            ));
         }
     } catch (std::exception const& e) {
         SPDLOG_ERROR("{}", e.what());

--- a/components/core/src/clp_s/indexer/IndexManager.cpp
+++ b/components/core/src/clp_s/indexer/IndexManager.cpp
@@ -102,7 +102,10 @@ void IndexManager::traverse_schema_tree_and_update_metadata(
     std::string path_buffer;
     // Stack of pairs of node_id and path_length
     std::stack<std::pair<int32_t, uint64_t>> s;
-    s.emplace(schema_tree->get_object_subtree_node_id(), 0);
+    s.emplace(
+            schema_tree->get_object_subtree_node_id_for_namespace(constants::cDefaultNamespace),
+            0
+    );
 
     while (false == s.empty()) {
         auto [node_id, path_length] = s.top();

--- a/components/core/src/clp_s/indexer/IndexManager.cpp
+++ b/components/core/src/clp_s/indexer/IndexManager.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <stack>
+#include <string>
 
 #include "../archive_constants.hpp"
 
@@ -99,8 +100,9 @@ void IndexManager::traverse_schema_tree_and_update_metadata(
         return;
     }
 
-    auto const object_subtree_root
-            = schema_tree->get_object_subtree_node_id_for_namespace(constants::cDefaultNamespace);
+    auto const object_subtree_root = schema_tree->get_object_subtree_node_id_for_namespace(
+            std::string{constants::cDefaultNamespace}
+    );
     if (-1 == object_subtree_root) {
         return;
     }

--- a/components/core/src/clp_s/indexer/IndexManager.cpp
+++ b/components/core/src/clp_s/indexer/IndexManager.cpp
@@ -99,13 +99,16 @@ void IndexManager::traverse_schema_tree_and_update_metadata(
         return;
     }
 
+    auto const object_subtree_root
+            = schema_tree->get_object_subtree_node_id_for_namespace(constants::cDefaultNamespace);
+    if (-1 == object_subtree_root) {
+        return;
+    }
+
     std::string path_buffer;
     // Stack of pairs of node_id and path_length
     std::stack<std::pair<int32_t, uint64_t>> s;
-    s.emplace(
-            schema_tree->get_object_subtree_node_id_for_namespace(constants::cDefaultNamespace),
-            0
-    );
+    s.emplace(object_subtree_root, 0);
 
     while (false == s.empty()) {
         auto [node_id, path_length] = s.top();

--- a/components/core/src/clp_s/indexer/IndexManager.cpp
+++ b/components/core/src/clp_s/indexer/IndexManager.cpp
@@ -100,9 +100,8 @@ void IndexManager::traverse_schema_tree_and_update_metadata(
         return;
     }
 
-    auto const object_subtree_root = schema_tree->get_object_subtree_node_id_for_namespace(
-            std::string{constants::cDefaultNamespace}
-    );
+    auto const object_subtree_root
+            = schema_tree->get_object_subtree_node_id_for_namespace(constants::cDefaultNamespace);
     if (-1 == object_subtree_root) {
         return;
     }

--- a/components/core/src/clp_s/search/AddTimestampConditions.cpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.cpp
@@ -18,8 +18,10 @@ std::shared_ptr<Expression> AddTimestampConditions::run(std::shared_ptr<Expressi
         return EmptyExpr::create();
     }
 
-    auto timestamp_column
-            = ColumnDescriptor::create_from_escaped_tokens(m_timestamp_column.value());
+    auto timestamp_column = ColumnDescriptor::create_from_escaped_tokens(
+            m_timestamp_column.value().first,
+            m_timestamp_column.value().second
+    );
 
     auto and_expr = AndExpr::create();
     if (m_begin_ts.has_value()) {

--- a/components/core/src/clp_s/search/AddTimestampConditions.hpp
+++ b/components/core/src/clp_s/search/AddTimestampConditions.hpp
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "../Defs.hpp"
@@ -22,7 +23,7 @@ class AddTimestampConditions : public Transformation {
 public:
     // Constructors
     AddTimestampConditions(
-            std::optional<std::vector<std::string>> const& timestamp_column,
+            std::optional<std::pair<std::vector<std::string>, std::string>> const& timestamp_column,
             std::optional<epochtime_t> begin_ts,
             std::optional<epochtime_t> end_ts
     )
@@ -38,7 +39,7 @@ public:
     std::shared_ptr<Expression> run(std::shared_ptr<Expression>& expr) override;
 
 private:
-    std::optional<std::vector<std::string>> m_timestamp_column;
+    std::optional<std::pair<std::vector<std::string>, std::string>> m_timestamp_column;
     std::optional<epochtime_t> m_begin_ts;
     std::optional<epochtime_t> m_end_ts;
 };

--- a/components/core/src/clp_s/search/ColumnDescriptor.cpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.cpp
@@ -22,16 +22,11 @@ void ColumnDescriptor::check_and_set_unresolved_descriptor_flag() {
     }
 }
 
-ColumnDescriptor::ColumnDescriptor(std::string const& token) {
-    m_flags = cAllTypes;
-    m_descriptors.emplace_back(DescriptorToken::create_descriptor_from_escaped_token(token));
-    check_and_set_unresolved_descriptor_flag();
-    if (is_unresolved_descriptor()) {
-        simplify_descriptor_wildcards();
-    }
-}
-
-ColumnDescriptor::ColumnDescriptor(std::vector<std::string> const& tokens) {
+ColumnDescriptor::ColumnDescriptor(
+        std::vector<std::string> const& tokens,
+        std::string_view descriptor_namespace
+)
+        : m_namespace{descriptor_namespace} {
     m_flags = cAllTypes;
     m_descriptors = std::move(tokenize_descriptor(tokens));
     check_and_set_unresolved_descriptor_flag();
@@ -40,7 +35,11 @@ ColumnDescriptor::ColumnDescriptor(std::vector<std::string> const& tokens) {
     }
 }
 
-ColumnDescriptor::ColumnDescriptor(DescriptorList const& descriptors) {
+ColumnDescriptor::ColumnDescriptor(
+        DescriptorList const& descriptors,
+        std::string_view descriptor_namespace
+)
+        : m_namespace{descriptor_namespace} {
     m_flags = cAllTypes;
     m_descriptors = descriptors;
     check_and_set_unresolved_descriptor_flag();
@@ -49,22 +48,19 @@ ColumnDescriptor::ColumnDescriptor(DescriptorList const& descriptors) {
     }
 }
 
-std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create_from_escaped_token(
-        std::string const& token
-) {
-    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(token));
-}
-
 std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create_from_escaped_tokens(
-        std::vector<std::string> const& tokens
+        std::vector<std::string> const& tokens,
+        std::string_view descriptor_namespace
 ) {
-    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(tokens));
+    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(tokens, descriptor_namespace));
 }
 
 std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create_from_descriptors(
-        DescriptorList const& descriptors
+        DescriptorList const& descriptors,
+        std::string_view descriptor_namespace
 ) {
-    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(descriptors));
+    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(descriptors, descriptor_namespace)
+    );
 }
 
 std::shared_ptr<ColumnDescriptor> ColumnDescriptor::copy() {

--- a/components/core/src/clp_s/search/ColumnDescriptor.hpp
+++ b/components/core/src/clp_s/search/ColumnDescriptor.hpp
@@ -126,20 +126,23 @@ public:
      * A '*' that is not escaped is treated as a wildcard descriptor.
      *
      * @param token(s) the escaped token or list of escaped tokens making up the descriptor
+     * @param descriptor_namespace
      * @return A ColumnDescriptor literal
      */
-    static std::shared_ptr<ColumnDescriptor> create_from_escaped_token(std::string const& token);
     static std::shared_ptr<ColumnDescriptor> create_from_escaped_tokens(
-            std::vector<std::string> const& tokens
+            std::vector<std::string> const& tokens,
+            std::string_view descriptor_namespace
     );
 
     /**
      * Create a ColumnDescriptor literal from a list of already-parsed DescriptorToken.
      * @param descriptors the list of parsed DescriptorToken
+     * @param descriptor_namespace
      * @return A ColumnDescriptor literal
      */
     static std::shared_ptr<ColumnDescriptor> create_from_descriptors(
-            DescriptorList const& descriptors
+            DescriptorList const& descriptors,
+            std::string_view descriptor_namespace
     );
 
     /**
@@ -270,20 +273,25 @@ public:
      */
     bool operator==(ColumnDescriptor const& rhs) const;
 
+    std::string const& get_namespace() const { return m_namespace; }
+
+    void set_namespace(std::string_view descriptor_namespace) {
+        m_namespace = descriptor_namespace;
+    }
+
 private:
     DescriptorList m_descriptors;  // list of descriptors describing the column
     DescriptorList m_unresolved_tokens;  // unresolved tokens used for array search
+    std::string m_namespace;
     LiteralTypeBitmask m_flags;  // set of types this column can match
     int32_t m_id;  // unambiguous CLJ column id this column represents. May be unset.
     bool m_unresolved_descriptors;  // true if contains wildcards
     bool m_pure_wildcard;  // true if column is single wildcard
 
     // Constructors
-    explicit ColumnDescriptor(std::string const&);
+    explicit ColumnDescriptor(std::vector<std::string> const&, std::string_view);
 
-    explicit ColumnDescriptor(std::vector<std::string> const&);
-
-    explicit ColumnDescriptor(DescriptorList const&);
+    explicit ColumnDescriptor(DescriptorList const&, std::string_view);
 
     /**
      * Scan the list of descriptors to check if they contain wildcards and

--- a/components/core/src/clp_s/search/Projection.cpp
+++ b/components/core/src/clp_s/search/Projection.cpp
@@ -52,7 +52,7 @@ void Projection::resolve_column(
      * what we need.
      */
 
-    auto cur_node_id = tree->get_object_subtree_node_id();
+    auto cur_node_id = tree->get_object_subtree_node_id_for_namespace(column->get_namespace());
     auto it = column->descriptor_begin();
     while (it != column->descriptor_end()) {
         bool matched_any{false};

--- a/components/core/src/clp_s/search/Projection.cpp
+++ b/components/core/src/clp_s/search/Projection.cpp
@@ -53,6 +53,9 @@ void Projection::resolve_column(
      */
 
     auto cur_node_id = tree->get_object_subtree_node_id_for_namespace(column->get_namespace());
+    if (-1 == cur_node_id) {
+        return;
+    }
     auto it = column->descriptor_begin();
     while (it != column->descriptor_end()) {
         bool matched_any{false};

--- a/components/core/src/clp_s/search/SchemaMatch.cpp
+++ b/components/core/src/clp_s/search/SchemaMatch.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<Expression> SchemaMatch::populate_column_mapping(std::shared_ptr
                     auto const* node = &m_tree->get_node(node_id);
                     auto literal_type = node_to_literal_type(node->get_type());
                     DescriptorList descriptors;
-                    // FIXME: this needs to be adjusted to be not JUST object subtrees
+                    // FIXME: this needs to be adjusted to handle more than JUST object subtrees
                     // TODO: consider whether fully resolving descriptors in this way is actually
                     // necessary. In principal the set of matching nodes is all that is really
                     // required (and has already been determined) so the main utility of the

--- a/components/core/src/clp_s/search/kql/Kql.g4
+++ b/components/core/src/clp_s/search/kql/Kql.g4
@@ -88,7 +88,7 @@ fragment ESCAPED_SPACE
     ;
 
 fragment SPECIAL_CHARACTER
-    : [\\():<>"*?{}.]
+    : [\\():<>"*?{}.@]
     ;
 
 // For unicode hex

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -49,6 +49,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(false == filter->has_only_expression_operands());
         REQUIRE(false == filter->is_inverted());
         REQUIRE(filter->get_column()->is_pure_wildcard());
+        REQUIRE(filter->get_column()->get_namespace().empty());
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         std::string extracted_value;
         REQUIRE(filter->get_operand()->as_var_string(extracted_value, filter->get_operation()));
@@ -66,6 +67,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(false == filter->is_inverted());
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         REQUIRE(1 == filter->get_column()->get_descriptor_list().size());
+        REQUIRE(filter->get_column()->get_namespace().empty());
         auto const key_token = DescriptorToken::create_descriptor_from_escaped_token("key");
         REQUIRE(key_token == *filter->get_column()->descriptor_begin());
         std::string extracted_value;
@@ -84,6 +86,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(true == not_filter->is_inverted());
         REQUIRE(FilterOperation::EQ == not_filter->get_operation());
         REQUIRE(1 == not_filter->get_column()->get_descriptor_list().size());
+        REQUIRE(not_filter->get_column()->get_namespace().empty());
         auto const key_token = DescriptorToken::create_descriptor_from_escaped_token("key");
         REQUIRE(key_token == *not_filter->get_column()->descriptor_begin());
         std::string extracted_value;
@@ -132,6 +135,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
             REQUIRE(value == extracted_value);
             auto const key_token = DescriptorToken::create_descriptor_from_escaped_token(key);
             REQUIRE(key_token == *filter->get_column()->descriptor_begin());
+            REQUIRE(filter->get_column()->get_namespace().empty());
             ++suffix_number;
         }
     }
@@ -182,6 +186,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
             REQUIRE(value == extracted_value);
             auto const key_token = DescriptorToken::create_descriptor_from_escaped_token(key);
             REQUIRE(key_token == *filter->get_column()->descriptor_begin());
+            REQUIRE(filter->get_column()->get_namespace().empty());
             ++suffix_number;
         }
     }
@@ -210,6 +215,7 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(false == filter->is_inverted());
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         REQUIRE(2 == filter->get_column()->get_descriptor_list().size());
+        REQUIRE(filter->get_column()->get_namespace().empty());
         auto it = filter->get_column()->descriptor_begin();
         auto const a_b_token = DescriptorToken::create_descriptor_from_escaped_token("a.b");
         REQUIRE(a_b_token == *it++);
@@ -264,8 +270,43 @@ TEST_CASE("Test parsing KQL", "[KQL]") {
         REQUIRE(false == filter->is_inverted());
         REQUIRE(FilterOperation::EQ == filter->get_operation());
         REQUIRE(true == filter->get_column()->is_pure_wildcard());
+        REQUIRE(filter->get_column()->get_namespace().empty());
         std::string literal;
         REQUIRE(true == filter->get_operand()->as_var_string(literal, FilterOperation::EQ));
         REQUIRE(literal == translated_pair.second);
+    }
+
+    SECTION("Column in @ namespace") {
+        auto namespaced_query = GENERATE("@column : *", "\"@column\": *");
+        stringstream query{namespaced_query};
+        auto filter = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(query));
+        REQUIRE(nullptr != filter);
+        REQUIRE(nullptr != filter->get_operand());
+        REQUIRE(nullptr != filter->get_column());
+        REQUIRE(false == filter->has_only_expression_operands());
+        REQUIRE(false == filter->is_inverted());
+        REQUIRE(FilterOperation::EQ == filter->get_operation());
+        REQUIRE("@" == filter->get_column()->get_namespace());
+        REQUIRE(1 == filter->get_column()->get_descriptor_list().size());
+        auto it = filter->get_column()->descriptor_begin();
+        auto const column_token = DescriptorToken::create_descriptor_from_escaped_token("column");
+        REQUIRE(column_token == *it);
+    }
+
+    SECTION("Escaped @ namespace in column") {
+        auto escaped_namespace_query = GENERATE("\\@column : *", "\"\\@column\": *");
+        stringstream query{escaped_namespace_query};
+        auto filter = std::dynamic_pointer_cast<FilterExpr>(parse_kql_expression(query));
+        REQUIRE(nullptr != filter);
+        REQUIRE(nullptr != filter->get_operand());
+        REQUIRE(nullptr != filter->get_column());
+        REQUIRE(false == filter->has_only_expression_operands());
+        REQUIRE(false == filter->is_inverted());
+        REQUIRE(FilterOperation::EQ == filter->get_operation());
+        REQUIRE(filter->get_column()->get_namespace().empty());
+        REQUIRE(1 == filter->get_column()->get_descriptor_list().size());
+        auto it = filter->get_column()->descriptor_begin();
+        auto const column_token = DescriptorToken::create_descriptor_from_escaped_token("@column");
+        REQUIRE(column_token == *it);
     }
 }

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -61,6 +61,24 @@ parent1: {parent2: {child: value}}
 
 The kv-pair may be nested one or more levels deep.
 
+### Querying auto-generated kv-pairs
+
+If the kv-pair is an auto-generated kv-pair ingested from a kv-ir stream you can specify that the
+key exists within the auto-generated namespace by prefixing the key with "@" as follows: 
+
+```
+@key: value
+```
+
+Here the key's name is "key" and the "@" only indicates the namespace.
+
+To specify a key named "@key" within the default namespace the "@" namespace can be escaped as
+follows:
+
+```
+\@key: value
+```
+
 ### Wildcards in values
 
 To search for a kv-pair with *any* value, you can specify the value as a single `*`.
@@ -172,6 +190,7 @@ Keys containing the following literal characters must escape the characters usin
 * `"`
 * `.`
 * `*`
+* `@` (only when `@` is the first character in a token making up the key)
 
 Values containing the following literal characters must escape the characters using a `\`
 (backslash):

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -63,7 +63,7 @@ The kv-pair may be nested one or more levels deep.
 
 ### Querying auto-generated kv-pairs
 
-If the kv-pair is an auto-generated kv-pair ingested from a kv-ir stream you can specify that the
+If the kv-pair is an auto-generated kv-pair ingested from a kv-ir stream, you can specify that the
 key exists within the auto-generated namespace by prefixing the key with "@" as follows: 
 
 ```

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -64,15 +64,16 @@ The kv-pair may be nested one or more levels deep.
 ### Querying auto-generated kv-pairs
 
 If the kv-pair is an auto-generated kv-pair ingested from a kv-ir stream, you can specify that the
-key exists within the auto-generated namespace by prefixing the key with "@" as follows: 
+key exists within the auto-generated namespace by prefixing the key with `@` as follows:
 
 ```
 @key: value
 ```
 
-Here the key's name is "key" and the "@" only indicates the namespace.
+In the query above, the key's name is `key` and the `@` only indicates the namespace (i.e., `@` is
+not considered to be part of the key).
 
-To specify a key named "@key" within the default namespace the "@" namespace can be escaped as
+To query for a key named `@key` within the default namespace, the `@` character can be escaped as
 follows:
 
 ```
@@ -190,7 +191,7 @@ Keys containing the following literal characters must escape the characters usin
 * `"`
 * `.`
 * `*`
-* `@` (only when `@` is the first character in a token making up the key)
+* `@` (only when `@` is the first character of the key)
 
 Values containing the following literal characters must escape the characters using a `\`
 (backslash):


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

This PR adds support for ingesting and searching on auto-generated keys in kv-ir. Broadly this encompasses the following aspects:
1) Traverse the auto-generated kv-pairs and auto-generated schema tree while ingesting kv-ir and add it to a namespaced subtree of the archive schema tree
2) Add support for specifying and escaping namespaces when parsing kql column descriptors
3) Respect namespaces in column resolution/search
4) Respect namespaces in projection
5) Respect namespaces in timestamp matching

Note that this is technically a breaking change because of item 2. In particular archives that contain an authoritative timestamp beginning with an '@' will incorrectly have that '@' interpreted as indicating a namespace per the new parsing rules. We do increment the minor version in this PR, and we could use that to add special casing when loading timestamp dictionaries from older archive versions, but that special casing has not been included in this PR.

The namespacing is achieved by dividing the schema tree as follows:
```
        /""<metadata>-...
-1:root--"@"<object>-... autogen subtree namespace distinguished by "@" name
        \""<object>-...  regular object subtree with "" name
```

Column resolution (and similar bits of code) have been changed to resolve a column against either the "@" object subtree or the default "" object subtree depending on the namespace associated with the column. One notable exception is that pure wildcards "*" currently do not respect namespaces: specifically `*: value` and `@*: value` will search for _any_ column that matches the value (as long as it isn't in the NodeType::Metadata subtree). It would be possible to get pure wildcards to respect namespaces, but it would require turning a lot of linear scans into tree traversals and using more memory to explicitly track sets of matching nodes, and might not be a necessary feature anyway.

For decompression to JSON we simply marshal only the "" object subtree. We could probably add support for merging the "@" and "" namespace during JSON decompression in one way or another, but that is left as future work.

Once we add support for decompression to kv-ir we will simply need to marshal the "" subtree into the user-generated keys and the "@" subtree into the auto-generated keys.

Once again these new features appear to have slightly decreased ingestion performance when specifying timestamp keys. The results are as follows:

| Dataset | (new compression time) / (old compression time) |
| ----- | ----- |
| cockroach | 1.080 |
| mongod | 1.062 |
| elasticsearch | 1.017 |
| postgresql | 1.058 |

There don't seem to be any noticeable new hotspots when I run these benchmarks using perf, but I will try to double-check my benchmarking methodology and continue looking into improving performance during the review process.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Added tests for new namespacing and namespace escaping rules
* Manually validated compression/search/specifying timestamp in auto-generated sub-tree


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for querying auto-generated key–value pairs with namespace indicators.
- **Improvements**
	- Enhanced timestamp and namespace handling improves search accuracy and overall data mapping.
	- Refined query parsing now supports additional special characters for more precise filtering.
- **Documentation**
	- Updated the user guide to include a new section on querying auto-generated key–value pairs and guidelines for escaping special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->