### PR TITLE
refactor(core):  Update`DictionaryReader:: get_entry_matching_value` to return a set instead of a vector (#735)

### DIFF
--- a/components/core/src/clp/DictionaryReader.hpp
+++ b/components/core/src/clp/DictionaryReader.hpp
@@ -2,6 +2,7 @@
 #define CLP_DICTIONARYREADER_HPP
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
@@ -82,9 +83,9 @@ public:
      * Gets the entries matching the given search string
      * @param search_string
      * @param ignore_case
-     * @return a vector of matching entries, or an empty vector if no entry matches.
+     * @return a set of matching entries, or an empty set if no entry matches.
      */
-    std::vector<EntryType const*>
+    std::unordered_set<EntryType const*>
     get_entry_matching_value(std::string const& search_string, bool ignore_case) const;
     /**
      * Gets the entries that match a given wildcard string
@@ -233,7 +234,7 @@ std::string const& DictionaryReader<DictionaryIdType, EntryType>::get_value(Dict
 }
 
 template <typename DictionaryIdType, typename EntryType>
-std::vector<EntryType const*>
+std::unordered_set<EntryType const*>
 DictionaryReader<DictionaryIdType, EntryType>::get_entry_matching_value(
         std::string const& search_string,
         bool ignore_case
@@ -251,11 +252,11 @@ DictionaryReader<DictionaryIdType, EntryType>::get_entry_matching_value(
         return {};
     }
 
-    std::vector<EntryType const*> entries;
+    std::unordered_set<EntryType const*> entries;
     auto const search_string_uppercase = boost::algorithm::to_upper_copy(search_string);
     for (auto const& entry : m_entries) {
         if (boost::algorithm::to_upper_copy(entry.get_value()) == search_string_uppercase) {
-            entries.push_back(&entry);
+            entries.insert(&entry);
         }
     }
     return entries;

--- a/components/core/src/clp/EncodedVariableInterpreter.cpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.cpp
@@ -396,21 +396,17 @@ bool EncodedVariableInterpreter::encode_and_search_dictionary(
         LogTypeDictionaryEntry::add_dict_var(logtype);
 
         if (entries.size() == 1) {
-            auto const* entry = entries.at(0);
+            auto const* entry = *entries.cbegin();
             sub_query.add_dict_var(encode_var_dict_id(entry->get_id()), entry);
             return true;
         }
 
-        std::unordered_set<clp::VariableDictionaryEntry const*> const entries_set{
-                entries.cbegin(),
-                entries.cend()
-        };
         std::unordered_set<encoded_variable_t> encoded_vars;
         encoded_vars.reserve(entries.size());
         for (auto const* entry : entries) {
             encoded_vars.emplace(encode_var_dict_id(entry->get_id()));
         }
-        sub_query.add_imprecise_dict_var(encoded_vars, entries_set);
+        sub_query.add_imprecise_dict_var(encoded_vars, entries);
     }
 
     return true;

--- a/components/core/src/clp_s/DictionaryReader.hpp
+++ b/components/core/src/clp_s/DictionaryReader.hpp
@@ -64,9 +64,9 @@ public:
      * Gets the entries matching the given search string
      * @param search_string
      * @param ignore_case
-     * @return a vector of matching entries, or an empty vector if no entry matches.
+     * @return a set of matching entries, or an empty set if no entry matches.
      */
-    std::vector<EntryType const*>
+    std::unordered_set<EntryType const*>
     get_entry_matching_value(std::string const& search_string, bool ignore_case) const;
 
     /**
@@ -156,7 +156,7 @@ std::string const& DictionaryReader<DictionaryIdType, EntryType>::get_value(Dict
 }
 
 template <typename DictionaryIdType, typename EntryType>
-std::vector<EntryType const*>
+std::unordered_set<EntryType const*>
 DictionaryReader<DictionaryIdType, EntryType>::get_entry_matching_value(
         std::string const& search_string,
         bool ignore_case
@@ -174,11 +174,11 @@ DictionaryReader<DictionaryIdType, EntryType>::get_entry_matching_value(
         return {};
     }
 
-    std::vector<EntryType const*> entries;
+    std::unordered_set<EntryType const*> entries;
     auto const search_string_uppercase = boost::algorithm::to_upper_copy(search_string);
     for (auto const& entry : m_entries) {
         if (boost::algorithm::to_upper_copy(entry.get_value()) == search_string_uppercase) {
-            entries.push_back(&entry);
+            entries.insert(&entry);
         }
     }
     return entries;

--- a/components/core/src/clp_s/search/clp_search/EncodedVariableInterpreter.cpp
+++ b/components/core/src/clp_s/search/clp_search/EncodedVariableInterpreter.cpp
@@ -44,21 +44,17 @@ bool EncodedVariableInterpreter::encode_and_search_dictionary(
         LogTypeDictionaryEntry::add_non_double_var(logtype);
 
         if (entries.size() == 1) {
-            auto const* entry = entries.at(0);
+            auto const* entry = *entries.cbegin();
             sub_query.add_dict_var(VariableEncoder::encode_var_dict_id(entry->get_id()), entry);
             return true;
         }
 
-        std::unordered_set<VariableDictionaryEntry const*> const entries_set{
-                entries.cbegin(),
-                entries.cend()
-        };
         std::unordered_set<encoded_variable_t> encoded_vars;
         encoded_vars.reserve(entries.size());
         for (auto const* entry : entries) {
             encoded_vars.emplace(VariableEncoder::encode_var_dict_id(entry->get_id()));
         }
-        sub_query.add_imprecise_dict_var(encoded_vars, entries_set);
+        sub_query.add_imprecise_dict_var(encoded_vars, entries);
     }
 
     return true;


### PR DESCRIPTION
This PR follows from the discussion in issue #648 and PR #690.

`clp::DictionaryReader:: get_entry_matching_value` and `clp_s::DictionaryReader::get_entry_matching_value` now return a `std::unordered_set`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved dictionary search functionality by ensuring that matching entries are unique.
  - Streamlined the process for retrieving initial results, enhancing overall efficiency.

- **Documentation**
  - Updated method descriptions to reflect the changes in search result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888489337443