### PR TITLE
docs: Add instructions for enabling Docker Desktop's host networking to support the Web UI.

### DIFF
--- a/docs/src/user-guide/quick-start-cluster-setup/single-node.md
+++ b/docs/src/user-guide/quick-start-cluster-setup/single-node.md
@@ -7,6 +7,7 @@ A single-node deployment allows you to run CLP on a single host.
 * [Docker]
   * If you're not running as root, ensure `docker` can be run
     [without superuser privileges][docker-non-root].
+  * If you're using Docker Desktop, you will need version 4.34 or later, and [enable host networking][docker-desktop-host-networking].
 * Python 3.8 or higher
 
 ## Starting CLP
@@ -34,4 +35,5 @@ sbin/stop-clp.sh
 ```
 
 [Docker]: https://docs.docker.com/engine/install/
+[docker-desktop-host-networking]: https://docs.docker.com/engine/network/drivers/host/#docker-desktop
 [docker-non-root]: https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user

--- a/docs/src/user-guide/quick-start-cluster-setup/single-node.md
+++ b/docs/src/user-guide/quick-start-cluster-setup/single-node.md
@@ -7,7 +7,8 @@ A single-node deployment allows you to run CLP on a single host.
 * [Docker]
   * If you're not running as root, ensure `docker` can be run
     [without superuser privileges][docker-non-root].
-  * If you're using Docker Desktop, you will need version 4.34 or later, and [enable host networking][docker-desktop-host-networking].
+  * If you're using Docker Desktop, ensure version 4.34 or higher is installed, and
+    [host networking is enabled][docker-desktop-host-networking].
 * Python 3.8 or higher
 
 ## Starting CLP


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

1. docs: Add guide for enabling host networking in Docker Desktop for Web UI.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Validated the instructions on MacBook Pro (16-inch, 2021; 15.3.1 (24D70)), by launching the [clp-json-x86_64-v0.3.0.tar.gz](https://github.com/y-scope/clp/releases/download/v0.3.0/clp-json-x86_64-v0.3.0.tar.gz) package with Docker Desktop `4.38.0`.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the single-node deployment guide to clarify that Docker Desktop version 4.34 or later is required, with host networking enabled.
	- Included a new reference link to assist users with enabling host networking on Docker Desktop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->