### PR TITLE
refactor(taskfiles): Change lint task `-check` and `-fix` suffixes to prefixes; Rename `yml` to `yaml` in relevant tasks.

### DIFF
--- a/docs/src/dev-guide/components-log-viewer-webui.md
+++ b/docs/src/dev-guide/components-log-viewer-webui.md
@@ -57,13 +57,13 @@ You can lint this component either as part of the entire project or as a standal
 To check for linting errors:
 
 ```shell
-task lint:js-check
+task lint:check-js
 ```
 
 To also fix linting errors (if applicable):
 
 ```shell
-task lint:js-fix
+task lint:fix-js
 ```
 
 ### Lint the component alone

--- a/docs/src/dev-guide/components-webui.md
+++ b/docs/src/dev-guide/components-webui.md
@@ -63,7 +63,7 @@ performing linting; you may choose either one according to your preference.
 #### Checking for linting errors
 
 ```shell
-task lint:js-check
+task lint:check-js
 ```
 
 This will run ESLint on the entire project's source code and report any linting errors.
@@ -71,7 +71,7 @@ This will run ESLint on the entire project's source code and report any linting 
 #### Automatically fixing linting errors
 
 ```shell
-task lint:js-fix
+task lint:fix-js
 ```
 
 This command attempts to automatically fix any linting issues found in the project.

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -7,27 +7,27 @@ vars:
 tasks:
   check:
     cmds:
-      - task: "cpp-check"
-      - task: "js-check"
-      - task: "py-check"
-      - task: "yml-check"
+      - task: "check-cpp"
+      - task: "check-js"
+      - task: "check-py"
+      - task: "check-yaml"
 
   fix:
     cmds:
-      - task: "cpp-fix"
-      - task: "js-fix"
-      - task: "py-fix"
-      - task: "yml-fix"
+      - task: "fix-cpp"
+      - task: "fix-js"
+      - task: "fix-py"
+      - task: "fix-yaml"
 
-  cpp-check:
+  check-cpp:
     cmds:
-      - task: "cpp-format-check"
+      - task: "check-cpp-format"
 
-  cpp-fix:
+  fix-cpp:
     cmds:
-      - task: "cpp-format-fix"
+      - task: "fix-cpp-format"
 
-  js-check:
+  check-js:
     sources: &js_source_files
       - "{{.G_BUILD_DIR}}/lint#linter-node-modules.md5"
       - "{{.G_BUILD_DIR}}/log-viewer-webui-node-modules.md5"
@@ -56,31 +56,31 @@ tasks:
         vars:
           LINT_CMD: "check"
 
-  js-fix:
+  fix-js:
     sources: *js_source_files
     cmds:
       - task: "js"
         vars:
           LINT_CMD: "fix"
 
-  py-check:
+  check-py:
     cmds:
       - task: "py"
         vars:
           BLACK_FLAGS: "--check --diff"
           RUFF_FLAGS: ""
 
-  py-fix:
+  fix-py:
     cmds:
       - task: "py"
         vars:
           BLACK_FLAGS: ""
           RUFF_FLAGS: "--fix"
 
-  yml:
+  yaml:
     aliases:
-      - "yml-check"
-      - "yml-fix"
+      - "check-yaml"
+      - "fix-yaml"
     deps: ["venv"]
     cmds:
       - |-
@@ -96,7 +96,7 @@ tasks:
           lint-tasks.yml \
           Taskfile.yml
 
-  cpp-format-check:
+  check-cpp-format:
     sources: &cpp_source_files
       - "{{.ROOT_DIR}}/.clang-format"
       - "{{.ROOT_DIR}}/.clang-tidy"
@@ -113,7 +113,7 @@ tasks:
           ROOT_PATHS: *cpp_source_files
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
-  cpp-format-fix:
+  fix-cpp-format:
     sources: *cpp_source_files
     deps: ["cpp-lint-configs", "venv"]
     cmds:


### PR DESCRIPTION
# Description

As title says.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tasks tested locally and with CI.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chore**
	- Refined naming conventions for linting tasks to improve consistency and clarity in the documentation and command usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->