### PR TITLE
fix(ci): Don't compare booleans against strings in GH expressions; Validate ubuntu-jammy-binaries-image GH workflow job in PRs (fixes #750).

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -73,7 +73,7 @@ jobs:
         # NOTE: We omit the Stopwatch tests since GH's macOS runner is too slow
         run: >-
           python3 ./tools/scripts/utils/build-and-run-unit-tests.py
-          ${{matrix.use_shared_libs == 'true' && '--use-shared-libs' || ''}}
+          ${{matrix.use_shared_libs == true && '--use-shared-libs' || ''}}
           --source-dir .
           --build-dir build
           --num-jobs $(getconf _NPROCESSORS_ONLN)

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -241,14 +241,8 @@ jobs:
           retention-days: 1
 
   ubuntu-jammy-binaries-image:
-    # Run if the ancestor jobs were successful/skipped, building clp was successful, and this is a
-    # push to `main`.
-    if: >-
-      !cancelled()
-      && !failure()
-      && needs.ubuntu-jammy-binaries.result == 'success'
-      && github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
+    # Run if the ancestor jobs were successful/skipped and building clp was successful.
+    if: "!cancelled() && !failure() && needs.ubuntu-jammy-binaries.result == 'success'"
     needs: "ubuntu-jammy-binaries"
     runs-on: "ubuntu-latest"
     env:
@@ -297,7 +291,10 @@ jobs:
             ghcr.io/${{steps.sanitize_repo_name.outputs.repository}}/clp-core-x86-${{env.OS_NAME}}
           tags: "type=raw,value=${{github.ref_name}}"
 
-      - uses: "docker/build-push-action@v5"
+      # Only publish the image if this workflow was triggered by a push to `main`.
+      # NOTE: We run the rest of the job to test that the binaries were uploaded correctly.
+      - if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
+        uses: "docker/build-push-action@v5"
         with:
           context: "${{env.TMP_OUTPUT_DIR}}/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
           file: "components/core/tools/docker-images/clp-core-${{env.OS_NAME}}/Dockerfile"

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -174,7 +174,7 @@ jobs:
           run_command: >-
             task deps:core
             && python3 /mnt/repo/components/core/tools/scripts/utils/build-and-run-unit-tests.py
-            ${{matrix.use_shared_libs == 'true' && '--use-shared-libs' || ''}}
+            ${{matrix.use_shared_libs == true && '--use-shared-libs' || ''}}
             --source-dir /mnt/repo/components/core
             --build-dir /mnt/repo/components/core/build
             --num-jobs $(getconf _NPROCESSORS_ONLN)
@@ -217,12 +217,12 @@ jobs:
           run_command: >-
             task deps:core
             && python3 /mnt/repo/components/core/tools/scripts/utils/build-and-run-unit-tests.py
-            ${{matrix.use_shared_libs == 'true' && '--use-shared-libs' || ''}}
+            ${{matrix.use_shared_libs == true && '--use-shared-libs' || ''}}
             --source-dir /mnt/repo/components/core
             --build-dir /mnt/repo/components/core/build
             --num-jobs $(getconf _NPROCESSORS_ONLN)
 
-      - if: "matrix.upload_binaries == 'true'"
+      - if: "matrix.upload_binaries == true"
         id: "copy_binaries"
         run: |-
           output_dir="/tmp/${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
@@ -233,7 +233,7 @@ jobs:
           tar cfvv "${output_dir}/clp.tar" clg clp clp-s glt make-dictionaries-readable
         shell: "bash"
 
-      - if: "matrix.upload_binaries == 'true'"
+      - if: "matrix.upload_binaries == true"
         uses: "actions/upload-artifact@v4"
         with:
           name: "${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       matrix:
         use_shared_libs: [true, false]
-    name: "centos-stream-9-${{matrix.use_shared_libs && 'dynamic' || 'static'}}-linked-bins"
+    name: "centos-stream-9-${{matrix.use_shared_libs == true && 'dynamic' || 'static'}}-linked-bins"
     continue-on-error: true
     runs-on: "ubuntu-latest"
     steps:
@@ -196,7 +196,7 @@ jobs:
             upload_binaries: true
     env:
       OS_NAME: "ubuntu-jammy"
-    name: "ubuntu-jammy-${{matrix.use_shared_libs && 'dynamic' || 'static'}}-linked-bins"
+    name: "ubuntu-jammy-${{matrix.use_shared_libs == true && 'dynamic' || 'static'}}-linked-bins"
     continue-on-error: true
     runs-on: "ubuntu-latest"
     steps:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As described in #750, #748 erroneously compared booleans against strings in some GH expressions in the clp-core-build GH workflow. The effect of the error was that the CLP core binaries weren't being uploaded by the ubuntu-jammy-binaries job, so then the ubuntu-jammy-binaries-image job couldn't download them and failed.

This PR changes the comparison to booleans against booleans in both the clp-core-build and clp-core-build-macos workflows. In addition, the PR enables the ubuntu-jammy-binaries-image to run even in PR workflow runs so that we can validate that downloading the binaries succeeds. However, we still disable publishing the binaries image from PR workflow runs.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Workflows succeeded in this PR.
* Merged change to `main` in my fork and validated that all workflows succeeded.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced our automated build process by refining the evaluation of key conditions. These updates streamline logic and improve the accuracy of job execution during workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->