### PR TITLE
feat(lint): Lock clang-format to v19 until we can upgrade our code to meet v20's formatting standards.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black>=24.4.2
-clang-format>=19.1.6
+# Lock to v19.x until we can upgrade our code to meet v20's formatting standards.
+clang-format~=19.1
 ruff>=0.4.4
 yamllint>=1.35.1


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As title.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* clp-lint workflow succeeds.
* `task lint:check` succeeds.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined an internal formatting dependency to lock to a specific version series, promoting consistent styling.
  - These backend improvements lay the groundwork for future enhancements and support reliable code practices.
  - End-user functionality remains unchanged, ensuring a seamless experience.
  - This update is part of ongoing efforts to enhance project maintainability and prepare for future style upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->