### PR TITLE
fix(CODEOWNERS): Add `@y-scope/maintainers` to clp-s; Improve accuracy of clp-s path pattern.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @y-scope/maintainers
-components/core/src/clp_s/* @gibber9809 @wraymo
+/components/core/src/clp_s/ @gibber9809 @wraymo @y-scope/maintainers


### PR DESCRIPTION
# Description

The current CODEOWNERS file has a few errors:

* `y-scope/maintainers` is overwritten as a reviewer of the clp-s code meaning that changes to the clp-s code can only be approved by gibber9809 or wraymo.
* The path pattern for clp-s code doesn't recurse into subdirectories and isn't absolute.

This PR fixes both issues.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

NA

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal repository management configurations to refine team responsibilities and ensure streamlined collaboration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->