### PR TITLE
feat(lint): Lock clang-tidy to v19 until we can upgrade our code to fix new v20 issues.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,6 @@
 black>=24.4.2
 clang-format>=20.1
-clang-tidy>=19.1
+# Lock to v19.x until we can upgrade our code to fix new v20 issues.
+clang-tidy~=19.1
 ruff>=0.4.4
 yamllint>=1.35.1


### PR DESCRIPTION
# Description

As title says. Use of `fmt`'s macro `FMT_STRING` from `spdlog` generate a new  error on clang-tidy v20.
An example:
```
Error while processing /home/lion/yscope/clp/components/core/src/clp/streaming_compression/lzma/Compressor.cpp.                                                                       
/usr/local/include/spdlog/fmt/bundled/format-inl.h:2514:30: error: call to consteval function 'fmt::basic_format_string<char, unsigned int &>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression [clang-diagnostic-error]
 2514 |         out = format_to(out, FMT_STRING("{:x}"), value);                                                                                                                      
      |                              ^ 
```



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Test locally and through CI.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
