### PR TITLE
fix(clp-s): Fix authoritative timestamp parsing bug introduced in #731.

### DIFF
--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -241,14 +241,15 @@ ArchiveWriter::append_message(int32_t schema_id, Schema const& schema, ParsedMes
 
 int32_t ArchiveWriter::add_node(int parent_node_id, NodeType type, std::string_view key) {
     auto const node_id{m_schema_tree.add_node(parent_node_id, type, key)};
-    if (NodeType::Object == type && m_matched_timestamp_prefix_node_id == parent_node_id
-        && m_authoritative_timestamp.size() > (m_matched_timestamp_prefix_length + 1))
-    {
-        if (constants::cRootNodeId == parent_node_id) {
+    if (NodeType::Object == type && m_matched_timestamp_prefix_node_id == parent_node_id) {
+        if (false == m_authoritative_timestamp.empty() && constants::cRootNodeId == parent_node_id)
+        {
             if (m_authoritative_timestamp_namespace == key) {
                 m_matched_timestamp_prefix_node_id = node_id;
             }
-        } else if (m_authoritative_timestamp.at(m_matched_timestamp_prefix_length) == key) {
+        } else if (m_authoritative_timestamp.size() > (m_matched_timestamp_prefix_length + 1)
+                   && m_authoritative_timestamp.at(m_matched_timestamp_prefix_length) == key)
+        {
             m_matched_timestamp_prefix_length += 1;
             m_matched_timestamp_prefix_node_id = node_id;
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fixes a bug introduced during some refactoring in #731. In particular, that PR adds the condition `m_authoritative_timestamp.size() > (m_matched_timestamp_prefix_length + 1)` to an if statement wrapping the rest of the timestamp key resolution logic, which prevented being able to correctly match the root of a given object subtree for keys consisting of a single token.

The fix simply involves removing this condition from that outermost if branch and adjusting some other conditions accordingly.

Alternatively we could simplify the matching logic by inserting the namespace into the start of the vector of tokens and use that to remove the special case for matching the root of an object subtree.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* Manually validated that timestamp key can be recognized for variety of kv-ir and json streams
<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced safety and reliability in internal archival processing by streamlining validation checks, reducing the risk of runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->