### PR TITLE
feat(clp-package): Add option for specifying archive compression level and update max compression level to 19.

### DIFF
--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -443,6 +443,7 @@ class ArchiveOutput(BaseModel):
     target_dictionaries_size: int = 32 * 1024 * 1024  # 32 MB
     target_encoded_file_size: int = 256 * 1024 * 1024  # 256 MB
     target_segment_size: int = 256 * 1024 * 1024  # 256 MB
+    compression_level: int = 3
 
     @validator("target_archive_size")
     def validate_target_archive_size(cls, field):
@@ -466,6 +467,12 @@ class ArchiveOutput(BaseModel):
     def validate_target_segment_size(cls, field):
         if field <= 0:
             raise ValueError("target_segment_size must be greater than 0")
+        return field
+        
+    @validator("compression_level")
+    def validate_compression_level(cls, field):
+        if field < 1 or field > 9:
+            raise ValueError("compression_level must be a value from 1 to 9")
         return field
 
     def set_directory(self, directory: pathlib.Path):

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -468,7 +468,7 @@ class ArchiveOutput(BaseModel):
         if field <= 0:
             raise ValueError("target_segment_size must be greater than 0")
         return field
-        
+
     @validator("compression_level")
     def validate_compression_level(cls, field):
         if field < 1 or field > 9:

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -471,8 +471,8 @@ class ArchiveOutput(BaseModel):
 
     @validator("compression_level")
     def validate_compression_level(cls, field):
-        if field < 1 or 9 < field:
-            raise ValueError("compression_level must be a value from 1 to 9")
+        if field < 1 or 19 < field:
+            raise ValueError("compression_level must be a value from 1 to 19")
         return field
 
     def set_directory(self, directory: pathlib.Path):

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -471,7 +471,7 @@ class ArchiveOutput(BaseModel):
 
     @validator("compression_level")
     def validate_compression_level(cls, field):
-        if field < 1 or field > 9:
+        if field < 1 or 9 < field:
             raise ValueError("compression_level must be a value from 1 to 9")
         return field
 

--- a/components/core/src/clp/clp/CommandLineArguments.cpp
+++ b/components/core/src/clp/clp/CommandLineArguments.cpp
@@ -357,7 +357,7 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                     po::value<int>(&m_compression_level)
                             ->value_name("LEVEL")
                             ->default_value(m_compression_level),
-                    "1 (fast/low compression) to 9 (slow/high compression)"
+                    "1 (fast/low compression) to 19 (slow/high compression)"
             )(
                     "print-archive-stats-progress",
                     po::bool_switch(&m_print_archive_stats_progress),

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -216,7 +216,7 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     "compression-level",
                     po::value<int>(&m_compression_level)->value_name("LEVEL")->
                         default_value(m_compression_level),
-                    "1 (fast/low compression) to 9 (slow/high compression)."
+                    "1 (fast/low compression) to 19 (slow/high compression)."
             )(
                     "target-encoded-size",
                     po::value<size_t>(&m_target_encoded_size)->value_name("TARGET_ENCODED_SIZE")->

--- a/components/core/src/glt/glt/CommandLineArguments.cpp
+++ b/components/core/src/glt/glt/CommandLineArguments.cpp
@@ -278,7 +278,7 @@ CommandLineArguments::parse_arguments(int argc, char const* argv[]) {
                     po::value<int>(&m_compression_level)
                             ->value_name("LEVEL")
                             ->default_value(m_compression_level),
-                    "1 (fast/low compression) to 9 (slow/high compression)"
+                    "1 (fast/low compression) to 19 (slow/high compression)"
             )(
                     "print-archive-stats-progress",
                     po::bool_switch(&m_print_archive_stats_progress),

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -140,6 +140,7 @@ def make_clp_command_and_env(
         "--target-dictionaries-size", str(clp_config.output.target_dictionaries_size),
         "--target-segment-size", str(clp_config.output.target_segment_size),
         "--target-encoded-file-size", str(clp_config.output.target_encoded_file_size),
+        "--compression-level", str(clp_config.output.compression_level),
         "--db-config-file", str(db_config_file_path),
     ]
     # fmt: on
@@ -180,6 +181,7 @@ def make_clp_s_command_and_env(
         "--print-archive-stats",
         "--target-encoded-size",
         str(clp_config.output.target_segment_size + clp_config.output.target_dictionaries_size),
+        "--compression-level", str(clp_config.output.compression_level),
         "--db-config-file", str(db_config_file_path),
     ]
     # fmt: on

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -44,6 +44,7 @@ class OutputConfig(BaseModel):
     target_dictionaries_size: int
     target_segment_size: int
     target_encoded_file_size: int
+    compression_level: int
 
 
 class ClpIoConfig(BaseModel):

--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -83,6 +83,9 @@
 #
 #  # How much data CLP should try to fit into each segment within an archive
 #  target_segment_size: 268435456  # 256 MB
+#  
+#  # How much archives should be compressed: 1 (fast/low compression) to 9 (slow/high compression)
+#  compression_level: 3
 #
 ## Where CLP stream files (e.g., IR streams) should be output
 #stream_output:

--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -84,7 +84,7 @@
 #  # How much data CLP should try to fit into each segment within an archive
 #  target_segment_size: 268435456  # 256 MB
 #
-#  # How much archives should be compressed: 1 (fast/low compression) to 9 (slow/high compression)
+#  # How much archives should be compressed: 1 (fast/low compression) to 19 (slow/high compression)
 #  compression_level: 3
 #
 ## Where CLP stream files (e.g., IR streams) should be output

--- a/components/package-template/src/etc/clp-config.yml
+++ b/components/package-template/src/etc/clp-config.yml
@@ -83,7 +83,7 @@
 #
 #  # How much data CLP should try to fit into each segment within an archive
 #  target_segment_size: 268435456  # 256 MB
-#  
+#
 #  # How much archives should be compressed: 1 (fast/low compression) to 9 (slow/high compression)
 #  compression_level: 3
 #


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds the `compression_level` option to `archive_output` in `clp-config.yml`. Compression level can be set to an integer value from 1 (lowest compression ratio, highest speed) to 19 (highest compression ratio, lowest speed).


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- Compressed logs at different levels on both clp and clp-s.
- Verified compression ratio and speed change according to selected level.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - A new compression-level setting has been introduced, allowing users to control archive compression with values ranging from 1 (fast/low compression) to 19 (slow/high compression), with a default of 3.
  - Job orchestration commands now support specifying the compression level, enabling greater flexibility in processing.
  - Configuration documentation has been enhanced to outline the new compression level option and its value range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->