### PR TITLE
refactor(ffi): Resolve clang-tidy violations in `ffi/utils.cpp`.

### DIFF
--- a/components/core/src/clp/ffi/utils.cpp
+++ b/components/core/src/clp/ffi/utils.cpp
@@ -61,6 +61,7 @@ auto validate_and_append_escaped_utf8_string(std::string_view src, std::string& 
                 constexpr uint8_t cLargestControlCharacter{0x1F};
                 auto const byte{static_cast<uint8_t>(*it)};
                 if (cLargestControlCharacter >= byte) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
                     std::ignore = snprintf(buf.data(), buf.size(), "\\u00%02x", byte);
                     escaped_char = {buf.data(), buf.size() - 1};
                 } else {

--- a/components/core/src/clp/ffi/utils.cpp
+++ b/components/core/src/clp/ffi/utils.cpp
@@ -66,6 +66,8 @@ auto validate_and_append_escaped_utf8_string(std::string_view src, std::string& 
                     // escaped_char = fmt::format("\\u00{:02x}", byte);
                     // We should update it once `fmtlib` is fully integrated into the FFI library.
 
+                    // Necessary since implementations (besides `fmtlib`) that don't violate
+                    // `cppcoreguidelines-pro-type-vararg` have much worse performance.
                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
                     std::ignore = snprintf(buf.data(), buf.size(), "\\u00%02x", byte);
                     escaped_char = {buf.data(), buf.size() - 1};

--- a/components/core/src/clp/ffi/utils.cpp
+++ b/components/core/src/clp/ffi/utils.cpp
@@ -61,6 +61,11 @@ auto validate_and_append_escaped_utf8_string(std::string_view src, std::string& 
                 constexpr uint8_t cLargestControlCharacter{0x1F};
                 auto const byte{static_cast<uint8_t>(*it)};
                 if (cLargestControlCharacter >= byte) {
+                    // NOTE: This section can be replaced with the following without losing any
+                    // performance:
+                    // escaped_char = fmt::format("\\u00{:02x}", byte);
+                    // We should update it once `fmtlib` is fully integrated into the FFI library.
+
                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
                     std::ignore = snprintf(buf.data(), buf.size(), "\\u00%02x", byte);
                     escaped_char = {buf.data(), buf.size() - 1};

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -269,7 +269,6 @@ tasks:
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp/ffi/search/Subquery.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp/ffi/search/WildcardToken.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp/ffi/search/WildcardToken.hpp"
-            - "{{.G_CORE_COMPONENT_DIR}}/src/clp/ffi/utils.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp/FileDescriptor.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp/FileDescriptor.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp/FileDescriptorReader.cpp"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR resolves clang-tidy warnings in `ffi/utils.cpp` as a part of #764.

The clang-tidy warning in this file was first reported and fixed in an unmerged PR #509. However, as explained in [this](https://github.com/y-scope/clp/pull/509/files#r1714472399) comment, the current implementation (using C-style vararg function) will lead to a better performance. Therefore, it is decided to silent the clang-tidy warning using `NOLINT` comment.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Ensure all workflows passed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Made minor enhancements to internal code quality practices.
	- Updated linting configurations by removing a specific file from the linting process.

These internal adjustments improve our development workflow without affecting application functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->