### PR TITLE
fix(clp-s): Reduce compiler warnings

### DIFF
--- a/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
@@ -131,7 +131,7 @@ auto encode_uri(string_view uri, bool is_object_key) -> string {
     string encoded_uri;
 
     for (auto const c : uri) {
-        if (is_unreserved_characters(c) || ('/' == c) && is_object_key) {
+        if (is_unreserved_characters(c) || ('/' == c && is_object_key)) {
             encoded_uri += c;
         } else {
             encoded_uri += fmt::format("%{:02X}", c);

--- a/components/core/src/clp_s/ArchiveReader.cpp
+++ b/components/core/src/clp_s/ArchiveReader.cpp
@@ -257,6 +257,7 @@ void ArchiveReader::append_unordered_reader_columns(
             // No need to push columns without associated object readers into the SchemaReader.
             case NodeType::StructuredArray:
             case NodeType::Object:
+            case NodeType::Metadata:
             case NodeType::NullValue:
             case NodeType::Unknown:
                 break;

--- a/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
+++ b/components/core/src/clp_s/ArchiveReaderAdaptor.cpp
@@ -25,8 +25,8 @@ ArchiveReaderAdaptor::ArchiveReaderAdaptor(
 )
         : m_archive_path{archive_path},
           m_network_auth{network_auth},
-          m_timestamp_dictionary{std::make_shared<TimestampDictionaryReader>()},
-          m_single_file_archive{false} {
+          m_single_file_archive{false},
+          m_timestamp_dictionary{std::make_shared<TimestampDictionaryReader>()} {
     if (InputSource::Filesystem != archive_path.source
         || std::filesystem::is_regular_file(archive_path.path))
     {

--- a/components/core/src/clp_s/DictionaryEntry.hpp
+++ b/components/core/src/clp_s/DictionaryEntry.hpp
@@ -30,8 +30,8 @@ public:
 
 protected:
     // Variables
-    DictionaryIdType m_id;
     std::string m_value;
+    DictionaryIdType m_id;
 };
 
 /**

--- a/components/core/src/clp_s/SchemaReader.cpp
+++ b/components/core/src/clp_s/SchemaReader.cpp
@@ -455,6 +455,7 @@ size_t SchemaReader::generate_structured_array_template(
                 }
                 case NodeType::DateString:
                 case NodeType::UnstructuredArray:
+                case NodeType::Metadata:
                 case NodeType::Unknown:
                     break;
             }
@@ -539,6 +540,7 @@ size_t SchemaReader::generate_structured_object_template(
                 }
                 case NodeType::DateString:
                 case NodeType::UnstructuredArray:
+                case NodeType::Metadata:
                 case NodeType::Unknown:
                     break;
             }
@@ -645,6 +647,7 @@ void SchemaReader::generate_json_template(int32_t id) {
                 m_json_serializer.add_special_key(key);
                 break;
             }
+            case NodeType::Metadata:
             case NodeType::Unknown:
                 break;
         }

--- a/components/core/src/clp_s/SchemaTree.hpp
+++ b/components/core/src/clp_s/SchemaTree.hpp
@@ -100,8 +100,8 @@ public:
     void add_child(int32_t child_id) { m_children_ids.push_back(child_id); }
 
 private:
-    int32_t m_id;
     int32_t m_parent_id;
+    int32_t m_id;
     std::vector<int32_t> m_children_ids;
     // We use a buffer so that references to this key name are stable after this SchemaNode is move
     // constructed

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -111,7 +111,7 @@ append_padded_value_notz(int value, char padding_character, size_t max_length, s
     if ("0" != value_str) {
         str.append(max_length - value_str.length(), padding_character);
         size_t last_zero = string::npos;
-        for (size_t last = value_str.size() - 1; last >= 0; --last) {
+        for (int last = value_str.size() - 1; last >= 0; --last) {
             if (value_str[last] == '0') {
                 last_zero = last;
             } else {

--- a/components/core/src/clp_s/ZstdCompressor.cpp
+++ b/components/core/src/clp_s/ZstdCompressor.cpp
@@ -4,8 +4,8 @@
 namespace clp_s {
 ZstdCompressor::ZstdCompressor()
         : Compressor(CompressorType::ZSTD),
-          m_compression_stream_contains_data(false),
-          m_compressed_stream_file_writer(nullptr) {
+          m_compressed_stream_file_writer(nullptr),
+          m_compression_stream_contains_data(false) {
     m_compression_stream = ZSTD_createCStream();
     if (nullptr == m_compression_stream) {
         SPDLOG_ERROR("ZstdCompressor: ZSTD_createCStream() error");


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fixes a lot of compiler warnings when building `clp-s`. It is an essential step when integrating with other tools with the default `Werror` option. 

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
+ Built the clp-s library for velox the the default CMake flags, all previous warnings are resolved
<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
