### PR TITLE
fix(docs): Add CLP logo to repo to avoid dependence on an external host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="CLP" src="https://yscope.com/img/clp-logo.png" width="300"/>
+<img alt="CLP" src="docs/src/clp-logo.png" width="300"/>
 
 [![Open bug reports](https://img.shields.io/github/issues/y-scope/clp/bug?label=bugs)](https://github.com/y-scope/clp/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 [![Open feature requests](https://img.shields.io/github/issues/y-scope/clp/enhancement?label=feature-requests)](https://github.com/y-scope/clp/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)

--- a/docs/conf/conf.py
+++ b/docs/conf/conf.py
@@ -37,7 +37,7 @@ autodoc_typehints = "description"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_favicon = "https://docs.yscope.com/_static/favicon.ico"
-html_logo = "https://yscope.com/img/clp-logo.png"
+html_logo = "../src/clp-logo.png"
 html_title = "CLP"
 html_show_copyright = True
 

--- a/docs/src/clp-logo.png
+++ b/docs/src/clp-logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ad3053dd8964fd5eef9d6d3636ff657c06de27a32bb436403aef31a3729a8a2
+size 24364

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-:::{image} https://yscope.com/img/clp-logo.png
+:::{image} clp-logo.png
 :class: bg-transparent
 :width: 300
 :::


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The CLP repo and docs currently depend on the [YScope website](https://yscope.com/img/clp-logo.png). As the website goes through redesigns, this image may not always be in the same place, so it's safer to move the logo directly into this repo.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* `task docs:serve` and validated the image showed up in the top-left and on the main page.
* Validated that the logo shows up in README.md in my fork.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the logo image source across documentation to use a local path instead of relying on an external URL. This ensures a more consistent presentation and improved local asset management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->