### PR TITLE
refactor(clp-s): Resolve clang-tidy violations and improve docstrings in `clp_s/search/ast/Value.hpp`.

### DIFF
--- a/components/core/src/clp_s/search/ast/AndExpr.cpp
+++ b/components/core/src/clp_s/search/ast/AndExpr.cpp
@@ -7,7 +7,7 @@ AndExpr::AndExpr(bool inverted, Expression* parent) : Expression(inverted, paren
 
 AndExpr::AndExpr(AndExpr const& expr) : Expression(expr) {}
 
-void AndExpr::print() {
+void AndExpr::print() const {
     auto& os = get_print_stream();
     if (is_inverted()) {
         os << "!";

--- a/components/core/src/clp_s/search/ast/AndExpr.hpp
+++ b/components/core/src/clp_s/search/ast/AndExpr.hpp
@@ -10,7 +10,7 @@ namespace clp_s::search::ast {
  */
 class AndExpr : public Expression {
 public:
-    void print() override;
+    void print() const override;
 
     /**
      * And expressions only have other expressions as children by construction

--- a/components/core/src/clp_s/search/ast/BooleanLiteral.cpp
+++ b/components/core/src/clp_s/search/ast/BooleanLiteral.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<Literal> BooleanLiteral::create_from_string(std::string const& v
     return {nullptr};
 }
 
-void BooleanLiteral::print() {
+void BooleanLiteral::print() const {
     auto& os = get_print_stream();
     if (m_v) {
         os << "true";

--- a/components/core/src/clp_s/search/ast/BooleanLiteral.hpp
+++ b/components/core/src/clp_s/search/ast/BooleanLiteral.hpp
@@ -32,7 +32,7 @@ public:
     static std::shared_ptr<Literal> create_from_string(std::string const& v);
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Literal
     bool matches_type(LiteralType type) override { return type & LiteralType::BooleanT; }

--- a/components/core/src/clp_s/search/ast/ColumnDescriptor.cpp
+++ b/components/core/src/clp_s/search/ast/ColumnDescriptor.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<ColumnDescriptor> ColumnDescriptor::copy() {
     return std::make_shared<ColumnDescriptor>(*this);
 }
 
-void ColumnDescriptor::print() {
+void ColumnDescriptor::print() const {
     auto& os = get_print_stream();
     os << "ColumnDescriptor<";
     for (uint32_t flag = LiteralType::TypesBegin; flag < LiteralType::TypesEnd; flag <<= 1) {

--- a/components/core/src/clp_s/search/ast/ColumnDescriptor.hpp
+++ b/components/core/src/clp_s/search/ast/ColumnDescriptor.hpp
@@ -258,7 +258,7 @@ public:
     bool is_pure_wildcard() const { return m_pure_wildcard; }
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Literal
     // ColumnDescriptor can implicitly match several different types at the same time.

--- a/components/core/src/clp_s/search/ast/DateLiteral.cpp
+++ b/components/core/src/clp_s/search/ast/DateLiteral.cpp
@@ -42,7 +42,7 @@ std::shared_ptr<Literal> DateLiteral::create_from_string(std::string const& v) {
     return std::shared_ptr<Literal>(static_cast<Literal*>(new DateLiteral(timestamp, v)));
 }
 
-void DateLiteral::print() {
+void DateLiteral::print() const {
     get_print_stream() << m_epoch_str;
 }
 

--- a/components/core/src/clp_s/search/ast/DateLiteral.hpp
+++ b/components/core/src/clp_s/search/ast/DateLiteral.hpp
@@ -35,7 +35,7 @@ public:
     static std::shared_ptr<Literal> create_from_string(std::string const& v);
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Literal
     bool matches_type(LiteralType type) override { return type & cDateLiteralTypes; }

--- a/components/core/src/clp_s/search/ast/EmptyExpr.cpp
+++ b/components/core/src/clp_s/search/ast/EmptyExpr.cpp
@@ -9,7 +9,7 @@ std::shared_ptr<Expression> EmptyExpr::create(Expression* parent) {
     return std::shared_ptr<Expression>(static_cast<Expression*>(new EmptyExpr(parent)));
 }
 
-void EmptyExpr::print() {
+void EmptyExpr::print() const {
     auto& os = get_print_stream();
     os << "EmptyExpr()";
 

--- a/components/core/src/clp_s/search/ast/EmptyExpr.hpp
+++ b/components/core/src/clp_s/search/ast/EmptyExpr.hpp
@@ -18,7 +18,7 @@ public:
     static std::shared_ptr<Expression> create(Expression* parent = nullptr);
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Expression
     // EmptyExpr never has any operands, so we arbitrarily say that all operands are Expression

--- a/components/core/src/clp_s/search/ast/Expression.hpp
+++ b/components/core/src/clp_s/search/ast/Expression.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_SEARCH_EXPRESSION_HPP
 #define CLP_S_SEARCH_EXPRESSION_HPP
 
+#include <cstddef>
 #include <list>
 #include <memory>
 
@@ -32,7 +33,7 @@ public:
     /**
      * @return The number of operands that this expression has
      */
-    auto get_num_operands() const -> size_t override { return m_operands.size(); }
+    [[nodiscard]] auto get_num_operands() const -> size_t override { return m_operands.size(); }
 
     /**
      * Gets iterators to this Expression's OpList

--- a/components/core/src/clp_s/search/ast/Expression.hpp
+++ b/components/core/src/clp_s/search/ast/Expression.hpp
@@ -36,8 +36,8 @@ public:
     [[nodiscard]] auto get_num_operands() const -> size_t override { return m_operands.size(); }
 
     /**
-     * Gets iterators to this Expression's OpList
-     * @return Iterators to the beggining/end of the OpList
+     * Gets iterators to this `Expression`'s OpList.
+     * @return Iterators to the beginning/end of the OpList
      */
     OpList::iterator op_begin() { return m_operands.begin(); }
 

--- a/components/core/src/clp_s/search/ast/Expression.hpp
+++ b/components/core/src/clp_s/search/ast/Expression.hpp
@@ -32,15 +32,19 @@ public:
     /**
      * @return The number of operands that this expression has
      */
-    unsigned get_num_operands() override { return m_operands.size(); }
+    auto get_num_operands() const -> size_t override { return m_operands.size(); }
 
     /**
-     * Get iterators to this Expression's OpList
+     * Gets iterators to this Expression's OpList
      * @return Iterators to the beggining/end of the OpList
      */
     OpList::iterator op_begin() { return m_operands.begin(); }
 
     OpList::iterator op_end() { return m_operands.end(); }
+
+    OpList::const_iterator op_begin() const { return m_operands.cbegin(); }
+
+    OpList::const_iterator op_end() const { return m_operands.cend(); }
 
     /**
      * @return A reference to the underlying OpList. Useful in cases where certain children
@@ -60,7 +64,7 @@ public:
     /**
      * @return The parent for this Expression. Can be nullptr if this is the top level.
      */
-    Expression* get_parent() { return m_parent; }
+    auto get_parent() const -> Expression* { return m_parent; }
 
     /**
      * Set the parent for this Expression
@@ -97,7 +101,7 @@ public:
     virtual bool has_only_expression_operands() = 0;
 
     // Methods inherited from Value
-    void print() override = 0;
+    void print() const override = 0;
 
 protected:
     /**

--- a/components/core/src/clp_s/search/ast/FilterExpr.cpp
+++ b/components/core/src/clp_s/search/ast/FilterExpr.cpp
@@ -39,7 +39,7 @@ std::string FilterExpr::op_type_str(FilterOperation op) {
     }
 }
 
-void FilterExpr::print() {
+void FilterExpr::print() const {
     auto& os = get_print_stream();
     if (is_inverted()) {
         os << "!";

--- a/components/core/src/clp_s/search/ast/FilterExpr.hpp
+++ b/components/core/src/clp_s/search/ast/FilterExpr.hpp
@@ -75,7 +75,7 @@ public:
     static std::string op_type_str(FilterOperation op);
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Expression
     bool has_only_expression_operands() override { return false; }

--- a/components/core/src/clp_s/search/ast/Integral.cpp
+++ b/components/core/src/clp_s/search/ast/Integral.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<Literal> Integral::create_from_string(std::string const& v) {
     return std::shared_ptr<Literal>(static_cast<Literal*>(ret));
 }
 
-void Integral::print() {
+void Integral::print() const {
     auto& os = get_print_stream();
     if (false == m_vstr.empty()) {
         os << m_vstr;

--- a/components/core/src/clp_s/search/ast/Integral.hpp
+++ b/components/core/src/clp_s/search/ast/Integral.hpp
@@ -51,7 +51,7 @@ public:
     Integral64 get();
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Literal
     bool matches_type(LiteralType type) override { return type & cIntegralLiteralTypes; }

--- a/components/core/src/clp_s/search/ast/Literal.hpp
+++ b/components/core/src/clp_s/search/ast/Literal.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_SEARCH_LITERAL_HPP
 #define CLP_S_SEARCH_LITERAL_HPP
 
+#include <cstddef>
 #include <string>
 
 #include "FilterOperation.hpp"
@@ -38,7 +39,7 @@ public:
      * Literals are considered to have 1 operand.
      * @return 1
      */
-    auto get_num_operands() const -> size_t override { return 1ULL; }
+    [[nodiscard]] auto get_num_operands() const -> size_t override { return 1ULL; }
 
     /**
      * Strict checks for type matching against a given literal type.

--- a/components/core/src/clp_s/search/ast/Literal.hpp
+++ b/components/core/src/clp_s/search/ast/Literal.hpp
@@ -38,7 +38,7 @@ public:
      * Literals are considered to have 1 operand.
      * @return 1
      */
-    unsigned get_num_operands() override { return 1; }
+    auto get_num_operands() const -> size_t override { return 1ULL; }
 
     /**
      * Strict checks for type matching against a given literal type.

--- a/components/core/src/clp_s/search/ast/NullLiteral.cpp
+++ b/components/core/src/clp_s/search/ast/NullLiteral.cpp
@@ -13,7 +13,7 @@ std::shared_ptr<Literal> NullLiteral::create_from_string(std::string const& v) {
     return {nullptr};
 }
 
-void NullLiteral::print() {
+void NullLiteral::print() const {
     get_print_stream() << "null";
 }
 

--- a/components/core/src/clp_s/search/ast/NullLiteral.hpp
+++ b/components/core/src/clp_s/search/ast/NullLiteral.hpp
@@ -32,7 +32,7 @@ public:
     static std::shared_ptr<Literal> create_from_string(std::string const& v);
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Literal
     bool matches_type(LiteralType type) override { return type & LiteralType::NullT; }

--- a/components/core/src/clp_s/search/ast/OrExpr.cpp
+++ b/components/core/src/clp_s/search/ast/OrExpr.cpp
@@ -5,7 +5,7 @@ OrExpr::OrExpr(bool inverted, Expression* parent) : Expression(inverted, parent)
 
 OrExpr::OrExpr(OrExpr const& expr) : Expression(expr) {}
 
-void OrExpr::print() {
+void OrExpr::print() const {
     auto& os = get_print_stream();
     if (is_inverted()) {
         os << "!";

--- a/components/core/src/clp_s/search/ast/OrExpr.hpp
+++ b/components/core/src/clp_s/search/ast/OrExpr.hpp
@@ -35,7 +35,7 @@ public:
     );
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Expression
     bool has_only_expression_operands() override { return true; }

--- a/components/core/src/clp_s/search/ast/StringLiteral.cpp
+++ b/components/core/src/clp_s/search/ast/StringLiteral.cpp
@@ -9,7 +9,7 @@ std::shared_ptr<Literal> StringLiteral::create(std::string const& v) {
     return std::shared_ptr<Literal>(static_cast<Literal*>(new StringLiteral(v)));
 }
 
-void StringLiteral::print() {
+void StringLiteral::print() const {
     get_print_stream() << "\"" << m_v << "\"";
 }
 

--- a/components/core/src/clp_s/search/ast/StringLiteral.hpp
+++ b/components/core/src/clp_s/search/ast/StringLiteral.hpp
@@ -34,7 +34,7 @@ public:
     std::string& get();
 
     // Methods inherited from Value
-    void print() override;
+    void print() const override;
 
     // Methods inherited from Literal
     bool matches_type(LiteralType type) override { return type & m_string_type; }

--- a/components/core/src/clp_s/search/ast/Value.hpp
+++ b/components/core/src/clp_s/search/ast/Value.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_SEARCH_VALUE_HPP
 #define CLP_S_SEARCH_VALUE_HPP
 
+#include <cstddef>
 #include <iostream>
 
 namespace clp_s::search::ast {
@@ -18,7 +19,7 @@ public:
     /**
      * @return The number of operands of this Value.
      */
-    virtual auto get_num_operands() const -> size_t = 0;
+    [[nodiscard]] virtual auto get_num_operands() const -> size_t = 0;
 
     /**
      * Prints a string representation of this Value to the output stream designated by
@@ -32,7 +33,7 @@ protected:
     /**
      * @return The output stream that should be used by the `print` function.
      */
-    static std::ostream& get_print_stream() { return std::cerr; }
+    [[nodiscard]] static auto get_print_stream() -> std::ostream& { return std::cerr; }
 };
 }  // namespace clp_s::search::ast
 

--- a/components/core/src/clp_s/search/ast/Value.hpp
+++ b/components/core/src/clp_s/search/ast/Value.hpp
@@ -13,7 +13,11 @@ namespace clp_s::search::ast {
  */
 class Value {
 public:
-    // Default virtual destructor
+    // Default copy & move constructors and assignment operators and destructor
+    Value(Value const&) = default;
+    auto operator=(Value const&) -> Value& = default;
+    Value(Value&&) = default;
+    auto operator=(Value&&) -> Value& = default;
     virtual ~Value() = default;
 
     /**

--- a/components/core/src/clp_s/search/ast/Value.hpp
+++ b/components/core/src/clp_s/search/ast/Value.hpp
@@ -5,26 +5,32 @@
 
 namespace clp_s::search::ast {
 /**
- * Class representing a generic value in the AST. Key subclasses are Literal and Expression.
+ * Class representing a generic value in the AST. Values can be both Literals and Expressions and
+ * can have some number of "operands", where each operand is a child node in the AST.
+ *
+ * All nodes in the AST are derived from Value.
  */
 class Value {
 public:
-    /**
-     * @return The number of operands this value has
-     */
-    virtual unsigned get_num_operands() = 0;
-
-    /**
-     * Print a string representation of the value to standard error.
-     * Useful for debugging in gdb.
-     */
-    virtual void print() = 0;
-
+    // Default virtual destructor
     virtual ~Value() = default;
+
+    /**
+     * @return The number of operands of this Value.
+     */
+    virtual auto get_num_operands() const -> size_t = 0;
+
+    /**
+     * Prints a string representation of this Value to the output stream designated by
+     * `get_print_stream`.
+     *
+     * This hook is meant to be used when debugging in gdb.
+     */
+    virtual void print() const = 0;
 
 protected:
     /**
-     * @return The stream to print to
+     * @return The output stream that should be used by the `print` function.
      */
     static std::ostream& get_print_stream() { return std::cerr; }
 };

--- a/components/core/src/clp_s/search/ast/Value.hpp
+++ b/components/core/src/clp_s/search/ast/Value.hpp
@@ -9,11 +9,11 @@ namespace clp_s::search::ast {
  * Class representing a generic value in the AST. Values can be both Literals and Expressions and
  * can have some number of "operands", where each operand is a child node in the AST.
  *
- * All nodes in the AST are derived from Value.
+ * All nodes in the AST are derived from `Value`.
  */
 class Value {
 public:
-    // Default copy & move constructors and assignment operators and destructor
+    // Default all special member functions
     Value() = default;
     Value(Value const&) = default;
     auto operator=(Value const&) -> Value& = default;
@@ -22,12 +22,12 @@ public:
     virtual ~Value() = default;
 
     /**
-     * @return The number of operands of this Value.
+     * @return The number of operands this `Value` has.
      */
     [[nodiscard]] virtual auto get_num_operands() const -> size_t = 0;
 
     /**
-     * Prints a string representation of this Value to the output stream designated by
+     * Prints a string representation of this `Value` to the output stream designated by
      * `get_print_stream`.
      *
      * This hook is meant to be used when debugging in gdb.
@@ -36,7 +36,7 @@ public:
 
 protected:
     /**
-     * @return The output stream that should be used by the `print` function.
+     * @return The output stream to be used by the `print` function.
      */
     [[nodiscard]] static auto get_print_stream() -> std::ostream& { return std::cerr; }
 };

--- a/components/core/src/clp_s/search/ast/Value.hpp
+++ b/components/core/src/clp_s/search/ast/Value.hpp
@@ -14,6 +14,7 @@ namespace clp_s::search::ast {
 class Value {
 public:
     // Default copy & move constructors and assignment operators and destructor
+    Value() = default;
     Value(Value const&) = default;
     auto operator=(Value const&) -> Value& = default;
     Value(Value&&) = default;

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -475,7 +475,6 @@ tasks:
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/StringLiteral.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/StringLiteral.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/Transformation.hpp"
-            - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/Value.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/antlr_common/ErrorListener.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/clp_search/EncodedVariableInterpreter.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/clp_search/EncodedVariableInterpreter.hpp"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR resolves clang-tidy violations in `clp_s/search/ast/Value.hpp` and generally cleans up the `Value.hpp` code and comments as part of #764.

While cleaning up `Value.hpp` we mark some members as const that were previously non-const, and propagate that constness throughout the derived classes. As a result we also end up having to add const iterators to the operand list of the `Expression` class.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that all code compiles and unit tests still pass



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced core functionalities to ensure that output and data access operations remain non-mutative, improving overall safety and consistency.
  - Introduced new, safe iteration methods for accessing internal collections.
- **Chores**
  - Updated code quality configurations to streamline linting processes.
  - Removed specific source file from linting tasks, which may affect the linting process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->