### PR TITLE
refactor(core): Resolve clang-tidy violations in `clp/networking/*.{cpp,hpp}`.

### DIFF
--- a/components/core/src/clp/networking/SocketOperationFailed.hpp
+++ b/components/core/src/clp/networking/SocketOperationFailed.hpp
@@ -12,7 +12,9 @@ public:
             : TraceableException(error_code, filename, line_number) {}
 
     // Methods
-    [[nodiscard]] char const* what() const noexcept override { return "Socket operation failed"; }
+    [[nodiscard]] auto what() const noexcept -> char const* override {
+        return "Socket operation failed";
+    }
 };
 }  // namespace clp::networking
 

--- a/components/core/src/clp/networking/socket_utils.hpp
+++ b/components/core/src/clp/networking/socket_utils.hpp
@@ -13,7 +13,7 @@ namespace clp::networking {
  * @return An open socket file descriptor on success
  * @return -1 on any error
  */
-int connect_to_server(std::string const& host, std::string const& port);
+auto connect_to_server(std::string const& host, std::string const& port) -> int;
 
 /**
  * Tries to send a buffer of data over the socket
@@ -24,14 +24,14 @@ int connect_to_server(std::string const& host, std::string const& port);
  * @return ErrorCode_errno if sending failed
  * @return ErrorCode_Success otherwise
  */
-ErrorCode try_send(int fd, char const* buf, size_t buf_len);
+auto try_send(int fd, char const* buf, size_t buf_len) -> ErrorCode;
 /**
  * Sends a buffer of data over the socket
  * @param fd
  * @param buf
  * @param buf_len
  */
-void send(int fd, char const* buf, size_t buf_len);
+auto send(int fd, char const* buf, size_t buf_len) -> void;
 
 /**
  * Tries to receive up to a given number of bytes over a socket
@@ -42,13 +42,13 @@ void send(int fd, char const* buf, size_t buf_len);
  * @return ErrorCode_errno if receiving failed
  * @return ErrorCode_Success otherwise
  */
-ErrorCode try_receive(int fd, char* buf, size_t buf_len, size_t& num_bytes_received);
+auto try_receive(int fd, char* buf, size_t buf_len, size_t& num_bytes_received) -> ErrorCode;
 /**
  * Receives up to the give number of bytes over a socket
  * @param buf Buffer to store received bytes
  * @param buf_len Number of bytes to receive
  */
-void receive(int fd, char* buf, size_t buf_len, size_t& num_bytes_received);
+auto receive(int fd, char* buf, size_t buf_len, size_t& num_bytes_received) -> void;
 }  // namespace clp::networking
 
 #endif  // CLP_NETWORKING_SOCKET_UTILS_HPP


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Resolved clang-tidy warnings in all files from `clp/networking` as a part of #764.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* `task lint:check-cpp-full` succeeded.
* ubuntu-jammy-lint workflow passed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
