### PR TITLE
build(taskfiles): Update to the latest version of yscope-dev-utils.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ vars:
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"
 
   # Taskfile paths
-  G_UTILS_TASKFILE: "{{.ROOT_DIR}}/tools/yscope-dev-utils/taskfiles/utils.yaml"
+  G_UTILS_TASKFILE: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/utils.yaml"
 
   # Versions
   G_PACKAGE_VERSION: "0.2.0-dev"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ includes:
   deps: "deps-tasks.yml"
   docs: "docs/tasks.yml"
   lint: "lint-tasks.yml"
-  utils: "tools/yscope-dev-utils/taskfiles/utils/utils.yaml"
+  utils: "tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
 vars:
   # Source paths

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -151,7 +151,7 @@ tasks:
 
   cpp-lint-configs:
     internal: true
-    cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/lint-configs/symlink-cpp-lint-configs.sh"
+    cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/symlink-cpp-lint-configs.sh"
 
   check-cpp-static-diff:
     sources: *cpp_source_files

--- a/tools/scripts/deps-download/init.sh
+++ b/tools/scripts/deps-download/init.sh
@@ -11,7 +11,7 @@ project_root_dir="$script_dir/../../../"
 download_dep_script="$script_dir/download-dep.py"
 
 python3 "${download_dep_script}" \
-    https://github.com/y-scope/yscope-dev-utils/archive/2caa3dcf.zip \
-    yscope-dev-utils-2caa3dcfbbccff052d179e643a509d8ad05bc217 \
+    https://github.com/y-scope/yscope-dev-utils/archive/30640b0.zip \
+    yscope-dev-utils-30640b0af5a8d344ae57afe02e8ae88a79233809 \
     "${project_root_dir}/tools/yscope-dev-utils" \
     --extract


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

https://github.com/y-scope/yscope-dev-utils/pull/37 moved the location of the externally-usable taskfiles in yscope-dev-utils, so this PR updates the yscope-dev-utils submodule and the paths to any taskfiles we're using from the submodule.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* `task --list-all` succeeds.
* `task docs` succeeds.
* `task` succeeds.
* `task lint:check` succeeds.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Reorganized internal configurations for utility tasks.
  - Updated command paths for linting utilities.
  - Refreshed integration to reference the latest subproject version.
  - Updated download script to fetch the latest version of the `yscope-dev-utils` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->