### PR TITLE
build(deps): Bump `ystdlib-cpp` to the commit before the `outcome` library was added.

### DIFF
--- a/deps-tasks.yml
+++ b/deps-tasks.yml
@@ -489,8 +489,8 @@ tasks:
         vars:
           DEST: "{{.DEST}}"
           FLAGS: "--extract"
-          SRC_NAME: "ystdlib-cpp-d1b4ae0"
-          SRC_URL: "https://github.com/y-scope/ystdlib-cpp/archive/d1b4ae0.zip"
+          SRC_NAME: "ystdlib-cpp-2ac17579d12c48e2f45d4688a10bcabb5becb466"
+          SRC_URL: "https://github.com/y-scope/ystdlib-cpp/archive/2ac1757.zip"
       # This command must be last
       - task: ":utils:checksum:compute"
         vars:

--- a/docs/src/dev-guide/components-core/index.md
+++ b/docs/src/dev-guide/components-core/index.md
@@ -44,7 +44,7 @@ This will download:
 * [uftcpp](https://github.com/nemtrif/utfcpp.git) (v4.0.6)
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp.git) (v0.7.0)
 * [yscope-log-viewer](https://github.com/y-scope/yscope-log-viewer.git) (969ff35)
-* [ystdlib-cpp](https://github.com/y-scope/ystdlib-cpp.git) (d1b4ae0)
+* [ystdlib-cpp](https://github.com/y-scope/ystdlib-cpp.git) (2ac1757)
 
 ### Environment
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Bump `ystdlib-cpp` version so that we can use `ystdlib::containers::Array`.

We do not bump to the newest version because currently CLP build will break upon the `find_package(outcome)` call in [`ystdlib-cpp`](https://github.com/y-scope/ystdlib-cpp/blob/d3fc9804eacb3ee4f156ae0ca37151cb04847580/CMakeLists.txt#L56). We will do so after we switch to use `Task` to manage all our dependencies.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] No code changes.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
