### PR TITLE
fix(lint): Use `**/*` glob pattern to match source files recursively (fixes #812).

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -127,8 +127,8 @@ tasks:
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
       - "{{.G_CORE_COMPONENT_DIR}}/.clang-format"
-      - "{{.G_CORE_COMPONENT_DIR}}/src/**"
-      - "{{.G_CORE_COMPONENT_DIR}}/tests/**"
+      - "{{.G_CORE_COMPONENT_DIR}}/src/**/*"
+      - "{{.G_CORE_COMPONENT_DIR}}/tests/**/*"
     deps: ["cpp-lint-configs", "venv"]
     cmds:
       - task: ":utils:cpp-lint:clang-format"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says. The difference between `**` and `**/*` in `task` has been documented in https://github.com/y-scope/yscope-docs/pull/34

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Followed the reproduction steps in #812 and observed the issue could no longer be reproduced.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded formatting checks to scan all subdirectories in both code and test areas, ensuring a more comprehensive review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->