### PR TITLE
feat(lint): Cache necessary files for lint:check-cpp-static-full to skip unnecessary re-runs.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -89,6 +89,8 @@ jobs:
           --num-jobs $(getconf _NPROCESSORS_ONLN)
           --test-spec "~[Stopwatch]"
 
+      # NOTE: We don't use the cache for scheduled runs so that they run lint:check-cpp-static-full
+      # on all files.
       - if: "'schedule' != github.event_name"
         name: "Restore lint:check-cpp-static-full cache"
         id: "cache-restore-lint-check-cpp-static-full"

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -103,7 +103,7 @@ jobs:
 
           # NOTE: We use a per-OS cache since different OSes may trigger different clang-tidy
           # violations.
-          key: "main-branch-${{matrix.os}}-lint:check-cpp-tidy-static-full"
+          key: "main-branch-${{matrix.os}}-lint:check-cpp-static-full"
 
       # TODO: When enough files are passing clang-tidy, switch to a full pass on schedule only.
       # - run: >-

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -89,8 +89,35 @@ jobs:
           --num-jobs $(getconf _NPROCESSORS_ONLN)
           --test-spec "~[Stopwatch]"
 
+      - if: "'schedule' != github.event_name"
+        name: "Restore lint:check-cpp-static-full cache"
+        id: "cache-restore-lint-check-cpp-static-full"
+        uses: "actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684"
+        with:
+          path: |
+            .task/checksum/lint-check-cpp-static-full
+            .task/checksum/utils-cpp-lint-clang-tidy-*
+            build/lint-clang-tidy
+
+          # NOTE: We use a per-OS cache since different OSes may trigger different clang-tidy
+          # violations.
+          key: "main-branch-${{matrix.os}}-lint:check-cpp-tidy-static-full"
+
       # TODO: When enough files are passing clang-tidy, switch to a full pass on schedule only.
       # - run: >-
       #     task lint:check-cpp-${{(github.event_name == 'schedule') && 'full' || 'diff'}}
       - run: "task lint:check-cpp-full"
         shell: "bash"
+
+      # Cache the source file checksums and the generated files (logs) for the
+      # lint:check-cpp-static-full task, but only if it runs successfully on the main branch.
+      # NOTE: If we don't cache the generated files, the task will re-run to generate them.
+      - if: "'pull_request' != github.event_name && 'refs/heads/main' == github.ref"
+        name: "Update lint:check-cpp-static-full cache"
+        uses: "actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684"
+        with:
+          path: |
+            .task/checksum/lint-check-cpp-static-full
+            .task/checksum/utils-cpp-lint-clang-tidy-*
+            build/lint-clang-tidy
+          key: "${{steps.cache-restore-lint-check-cpp-static-full.outputs.cache-primary-key}}"

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -327,6 +327,8 @@ jobs:
         run: "chown $(id -u):$(id -g) -R ."
         shell: "bash"
 
+      # NOTE: We don't use the cache for scheduled runs so that they run lint:check-cpp-static-full
+      # on all files.
       - if: "'schedule' != github.event_name"
         name: "Restore lint:check-cpp-static-full cache"
         id: "cache-restore-lint-check-cpp-static-full"

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -341,7 +341,7 @@ jobs:
 
           # NOTE: We use a per-OS cache since different OSes may trigger different clang-tidy
           # violations.
-          key: "main-branch-ubuntu-jammy-lint:check-cpp-tidy-static-full"
+          key: "main-branch-ubuntu-jammy-lint:check-cpp-static-full"
 
       - uses: "./.github/actions/run-on-image"
         env:

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -327,6 +327,20 @@ jobs:
         run: "chown $(id -u):$(id -g) -R ."
         shell: "bash"
 
+      - if: "'schedule' != github.event_name"
+        name: "Restore lint:check-cpp-static-full cache"
+        id: "cache-restore-lint-check-cpp-static-full"
+        uses: "actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684"
+        with:
+          path: |
+            .task/checksum/lint-check-cpp-static-full
+            .task/checksum/utils-cpp-lint-clang-tidy-*
+            build/lint-clang-tidy
+
+          # NOTE: We use a per-OS cache since different OSes may trigger different clang-tidy
+          # violations.
+          key: "main-branch-ubuntu-jammy-lint:check-cpp-tidy-static-full"
+
       - uses: "./.github/actions/run-on-image"
         env:
           OS_NAME: "ubuntu-jammy"
@@ -339,3 +353,16 @@ jobs:
           # run_command: >-
           #   task lint:check-cpp-${{(github.event_name == 'schedule') && 'full' || 'diff'}}
           run_command: "task lint:check-cpp-full"
+
+      # Cache the source file checksums and the generated files (logs) for the
+      # lint:check-cpp-static-full task, but only if it runs successfully on the main branch.
+      # NOTE: If we don't cache the generated files, the task will re-run to generate them.
+      - if: "'pull_request' != github.event_name && 'refs/heads/main' == github.ref"
+        name: "Update lint:check-cpp-static-full cache"
+        uses: "actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684"
+        with:
+          path: |
+            .task/checksum/lint-check-cpp-static-full
+            .task/checksum/utils-cpp-lint-clang-tidy-*
+            build/lint-clang-tidy
+          key: "${{steps.cache-restore-lint-check-cpp-static-full.outputs.cache-primary-key}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The lint:check-cpp-static-full task in the clp-core-build and clp-core-build-macos workflows currently takes ~10m to run. As we fix clang-tidy violations in more files, this time will likely increase steadily. However, since a pull request might only change a few C++ source files, the time spent re-checking the other source files is wasted.

This PR uses the [actions/cache](https://github.com/actions/cache) action to cache the lint:check-cpp-static-full task from the main branch, so that when run in a pull request, it will skip re-running clang-tidy on the files which haven't changed. This could miss issues in files that haven't changed but that depend on the files which have changed, but those will still be caught by the nightly scheduled run which doesn't use the cache.

Note that we cache both:

* the source file checksums that task uses to determine whether a source file has changed; and
* the files generated by the task, which in this case are the logs of clang-tidy's output and a failure/success message.

The cache is only updated when it's run successfully on main, so the generated files should all contain a success message.

Overall, this reduces the time for the lint:check-cpp-static-full task in the workflows to less than a minute when the C++ files haven't been changed or only small changes have been made.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Committed this change to the main branch of my fork.
* Waited for the cache to be successfully built.
* Created a branch from the main branch of my fork.
* Added a clang-tidy violation to that branch.
* Validated that it was [detected](https://github.com/kirkrodrigues/clp/actions/runs/14386334909/job/40342612226) (quickly) by the workflow that runs lint:check-cpp-static-full.
* Reverted the clang-tidy violation.
* Validated that the workflow [succeeded](https://github.com/kirkrodrigues/clp/actions/runs/14386986200/job/40344736782) (quickly).

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Enhanced the build process by optimising the caching mechanism for linting operations across multiple operating systems.
  - Implemented conditional steps to update caching only when necessary, contributing to more efficient build times and resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->