### PR TITLE
refactor(clp-package): Move archive metadata update from `clp-s` to compression task workers.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -83,6 +83,7 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
                 if job_last_uncompressed_size < job_uncompressed_size:
                     print_compression_job_status(job_row, current_time)
                 else:
+                    # No progress in the final iteration; repeat the last status update verbatim
                     print_compression_job_status(job_row, last_current_time)
             break  # Done
         if CompressionJobStatus.FAILED == job_status:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -61,6 +61,7 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
         )
 
     job_last_uncompressed_size = 0
+    last_current_time = datetime.datetime.now()
 
     while True:
         db_cursor.execute(polling_query)
@@ -79,7 +80,10 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
             # All tasks in the job is done
             if not no_progress_reporting:
                 logger.info("Compression finished.")
-                print_compression_job_status(job_row, current_time)
+                if job_last_uncompressed_size < job_uncompressed_size:
+                    print_compression_job_status(job_row, current_time)
+                else:
+                    print_compression_job_status(job_row, last_current_time)
             break  # Done
         if CompressionJobStatus.FAILED == job_status:
             # One or more tasks in the job has failed
@@ -98,6 +102,7 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
             error_msg = f"Unhandled CompressionJobStatus: {job_status}"
             raise NotImplementedError(error_msg)
 
+        last_current_time = current_time
         time.sleep(0.5)
 
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -61,7 +61,6 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
         )
 
     job_last_uncompressed_size = 0
-    last_current_time = datetime.datetime.now()
 
     while True:
         db_cursor.execute(polling_query)
@@ -80,11 +79,7 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
             # All tasks in the job is done
             if not no_progress_reporting:
                 logger.info("Compression finished.")
-                if job_last_uncompressed_size < job_uncompressed_size:
-                    print_compression_job_status(job_row, current_time)
-                else:
-                    # No progress in the final iteration; repeat the last status update verbatim
-                    print_compression_job_status(job_row, last_current_time)
+                print_compression_job_status(job_row, current_time)
             break  # Done
         if CompressionJobStatus.FAILED == job_status:
             # One or more tasks in the job has failed
@@ -103,7 +98,6 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
             error_msg = f"Unhandled CompressionJobStatus: {job_status}"
             raise NotImplementedError(error_msg)
 
-        last_current_time = current_time
         time.sleep(0.5)
 
 

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -36,7 +36,7 @@ QUERY_JOBS_TABLE_NAME = "query_jobs"
 QUERY_TASKS_TABLE_NAME = "query_tasks"
 COMPRESSION_JOBS_TABLE_NAME = "compression_jobs"
 COMPRESSION_TASKS_TABLE_NAME = "compression_tasks"
-ARCHIVES_TABLE_NAME = "clp_archives"
+ARCHIVES_TABLE_SUFFIX = "archives"
 
 OS_RELEASE_FILE_PATH = pathlib.Path("etc") / "os-release"
 

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -36,6 +36,7 @@ QUERY_JOBS_TABLE_NAME = "query_jobs"
 QUERY_TASKS_TABLE_NAME = "query_tasks"
 COMPRESSION_JOBS_TABLE_NAME = "compression_jobs"
 COMPRESSION_TASKS_TABLE_NAME = "compression_tasks"
+ARCHIVES_TABLE_NAME = "clp_archives"
 
 OS_RELEASE_FILE_PATH = pathlib.Path("etc") / "os-release"
 

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -6,6 +6,7 @@
 
 #include <json/single_include/nlohmann/json.hpp>
 
+#include "../clp/streaming_archive/Constants.hpp"
 #include "archive_constants.hpp"
 #include "Defs.hpp"
 #include "SchemaTree.hpp"
@@ -426,13 +427,14 @@ std::pair<size_t, size_t> ArchiveWriter::store_tables() {
     return {table_metadata_compressed_size, table_compressed_size};
 }
 
-void ArchiveWriter::print_archive_stats() {
-    nlohmann::json json_msg;
-    json_msg["id"] = m_id;
-    json_msg["begin_timestamp"] = m_timestamp_dict.get_begin_timestamp();
-    json_msg["end_timestamp"] = m_timestamp_dict.get_end_timestamp();
-    json_msg["uncompressed_size"] = m_uncompressed_size;
-    json_msg["size"] = m_compressed_size;
+auto ArchiveWriter::print_archive_stats() const -> void {
+    using clp::streaming_archive::cMetadataDB::Archive;
+    nlohmann::json json_msg
+            = {{Archive::Id, m_id},
+               {Archive::BeginTimestamp, m_timestamp_dict.get_begin_timestamp()},
+               {Archive::EndTimestamp, m_timestamp_dict.get_end_timestamp()},
+               {Archive::UncompressedSize, m_uncompressed_size},
+               {Archive::Size, m_compressed_size}};
     std::cout << json_msg.dump(-1, ' ', true, nlohmann::json::error_handler_t::ignore) << std::endl;
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -428,7 +428,7 @@ std::pair<size_t, size_t> ArchiveWriter::store_tables() {
 }
 
 auto ArchiveWriter::print_archive_stats() const -> void {
-    using clp::streaming_archive::cMetadataDB::Archive;
+    namespace Archive = clp::streaming_archive::cMetadataDB::Archive;
     nlohmann::json json_msg
             = {{Archive::Id, m_id},
                {Archive::BeginTimestamp, m_timestamp_dict.get_begin_timestamp()},

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -7,7 +7,6 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-#include "../clp/GlobalMySQLMetadataDB.hpp"
 #include "archive_constants.hpp"
 #include "DictionaryWriter.hpp"
 #include "Schema.hpp"
@@ -66,8 +65,7 @@ public:
     };
 
     // Constructor
-    explicit ArchiveWriter(std::shared_ptr<clp::GlobalMySQLMetadataDB> metadata_db)
-            : m_metadata_db(std::move(metadata_db)) {}
+    ArchiveWriter() = default;
 
     // Destructor
     ~ArchiveWriter() = default;
@@ -212,11 +210,6 @@ private:
     void write_archive_header(FileWriter& archive_writer, size_t metadata_section_size);
 
     /**
-     * Updates the metadata db with the archive's metadata (id, size, timestamp ranges, etc.)
-     */
-    void update_metadata_db();
-
-    /**
      * Prints the archive's statistics (id, uncompressed size, compressed size, etc.)
      */
     void print_archive_stats();
@@ -238,7 +231,6 @@ private:
     std::shared_ptr<LogTypeDictionaryWriter> m_log_dict;
     std::shared_ptr<LogTypeDictionaryWriter> m_array_dict;  // log type dictionary for arrays
     TimestampDictionaryWriter m_timestamp_dict;
-    std::shared_ptr<clp::GlobalMySQLMetadataDB> m_metadata_db;
     int m_compression_level{};
     bool m_print_archive_stats{};
     bool m_single_file_archive{};

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -212,7 +212,7 @@ private:
     /**
      * Prints the archive's statistics (id, uncompressed size, compressed size, etc.)
      */
-    void print_archive_stats();
+    auto print_archive_stats() const -> void;
 
     static constexpr size_t cReadBlockSize = 4 * 1024;
 

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -57,6 +57,7 @@ set(
         ../clp/spdlog_with_specializations.hpp
         ../clp/streaming_archive/ArchiveMetadata.cpp
         ../clp/streaming_archive/ArchiveMetadata.hpp
+        ../clp/streaming_archive/Constants.hpp
         ../clp/streaming_compression/zstd/Decompressor.cpp
         ../clp/streaming_compression/zstd/Decompressor.hpp
         ../clp/Thread.cpp

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -45,8 +45,6 @@ set(
         ../clp/GlobalMetadataDB.hpp
         ../clp/GlobalMetadataDBConfig.cpp
         ../clp/GlobalMetadataDBConfig.hpp
-        ../clp/GlobalMySQLMetadataDB.cpp
-        ../clp/GlobalMySQLMetadataDB.hpp
         ../clp/hash_utils.cpp
         ../clp/hash_utils.hpp
         ../clp/ir/EncodedTextAst.cpp

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -18,8 +18,6 @@ set(
         ../clp/CurlStringList.hpp
         ../clp/cli_utils.cpp
         ../clp/cli_utils.hpp
-        ../clp/database_utils.cpp
-        ../clp/database_utils.hpp
         ../clp/Defs.h
         ../clp/ErrorCode.hpp
         ../clp/ffi/ir_stream/decoding_methods.cpp
@@ -42,21 +40,12 @@ set(
         ../clp/FileDescriptor.hpp
         ../clp/FileReader.cpp
         ../clp/FileReader.hpp
-        ../clp/GlobalMetadataDB.hpp
-        ../clp/GlobalMetadataDBConfig.cpp
-        ../clp/GlobalMetadataDBConfig.hpp
         ../clp/hash_utils.cpp
         ../clp/hash_utils.hpp
         ../clp/ir/EncodedTextAst.cpp
         ../clp/ir/EncodedTextAst.hpp
         ../clp/ir/parsing.cpp
         ../clp/ir/parsing.hpp
-        ../clp/MySQLDB.cpp
-        ../clp/MySQLDB.hpp
-        ../clp/MySQLParamBindings.cpp
-        ../clp/MySQLParamBindings.hpp
-        ../clp/MySQLPreparedStatement.cpp
-        ../clp/MySQLPreparedStatement.hpp
         ../clp/NetworkReader.cpp
         ../clp/NetworkReader.hpp
         ../clp/networking/socket_utils.cpp

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -205,7 +205,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             // clang-format on
 
             po::options_description compression_options("Compression options");
-            std::string metadata_db_config_file_path;
             std::string input_path_list_file_path;
             constexpr std::string_view cJsonFileType{"json"};
             constexpr std::string_view cKeyValueIrFileType{"kv-ir"};
@@ -238,11 +237,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::value<std::string>(&m_timestamp_key)->value_name("TIMESTAMP_COLUMN_KEY")->
                         default_value(m_timestamp_key),
                     "Path (e.g. x.y) for the field containing the log event's timestamp."
-            )(
-                    "db-config-file",
-                    po::value<std::string>(&metadata_db_config_file_path)->value_name("FILE")->
-                    default_value(metadata_db_config_file_path),
-                    "Global metadata DB YAML config"
             )(
                     "files-from,f",
                     po::value<std::string>(&input_path_list_file_path)
@@ -353,29 +347,6 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
             }
 
             validate_network_auth(auth, m_network_auth);
-
-            // Parse and validate global metadata DB config
-            if (false == metadata_db_config_file_path.empty()) {
-                clp::GlobalMetadataDBConfig metadata_db_config;
-                try {
-                    metadata_db_config.parse_config_file(metadata_db_config_file_path);
-                } catch (std::exception& e) {
-                    SPDLOG_ERROR("Failed to validate metadata database config - {}.", e.what());
-                    return ParsingResult::Failure;
-                }
-
-                if (clp::GlobalMetadataDBConfig::MetadataDBType::MySQL
-                    != metadata_db_config.get_metadata_db_type())
-                {
-                    SPDLOG_ERROR(
-                            "Invalid metadata database type for {}; only supported type is MySQL.",
-                            m_program_name
-                    );
-                    return ParsingResult::Failure;
-                }
-
-                m_metadata_db_config = std::move(metadata_db_config);
-            }
         } else if ((char)Command::Extract == command_input) {
             po::options_description extraction_options;
             std::string archive_path;

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -9,7 +9,6 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 
-#include "../clp/GlobalMetadataDBConfig.hpp"
 #include "../reducer/types.hpp"
 #include "Defs.hpp"
 #include "InputConfig.hpp"
@@ -93,10 +92,6 @@ public:
     std::optional<epochtime_t> get_search_end_ts() const { return m_search_end_ts; }
 
     bool get_ignore_case() const { return m_ignore_case; }
-
-    std::optional<clp::GlobalMetadataDBConfig> const& get_metadata_db_config() const {
-        return m_metadata_db_config;
-    }
 
     std::string const& get_reducer_host() const { return m_reducer_host; }
 
@@ -199,9 +194,6 @@ private:
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MB
     bool m_disable_log_order{false};
     FileType m_file_type{FileType::Json};
-
-    // Metadata db variables
-    std::optional<clp::GlobalMetadataDBConfig> m_metadata_db_config;
 
     // MongoDB configuration variables
     std::string m_mongodb_uri;

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -127,7 +127,7 @@ JsonParser::JsonParser(JsonParserOption const& option)
     m_archive_options.authoritative_timestamp = m_timestamp_column;
     m_archive_options.authoritative_timestamp_namespace = m_timestamp_namespace;
 
-    m_archive_writer = std::make_unique<ArchiveWriter>(option.metadata_db);
+    m_archive_writer = std::make_unique<ArchiveWriter>();
     m_archive_writer->open(m_archive_options);
 }
 

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -17,7 +17,6 @@
 #include "../clp/ffi/KeyValuePairLogEvent.hpp"
 #include "../clp/ffi/SchemaTree.hpp"
 #include "../clp/ffi/Value.hpp"
-#include "../clp/GlobalMySQLMetadataDB.hpp"
 #include "../clp/ReaderInterface.hpp"
 #include "ArchiveWriter.hpp"
 #include "CommandLineArguments.hpp"
@@ -51,7 +50,6 @@ struct JsonParserOption {
     bool structurize_arrays{};
     bool record_log_order{true};
     bool single_file_archive{false};
-    std::shared_ptr<clp::GlobalMySQLMetadataDB> metadata_db;
     NetworkAuthOption network_auth{};
 };
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -13,7 +13,6 @@
 #include <spdlog/spdlog.h>
 
 #include "../clp/CurlGlobalInstance.hpp"
-#include "../clp/GlobalMySQLMetadataDB.hpp"
 #include "../clp/streaming_archive/ArchiveMetadata.hpp"
 #include "../reducer/network_utils.hpp"
 #include "CommandLineArguments.hpp"
@@ -101,19 +100,6 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     option.single_file_archive = command_line_arguments.get_single_file_archive();
     option.structurize_arrays = command_line_arguments.get_structurize_arrays();
     option.record_log_order = command_line_arguments.get_record_log_order();
-
-    auto const& db_config_container = command_line_arguments.get_metadata_db_config();
-    if (db_config_container.has_value()) {
-        auto const& db_config = db_config_container.value();
-        option.metadata_db = std::make_shared<clp::GlobalMySQLMetadataDB>(
-                db_config.get_metadata_db_host(),
-                db_config.get_metadata_db_port(),
-                db_config.get_metadata_db_username(),
-                db_config.get_metadata_db_password(),
-                db_config.get_metadata_db_name(),
-                db_config.get_metadata_table_prefix()
-        );
-    }
 
     clp_s::JsonParser parser(option);
     if (CommandLineArguments::FileType::KeyValueIr == option.input_file_type) {

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -93,9 +93,9 @@ def update_archive_metadata(db_cursor, archive_stats):
     for k, v in archive_stats_defaults.items():
         archive_stats.setdefault(k, v)
     keys = ", ".join(archive_stats.keys())
-    values = ", ".join(f'"{v}"' if isinstance(v, str) else str(v) for v in archive_stats.values())
-    query = f"INSERT INTO clp_archives ({keys}) VALUES ({values})"
-    db_cursor.execute(query)
+    value_placeholders = ", ".join(["%s"] * len(archive_stats))
+    query = f"INSERT INTO {ARCHIVES_TABLE_NAME} ({keys}) VALUES ({value_placeholders})"
+    db_cursor.execute(query, list(archive_stats.values()))
 
 
 def _generate_fs_logs_list(

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -198,7 +198,6 @@ def make_clp_s_command_and_env(
         "--target-encoded-size",
         str(clp_config.output.target_segment_size + clp_config.output.target_dictionaries_size),
         "--compression-level", str(clp_config.output.compression_level),
-        "--db-config-file", str(db_config_file_path),
     ]
     # fmt: on
 

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -363,7 +363,8 @@ def run_clp(
                 with closing(sql_adapter.create_connection(True)) as db_conn, closing(
                     db_conn.cursor(dictionary=True)
                 ) as db_cursor:
-                    update_archive_metadata(db_cursor, last_archive_stats)
+                    if StorageEngine.CLP_S == clp_storage_engine:
+                        update_archive_metadata(db_cursor, last_archive_stats)
                     update_job_metadata_and_tags(
                         db_cursor,
                         job_id,

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -286,7 +286,6 @@ def run_clp(
             clp_home=clp_home,
             archive_output_dir=archive_output_dir,
             clp_config=clp_config,
-            db_config_file_path=db_config_file_path,
             use_single_file_archive=enable_s3_write,
         )
     else:

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -177,7 +177,6 @@ def make_clp_s_command_and_env(
     clp_home: pathlib.Path,
     archive_output_dir: pathlib.Path,
     clp_config: ClpIoConfig,
-    db_config_file_path: pathlib.Path,
     use_single_file_archive: bool,
 ) -> Tuple[List[str], Optional[Dict[str, str]]]:
     """
@@ -185,7 +184,6 @@ def make_clp_s_command_and_env(
     :param clp_home:
     :param archive_output_dir:
     :param clp_config:
-    :param db_config_file_path:
     :param use_single_file_archive:
     :return: Tuple of (compression_command, compression_env_vars)
     """


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Moves the archive metadata update logic out of clp-s and into the compression task worker. Specifically, in `clp-s`, this PR:
* Removes the command line arguments and parsing for anything metadata-db-related in `clp-s`.
* Removes metadata-db code from `ArchiveWriter` and `JsonParser`
* Removes database related source files from the `clp-s` target

This is the first step outlined in the dataset feature implementation [plan](https://docs.google.com/document/d/1BXDG1LSFOS7I52BRc0s1ahk_9MebCiH2HlLefLJ9unM/edit?tab=t.0#heading=h.kjcfz55f6si7).


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Verified correctness by inspecting the SQL database in clp container.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Archive compression now provides enhanced statistics by including begin and end timestamps.
  - Automatic metadata updates during compression improve archival tracking.

- **Refactor**
  - Legacy metadata handling and associated configuration options have been removed, streamlining the command-line interface and overall processing.
  - Archive writer no longer relies on external metadata database connections, simplifying initialization and usage.
  - Archive metadata database integration has been fully removed from the compression workflow and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->