### PR TITLE
fix(clp-package): Use job `duration` for final compression speed summary.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -41,12 +41,12 @@ def print_compression_job_status(job_row):
     job_compressed_size = job_row["compressed_size"]
     compression_ratio = float(job_uncompressed_size) / job_compressed_size
     if CompressionJobStatus.SUCCEEDED == job_row["status"]:
+        compression_speed = job_uncompressed_size / job_row["duration"]
+    else:
         compression_speed = (
             job_uncompressed_size
             / (datetime.datetime.now() - job_row["start_time"]).total_seconds()
         )
-    else:
-        compression_speed = job_uncompressed_size / job_row["duration"]
     logger.info(
         f"Compressed {pretty_size(job_uncompressed_size)} into "
         f"{pretty_size(job_compressed_size)} ({compression_ratio:.2f}x). "

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -36,12 +36,17 @@ from clp_package_utils.general import (
 logger = logging.getLogger(__file__)
 
 
-def print_compression_job_status(job_row, current_time):
+def print_compression_job_status(job_row):
     job_uncompressed_size = job_row["uncompressed_size"]
     job_compressed_size = job_row["compressed_size"]
-    job_start_time = job_row["start_time"]
     compression_ratio = float(job_uncompressed_size) / job_compressed_size
-    compression_speed = job_uncompressed_size / (current_time - job_start_time).total_seconds()
+    if CompressionJobStatus.SUCCEEDED == job_row["status"]:
+        compression_speed = (
+            job_uncompressed_size
+            / (datetime.datetime.now() - job_row["start_time"]).total_seconds()
+        )
+    else:
+        compression_speed = job_uncompressed_size / job_row["duration"]
     logger.info(
         f"Compressed {pretty_size(job_uncompressed_size)} into "
         f"{pretty_size(job_compressed_size)} ({compression_ratio:.2f}x). "
@@ -56,7 +61,7 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
         )
     else:
         polling_query = (
-            f"SELECT start_time, status, status_msg, uncompressed_size, compressed_size "
+            f"SELECT start_time, status, status_msg, uncompressed_size, compressed_size, duration "
             f"FROM {COMPRESSION_JOBS_TABLE_NAME} WHERE id={job_id}"
         )
 
@@ -73,13 +78,12 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
 
         job_row = results[0]
         job_status = job_row["status"]
-        current_time = datetime.datetime.now()
 
         if CompressionJobStatus.SUCCEEDED == job_status:
             # All tasks in the job is done
             if not no_progress_reporting:
                 logger.info("Compression finished.")
-                print_compression_job_status(job_row, current_time)
+                print_compression_job_status(job_row)
             break  # Done
         if CompressionJobStatus.FAILED == job_status:
             # One or more tasks in the job has failed
@@ -90,7 +94,7 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
             if not no_progress_reporting:
                 job_uncompressed_size = job_row["uncompressed_size"]
                 if job_last_uncompressed_size < job_uncompressed_size:
-                    print_compression_job_status(job_row, current_time)
+                    print_compression_job_status(job_row)
                     job_last_uncompressed_size = job_uncompressed_size
         elif CompressionJobStatus.PENDING == job_status:
             pass  # Simply wait another iteration


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

For accurate reporting of the final compression speed after a job succeeds, the `duration` field of the job should be used rather than relying on the progress reporter's polling interval.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Tested with CLP package.

Report with the PR change:
```
bingranhu@baker22:/home/bingranhu/clp/build/clp-package$ ./sbin/compress.sh --config etc/clp-config.yml fs ~/dataset/data/
2025-04-15T15:14:57.294 INFO [compress] Compression job 1 submitted.
2025-04-15T15:14:57.797 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 4.32KB/s.
2025-04-15T15:14:58.299 INFO [compress] Compression finished.
2025-04-15T15:14:58.299 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 2.80KB/s.
bingranhu@baker22:/home/bingranhu/clp/build/clp-package$ ./sbin/compress.sh --config etc/clp-config.yml fs ~/dataset/data/
2025-04-15T15:15:06.585 INFO [compress] Compression job 2 submitted.
2025-04-15T15:15:07.088 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 4.55KB/s.
2025-04-15T15:15:07.590 INFO [compress] Compression finished.
2025-04-15T15:15:07.590 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 3.63KB/s.
```

Report without the PR change and with a polling interval of `0.5s`
```
bingranhu@baker22:/home/bingranhu/clp/build/clp-package$ ./sbin/compress.sh --config etc/clp-config.yml fs ~/dataset/data/
2025-04-15T15:19:55.590 INFO [compress] Compression job 3 submitted.
2025-04-15T15:19:56.092 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 4.21KB/s.
2025-04-15T15:19:56.594 INFO [compress] Compression finished.
2025-04-15T15:19:56.594 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 2.01KB/s.
bingranhu@baker22:/home/bingranhu/clp/build/clp-package$ ./sbin/compress.sh --config etc/clp-config.yml fs ~/dataset/data/
2025-04-15T15:20:01.539 INFO [compress] Compression job 4 submitted.
2025-04-15T15:20:02.041 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 4.09KB/s.
2025-04-15T15:20:02.543 INFO [compress] Compression finished.
2025-04-15T15:20:02.543 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 1.98KB/s.
```
Speed becomes inaccurate (slower) because we accounted for the polling interval when calculating the speed.

Report without the PR change and with the polling interval changed to `10s` (to magnify the inaccuracy we get by depending on the polling interval to report compression speed status)
```
bingranhu@baker22:/home/bingranhu/clp/build/clp-package$ ./sbin/compress.sh --config etc/clp-config.yml fs ~/dataset/data/
2025-04-15T15:21:15.329 INFO [compress] Compression job 5 submitted.
2025-04-15T15:21:25.341 INFO [compress] Compression finished.
2025-04-15T15:21:25.341 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 198.21B/s.
bingranhu@baker22:/home/bingranhu/clp/build/clp-package$ ./sbin/compress.sh --config etc/clp-config.yml fs ~/dataset/data/
2025-04-15T15:22:17.688 INFO [compress] Compression job 6 submitted.
2025-04-15T15:22:27.700 INFO [compress] Compression finished.
2025-04-15T15:22:27.701 INFO [compress] Compressed 1.93KB into 827.00B (2.39x). Speed: 198.61B/s.
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for calculating compression job performance. Speed metrics now adjust automatically: successful jobs display a recorded duration value, while others reflect elapsed time since the start, resulting in more accurate feedback for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->