### PR TITLE
feat(clp-s)!: Reserve the `$`, `!`, and `#` namespaces for future use.

### DIFF
--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -31,6 +31,9 @@ constexpr char cMetadataSubtreeName[] = "";
 constexpr char cLogEventIdxName[] = "log_event_idx";
 constexpr std::string_view cAutogenNamespace{"@"};
 constexpr std::string_view cDefaultNamespace{""};
+constexpr std::string_view cRangeIndexNamespace{"$"};
+constexpr std::string_view cReservedNamespace1{"!"};
+constexpr std::string_view cReservedNamespace2{"#"};
 
 namespace results_cache::decompression {
 constexpr char cPath[]{"path"};

--- a/components/core/src/clp_s/search/ast/SearchUtils.cpp
+++ b/components/core/src/clp_s/search/ast/SearchUtils.cpp
@@ -70,16 +70,20 @@ auto tokenize_column_descriptor(
     bool escaped{false};
     descriptor_namespace.clear();
     size_t start_index = 0;
-    if (descriptor.size() > 0
-        && std::string_view{descriptor.data(), 1} == constants::cAutogenNamespace)
-    {
-        descriptor_namespace = constants::cAutogenNamespace;
-        start_index += 1;
-
-        if (descriptor.size() <= descriptor_namespace.size()) {
-            return false;
+    if (descriptor.size() > 0) {
+        switch (descriptor.at(0)) {
+            case constants::cAutogenNamespace.at(0):
+            case constants::cRangeIndexNamespace.at(0):
+            case constants::cReservedNamespace1.at(0):
+            case constants::cReservedNamespace2.at(0):
+                descriptor_namespace = descriptor.at(0);
+                start_index += 1;
+                break;
+            default:
+                break;
         }
     }
+
     for (size_t i = start_index; i < descriptor.size(); ++i) {
         if (false == escaped) {
             if ('\\' == descriptor[i]) {
@@ -267,6 +271,15 @@ auto unescape_kql_internal(std::string const& value, std::string& unescaped, boo
                 break;
             case '@':
                 unescaped.push_back('@');
+                break;
+            case '$':
+                unescaped.push_back('$');
+                break;
+            case '!':
+                unescaped.push_back('!');
+                break;
+            case '#':
+                unescaped.push_back('#');
                 break;
             default:
                 return false;

--- a/components/core/src/clp_s/search/kql/Kql.g4
+++ b/components/core/src/clp_s/search/kql/Kql.g4
@@ -88,7 +88,7 @@ fragment ESCAPED_SPACE
     ;
 
 fragment SPECIAL_CHARACTER
-    : [\\():<>"*?{}.@]
+    : [\\():<>"*?{}.@$!#]
     ;
 
 // For unicode hex

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -195,7 +195,7 @@ Keys containing the following literal characters must escape the characters usin
 Furthermore, keys that _start_ with the following literal characters must escape the characters
 using a `\` (backslash):
 
-a `\` (backslash):
+* `\` (backslash):
 * `@`
 * `$`
 * `!`

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -195,7 +195,6 @@ Keys containing the following literal characters must escape the characters usin
 Furthermore, keys that _start_ with the following literal characters must escape the characters
 using a `\` (backslash):
 
-* `\` (backslash):
 * `@`
 * `$`
 * `!`

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -192,7 +192,9 @@ Keys containing the following literal characters must escape the characters usin
 * `.`
 * `*`
 
-Furthermore, keys _starting with_ the following literal characters must escape the characters using
+Furthermore, keys that _start_ with the following literal characters must escape the characters
+using a `\` (backslash):
+
 a `\` (backslash):
 * `@`
 * `$`

--- a/docs/src/user-guide/reference-json-search-syntax.md
+++ b/docs/src/user-guide/reference-json-search-syntax.md
@@ -191,7 +191,13 @@ Keys containing the following literal characters must escape the characters usin
 * `"`
 * `.`
 * `*`
-* `@` (only when `@` is the first character of the key)
+
+Furthermore, keys _starting with_ the following literal characters must escape the characters using
+a `\` (backslash):
+* `@`
+* `$`
+* `!`
+* `#`
 
 Values containing the following literal characters must escape the characters using a `\`
 (backslash):


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR reserves the `$`, `!`, and `#` namespaces for future use. Specifically we update the parsing and unescaping rules for columns to treat columns beginning with `$`, `!`, and `#` as belonging to those respective namespaces unless escaped with a backslash.

Note that each change to the column parsing and unescaping rules is a breaking archive format change because it affects the interpretation of the authoritative timestamp column stored in the archive. Even though this is a breaking change we don't increment the archive version because if this PR gets merged before the next release we get to batch it together with a similar column format change for which we did increment the archive version.

We have near-term plans to use the `$` namespace to allow users to reference columns in the archive range index (see #737). The `!` and `#` namespaces have no immediate use, but they are reserved in this PR to avoid having to introduce more breaking changes of this type for the foreseeable future.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Added tests for column format changes


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced query parsing to support additional namespace characters ($, !, #), expanding the range of recognized symbols in search queries.
  - Improved unescaping functionality to handle more special characters in queries.
  - Added new namespace constants to support expanded query syntax.

- **Documentation**
  - Updated JSON search syntax guidelines to clarify that keys starting with special symbols (\, @, $, !, #) must now be escaped.

- **Tests**
  - Improved test cases to verify the handling of multiple namespace characters in search queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->