### PR TITLE
build(deps): Upgrade simdjson to 3.12.3

### DIFF
--- a/deps-tasks.yml
+++ b/deps-tasks.yml
@@ -337,8 +337,8 @@ tasks:
         vars:
           DEST: "{{.DEST}}"
           FLAGS: "--extract"
-          SRC_NAME: "simdjson-3.6.3"
-          SRC_URL: "https://github.com/simdjson/simdjson/archive/refs/tags/v3.6.3.zip"
+          SRC_NAME: "simdjson-3.12.3"
+          SRC_URL: "https://github.com/simdjson/simdjson/archive/refs/tags/v3.12.3.zip"
       # This command must be last
       - task: ":utils:checksum:compute"
         vars:

--- a/docs/src/dev-guide/components-core/index.md
+++ b/docs/src/dev-guide/components-core/index.md
@@ -39,7 +39,7 @@ This will download:
 * [json](https://github.com/nlohmann/json.git) (v3.11.3)
 * [log-surgeon](https://github.com/y-scope/log-surgeon.git) (895f464)
 * [outcome](https://github.com/ned14/outcome) (v2.2.9)
-* [simdjson](https://github.com/simdjson/simdjson) (v3.6.3)
+* [simdjson](https://github.com/simdjson/simdjson) (v3.12.3)
 * [SQLite3](https://www.sqlite.org/download.html) (v3.36.0)
 * [uftcpp](https://github.com/nemtrif/utfcpp.git) (v4.0.6)
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp.git) (v0.7.0)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
We're currently using simdjson 3.6.3 (from 2023), which is incompatible with llvm-19 builds, causing errors like
```
/Users/runner/work/clp/clp/components/core/submodules/simdjson/include/simdjson/dom/serialization.h:60:13: error: no member named 'print_newline' in 'base_formatter<formatter>' [clang-diagnostic-error]
[774](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:775)
   60 |       this->print_newline();
[775](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:776)
      |       ~~~~  ^
[776](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:777)
/Users/runner/work/clp/clp/components/core/submodules/simdjson/include/simdjson/dom/serialization.h:64:13: error: no member named 'print_indents' in 'base_formatter<formatter>' [clang-diagnostic-error]
[777](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:778)
   64 |       this->print_indents(depth);
[778](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:779)
      |       ~~~~  ^
[779](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:780)
/Users/runner/work/clp/clp/components/core/submodules/simdjson/include/simdjson/dom/serialization.h:68:13: error: no member named 'print_space' in 'base_formatter<formatter>' [clang-diagnostic-error]
[780](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:781)
   68 |       this->print_space();
[781](https://github.com/y-scope/clp/actions/runs/14470861999/job/40584141960?pr=817#step:9:782)
      |       ~~~~  ^
```
This issue was resolved in simdjson PR [#2187](https://github.com/simdjson/simdjson/pull/2187). To ensure compatibility and leverage potential performance improvements, we're upgrading to the latest simdjson version.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
