### PR TITLE
docs: Update copyright year dynamically.

### DIFF
--- a/docs/conf/conf.py
+++ b/docs/conf/conf.py
@@ -1,11 +1,11 @@
-from datetime import datetime
+from datetime import date
 
 # -- Project information -------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "CLP"
 # NOTE: We don't include a period after "Inc" since the theme adds one already.
-copyright = f"2021-{datetime.now().year} YScope Inc"
+copyright = f"2021-{date.today().year} YScope Inc"
 
 # -- General configuration -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf/conf.py
+++ b/docs/conf/conf.py
@@ -1,9 +1,11 @@
+from datetime import datetime
+
 # -- Project information -------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "CLP"
 # NOTE: We don't include a period after "Inc" since the theme adds one already.
-copyright = "2021-2025 YScope Inc"
+copyright = f"2021-{datetime.now().year} YScope Inc"
 
 # -- General configuration -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf/conf.py
+++ b/docs/conf/conf.py
@@ -3,7 +3,7 @@
 
 project = "CLP"
 # NOTE: We don't include a period after "Inc" since the theme adds one already.
-copyright = "2021-2024 YScope Inc"
+copyright = "2021-2025 YScope Inc"
 
 # -- General configuration -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Adds code to set the end of the copyright time range to the current year. The reason we didn't do this previously is because technically if you're building and publishing the site, there's no guarantee that you've modified it and so the copyright year should remain the same as it was previously. However, it's unlikely that someone would build and publish the site without having modified it first, so for convenience, we add the code.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* `task docs:serve`
* Validated that the end of the copyright time range showed up as 2025.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated documentation to automatically display the current year in the copyright notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->