### PR TITLE
build(deps): Migrate yscope-log-viewer dependency from submodule to task-based source download.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,9 +26,6 @@
 [submodule "components/core/submodules/outcome"]
 	path = components/core/submodules/outcome
 	url = https://github.com/ned14/outcome.git
-[submodule "components/log-viewer-webui/yscope-log-viewer"]
-	path = components/log-viewer-webui/yscope-log-viewer
-	url = https://github.com/y-scope/yscope-log-viewer.git
 [submodule "components/core/submodules/utfcpp"]
 	path = components/core/submodules/utfcpp
 	url = https://github.com/nemtrif/utfcpp.git

--- a/docs/src/dev-guide/components-log-viewer-webui.md
+++ b/docs/src/dev-guide/components-log-viewer-webui.md
@@ -9,6 +9,12 @@ currently consists of a [React] client and a [Fastify] server.
 
 ## Setup
 
+Download the log-viewer's source code:
+
+```bash
+task deps:log-viewer
+```
+
 Install the app's dependencies:
 
 ```shell

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -104,7 +104,6 @@ tasks:
       - task: "sqlite3"
       - task: "utfcpp"
       - task: "yaml-cpp"
-      - task: "yscope-log-viewer"
       - task: "ystdlib-cpp"
 
   abseil-cpp:

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -28,9 +28,9 @@ vars:
 
 tasks:
   default:
-    cmds:
-      - task: "core"
-      - task: "log-viewer"
+    deps:
+      - "core"
+      - "log-viewer"
 
   core:
     vars:

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -73,8 +73,8 @@ tasks:
           CHECKSUM_FILE: "{{.G_DEPS_LOG_VIEWER_CHECKSUM_FILE}}"
           FILE_SHA256: "de0600b505545f1bceb7ff5725941035f7c1dc875d08249d9b6d679e3ba77f26"
           OUTPUT_DIR: "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/yscope-log-viewer"
-          URL: "https://github.com/y-scope/yscope-log-viewer/archive/969ff35.tar.gz"
           TAR_FILE: "{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz"
+          URL: "https://github.com/y-scope/yscope-log-viewer/archive/969ff35.tar.gz"
 
   # NOTE: `git submodule update` doesn't support parallel invocations, so we can't use it to
   # download submodules in parallel. This means:

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -1,4 +1,8 @@
 version: "3"
+
+includes:
+  yscope-dev-utils: "../tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
+
 vars:
   # Utility script path
   G_DEP_DOWNLOAD_SCRIPT: "{{.ROOT_DIR}}/tools/scripts/deps-download/download-dep.py"
@@ -63,15 +67,14 @@ tasks:
         >> "{{.G_DEPS_CORE_CHECKSUM_FILE}}"
 
   log-viewer:
-    sources:
-      - "{{.G_YSCOPE_LOG_VIEWER_CHECKSUM_FILE}}"
-    generates: ["{{.G_DEPS_LOG_VIEWER_CHECKSUM_FILE}}"]
-    deps: ["all-internal-deps"]
     cmds:
-      - >-
-        cat
-        "{{.G_YSCOPE_LOG_VIEWER_CHECKSUM_FILE}}"
-        >> "{{.G_DEPS_LOG_VIEWER_CHECKSUM_FILE}}"
+      - task: "yscope-dev-utils:remote:download-and-extract-tar"
+        vars:
+          CHECKSUM_FILE: "{{.G_DEPS_LOG_VIEWER_CHECKSUM_FILE}}"
+          FILE_SHA256: "de0600b505545f1bceb7ff5725941035f7c1dc875d08249d9b6d679e3ba77f26"
+          OUTPUT_DIR: "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/yscope-log-viewer"
+          URL: "https://github.com/y-scope/yscope-log-viewer/archive/969ff35.tar.gz"
+          TAR_FILE: "{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz"
 
   # NOTE: `git submodule update` doesn't support parallel invocations, so we can't use it to
   # download submodules in parallel. This means:
@@ -431,36 +434,6 @@ tasks:
           FLAGS: "--extract"
           SRC_NAME: "yaml-cpp-yaml-cpp-0.7.0"
           SRC_URL: "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
-
-  yscope-log-viewer:
-    internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_YSCOPE_LOG_VIEWER_CHECKSUM_FILE}}"
-      DEST: "{{.G_LOG_VIEWER_WEBUI_SRC_DIR}}/yscope-log-viewer"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - ":init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
-    cmds:
-      - task: "download-dependency"
-        vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "yscope-log-viewer-969ff35b2387bcdc3580b441907e3656640ce16d"
-          SRC_URL: "https://github.com/y-scope/yscope-log-viewer/archive/969ff35.zip"
       # This command must be last
       - task: ":utils:checksum:compute"
         vars:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

We want to move away from using submodules since they cause a few issues:

* Submodules download the entire history of a the submodule repo unless we ask git to do a sparse checkout (`--shallow-submodules`); but that's not much different than using `task` to download a snapshot release.
* When we make a release on GitHub, GitHub automatically generates a source tar without any info about the repo in it, so there's no way to download the submodules. Instead, we use a script to download them, but that means we need to keep the URLs that the script downloads in-sync with the submodules---which can be error-prone.

To address this, we've been adding tasks to yscope-dev-utils for downloading dependencies. This PR starts by replacing the yscope-log-viewer submodule with tasks to download it directly.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Cloned a clean repo, checked out the PR branch, and then validated:

  ```bash
  ./tools/scripts/deps-download/init.sh
  task
  ```

* Cloned a clean repo, checked out the PR branch, and then validated:

  ```bash
  rm -r .git
  ./tools/scripts/deps-download/init.sh
  task
  ```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed the yscope-log-viewer submodule and all related files from the project.
	- Updated dependency management tasks to use an external utility for downloading the log viewer, simplifying setup steps.
- **Documentation**
	- Updated setup instructions to clarify how to download the log viewer source code before installing dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->