### PR TITLE
feat(job-orchestration): Add `dataset` fields to input configs of compression and search jobs.

### DIFF
--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -42,6 +42,7 @@ OS_RELEASE_FILE_PATH = pathlib.Path("etc") / "os-release"
 
 CLP_DEFAULT_CREDENTIALS_FILE_PATH = pathlib.Path("etc") / "credentials.yml"
 CLP_DEFAULT_DATA_DIRECTORY_PATH = pathlib.Path("var") / "data"
+CLP_DEFAULT_DATASET_NAME = "default"
 CLP_METADATA_TABLE_PREFIX = "clp_"
 
 

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -22,6 +22,7 @@ class PathsToCompress(BaseModel):
 
 class FsInputConfig(BaseModel):
     type: typing.Literal[InputType.FS.value] = InputType.FS.value
+    dataset: str = "default"
     paths_to_compress: typing.List[str]
     path_prefix_to_remove: str = None
     timestamp_key: typing.Optional[str] = None
@@ -29,6 +30,7 @@ class FsInputConfig(BaseModel):
 
 class S3InputConfig(BaseModel):
     type: typing.Literal[InputType.S3.value] = InputType.S3.value
+    dataset: str = "default"
     timestamp_key: typing.Optional[str] = None
 
     region_code: str
@@ -76,6 +78,7 @@ class ExtractJsonJobConfig(QueryJobConfig):
 
 
 class SearchJobConfig(QueryJobConfig):
+    dataset: str = "default"
     query_string: str
     max_num_results: int
     tags: typing.Optional[typing.List[str]] = None

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 from enum import auto
 
-from clp_py_utils.clp_config import S3Credentials
+from clp_py_utils.clp_config import CLP_DEFAULT_DATASET_NAME, S3Credentials
 from pydantic import BaseModel, validator
 from strenum import LowercaseStrEnum
 
@@ -22,7 +22,7 @@ class PathsToCompress(BaseModel):
 
 class FsInputConfig(BaseModel):
     type: typing.Literal[InputType.FS.value] = InputType.FS.value
-    dataset: str = "default"
+    dataset: str = CLP_DEFAULT_DATASET_NAME
     paths_to_compress: typing.List[str]
     path_prefix_to_remove: str = None
     timestamp_key: typing.Optional[str] = None
@@ -30,7 +30,7 @@ class FsInputConfig(BaseModel):
 
 class S3InputConfig(BaseModel):
     type: typing.Literal[InputType.S3.value] = InputType.S3.value
-    dataset: str = "default"
+    dataset: str = CLP_DEFAULT_DATASET_NAME
     timestamp_key: typing.Optional[str] = None
 
     region_code: str
@@ -78,7 +78,7 @@ class ExtractJsonJobConfig(QueryJobConfig):
 
 
 class SearchJobConfig(QueryJobConfig):
-    dataset: str = "default"
+    dataset: str = CLP_DEFAULT_DATASET_NAME
     query_string: str
     max_num_results: int
     tags: typing.Optional[typing.List[str]] = None


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR succeeds #819 and covers the following parts of the dataset feature implementation [plan](https://docs.google.com/document/d/1BXDG1LSFOS7I52BRc0s1ahk_9MebCiH2HlLefLJ9unM/edit?tab=t.0#heading=h.kjcfz55f6si7):
* The part of Step 2 regarding creating default `dataset` fields for compression jobs' input configs and search jobs' config.

These options will only be used by `clp-s` upon completion of this `dataset` feature implementation. When not specified, these options default to `default`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] No changes to functionality. The default `dataset` configs neither take effect nor break anything.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new field to configuration options allowing users to specify a dataset, with a default value set to "default".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->