### PR TITLE
refactor(clp-s): Resolve clang-tidy violations in `clp_s/search/ast/FilterExpr.{cpp,hpp}` and apply our latest coding guidelines.

### DIFF
--- a/components/core/src/clp_s/search/ast/FilterExpr.hpp
+++ b/components/core/src/clp_s/search/ast/FilterExpr.hpp
@@ -58,11 +58,14 @@ public:
      */
     [[nodiscard]] static auto op_type_str(FilterOperation op) -> std::string;
 
+    // Delete copy assignment operator
     auto operator=(FilterExpr const&) -> FilterExpr& = delete;
 
+    // Delete move constructor and assignment operator
     FilterExpr(FilterExpr&&) = delete;
     auto operator=(FilterExpr&&) -> FilterExpr& = delete;
 
+    // Destructor
     ~FilterExpr() override = default;
 
     // Methods inherited from Value
@@ -100,6 +103,7 @@ private:
             Expression* parent = nullptr
     );
 
+    // Default copy constructor
     FilterExpr(FilterExpr const&) = default;
 
     // Variables

--- a/components/core/src/clp_s/search/ast/FilterExpr.hpp
+++ b/components/core/src/clp_s/search/ast/FilterExpr.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_SEARCH_FILTEREXPR_HPP
 #define CLP_S_SEARCH_FILTEREXPR_HPP
 
+#include <memory>
 #include <string>
 
 #include "ColumnDescriptor.hpp"
@@ -19,23 +20,6 @@ namespace clp_s::search::ast {
 class FilterExpr : public Expression {
 public:
     /**
-     * @return FilterOperation this Filter performs
-     */
-    FilterOperation get_operation() { return m_op; }
-
-    /**
-     * @return The Column this Filter acts on
-     */
-    std::shared_ptr<ColumnDescriptor> get_column() {
-        return std::static_pointer_cast<ColumnDescriptor>(*op_begin());
-    }
-
-    /**
-     * @return This Filter's Literal or nullptr if there is no Literal
-     */
-    std::shared_ptr<Literal> get_operand();
-
-    /**
      * Create a Filter expression with a Column and FilterOperation but no Literal
      * Literal can be added later using mutators provided by the Expression parent class
      * @param column the Column this Filter acts on
@@ -44,12 +28,12 @@ public:
      * @param parent parent this expression is attached to
      * @return Newly created Or expression
      */
-    static std::shared_ptr<Expression> create(
+    [[nodiscard]] static auto create(
             std::shared_ptr<ColumnDescriptor>& column,
             FilterOperation op,
             bool inverted = false,
             Expression* parent = nullptr
-    );
+    ) -> std::shared_ptr<Expression>;
 
     /**
      * Create a Filter expression with a Column, FilterOperation and Literal
@@ -59,32 +43,55 @@ public:
      * @param parent parent this expression is attached to
      * @return newly created Or expression
      */
-    static std::shared_ptr<Expression> create(
+    [[nodiscard]] static auto create(
             std::shared_ptr<ColumnDescriptor>& column,
             FilterOperation op,
             std::shared_ptr<Literal>& operand,
             bool inverted = false,
             Expression* parent = nullptr
-    );
+    ) -> std::shared_ptr<Expression>;
 
     /**
      * Helper function to turn FilterOperation into string for printing
      * @param op the operation we want to convert to string
      * @return a string representing the operation
      */
-    static std::string op_type_str(FilterOperation op);
+    [[nodiscard]] static auto op_type_str(FilterOperation op) -> std::string;
+
+    auto operator=(FilterExpr const&) -> FilterExpr& = delete;
+
+    FilterExpr(FilterExpr&&) = delete;
+    auto operator=(FilterExpr&&) -> FilterExpr& = delete;
+
+    ~FilterExpr() override = default;
 
     // Methods inherited from Value
-    void print() const override;
+    auto print() const -> void override;
 
     // Methods inherited from Expression
-    bool has_only_expression_operands() override { return false; }
+    [[nodiscard]] auto has_only_expression_operands() -> bool override { return false; }
 
-    std::shared_ptr<Expression> copy() const override;
+    [[nodiscard]] auto copy() const -> std::shared_ptr<Expression> override;
+
+    // Methods
+    /**
+     * @return FilterOperation this Filter performs
+     */
+    [[nodiscard]] auto get_operation() const -> FilterOperation { return m_op; }
+
+    /**
+     * @return The Column this Filter acts on
+     */
+    [[nodiscard]] auto get_column() -> std::shared_ptr<ColumnDescriptor> {
+        return std::static_pointer_cast<ColumnDescriptor>(*op_begin());
+    }
+
+    /**
+     * @return This Filter's Literal or nullptr if there is no Literal
+     */
+    [[nodiscard]] auto get_operand() const -> std::shared_ptr<Literal>;
 
 private:
-    FilterOperation m_op;
-
     // Constructor
     FilterExpr(
             std::shared_ptr<ColumnDescriptor> const& column,
@@ -93,7 +100,10 @@ private:
             Expression* parent = nullptr
     );
 
-    FilterExpr(FilterExpr const&);
+    FilterExpr(FilterExpr const&) = default;
+
+    // Variables
+    FilterOperation m_op;
 };
 }  // namespace clp_s::search::ast
 

--- a/components/core/src/clp_s/search/ast/FilterExpr.hpp
+++ b/components/core/src/clp_s/search/ast/FilterExpr.hpp
@@ -75,19 +75,19 @@ public:
 
     // Methods
     /**
-     * @return FilterOperation this Filter performs
+     * @return The FilterOperation performed by this Filter.
      */
     [[nodiscard]] auto get_operation() const -> FilterOperation { return m_op; }
 
     /**
-     * @return The Column this Filter acts on
+     * @return The ColumnDescriptor that this Filter acts on.
      */
     [[nodiscard]] auto get_column() -> std::shared_ptr<ColumnDescriptor> {
         return std::static_pointer_cast<ColumnDescriptor>(*op_begin());
     }
 
     /**
-     * @return This Filter's Literal or nullptr if there is no Literal
+     * @return This Filter's Literal or nullptr if there is no Literal.
      */
     [[nodiscard]] auto get_operand() const -> std::shared_ptr<Literal>;
 

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -456,8 +456,6 @@ tasks:
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/EmptyExpr.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/Expression.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/Expression.hpp"
-            - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/FilterExpr.cpp"
-            - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/FilterExpr.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/FilterOperation.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/Integral.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/ast/Integral.hpp"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is one of #764.

This PR fixes all clang-tidy warnings in `clp_s::search::ast::FilterExpr`. It also contains the following refactoring:
- Ensure class member ordering matches our latest standard.
- Use `default` or `delete` for copy/move assignment operators and constructors.
- Use `{}` for explicitly typed initialization.
- Mark class methods `const` when possible.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Ensure all workflows passed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Modernized and clarified the interface and implementation of filter expression handling, improving code style, const-correctness, and usage of smart pointers.
  - Updated method signatures and added attributes to encourage safer and more explicit usage.
  - Adjusted output formatting behaviour for filter expressions.

- **Chores**
  - Updated linting configuration to include filter expression files in static analysis checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->