### PR TITLE
fix(core): Use a more reliable HTTP-header echo-server in unit tests (fixes #853).

### DIFF
--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -22,9 +22,11 @@
 #include "../src/clp/NetworkReader.hpp"
 #include "../src/clp/Platform.hpp"
 #include "../src/clp/ReaderInterface.hpp"
+#include "../src/clp/string_utils/string_utils.hpp"
 
 namespace {
 constexpr size_t cDefaultReaderBufferSize{1024};
+constexpr std::string_view cHttpHeadersEchoServerUrl{"https://mockhttp.org/headers"};
 
 [[nodiscard]] auto get_test_input_local_path() -> std::string;
 
@@ -192,10 +194,12 @@ TEST_CASE("network_reader_illegal_offset", "[NetworkReader]") {
     REQUIRE((clp::ErrorCode_Failure == reader.try_get_pos(pos)));
 }
 
+/**
+ * Sends some headers to an HTTP header echo server and validates that they're returned correctly in
+ * a JSON object under the "headers" key.
+ */
 TEST_CASE("network_reader_with_valid_http_header_kv_pairs", "[NetworkReader]") {
     std::unordered_map<std::string, std::string> valid_http_header_kv_pairs;
-    // We use httpbin (https://httpbin.org/) to test the user-specified headers. On success, it is
-    // supposed to respond all the user-specified headers as key-value pairs in JSON form.
     constexpr size_t cNumHttpHeaderKeyValuePairs{10};
     for (size_t i{0}; i < cNumHttpHeaderKeyValuePairs; ++i) {
         valid_http_header_kv_pairs.emplace(
@@ -204,12 +208,13 @@ TEST_CASE("network_reader_with_valid_http_header_kv_pairs", "[NetworkReader]") {
         );
     }
     std::optional<std::vector<char>> optional_content;
+
     // Retry the unit test a limited number of times to handle transient server-side HTTP errors.
     // This ensures the test is not marked as failed due to temporary issues beyond our control.
     constexpr size_t cNumMaxTrials{10};
     for (size_t i{0}; i < cNumMaxTrials; ++i) {
         clp::NetworkReader reader{
-                "https://httpbin.org/headers",
+                cHttpHeadersEchoServerUrl,
                 0,
                 false,
                 clp::CurlDownloadHandler::cDefaultOverallTimeout,
@@ -228,7 +233,11 @@ TEST_CASE("network_reader_with_valid_http_header_kv_pairs", "[NetworkReader]") {
     auto const parsed_content = nlohmann::json::parse(optional_content.value());
     auto const& headers{parsed_content.at("headers")};
     for (auto const& [key, value] : valid_http_header_kv_pairs) {
-        REQUIRE((value == headers.at(key).get<std::string_view>()));
+        // The echo server we're using returns the HTTP header names as lowercase (under the spec,
+        // they're case insensitive).
+        std::string key_lowercase{key};
+        clp::string_utils::to_lower(key_lowercase);
+        REQUIRE((value == headers.at(key_lowercase).get<std::string_view>()));
     }
 }
 
@@ -244,7 +253,7 @@ TEST_CASE("network_reader_with_illegal_http_header_kv_pairs", "[NetworkReader]")
             std::unordered_map<std::string, std::string>{{"Legal-Name", "CRLF\r\n"}}
     );
     clp::NetworkReader reader{
-            "https://httpbin.org/headers",
+            cHttpHeadersEchoServerUrl,
             0,
             false,
             clp::CurlDownloadHandler::cDefaultOverallTimeout,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Switches the HTTP-header echo-server we use in unit tests from httpbin.org to mockhttp.org since the latter seems much more reliable.

Although we can't guarantee that mockhttp.org is more reliable than httpbin.org, the former at least seems to be [maintained](https://github.com/jaredwray/mockhttp) compared to httpbin.org whose source hasn't been updated in years.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

GH workflows succeeded.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated tests to use a new HTTP header echo server URL.
  - Enhanced header comparison logic to handle lowercase header names returned by the new server.
  - Added clarifying comments about header case handling in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->