### PR TITLE
fix(taskfiles): Alias `lint:fix-cpp-static-*` to `lint:check-cpp-static-*` (fixes #849).

### DIFF
--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -154,6 +154,8 @@ tasks:
     cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/symlink-cpp-lint-configs.sh"
 
   check-cpp-static-diff:
+    # Alias for fix until we determine which clang-tidy fixes can applied safely.
+    aliases: ["fix-cpp-static-diff"]
     sources: *cpp_source_files
     deps:
       - ":core-generate"
@@ -169,6 +171,8 @@ tasks:
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
   check-cpp-static-full:
+    # Alias for fix until we determine which clang-tidy fixes can applied safely.
+    aliases: ["fix-cpp-static-full"]
     sources: *cpp_source_files
     deps:
       - ":core-generate"

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -154,7 +154,7 @@ tasks:
     cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/symlink-cpp-lint-configs.sh"
 
   check-cpp-static-diff:
-    # Alias for fix until we determine which clang-tidy fixes can applied safely.
+    # Alias for fix until we determine which clang-tidy fixes can be applied safely.
     aliases: ["fix-cpp-static-diff"]
     sources: *cpp_source_files
     deps:
@@ -171,7 +171,7 @@ tasks:
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
   check-cpp-static-full:
-    # Alias for fix until we determine which clang-tidy fixes can applied safely.
+    # Alias for fix until we determine which clang-tidy fixes can be applied safely.
     aliases: ["fix-cpp-static-full"]
     sources: *cpp_source_files
     deps:

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -154,7 +154,7 @@ tasks:
     cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/symlink-cpp-lint-configs.sh"
 
   check-cpp-static-diff:
-    # Alias for fix until we determine which clang-tidy fixes can be applied safely.
+    # NOTE: We alias the fix task until we determine which clang-tidy fixes can be applied safely.
     aliases: ["fix-cpp-static-diff"]
     sources: *cpp_source_files
     deps:
@@ -171,7 +171,7 @@ tasks:
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
   check-cpp-static-full:
-    # Alias for fix until we determine which clang-tidy fixes can be applied safely.
+    # NOTE: We alias the fix task until we determine which clang-tidy fixes can be applied safely.
     aliases: ["fix-cpp-static-full"]
     sources: *cpp_source_files
     deps:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

As stated in #849, CLP's `taskfiles/lint.yaml` is missing both `fix-cpp-static-diff` and `fix-cpp-static-full`. This PR aliases these names to `check-cpp-static-diff` and `check-cpp-static-full` as we currently do not support running the fixes from clang-tidy. These aliases were missing from a previous refactor PR. 



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Ran tasks locally.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added alternative aliases for existing linting tasks, allowing them to be run using new command names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->