### PR TITLE
build(deps): Migrate core's submodule-based dependencies to task-based installation.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -13,7 +13,7 @@ on:
       - "components/core/tools/scripts/deps-download/**"
       - "components/core/tools/scripts/utils/build-and-run-unit-tests.py"
       - "taskfile.yaml"
-      - "taskfiles/deps.yaml"
+      - "taskfiles/deps/main.yaml"
       - "tools/scripts/deps-download/**"
   push:
     paths:
@@ -27,7 +27,7 @@ on:
       - "components/core/tools/scripts/deps-download/**"
       - "components/core/tools/scripts/utils/build-and-run-unit-tests.py"
       - "taskfile.yaml"
-      - "taskfiles/deps.yaml"
+      - "taskfiles/deps/main.yaml"
       - "tools/scripts/deps-download/**"
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -13,7 +13,7 @@ on:
       - "components/core/tools/scripts/deps-download/**"
       - "components/core/tools/scripts/utils/build-and-run-unit-tests.py"
       - "taskfile.yaml"
-      - "taskfiles/deps/main.yaml"
+      - "taskfiles/**"
       - "tools/scripts/deps-download/**"
   push:
     paths:
@@ -27,7 +27,7 @@ on:
       - "components/core/tools/scripts/deps-download/**"
       - "components/core/tools/scripts/utils/build-and-run-unit-tests.py"
       - "taskfile.yaml"
-      - "taskfiles/deps/main.yaml"
+      - "taskfiles/**"
       - "tools/scripts/deps-download/**"
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -9,7 +9,7 @@ on:
       - ".gitmodules"
       - "components/core/**"
       - "taskfile.yaml"
-      - "taskfiles/deps.yaml"
+      - "taskfiles/deps/main.yaml"
       - "tools/scripts/deps-download/**"
       - "!components/core/tools/scripts/lib_install/macos/**"
   push:
@@ -20,7 +20,7 @@ on:
       - ".gitmodules"
       - "components/core/**"
       - "taskfile.yaml"
-      - "taskfiles/deps.yaml"
+      - "taskfiles/deps/main.yaml"
       - "tools/scripts/deps-download/**"
       - "!components/core/tools/scripts/lib_install/macos/**"
   schedule:
@@ -88,7 +88,7 @@ jobs:
               - "components/core/tests/**"
               - "components/core/tools/scripts/utils/build-and-run-unit-tests.py"
               - "taskfile.yaml"
-              - "taskfiles/deps.yaml"
+              - "taskfiles/deps/main.yaml"
               - "tools/scripts/deps-download/**"
 
   centos-stream-9-deps-image:

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -9,7 +9,7 @@ on:
       - ".gitmodules"
       - "components/core/**"
       - "taskfile.yaml"
-      - "taskfiles/deps/main.yaml"
+      - "taskfiles/**"
       - "tools/scripts/deps-download/**"
       - "!components/core/tools/scripts/lib_install/macos/**"
   push:
@@ -20,7 +20,7 @@ on:
       - ".gitmodules"
       - "components/core/**"
       - "taskfile.yaml"
-      - "taskfiles/deps/main.yaml"
+      - "taskfiles/**"
       - "tools/scripts/deps-download/**"
       - "!components/core/tools/scripts/lib_install/macos/**"
   schedule:
@@ -88,7 +88,7 @@ jobs:
               - "components/core/tests/**"
               - "components/core/tools/scripts/utils/build-and-run-unit-tests.py"
               - "taskfile.yaml"
-              - "taskfiles/deps/main.yaml"
+              - "taskfiles/**"
               - "tools/scripts/deps-download/**"
 
   centos-stream-9-deps-image:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "components/core/submodules/log-surgeon"]
-	path = components/core/submodules/log-surgeon
-	url = https://github.com/y-scope/log-surgeon.git
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,9 +23,6 @@
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git
-[submodule "components/core/submodules/outcome"]
-	path = components/core/submodules/outcome
-	url = https://github.com/ned14/outcome.git
 [submodule "components/core/submodules/utfcpp"]
 	path = components/core/submodules/utfcpp
 	url = https://github.com/nemtrif/utfcpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "components/core/submodules/date"]
-	path = components/core/submodules/date
-	url = https://github.com/HowardHinnant/date.git
 [submodule "components/core/submodules/yaml-cpp"]
 	path = components/core/submodules/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "components/core/submodules/log-surgeon"]
 	path = components/core/submodules/log-surgeon
 	url = https://github.com/y-scope/log-surgeon.git
-[submodule "components/core/submodules/simdjson"]
-	path = components/core/submodules/simdjson
-	url = https://github.com/simdjson/simdjson.git
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,6 @@
 [submodule "components/core/submodules/date"]
 	path = components/core/submodules/date
 	url = https://github.com/HowardHinnant/date.git
-[submodule "components/core/submodules/json"]
-	path = components/core/submodules/json
-	url = https://github.com/nlohmann/json.git
-	shallow = true
 [submodule "components/core/submodules/yaml-cpp"]
 	path = components/core/submodules/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "components/core/submodules/Catch2"]
-	path = components/core/submodules/Catch2
-	url = https://github.com/catchorg/Catch2.git
 [submodule "components/core/submodules/date"]
 	path = components/core/submodules/date
 	url = https://github.com/HowardHinnant/date.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "components/core/submodules/yaml-cpp"]
-	path = components/core/submodules/yaml-cpp
-	url = https://github.com/jbeder/yaml-cpp.git
 [submodule "components/core/submodules/log-surgeon"]
 	path = components/core/submodules/log-surgeon
 	url = https://github.com/y-scope/log-surgeon.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,9 +23,6 @@
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git
-[submodule "components/core/submodules/utfcpp"]
-	path = components/core/submodules/utfcpp
-	url = https://github.com/nemtrif/utfcpp.git
 [submodule "components/core/submodules/ystdlib-cpp"]
 	path = components/core/submodules/ystdlib-cpp
 	url = https://github.com/y-scope/ystdlib-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git
-[submodule "components/core/submodules/ystdlib-cpp"]
-	path = components/core/submodules/ystdlib-cpp
-	url = https://github.com/y-scope/ystdlib-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,9 +17,6 @@
 [submodule "components/core/submodules/simdjson"]
 	path = components/core/submodules/simdjson
 	url = https://github.com/simdjson/simdjson.git
-[submodule "components/core/submodules/abseil-cpp"]
-	path = components/core/submodules/abseil-cpp
-	url = https://github.com/abseil/abseil-cpp.git
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git

--- a/components/core/.clang-format
+++ b/components/core/.clang-format
@@ -4,9 +4,9 @@ IncludeCategories:
   # NOTE: A header is grouped by first matching regex
   # Library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
-  - Regex: "<(absl|antlr4|archive|boost|bsoncxx|catch2|curl|date|fmt|json|log_surgeon|lzma|mongocxx\
-|msgpack|mysql|openssl|outcome|regex_utils|simdjson|spdlog|sqlite3|string_utils|yaml-cpp|ystdlib\
-|zstd)"
+  - Regex: "<(absl|antlr4|archive|boost|bsoncxx|catch2|curl|date|fmt|log_surgeon|lzma|mongocxx\
+|msgpack|mysql|nlohmann|openssl|outcome|regex_utils|simdjson|spdlog|sqlite3|string_utils|yaml-cpp\
+|ystdlib|zstd)"
     Priority: 3
   # C system headers
   - Regex: "^<.+\\.h>"

--- a/components/core/.gitignore
+++ b/components/core/.gitignore
@@ -1,3 +1,2 @@
 build/**
 submodules/sqlite3/*
-third-party/**

--- a/components/core/.gitignore
+++ b/components/core/.gitignore
@@ -1,2 +1,1 @@
 build/**
-submodules/sqlite3/*

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -680,7 +680,6 @@ target_include_directories(unitTest
         PRIVATE
         ${CLP_OUTCOME_SOURCE_DIRECTORY}
         ${CLP_SQLITE3_SOURCE_DIRECTORY}
-        ${CMAKE_SOURCE_DIR}/submodules
         )
 target_link_libraries(unitTest
         PRIVATE

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -656,6 +656,7 @@ add_executable(unitTest
         )
 target_include_directories(unitTest
         PRIVATE
+        ${CLP_OUTCOME_SOURCE_DIRECTORY}
         ${CMAKE_SOURCE_DIR}/submodules
         )
 target_link_libraries(unitTest

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -96,6 +96,23 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif ()
 endif ()
 
+if(PROJECT_IS_TOP_LEVEL)
+    # Include dependency settings if the project isn't being included as a subproject.
+    # NOTE: We mark the file optional because if the user happens to have the dependencies
+    # installed, this file isn't necessary.
+    include("${CMAKE_SOURCE_DIR}/../../build/deps/core/cmake-settings/all.cmake"
+            OPTIONAL
+            RESULT_VARIABLE CLP_DEPS_SETTINGS_FILE_PATH
+    )
+
+    if(NOT CLP_DEPS_SETTINGS_FILE_PATH STREQUAL "NOTFOUND")
+        # Set CMP0144 since our minimum required CMake version is less than 3.27.
+        if(POLICY "CMP0144")
+            cmake_policy(SET "CMP0144" "NEW")
+        endif()
+    endif()
+endif()
+
 # Find and setup ANTLR Library
 # We build and link to the static library
 find_package(ANTLR REQUIRED)

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -263,9 +263,9 @@ if(yaml-cpp_FOUND)
     message(STATUS "Found yaml-cpp ${yaml-cpp_VERSION}")
 endif()
 
-# Add ystdlib-cpp
+# Add ystdlib
 set(YSTDLIB_CPP_BUILD_TESTING OFF)
-add_subdirectory(submodules/ystdlib-cpp EXCLUDE_FROM_ALL)
+add_subdirectory("${CLP_YSTDLIB_SOURCE_DIRECTORY}" "${CMAKE_BINARY_DIR}/ystdlib" EXCLUDE_FROM_ALL)
 
 # Find and setup ZStd Library
 if(CLP_USE_STATIC_LIBS)

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -159,6 +159,11 @@ else()
     message(FATAL_ERROR "Could not find static libraries for fmt")
 endif()
 
+find_package(log_surgeon REQUIRED)
+if(log_surgeon_FOUND)
+    message(STATUS "Found log_surgeon ${log_surgeon_VERSION}")
+endif()
+
 find_package(nlohmann_json REQUIRED)
 if(nlohmann_json_FOUND)
     message(STATUS "Found nlohmann_json ${nlohmann_json_VERSION}")
@@ -216,9 +221,6 @@ if (OPENSSL_FOUND)
 else ()
     message(FATAL_ERROR "OpenSSL not found")
 endif ()
-
-# Add log surgeon
-add_subdirectory(submodules/log-surgeon EXCLUDE_FROM_ALL)
 
 # Find and setup MariaDBClient library
 if(CLP_USE_STATIC_LIBS)

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -256,8 +256,10 @@ endif()
 
 find_package(Threads REQUIRED)
 
-# Add yaml-cpp
-add_subdirectory(submodules/yaml-cpp EXCLUDE_FROM_ALL)
+find_package(yaml-cpp REQUIRED)
+if(yaml-cpp_FOUND)
+    message(STATUS "Found yaml-cpp ${yaml-cpp_VERSION}")
+endif()
 
 # Add ystdlib-cpp
 set(YSTDLIB_CPP_BUILD_TESTING OFF)
@@ -702,7 +704,7 @@ target_link_libraries(unitTest
         ${STD_FS_LIBS}
         clp::regex_utils
         clp::string_utils
-        yaml-cpp::yaml-cpp
+        yaml-cpp
         ystdlib::containers
         ystdlib::error_handling
         ${LIBLZMA_LIBRARIES}

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -676,8 +676,8 @@ add_executable(unitTest
         )
 target_include_directories(unitTest
         PRIVATE
-        ${CLP_OUTCOME_INCLUDES_DIRECTORY}
-        ${CLP_SQLITE3_INCLUDES_DIRECTORY}
+        ${CLP_OUTCOME_INCLUDE_DIRECTORY}
+        ${CLP_SQLITE3_INCLUDE_DIRECTORY}
         )
 target_link_libraries(unitTest
         PRIVATE

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -389,6 +389,9 @@ set(SOURCE_FILES_reducer_unitTest
     )
 
 set(SOURCE_FILES_unitTest
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3ext.h"
         src/clp/aws/AwsAuthenticationSigner.cpp
         src/clp/aws/AwsAuthenticationSigner.hpp
         src/clp/aws/constants.hpp
@@ -611,9 +614,6 @@ set(SOURCE_FILES_unitTest
         src/clp/version.hpp
         src/clp/WriterInterface.cpp
         src/clp/WriterInterface.hpp
-        submodules/sqlite3/sqlite3.c
-        submodules/sqlite3/sqlite3.h
-        submodules/sqlite3/sqlite3ext.h
         tests/LogSuppressor.hpp
         tests/TestOutputCleaner.hpp
         tests/test-BoundedReader.cpp
@@ -657,6 +657,7 @@ add_executable(unitTest
 target_include_directories(unitTest
         PRIVATE
         ${CLP_OUTCOME_SOURCE_DIRECTORY}
+        ${CLP_SQLITE3_SOURCE_DIRECTORY}
         ${CMAKE_SOURCE_DIR}/submodules
         )
 target_link_libraries(unitTest

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -154,6 +154,11 @@ else()
     message(FATAL_ERROR "Could not find static libraries for fmt")
 endif()
 
+find_package(nlohmann_json REQUIRED)
+if(nlohmann_json_FOUND)
+    message(STATUS "Found nlohmann_json ${nlohmann_json_VERSION}")
+endif()
+
 # Find and setup spdlog
 if(CLP_USE_STATIC_LIBS)
     # NOTE: On some Linux distributions (e.g. Ubuntu), the spdlog package only contains a dynamic
@@ -680,6 +685,7 @@ target_link_libraries(unitTest
         LibArchive::LibArchive
         MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
+        nlohmann_json::nlohmann_json
         simdjson
         spdlog::spdlog
         sql

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -413,7 +413,6 @@ set(SOURCE_FILES_reducer_unitTest
 set(SOURCE_FILES_unitTest
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3ext.h"
         src/clp/aws/AwsAuthenticationSigner.cpp
         src/clp/aws/AwsAuthenticationSigner.hpp
         src/clp/aws/constants.hpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -98,8 +98,8 @@ endif ()
 
 if(PROJECT_IS_TOP_LEVEL)
     # Include dependency settings if the project isn't being included as a subproject.
-    # NOTE: We mark the file optional because this file is not required if the user happens to have
-    # the dependencies installed already.
+    # NOTE: We mark the file optional since it's not required if the user happens to have the
+    # dependencies installed already.
     include("${CMAKE_SOURCE_DIR}/../../build/deps/core/cmake-settings/all.cmake"
             OPTIONAL
             RESULT_VARIABLE CLP_DEPS_SETTINGS_FILE_PATH

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -113,6 +113,11 @@ if(PROJECT_IS_TOP_LEVEL)
     endif()
 endif()
 
+find_package(absl REQUIRED)
+if (absl_FOUND)
+    message(STATUS "Found absl ${absl_VERSION}")
+endif()
+
 # Find and setup ANTLR Library
 # We build and link to the static library
 find_package(ANTLR REQUIRED)
@@ -228,10 +233,6 @@ if(msgpack-cxx_FOUND)
 else()
     message(FATAL_ERROR "Could not find msgpack-cxx")
 endif()
-
-# Add abseil-cpp
-set(ABSL_PROPAGATE_CXX_STD ON)
-add_subdirectory(submodules/abseil-cpp EXCLUDE_FROM_ALL)
 
 # Add simdjson
 add_subdirectory(submodules/simdjson EXCLUDE_FROM_ALL)

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -412,7 +412,6 @@ set(SOURCE_FILES_reducer_unitTest
 
 set(SOURCE_FILES_unitTest
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
         src/clp/aws/AwsAuthenticationSigner.cpp
         src/clp/aws/AwsAuthenticationSigner.hpp
         src/clp/aws/constants.hpp
@@ -678,7 +677,7 @@ add_executable(unitTest
 target_include_directories(unitTest
         PRIVATE
         ${CLP_OUTCOME_INCLUDES_DIRECTORY}
-        ${CLP_SQLITE3_SOURCE_DIRECTORY}
+        ${CLP_SQLITE3_INCLUDES_DIRECTORY}
         )
 target_link_libraries(unitTest
         PRIVATE

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -98,8 +98,8 @@ endif ()
 
 if(PROJECT_IS_TOP_LEVEL)
     # Include dependency settings if the project isn't being included as a subproject.
-    # NOTE: We mark the file optional because if the user happens to have the dependencies
-    # installed, this file isn't necessary.
+    # NOTE: We mark the file optional because this file is not required if the user happens to have
+    # the dependencies installed already.
     include("${CMAKE_SOURCE_DIR}/../../build/deps/core/cmake-settings/all.cmake"
             OPTIONAL
             RESULT_VARIABLE CLP_DEPS_SETTINGS_FILE_PATH

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -677,7 +677,7 @@ add_executable(unitTest
         )
 target_include_directories(unitTest
         PRIVATE
-        ${CLP_OUTCOME_SOURCE_DIRECTORY}
+        ${CLP_OUTCOME_INCLUDES_DIRECTORY}
         ${CLP_SQLITE3_SOURCE_DIRECTORY}
         )
 target_link_libraries(unitTest

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -143,6 +143,11 @@ if (Catch2_FOUND)
     message(STATUS "Found Catch2 ${Catch2_VERSION}")
 endif()
 
+find_package(date REQUIRED)
+if (date_FOUND)
+    message(STATUS "Found date ${date_VERSION}")
+endif()
+
 # Find and setup fmt
 # NOTE:
 # - We only try to link to the static library
@@ -679,6 +684,7 @@ target_link_libraries(unitTest
         ${CURL_LIBRARIES}
         clp_s::search::ast
         clp_s::TimestampPattern
+        date::date
         fmt::fmt
         kql
         log_surgeon::log_surgeon

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -164,6 +164,11 @@ if(nlohmann_json_FOUND)
     message(STATUS "Found nlohmann_json ${nlohmann_json_VERSION}")
 endif()
 
+find_package(simdjson REQUIRED)
+if(simdjson_FOUND)
+    message(STATUS "Found simdjson ${simdjson_VERSION}")
+endif()
+
 # Find and setup spdlog
 if(CLP_USE_STATIC_LIBS)
     # NOTE: On some Linux distributions (e.g. Ubuntu), the spdlog package only contains a dynamic
@@ -248,9 +253,6 @@ if(msgpack-cxx_FOUND)
 else()
     message(FATAL_ERROR "Could not find msgpack-cxx")
 endif()
-
-# Add simdjson
-add_subdirectory(submodules/simdjson EXCLUDE_FROM_ALL)
 
 find_package(Threads REQUIRED)
 
@@ -692,7 +694,7 @@ target_link_libraries(unitTest
         MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
         nlohmann_json::nlohmann_json
-        simdjson
+        simdjson::simdjson
         spdlog::spdlog
         sql
         OpenSSL::Crypto

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -138,6 +138,11 @@ else()
     message(FATAL_ERROR "Could not find ${CLP_LIBS_STRING} libraries for Boost")
 endif()
 
+find_package(Catch2 REQUIRED)
+if (Catch2_FOUND)
+    message(STATUS "Found Catch2 ${Catch2_VERSION}")
+endif()
+
 # Find and setup fmt
 # NOTE:
 # - We only try to link to the static library
@@ -665,6 +670,7 @@ target_link_libraries(unitTest
         PRIVATE
         absl::flat_hash_map
         Boost::filesystem Boost::iostreams Boost::program_options Boost::regex Boost::url
+        Catch2::Catch2
         ${CURL_LIBRARIES}
         clp_s::search::ast
         clp_s::TimestampPattern

--- a/components/core/cmake/Modules/FindANTLR.cmake
+++ b/components/core/cmake/Modules/FindANTLR.cmake
@@ -10,7 +10,6 @@ endif ()
 
 set(ANTLR4_TAG 4.13.1)
 add_definitions(-DANTLR4CPP_STATIC)
-set(ANTLR_EXECUTABLE ${PROJECT_SOURCE_DIR}/third-party/antlr/antlr-${ANTLR4_TAG}-complete.jar)
 include(ExternalAntlr4Cpp)
 
 find_package(Java 11 REQUIRED COMPONENTS Runtime)

--- a/components/core/src/clp/GlobalMetadataDBConfig.cpp
+++ b/components/core/src/clp/GlobalMetadataDBConfig.cpp
@@ -1,7 +1,7 @@
 #include "GlobalMetadataDBConfig.hpp"
 
 #include <fmt/core.h>
-#include <yaml-cpp/include/yaml-cpp/yaml.h>
+#include <yaml-cpp/yaml.h>
 
 using std::exception;
 using std::invalid_argument;

--- a/components/core/src/clp/SQLiteDB.hpp
+++ b/components/core/src/clp/SQLiteDB.hpp
@@ -3,8 +3,9 @@
 
 #include <string>
 
+#include <sqlite3.h>
+
 #include "ErrorCode.hpp"
-#include "sqlite3/sqlite3.h"
 #include "SQLitePreparedStatement.hpp"
 #include "TraceableException.hpp"
 

--- a/components/core/src/clp/SQLiteDB.hpp
+++ b/components/core/src/clp/SQLiteDB.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <sqlite3.h>
+#include <sqlite3/sqlite3.h>
 
 #include "ErrorCode.hpp"
 #include "SQLitePreparedStatement.hpp"

--- a/components/core/src/clp/SQLitePreparedStatement.hpp
+++ b/components/core/src/clp/SQLitePreparedStatement.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <sqlite3/sqlite3.h>
+#include <sqlite3.h>
 
 #include "ErrorCode.hpp"
 #include "TraceableException.hpp"

--- a/components/core/src/clp/SQLitePreparedStatement.hpp
+++ b/components/core/src/clp/SQLitePreparedStatement.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <sqlite3.h>
+#include <sqlite3/sqlite3.h>
 
 #include "ErrorCode.hpp"
 #include "TraceableException.hpp"

--- a/components/core/src/clp/TimestampPattern.cpp
+++ b/components/core/src/clp/TimestampPattern.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <vector>
 
-#include <date/include/date/date.h>
+#include <date/date.h>
 
 #include "spdlog_with_specializations.hpp"
 

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -117,9 +117,9 @@ set(
         ../version.hpp
         ../WriterInterface.cpp
         ../WriterInterface.hpp
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.c"
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.h"
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3ext.h"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3ext.h"
         clg.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -130,6 +130,7 @@ target_compile_features(clg PRIVATE cxx_std_20)
 target_include_directories(clg
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
         "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(clg

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -136,6 +136,7 @@ target_include_directories(clg
 target_link_libraries(clg
         PRIVATE
         Boost::filesystem Boost::program_options
+        date::date
         fmt::fmt
         log_surgeon::log_surgeon
         MariaDBClient::MariaDBClient

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -127,8 +127,8 @@ add_executable(clg ${CLG_SOURCES})
 target_compile_features(clg PRIVATE cxx_std_20)
 target_include_directories(clg
         PRIVATE
-        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDE_DIRECTORY}"
 )
 target_link_libraries(clg
         PRIVATE

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -145,7 +145,7 @@ target_link_libraries(clg
         ${sqlite_LIBRARY_DEPENDENCIES}
         ${STD_FS_LIBS}
         clp::string_utils
-        yaml-cpp::yaml-cpp
+        yaml-cpp
         ystdlib::containers
         ZStd::ZStd
 )

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -128,7 +128,7 @@ add_executable(clg ${CLG_SOURCES})
 target_compile_features(clg PRIVATE cxx_std_20)
 target_include_directories(clg
         PRIVATE
-        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
 )
 target_link_libraries(clg

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -139,6 +139,7 @@ target_link_libraries(clg
         fmt::fmt
         log_surgeon::log_surgeon
         MariaDBClient::MariaDBClient
+        nlohmann_json::nlohmann_json
         spdlog::spdlog
         ${sqlite_LIBRARY_DEPENDENCIES}
         ${STD_FS_LIBS}

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -118,7 +118,6 @@ set(
         ../WriterInterface.cpp
         ../WriterInterface.hpp
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
         clg.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -129,7 +128,7 @@ target_compile_features(clg PRIVATE cxx_std_20)
 target_include_directories(clg
         PRIVATE
         "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
 )
 target_link_libraries(clg
         PRIVATE

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -127,7 +127,11 @@ set(
 
 add_executable(clg ${CLG_SOURCES})
 target_compile_features(clg PRIVATE cxx_std_20)
-target_include_directories(clg PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
+target_include_directories(clg
+        PRIVATE
+        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${PROJECT_SOURCE_DIR}/submodules"
+)
 target_link_libraries(clg
         PRIVATE
         Boost::filesystem Boost::program_options

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -119,7 +119,6 @@ set(
         ../WriterInterface.hpp
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3ext.h"
         clg.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -131,7 +131,6 @@ target_include_directories(clg
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
-        "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(clg
         PRIVATE

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -155,8 +155,8 @@ add_executable(clo ${CLO_SOURCES} ${REDUCER_SOURCES})
 target_compile_features(clo PRIVATE cxx_std_20)
 target_include_directories(clo
         PRIVATE
-        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDE_DIRECTORY}"
 )
 target_link_libraries(clo
         PRIVATE

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -120,7 +120,6 @@ set(
         ../WriterInterface.cpp
         ../WriterInterface.hpp
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
         clo.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -157,7 +156,7 @@ target_compile_features(clo PRIVATE cxx_std_20)
 target_include_directories(clo
         PRIVATE
         "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
 )
 target_link_libraries(clo
         PRIVATE

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -156,7 +156,7 @@ add_executable(clo ${CLO_SOURCES} ${REDUCER_SOURCES})
 target_compile_features(clo PRIVATE cxx_std_20)
 target_include_directories(clo
         PRIVATE
-        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
 )
 target_link_libraries(clo

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -164,6 +164,7 @@ target_include_directories(clo
 target_link_libraries(clo
         PRIVATE
         Boost::filesystem Boost::program_options
+        date::date
         fmt::fmt
         log_surgeon::log_surgeon
         ${MONGOCXX_TARGET}

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -121,7 +121,6 @@ set(
         ../WriterInterface.hpp
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3ext.h"
         clo.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -168,6 +168,7 @@ target_link_libraries(clo
         log_surgeon::log_surgeon
         ${MONGOCXX_TARGET}
         msgpack-cxx
+        nlohmann_json::nlohmann_json
         spdlog::spdlog
         ${sqlite_LIBRARY_DEPENDENCIES}
         ${STD_FS_LIBS}

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -119,9 +119,9 @@ set(
         ../version.hpp
         ../WriterInterface.cpp
         ../WriterInterface.hpp
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.c"
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.h"
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3ext.h"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3ext.h"
         clo.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -158,6 +158,7 @@ target_compile_features(clo PRIVATE cxx_std_20)
 target_include_directories(clo
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
         "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(clo

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -155,7 +155,11 @@ set(
 
 add_executable(clo ${CLO_SOURCES} ${REDUCER_SOURCES})
 target_compile_features(clo PRIVATE cxx_std_20)
-target_include_directories(clo PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
+target_include_directories(clo
+        PRIVATE
+        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${PROJECT_SOURCE_DIR}/submodules"
+)
 target_link_libraries(clo
         PRIVATE
         Boost::filesystem Boost::program_options

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -159,7 +159,6 @@ target_include_directories(clo
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
-        "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(clo
         PRIVATE

--- a/components/core/src/clp/clo/clo.cpp
+++ b/components/core/src/clp/clo/clo.cpp
@@ -3,8 +3,8 @@
 #include <memory>
 #include <string>
 
-#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/instance.hpp>
+#include <nlohmann/json.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "../../reducer/network_utils.hpp"

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -177,6 +177,7 @@ target_include_directories(clp
 target_link_libraries(clp
         PRIVATE
         Boost::filesystem Boost::program_options
+        date::date
         fmt::fmt
         log_surgeon::log_surgeon
         spdlog::spdlog

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -172,7 +172,6 @@ target_include_directories(clp
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
-        "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(clp
         PRIVATE

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -183,6 +183,7 @@ target_link_libraries(clp
         ${sqlite_LIBRARY_DEPENDENCIES}
         LibArchive::LibArchive
         MariaDBClient::MariaDBClient
+        nlohmann_json::nlohmann_json
         ${STD_FS_LIBS}
         clp::string_utils
         yaml-cpp::yaml-cpp

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -147,8 +147,8 @@ set(
         ../version.hpp
         ../WriterInterface.cpp
         ../WriterInterface.hpp
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.c"
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.h"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
         clp.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -171,6 +171,7 @@ target_compile_features(clp PRIVATE cxx_std_20)
 target_include_directories(clp
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
         "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(clp

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -168,7 +168,11 @@ set(
 
 add_executable(clp ${CLP_SOURCES})
 target_compile_features(clp PRIVATE cxx_std_20)
-target_include_directories(clp PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
+target_include_directories(clp
+        PRIVATE
+        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${PROJECT_SOURCE_DIR}/submodules"
+)
 target_link_libraries(clp
         PRIVATE
         Boost::filesystem Boost::program_options

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -169,8 +169,8 @@ add_executable(clp ${CLP_SOURCES})
 target_compile_features(clp PRIVATE cxx_std_20)
 target_include_directories(clp
         PRIVATE
-        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDE_DIRECTORY}"
 )
 target_link_libraries(clp
         PRIVATE

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -187,7 +187,7 @@ target_link_libraries(clp
         nlohmann_json::nlohmann_json
         ${STD_FS_LIBS}
         clp::string_utils
-        yaml-cpp::yaml-cpp
+        yaml-cpp
         ystdlib::containers
         ZStd::ZStd
 )

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -148,7 +148,6 @@ set(
         ../WriterInterface.cpp
         ../WriterInterface.hpp
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
         clp.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -171,7 +170,7 @@ target_compile_features(clp PRIVATE cxx_std_20)
 target_include_directories(clp
         PRIVATE
         "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
 )
 target_link_libraries(clp
         PRIVATE

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -170,7 +170,7 @@ add_executable(clp ${CLP_SOURCES})
 target_compile_features(clp PRIVATE cxx_std_20)
 target_include_directories(clp
         PRIVATE
-        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
 )
 target_link_libraries(clp

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include <json/single_include/nlohmann/json.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../ir/EncodedTextAst.hpp"
 #include "../time_types.hpp"

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
@@ -11,7 +11,8 @@
 #include <utility>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <outcome.hpp>
 
 #include "../ir/EncodedTextAst.hpp"

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
@@ -13,7 +13,7 @@
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../ir/EncodedTextAst.hpp"
 #include "../time_types.hpp"

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
@@ -7,7 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <outcome.hpp>
 
 #include "../time_types.hpp"

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include <nlohmann/json_fwd.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../time_types.hpp"
 #include "SchemaTree.hpp"

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include <json/single_include/nlohmann/json.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../time_types.hpp"
 #include "SchemaTree.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../../ReaderInterface.hpp"
 #include "../../time_types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include <json/single_include/nlohmann/json.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../../ReaderInterface.hpp"
 #include "../../time_types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -9,7 +9,7 @@
 #include <tuple>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 #include <outcome.hpp>
 
 #include "../../ReaderInterface.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -13,7 +13,7 @@
 
 #include <msgpack.hpp>
 #include <nlohmann/json.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../../ir/types.hpp"
 #include "../../time_types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -13,7 +13,7 @@
 
 #include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../../ir/types.hpp"
 #include "../../time_types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Serializer.cpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.cpp
@@ -11,8 +11,8 @@
 #include <utility>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
+#include <nlohmann/json.hpp>
 #include <outcome.hpp>
 
 #include "../../ir/types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -9,7 +9,7 @@
 
 #include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../../time_types.hpp"
 #include "../SchemaTree.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
+#include <nlohmann/json.hpp>
 #include <outcome.hpp>
 
 #include "../../time_types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/Serializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Serializer.hpp
@@ -9,7 +9,7 @@
 
 #include <msgpack.hpp>
 #include <nlohmann/json.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../../time_types.hpp"
 #include "../SchemaTree.hpp"

--- a/components/core/src/clp/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/encoding_methods.cpp
@@ -1,6 +1,6 @@
 #include "encoding_methods.hpp"
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../../ir/parsing.hpp"
 #include "../../ir/types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../../ErrorCode.hpp"
 #include "../../ir/EncodedTextAst.hpp"

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../../ErrorCode.hpp"
 #include "../../ir/EncodedTextAst.hpp"

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <utility>
 
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../../ReaderInterface.hpp"
 #include "../../time_types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
+++ b/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <utility>
 
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../../ReaderInterface.hpp"
 #include "../../time_types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/search/NewProjectedSchemaTreeNodeCallbackReq.hpp
+++ b/components/core/src/clp/ffi/ir_stream/search/NewProjectedSchemaTreeNodeCallbackReq.hpp
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <type_traits>
 
-#include <outcome/single-header/outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../../SchemaTree.hpp"
 

--- a/components/core/src/clp/ffi/ir_stream/utils.cpp
+++ b/components/core/src/clp/ffi/ir_stream/utils.cpp
@@ -5,7 +5,8 @@
 #include <system_error>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include "../../type_utils.hpp"
 #include "decoding_methods.hpp"

--- a/components/core/src/clp/ffi/ir_stream/utils.hpp
+++ b/components/core/src/clp/ffi/ir_stream/utils.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include <json/single_include/nlohmann/json.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../../ErrorCode.hpp"
 #include "../../ir/types.hpp"

--- a/components/core/src/clp/ffi/ir_stream/utils.hpp
+++ b/components/core/src/clp/ffi/ir_stream/utils.hpp
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 #include <outcome.hpp>
 
 #include "../../ErrorCode.hpp"

--- a/components/core/src/clp/ffi/ir_stream/utils.hpp
+++ b/components/core/src/clp/ffi/ir_stream/utils.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../../ErrorCode.hpp"
 #include "../../ir/types.hpp"

--- a/components/core/src/clp/ir/LogEventDeserializer.cpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include <json/single_include/nlohmann/json.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 #include <string_utils/string_utils.hpp>
 
 #include "../ffi/ir_stream/decoding_methods.hpp"

--- a/components/core/src/clp/ir/LogEventDeserializer.cpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 #include <string_utils/string_utils.hpp>
 
 #include "../ffi/ir_stream/decoding_methods.hpp"

--- a/components/core/src/clp/ir/LogEventDeserializer.cpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.cpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 #include <outcome.hpp>
 #include <string_utils/string_utils.hpp>
 

--- a/components/core/src/clp/ir/LogEventDeserializer.hpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.hpp
@@ -3,7 +3,7 @@
 
 #include <optional>
 
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../ReaderInterface.hpp"
 #include "../time_types.hpp"

--- a/components/core/src/clp/ir/LogEventDeserializer.hpp
+++ b/components/core/src/clp/ir/LogEventDeserializer.hpp
@@ -3,7 +3,7 @@
 
 #include <optional>
 
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../ReaderInterface.hpp"
 #include "../time_types.hpp"

--- a/components/core/src/clp/make_dictionaries_readable/CMakeLists.txt
+++ b/components/core/src/clp/make_dictionaries_readable/CMakeLists.txt
@@ -34,7 +34,6 @@ set(
         ../VariableDictionaryReader.hpp
         ../WriterInterface.cpp
         ../WriterInterface.hpp
-        "${PROJECT_SOURCE_DIR}/submodules/date/include/date/date.h"
         CommandLineArguments.cpp
         CommandLineArguments.hpp
         make-dictionaries-readable.cpp

--- a/components/core/src/clp/make_dictionaries_readable/CMakeLists.txt
+++ b/components/core/src/clp/make_dictionaries_readable/CMakeLists.txt
@@ -41,7 +41,6 @@ set(
 
 add_executable(make-dictionaries-readable ${MAKE_DICTIONARIES_READABLE_SOURCES})
 target_compile_features(make-dictionaries-readable PRIVATE cxx_std_20)
-target_include_directories(make-dictionaries-readable PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
 target_link_libraries(make-dictionaries-readable
         PRIVATE
         Boost::filesystem Boost::program_options

--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(clp::regex_utils ALIAS regex_utils)
 target_include_directories(regex_utils
         PUBLIC
         ../
+        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
         "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(regex_utils

--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(clp::regex_utils ALIAS regex_utils)
 target_include_directories(regex_utils
         PUBLIC
         ../
-        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
 )
 target_link_libraries(regex_utils
         PUBLIC

--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -16,7 +16,6 @@ target_include_directories(regex_utils
         PUBLIC
         ../
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
-        "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(regex_utils
         PUBLIC

--- a/components/core/src/clp/regex_utils/CMakeLists.txt
+++ b/components/core/src/clp/regex_utils/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(clp::regex_utils ALIAS regex_utils)
 target_include_directories(regex_utils
         PUBLIC
         ../
-        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDE_DIRECTORY}"
 )
 target_link_libraries(regex_utils
         PUBLIC

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <string_view>
 
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 #include <string_utils/string_utils.hpp>
 
 #include "constants.hpp"

--- a/components/core/src/clp/regex_utils/regex_translation_utils.cpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <string_view>
 
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 #include <string_utils/string_utils.hpp>
 
 #include "constants.hpp"

--- a/components/core/src/clp/regex_utils/regex_translation_utils.hpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <string_view>
 
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "regex_utils/RegexToWildcardTranslatorConfig.hpp"
 

--- a/components/core/src/clp/regex_utils/regex_translation_utils.hpp
+++ b/components/core/src/clp/regex_utils/regex_translation_utils.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <string_view>
 
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "regex_utils/RegexToWildcardTranslatorConfig.hpp"
 

--- a/components/core/src/clp/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/clp/streaming_archive/writer/Archive.cpp
@@ -10,9 +10,9 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <json/single_include/nlohmann/json.hpp>
 #include <log_surgeon/LogEvent.hpp>
 #include <log_surgeon/LogParser.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../../EncodedVariableInterpreter.hpp"
 #include "../../ir/types.hpp"

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -4,7 +4,7 @@
 #include <filesystem>
 #include <sstream>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../clp/streaming_archive/Constants.hpp"
 #include "archive_constants.hpp"

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -234,6 +234,7 @@ target_link_libraries(
         kql
         MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
+        nlohmann_json::nlohmann_json
         msgpack-cxx
         OpenSSL::Crypto
         simdjson

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -204,7 +204,6 @@ add_library(
         ${CLP_S_TIMESTAMP_PATTERN_SOURCES}
 )
 add_library(clp_s::TimestampPattern ALIAS clp_s_TimestampPattern)
-target_include_directories(clp_s_TimestampPattern PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
 target_compile_features(clp_s_TimestampPattern PRIVATE cxx_std_20)
 target_link_libraries(
         clp_s_TimestampPattern
@@ -246,7 +245,6 @@ target_link_libraries(
 target_include_directories(clp-s
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
-        "${PROJECT_SOURCE_DIR}/submodules"
 )
 set_target_properties(
         clp-s

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -242,7 +242,11 @@ target_link_libraries(
         ystdlib::containers
         ZStd::ZStd
 )
-target_include_directories(clp-s PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
+target_include_directories(clp-s
+        PRIVATE
+        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${PROJECT_SOURCE_DIR}/submodules"
+)
 set_target_properties(
         clp-s
         PROPERTIES

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -244,7 +244,7 @@ target_link_libraries(
 )
 target_include_directories(clp-s
         PRIVATE
-        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
 )
 set_target_properties(
         clp-s

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -239,7 +239,7 @@ target_link_libraries(
         OpenSSL::Crypto
         simdjson::simdjson
         spdlog::spdlog
-        yaml-cpp::yaml-cpp
+        yaml-cpp
         ystdlib::containers
         ZStd::ZStd
 )

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -73,7 +73,6 @@ set(
 
 set(
         CLP_S_SOURCES
-        "${PROJECT_SOURCE_DIR}/submodules/date/include/date/date.h"
         archive_constants.hpp
         ArchiveReader.cpp
         ArchiveReader.hpp
@@ -211,6 +210,7 @@ target_link_libraries(
         clp_s_TimestampPattern
         PRIVATE
         clp::string_utils
+        date::date
 )
 
 add_executable(

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -244,7 +244,7 @@ target_link_libraries(
 )
 target_include_directories(clp-s
         PRIVATE
-        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDE_DIRECTORY}"
 )
 set_target_properties(
         clp-s

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -234,8 +234,8 @@ target_link_libraries(
         kql
         MariaDBClient::MariaDBClient
         ${MONGOCXX_TARGET}
-        nlohmann_json::nlohmann_json
         msgpack-cxx
+        nlohmann_json::nlohmann_json
         OpenSSL::Crypto
         simdjson::simdjson
         spdlog::spdlog

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -237,7 +237,7 @@ target_link_libraries(
         nlohmann_json::nlohmann_json
         msgpack-cxx
         OpenSSL::Crypto
-        simdjson
+        simdjson::simdjson
         spdlog::spdlog
         yaml-cpp::yaml-cpp
         ystdlib::containers

--- a/components/core/src/clp_s/JsonConstructor.cpp
+++ b/components/core/src/clp_s/JsonConstructor.cpp
@@ -5,11 +5,11 @@
 #include <system_error>
 
 #include <fmt/core.h>
-#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/uri.hpp>
+#include <nlohmann/json.hpp>
 
 #include "archive_constants.hpp"
 #include "ErrorCode.hpp"

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -8,7 +8,7 @@
 #include <string_view>
 #include <vector>
 
-#include <date/include/date/date.h>
+#include <date/date.h>
 #include <spdlog/spdlog.h>
 #include <string_utils/string_utils.hpp>
 

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -7,8 +7,8 @@
 #include <string>
 #include <utility>
 
-#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/instance.hpp>
+#include <nlohmann/json.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
 

--- a/components/core/src/clp_s/indexer/CMakeLists.txt
+++ b/components/core/src/clp_s/indexer/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(indexer
         OpenSSL::Crypto
         simdjson::simdjson
         spdlog::spdlog
-        yaml-cpp::yaml-cpp
+        yaml-cpp
         ystdlib::containers
         ZStd::ZStd
 )

--- a/components/core/src/clp_s/indexer/CMakeLists.txt
+++ b/components/core/src/clp_s/indexer/CMakeLists.txt
@@ -82,7 +82,6 @@ set(
 
 add_executable(indexer ${INDEXER_SOURCES})
 target_compile_features(indexer PRIVATE cxx_std_20)
-target_include_directories(indexer PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
 target_link_libraries(indexer
         PRIVATE
         absl::flat_hash_map

--- a/components/core/src/clp_s/indexer/CMakeLists.txt
+++ b/components/core/src/clp_s/indexer/CMakeLists.txt
@@ -89,6 +89,7 @@ target_link_libraries(indexer
         Boost::iostreams Boost::program_options Boost::url
         ${CURL_LIBRARIES}
         clp::string_utils
+        date::date
         MariaDBClient::MariaDBClient
         OpenSSL::Crypto
         simdjson

--- a/components/core/src/clp_s/indexer/CMakeLists.txt
+++ b/components/core/src/clp_s/indexer/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(indexer
         date::date
         MariaDBClient::MariaDBClient
         OpenSSL::Crypto
-        simdjson
+        simdjson::simdjson
         spdlog::spdlog
         yaml-cpp::yaml-cpp
         ystdlib::containers

--- a/components/core/src/clp_s/search/ast/CMakeLists.txt
+++ b/components/core/src/clp_s/search/ast/CMakeLists.txt
@@ -55,7 +55,6 @@ add_library(
     ${CLP_S_CORE_SOURCES}
 )
 add_library(clp_s::search::ast ALIAS clp_s_search_ast)
-target_include_directories(clp_s_search_ast PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
 target_compile_features(clp_s_search_ast PRIVATE cxx_std_20)
 target_link_libraries(
     clp_s_search_ast

--- a/components/core/src/clp_s/search/ast/CMakeLists.txt
+++ b/components/core/src/clp_s/search/ast/CMakeLists.txt
@@ -62,5 +62,5 @@ target_link_libraries(
     PUBLIC
     clp_s::TimestampPattern
     PRIVATE
-    simdjson
+    simdjson::simdjson
 )

--- a/components/core/src/glt/GlobalMetadataDBConfig.cpp
+++ b/components/core/src/glt/GlobalMetadataDBConfig.cpp
@@ -1,7 +1,7 @@
 #include "GlobalMetadataDBConfig.hpp"
 
 #include <fmt/core.h>
-#include <yaml-cpp/include/yaml-cpp/yaml.h>
+#include <yaml-cpp/yaml.h>
 
 using std::exception;
 using std::invalid_argument;

--- a/components/core/src/glt/SQLiteDB.hpp
+++ b/components/core/src/glt/SQLiteDB.hpp
@@ -3,8 +3,9 @@
 
 #include <string>
 
+#include <sqlite3.h>
+
 #include "ErrorCode.hpp"
-#include "sqlite3/sqlite3.h"
 #include "SQLitePreparedStatement.hpp"
 #include "TraceableException.hpp"
 

--- a/components/core/src/glt/SQLiteDB.hpp
+++ b/components/core/src/glt/SQLiteDB.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <sqlite3.h>
+#include <sqlite3/sqlite3.h>
 
 #include "ErrorCode.hpp"
 #include "SQLitePreparedStatement.hpp"

--- a/components/core/src/glt/SQLitePreparedStatement.hpp
+++ b/components/core/src/glt/SQLitePreparedStatement.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <sqlite3/sqlite3.h>
+#include <sqlite3.h>
 
 #include "ErrorCode.hpp"
 #include "TraceableException.hpp"

--- a/components/core/src/glt/SQLitePreparedStatement.hpp
+++ b/components/core/src/glt/SQLitePreparedStatement.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <sqlite3.h>
+#include <sqlite3/sqlite3.h>
 
 #include "ErrorCode.hpp"
 #include "TraceableException.hpp"

--- a/components/core/src/glt/TimestampPattern.cpp
+++ b/components/core/src/glt/TimestampPattern.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <vector>
 
-#include <date/include/date/date.h>
+#include <date/date.h>
 
 #include "spdlog_with_specializations.hpp"
 

--- a/components/core/src/glt/ffi/ir_stream/encoding_methods.cpp
+++ b/components/core/src/glt/ffi/ir_stream/encoding_methods.cpp
@@ -1,6 +1,6 @@
 #include "encoding_methods.hpp"
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../../ir/parsing.hpp"
 #include "../../ir/types.hpp"

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -151,8 +151,8 @@ set(
         ../version.hpp
         ../WriterInterface.cpp
         ../WriterInterface.hpp
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.c"
-        "${PROJECT_SOURCE_DIR}/submodules/sqlite3/sqlite3.h"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
         glt.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -177,6 +177,7 @@ target_compile_features(glt PRIVATE cxx_std_20)
 target_include_directories(glt
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
         "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(glt

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -175,8 +175,8 @@ add_executable(glt ${GLT_SOURCES})
 target_compile_features(glt PRIVATE cxx_std_20)
 target_include_directories(glt
         PRIVATE
-        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDE_DIRECTORY}"
 )
 target_link_libraries(glt
         PRIVATE

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -174,7 +174,11 @@ set(
 
 add_executable(glt ${GLT_SOURCES})
 target_compile_features(glt PRIVATE cxx_std_20)
-target_include_directories(glt PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
+target_include_directories(glt
+        PRIVATE
+        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${PROJECT_SOURCE_DIR}/submodules"
+)
 target_link_libraries(glt
         PRIVATE
         Boost::filesystem Boost::iostreams Boost::program_options

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -183,6 +183,7 @@ target_include_directories(glt
 target_link_libraries(glt
         PRIVATE
         Boost::filesystem Boost::iostreams Boost::program_options
+        date::date
         fmt::fmt
         spdlog::spdlog
         ${sqlite_LIBRARY_DEPENDENCIES}

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -188,6 +188,7 @@ target_link_libraries(glt
         ${sqlite_LIBRARY_DEPENDENCIES}
         LibArchive::LibArchive
         MariaDBClient::MariaDBClient
+        nlohmann_json::nlohmann_json
         ${STD_FS_LIBS}
         clp::string_utils
         yaml-cpp::yaml-cpp

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -178,7 +178,6 @@ target_include_directories(glt
         PRIVATE
         "${CLP_OUTCOME_SOURCE_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
-        "${PROJECT_SOURCE_DIR}/submodules"
 )
 target_link_libraries(glt
         PRIVATE

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -176,7 +176,7 @@ add_executable(glt ${GLT_SOURCES})
 target_compile_features(glt PRIVATE cxx_std_20)
 target_include_directories(glt
         PRIVATE
-        "${CLP_OUTCOME_SOURCE_DIRECTORY}"
+        "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
         "${CLP_SQLITE3_SOURCE_DIRECTORY}"
 )
 target_link_libraries(glt

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -192,7 +192,7 @@ target_link_libraries(glt
         nlohmann_json::nlohmann_json
         ${STD_FS_LIBS}
         clp::string_utils
-        yaml-cpp::yaml-cpp
+        yaml-cpp
         ZStd::ZStd
 )
 # Put the built executable at the root of the build directory

--- a/components/core/src/glt/glt/CMakeLists.txt
+++ b/components/core/src/glt/glt/CMakeLists.txt
@@ -152,7 +152,6 @@ set(
         ../WriterInterface.cpp
         ../WriterInterface.hpp
         "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.c"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}/sqlite3.h"
         glt.cpp
         CommandLineArguments.cpp
         CommandLineArguments.hpp
@@ -177,7 +176,7 @@ target_compile_features(glt PRIVATE cxx_std_20)
 target_include_directories(glt
         PRIVATE
         "${CLP_OUTCOME_INCLUDES_DIRECTORY}"
-        "${CLP_SQLITE3_SOURCE_DIRECTORY}"
+        "${CLP_SQLITE3_INCLUDES_DIRECTORY}"
 )
 target_link_libraries(glt
         PRIVATE

--- a/components/core/src/glt/ir/LogEventDeserializer.cpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include <json/single_include/nlohmann/json.hpp>
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 #include <string_utils/string_utils.hpp>
 
 #include "../ffi/ir_stream/decoding_methods.hpp"

--- a/components/core/src/glt/ir/LogEventDeserializer.cpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 #include <string_utils/string_utils.hpp>
 
 #include "../ffi/ir_stream/decoding_methods.hpp"

--- a/components/core/src/glt/ir/LogEventDeserializer.cpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.cpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 #include <outcome.hpp>
 #include <string_utils/string_utils.hpp>
 

--- a/components/core/src/glt/ir/LogEventDeserializer.hpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.hpp
@@ -3,7 +3,7 @@
 
 #include <optional>
 
-#include <outcome/single-header/outcome.hpp>
+#include <outcome.hpp>
 
 #include "../ReaderInterface.hpp"
 #include "../TimestampPattern.hpp"

--- a/components/core/src/glt/ir/LogEventDeserializer.hpp
+++ b/components/core/src/glt/ir/LogEventDeserializer.hpp
@@ -3,7 +3,7 @@
 
 #include <optional>
 
-#include <outcome.hpp>
+#include <outcome/outcome.hpp>
 
 #include "../ReaderInterface.hpp"
 #include "../TimestampPattern.hpp"

--- a/components/core/src/glt/streaming_archive/writer/Archive.cpp
+++ b/components/core/src/glt/streaming_archive/writer/Archive.cpp
@@ -10,7 +10,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../../EncodedVariableInterpreter.hpp"
 #include "../../ir/types.hpp"

--- a/components/core/src/reducer/CMakeLists.txt
+++ b/components/core/src/reducer/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(reducer-server
         fmt::fmt
         ${MONGOCXX_TARGET}
         msgpack-cxx
+        nlohmann_json::nlohmann_json
         spdlog::spdlog
 )
 # Put the built executable at the root of the build directory

--- a/components/core/src/reducer/CMakeLists.txt
+++ b/components/core/src/reducer/CMakeLists.txt
@@ -40,7 +40,6 @@ set(
 
 add_executable(reducer-server ${REDUCER_SOURCES})
 target_compile_features(reducer-server PRIVATE cxx_std_20)
-target_include_directories(reducer-server PRIVATE "${PROJECT_SOURCE_DIR}/submodules")
 target_link_libraries(reducer-server
         PRIVATE
         Boost::program_options

--- a/components/core/src/reducer/DeserializedRecordGroup.cpp
+++ b/components/core/src/reducer/DeserializedRecordGroup.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace reducer {
 DeserializedRecordGroup::DeserializedRecordGroup(std::vector<uint8_t>& serialized_data)

--- a/components/core/src/reducer/DeserializedRecordGroup.hpp
+++ b/components/core/src/reducer/DeserializedRecordGroup.hpp
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "ConstRecordIterator.hpp"
 #include "JsonArrayRecordIterator.hpp"

--- a/components/core/src/reducer/JsonArrayRecordIterator.hpp
+++ b/components/core/src/reducer/JsonArrayRecordIterator.hpp
@@ -1,7 +1,7 @@
 #ifndef REDUCER_JSONARRAYRECORDITERATOR_HPP
 #define REDUCER_JSONARRAYRECORDITERATOR_HPP
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "ConstRecordIterator.hpp"
 #include "JsonRecord.hpp"

--- a/components/core/src/reducer/JsonRecord.hpp
+++ b/components/core/src/reducer/JsonRecord.hpp
@@ -1,7 +1,7 @@
 #ifndef REDUCER_JSONRECORD_HPP
 #define REDUCER_JSONRECORD_HPP
 
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "Record.hpp"
 

--- a/components/core/src/reducer/ServerContext.cpp
+++ b/components/core/src/reducer/ServerContext.cpp
@@ -1,7 +1,6 @@
 #include "ServerContext.hpp"
 
 #include <bsoncxx/builder/stream/document.hpp>
-#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/bulk_write.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
@@ -10,6 +9,7 @@
 #include <mongocxx/model/replace_one.hpp>
 #include <mongocxx/uri.hpp>
 #include <msgpack.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../clp/spdlog_with_specializations.hpp"
 #include "CommandLineArguments.hpp"

--- a/components/core/src/reducer/ServerContext.hpp
+++ b/components/core/src/reducer/ServerContext.hpp
@@ -5,9 +5,9 @@
 #include <set>
 
 #include <boost/asio.hpp>
-#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../clp/TraceableException.hpp"
 #include "CommandLineArguments.hpp"

--- a/components/core/src/reducer/reducer_server.cpp
+++ b/components/core/src/reducer/reducer_server.cpp
@@ -4,9 +4,9 @@
 #include <utility>
 
 #include <boost/asio.hpp>
-#include <json/single_include/nlohmann/json.hpp>
 #include <mongocxx/instance.hpp>
 #include <msgpack.hpp>
+#include <nlohmann/json.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "../clp/spdlog_with_specializations.hpp"

--- a/components/core/tests/test-BoundedReader.cpp
+++ b/components/core/tests/test-BoundedReader.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <string_view>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/BoundedReader.hpp"
 #include "../src/clp/ErrorCode.hpp"

--- a/components/core/tests/test-BufferedFileReader.cpp
+++ b/components/core/tests/test-BufferedFileReader.cpp
@@ -1,7 +1,7 @@
 #include <array>
 
 #include <boost/filesystem.hpp>
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/BufferedFileReader.hpp"
 #include "../src/clp/FileReader.hpp"

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -1,6 +1,6 @@
 #include <unistd.h>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/EncodedVariableInterpreter.hpp"
 #include "../src/clp/ir/types.hpp"

--- a/components/core/tests/test-FileDescriptorReader.cpp
+++ b/components/core/tests/test-FileDescriptorReader.cpp
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <ystdlib/containers/Array.hpp>
 
 #include "../src/clp/FileDescriptorReader.hpp"

--- a/components/core/tests/test-Grep.cpp
+++ b/components/core/tests/test-Grep.cpp
@@ -1,6 +1,6 @@
 #include <string>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <log_surgeon/Lexer.hpp>
 #include <log_surgeon/SchemaParser.hpp>
 

--- a/components/core/tests/test-MemoryMappedFile.cpp
+++ b/components/core/tests/test-MemoryMappedFile.cpp
@@ -4,7 +4,7 @@
 #include <filesystem>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/FileReader.hpp"
 #include "../src/clp/ReaderInterface.hpp"

--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <curl/curl.h>
 #include <fmt/core.h>
 #include <json/single_include/nlohmann/json.hpp>

--- a/components/core/tests/test-NetworkReader.cpp
+++ b/components/core/tests/test-NetworkReader.cpp
@@ -12,7 +12,7 @@
 #include <catch2/catch.hpp>
 #include <curl/curl.h>
 #include <fmt/core.h>
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 #include <ystdlib/containers/Array.hpp>
 
 #include "../src/clp/CurlDownloadHandler.hpp"

--- a/components/core/tests/test-ParserWithUserSchema.cpp
+++ b/components/core/tests/test-ParserWithUserSchema.cpp
@@ -7,7 +7,7 @@
 #include <utility>
 
 #include <boost/filesystem.hpp>
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <log_surgeon/LogParser.hpp>
 
 #include "../src/clp/clp/run.hpp"

--- a/components/core/tests/test-SQLiteDB.cpp
+++ b/components/core/tests/test-SQLiteDB.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <fmt/core.h>
 #include <fmt/format.h>
 

--- a/components/core/tests/test-Segment.cpp
+++ b/components/core/tests/test-Segment.cpp
@@ -1,7 +1,7 @@
 #include <unistd.h>
 
 #include <boost/filesystem.hpp>
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/streaming_archive/reader/Segment.hpp"
 #include "../src/clp/streaming_archive/writer/Segment.hpp"

--- a/components/core/tests/test-Stopwatch.cpp
+++ b/components/core/tests/test-Stopwatch.cpp
@@ -1,6 +1,6 @@
 #include <unistd.h>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/Stopwatch.hpp"
 

--- a/components/core/tests/test-StreamingCompression.cpp
+++ b/components/core/tests/test-StreamingCompression.cpp
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include <boost/filesystem/operations.hpp>
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <ystdlib/containers/Array.hpp>
 #include <zstd.h>
 

--- a/components/core/tests/test-TimestampPattern.cpp
+++ b/components/core/tests/test-TimestampPattern.cpp
@@ -1,4 +1,4 @@
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/TimestampPattern.hpp"
 

--- a/components/core/tests/test-Utils.cpp
+++ b/components/core/tests/test-Utils.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/range/combine.hpp>
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/Utils.hpp"
 

--- a/components/core/tests/test-clp_s-end_to_end.cpp
+++ b/components/core/tests/test-clp_s-end_to_end.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <string_view>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <fmt/format.h>
 
 #include "../src/clp_s/InputConfig.hpp"

--- a/components/core/tests/test-clp_s-search.cpp
+++ b/components/core/tests/test-clp_s-search.cpp
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <fmt/format.h>
 #include <json/single_include/nlohmann/json.hpp>
 

--- a/components/core/tests/test-clp_s-search.cpp
+++ b/components/core/tests/test-clp_s-search.cpp
@@ -11,7 +11,7 @@
 
 #include <catch2/catch.hpp>
 #include <fmt/format.h>
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../src/clp_s/ArchiveReader.hpp"
 #include "../src/clp_s/InputConfig.hpp"

--- a/components/core/tests/test-encoding_methods.cpp
+++ b/components/core/tests/test-encoding_methods.cpp
@@ -1,4 +1,4 @@
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/ffi/encoding_methods.hpp"
 #include "../src/clp/ir/types.hpp"

--- a/components/core/tests/test-ffi_IrUnitHandlerInterface.cpp
+++ b/components/core/tests/test-ffi_IrUnitHandlerInterface.cpp
@@ -3,7 +3,7 @@
 #include <string_view>
 #include <utility>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/ffi/ir_stream/decoding_methods.hpp"
 #include "../src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp"

--- a/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
+++ b/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
@@ -10,7 +10,7 @@
 #include <variant>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <json/single_include/nlohmann/json.hpp>
 
 #include "../src/clp/ffi/encoding_methods.hpp"

--- a/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
+++ b/components/core/tests/test-ffi_KeyValuePairLogEvent.cpp
@@ -11,7 +11,8 @@
 #include <vector>
 
 #include <catch2/catch.hpp>
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include "../src/clp/ffi/encoding_methods.hpp"
 #include "../src/clp/ffi/KeyValuePairLogEvent.hpp"

--- a/components/core/tests/test-ffi_SchemaTree.cpp
+++ b/components/core/tests/test-ffi_SchemaTree.cpp
@@ -1,6 +1,6 @@
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <msgpack.hpp>
 
 #include "../src/clp/ffi/SchemaTree.hpp"

--- a/components/core/tests/test-hash_utils.cpp
+++ b/components/core/tests/test-hash_utils.cpp
@@ -1,7 +1,7 @@
 #include <string_view>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/ErrorCode.hpp"
 #include "../src/clp/hash_utils.hpp"

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include <catch2/catch.hpp>
-#include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../src/clp/BufferReader.hpp"
 #include "../src/clp/ErrorCode.hpp"

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -12,7 +12,7 @@
 #include <utility>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <json/single_include/nlohmann/json.hpp>
 #include <msgpack.hpp>
 

--- a/components/core/tests/test-ir_parsing.cpp
+++ b/components/core/tests/test-ir_parsing.cpp
@@ -1,4 +1,4 @@
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/ir/parsing.hpp"
 #include "../src/clp/ir/types.hpp"

--- a/components/core/tests/test-ir_serializer.cpp
+++ b/components/core/tests/test-ir_serializer.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/ffi/ir_stream/decoding_methods.hpp"
 #include "../src/clp/ir/constants.hpp"

--- a/components/core/tests/test-kql.cpp
+++ b/components/core/tests/test-kql.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
 

--- a/components/core/tests/test-main.cpp
+++ b/components/core/tests/test-main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>

--- a/components/core/tests/test-math_utils.cpp
+++ b/components/core/tests/test-math_utils.cpp
@@ -1,4 +1,4 @@
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/math_utils.hpp"
 

--- a/components/core/tests/test-query_methods.cpp
+++ b/components/core/tests/test-query_methods.cpp
@@ -1,6 +1,6 @@
 #include <unordered_map>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp/ffi/encoding_methods.hpp"
 #include "../src/clp/ffi/search/ExactVariableToken.hpp"

--- a/components/core/tests/test-regex_utils.cpp
+++ b/components/core/tests/test-regex_utils.cpp
@@ -1,6 +1,6 @@
 #include <string>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <regex_utils/ErrorCode.hpp>
 #include <regex_utils/regex_translation_utils.hpp>
 #include <regex_utils/RegexToWildcardTranslatorConfig.hpp>

--- a/components/core/tests/test-sql.cpp
+++ b/components/core/tests/test-sql.cpp
@@ -1,7 +1,7 @@
 #include <memory>
 #include <sstream>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../src/clp_s/search/ast/EmptyExpr.hpp"
 #include "../src/clp_s/search/sql/sql.hpp"

--- a/components/core/tests/test-string_utils.cpp
+++ b/components/core/tests/test-string_utils.cpp
@@ -2,7 +2,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/range/combine.hpp>
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <string_utils/string_utils.hpp>
 
 using clp::string_utils::clean_up_wildcard_search_string;

--- a/components/core/tests/test-utf8_utils.cpp
+++ b/components/core/tests/test-utf8_utils.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include <catch2/catch.hpp>
-#include <json/single_include/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "../src/clp/ffi/utils.hpp"
 #include "../src/clp/utf8_utils.hpp"

--- a/components/core/tests/test-utf8_utils.cpp
+++ b/components/core/tests/test-utf8_utils.cpp
@@ -7,7 +7,7 @@
 #include <string_view>
 #include <vector>
 
-#include <Catch2/single_include/catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <json/single_include/nlohmann/json.hpp>
 
 #include "../src/clp/ffi/utils.hpp"

--- a/components/core/tools/scripts/lib_install/centos-stream-9/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/centos-stream-9/install-prebuilt-packages.sh
@@ -20,4 +20,6 @@ dnf install -y \
     mariadb-connector-c-devel \
     openssl-devel \
     python3-pip \
+    unzip \
+    xz \
     xz-devel

--- a/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-focal/install-prebuilt-packages.sh
@@ -28,6 +28,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   pkg-config \
   python3 \
   python3-pip \
+  unzip \
   zlib1g-dev
 
 # Add alternatives for cpp-10, gcc-10, and g++-10

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
@@ -25,4 +25,5 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   python3 \
   python3-pip \
   python3-venv \
-  software-properties-common
+  software-properties-common \
+  unzip

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -27,7 +27,7 @@ vars:
   G_WEBUI_BUILD_DIR: "{{.G_BUILD_DIR}}/webui"
 
   # Taskfile paths
-  G_UTILS_TASKFILE: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/utils.yaml"
+  G_UTILS_TASKFILE: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
   # Versions
   G_PACKAGE_VERSION: "0.2.0-dev"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -1,7 +1,7 @@
 version: "3"
 
 includes:
-  deps: "taskfiles/deps.yaml"
+  deps: "taskfiles/deps/main.yaml"
   docs: "taskfiles/docs.yaml"
   lint: "taskfiles/lint.yaml"
   utils: "tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -222,6 +222,8 @@ tasks:
       ZIP_FILENAME_STEM: "sqlite-amalgamation-3360000"
       SRC_DIR: "{{.EXTRACTION_DIR}}/{{.ZIP_FILENAME_STEM}}"
     run: "once"
+    deps:
+      - task: "utils:init"
     cmds:
       - task: "yscope-dev-utils:remote:download-and-extract-zip"
         vars:
@@ -244,6 +246,8 @@ tasks:
       LIB_NAME: "utfcpp"
       UTFCPP_OUTPUT_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
     run: "once"
+    deps:
+      - task: "utils:init"
     cmds:
       - task: "yscope-dev-utils:remote:download-and-extract-tar"
         vars:

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -14,6 +14,10 @@ vars:
   G_DEPS_CORE_CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/all.md5"
   G_DEPS_LOG_VIEWER_CHECKSUM_FILE: "{{.G_DEPS_DIR}}/log-viewer.md5"
 
+  # NOTE: These must be kept in-sync with their usage in components/core/CMakeLists.txt
+  G_DEPS_CORE_CMAKE_SETTINGS_DIR: "{{.G_DEPS_CORE_DIR}}/cmake-settings"
+  G_DEPS_CORE_CMAKE_SETTINGS_FILE: "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/all.cmake"
+
   # Utility script path
   G_DEP_DOWNLOAD_SCRIPT: "{{.ROOT_DIR}}/tools/scripts/deps-download/download-dep.py"
 
@@ -28,7 +32,12 @@ tasks:
       - "utils:clean-old-core-checksum-files"
       - "utils:init"
     cmds:
-      - task: "all-internal-deps"
+      - "rm -rf '{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}'"
+      - "mkdir -p '{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}'"
+      - task: "yscope-dev-utils:cmake:install-deps-and-generate-settings"
+        vars:
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}"
+          DEP_TASK: "all-internal-deps"
       - task: "utils:combine-core-checksum-files"
 
   log-viewer:
@@ -61,7 +70,7 @@ tasks:
     run: "once"
     cmds:
       - task: "abseil-cpp"
-      - task: "antlr4"
+      - task: "antlr"
       - task: "Catch2"
       - task: "date"
       - task: "json"
@@ -103,36 +112,39 @@ tasks:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           INCLUDE_PATTERNS: ["{{.DEST}}"]
 
-  antlr4:
+  antlr:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/antlr4.md5"
-      DEST_DIR: "{{.G_CORE_COMPONENT_DIR}}/third-party/antlr"
-      DEST: "{{.DEST_DIR}}/antlr-4.13.1-complete.jar"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
+      DEP_NAME: "antlr"
+
+      # Paths
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.DEP_NAME}}.md5"
+      OUTPUT_FILE: "{{.G_DEPS_CORE_DIR}}/antlr-4.13.1-complete.jar"
+    run: "once"
     deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
+      - task: "yscope-dev-utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST_DIR}}"]
+          INCLUDE_PATTERNS:
+            - "{{.OUTPUT_FILE}}"
+      - task: "utils:init"
     cmds:
-      - task: "download-dependency"
+      - task: "yscope-dev-utils:remote:curl"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--no-submodule"
-          SRC_NAME: "antlr-4.13.1-complete.jar"
-          SRC_URL: "https://www.antlr.org/download/antlr-4.13.1-complete.jar"
+          FILE_SHA256: "bc13a9c57a8dd7d5196888211e5ede657cb64a3ce968608697e4f668251a8487"
+          OUTPUT_FILE: "{{.OUTPUT_FILE}}"
+          URL: "https://www.antlr.org/download/antlr-4.13.1-complete.jar"
+      - >-
+        echo "set(
+        ANTLR_EXECUTABLE \"{{.OUTPUT_FILE}}\"
+        )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.DEP_NAME}}.cmake"
+
       # This command must be last
-      - task: ":utils:checksum:compute"
+      - task: "yscope-dev-utils:checksum:compute"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST_DIR}}"]
+          INCLUDE_PATTERNS:
+            - "{{.OUTPUT_FILE}}"
 
   Catch2:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -18,9 +18,6 @@ vars:
   G_DEPS_CORE_CMAKE_SETTINGS_DIR: "{{.G_DEPS_CORE_DIR}}/cmake-settings"
   G_DEPS_CORE_CMAKE_SETTINGS_FILE: "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/all.cmake"
 
-  # Utility script path
-  G_DEP_DOWNLOAD_SCRIPT: "{{.ROOT_DIR}}/tools/scripts/deps-download/download-dep.py"
-
 tasks:
   default:
     deps:
@@ -294,19 +291,3 @@ tasks:
         echo "set(
         CLP_YSTDLIB_SOURCE_DIRECTORY \"{{.YSTDLIB_OUTPUT_DIR}}\"
         )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
-
-
-  download-dependency:
-    internal: true
-    label: "{{.TASK}}-{{.SRC_NAME}}"
-    requires:
-      vars: ["DEST", "FLAGS", "SRC_NAME", "SRC_URL"]
-    deps:
-      - "utils:init"
-    cmds:
-      - >-
-        python3 "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-        "{{.SRC_URL}}"
-        {{.SRC_NAME}}
-        "{{.DEST}}"
-        {{.FLAGS}}

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -171,7 +171,11 @@ tasks:
     internal: true
     vars:
       LIB_NAME: "outcome"
-      OUTPUT_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
+
+      # Paths
+      INSTALL_INCLUDES_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install/includes"
+      INSTALL_SYMLINK: "{{.INSTALL_INCLUDES_DIR}}/{{.LIB_NAME}}"
+      SRC_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
     run: "once"
     deps:
       - task: "utils:init"
@@ -182,13 +186,15 @@ tasks:
           FILE_SHA256: "9588c01465b287296ab647b2caf50d5137e3eeaf662e3105b858d5c5c7579428"
           INCLUDE_PATTERNS:
             - "outcome/single-header"
-          NUM_COMPONENTS_TO_STRIP: 2
-          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_DIR: "{{.SRC_DIR}}"
           URL: "https://github.com/ned14/outcome/releases/download/v2.2.9\
           /outcome-v2-all-sources-571f9c930e672950e99d5d30f743603aaaf8014c.tar.xz"
+      - "mkdir -p '{{.INSTALL_INCLUDES_DIR}}'"
+      - "rm -f '{{.INSTALL_SYMLINK}}'"
+      - "ln -s '{{.SRC_DIR}}/single-header' '{{.INSTALL_SYMLINK}}'"
       - >-
         echo "set(
-        CLP_OUTCOME_INCLUDES_DIRECTORY \"{{.OUTPUT_DIR}}\"
+        CLP_OUTCOME_INCLUDES_DIRECTORY \"{{.INSTALL_INCLUDES_DIR}}\"
         )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   simdjson:

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -71,7 +71,7 @@ tasks:
     cmds:
       - task: "absl"
       - task: "antlr"
-      - task: "Catch2"
+      - task: "catch2"
       - task: "date"
       - task: "json"
       - task: "log-surgeon"
@@ -130,35 +130,19 @@ tasks:
           INCLUDE_PATTERNS:
             - "{{.OUTPUT_FILE}}"
 
-  Catch2:
+  catch2:
     internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/Catch2.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/Catch2"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "utils:install-remote-cmake-lib"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "Catch2-2.13.7"
-          SRC_URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.7.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CMAKE_GEN_ARGS:
+            - "-DBUILD_TESTING=OFF"
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+          LIB_NAME: "Catch2"
+          TARBALL_SHA256: "3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae"
+          TARBALL_URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.7.tar.gz"
 
   date:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -1,7 +1,7 @@
 version: "3"
 
 includes:
-  yscope-dev-utils: "../tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
+  yscope-dev-utils: "../../tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
 vars:
   # Utility script path

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -164,8 +164,12 @@ tasks:
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
             - "-DJSON_BuildTests=OFF"
           LIB_NAME: "nlohmann_json"
-          TARBALL_SHA256: "d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d"
-          TARBALL_URL: "https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz"
+          TARBALL_SHA256: "0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406"
+
+          # NOTE: We use the GitHub-generated source tarball for this version rather than the
+          # release tarball, since the latter is served from githubusercontent.com which is blocked
+          # by some developer's firewalls. The contents of the former are a superset of the latter.
+          TARBALL_URL: "https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz"
 
   outcome:
     internal: true
@@ -187,6 +191,11 @@ tasks:
           INCLUDE_PATTERNS:
             - "*/single-header"
           OUTPUT_DIR: "{{.SRC_DIR}}"
+
+          # NOTE: We use the GitHub-generated source tarball for this version rather than the
+          # release tarball, since the latter is served from githubusercontent.com which is blocked
+          # by some developer's firewalls. The source files we use are identical between the two
+          # tarballs.
           URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.9.tar.gz"
       - "mkdir -p '{{.INSTALL_INCLUDE_DIR}}'"
       - "rm -f '{{.INSTALL_SYMLINK}}'"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -146,33 +146,16 @@ tasks:
 
   date:
     internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/date.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/date"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "utils:install-remote-cmake-lib"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "date-3.0.1"
-          SRC_URL: "https://github.com/HowardHinnant/date/archive/refs/tags/v3.0.1.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CMAKE_GEN_ARGS:
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+          LIB_NAME: "date"
+          TARBALL_SHA256: "7a390f200f0ccd207e8cff6757e04817c1a0aec3e327b006b7eb451c57ee3538"
+          TARBALL_URL: "https://github.com/HowardHinnant/date/archive/refs/tags/v3.0.1.tar.gz"
 
   log-surgeon:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -14,9 +14,8 @@ vars:
   G_DEPS_CORE_CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/all.md5"
   G_DEPS_LOG_VIEWER_CHECKSUM_FILE: "{{.G_DEPS_DIR}}/log-viewer.md5"
 
-  # NOTE: These must be kept in-sync with their usage in components/core/CMakeLists.txt
+  # NOTE: This must be kept in-sync with its usage in components/core/CMakeLists.txt
   G_DEPS_CORE_CMAKE_SETTINGS_DIR: "{{.G_DEPS_CORE_DIR}}/cmake-settings"
-  G_DEPS_CORE_CMAKE_SETTINGS_FILE: "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/all.cmake"
 
 tasks:
   default:

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -280,33 +280,17 @@ tasks:
 
   yaml-cpp:
     internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/yaml-cpp.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/yaml-cpp"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "utils:install-remote-cmake-lib"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "yaml-cpp-yaml-cpp-0.7.0"
-          SRC_URL: "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CMAKE_GEN_ARGS:
+            - "-DBUILD_TESTING=OFF"
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+          LIB_NAME: "yaml-cpp"
+          TARBALL_SHA256: "43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3"
+          TARBALL_URL: "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz"
 
   ystdlib-cpp:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -26,7 +26,7 @@ tasks:
 
   core:
     deps:
-      - "utils:clean-old-core-checksum-files"
+      - "utils:clean-outdated-core-checksum-files"
       - "utils:init"
     cmds:
       - "rm -rf '{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}'"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -173,8 +173,8 @@ tasks:
       LIB_NAME: "outcome"
 
       # Paths
-      INSTALL_INCLUDES_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install/includes"
-      INSTALL_SYMLINK: "{{.INSTALL_INCLUDES_DIR}}/{{.LIB_NAME}}"
+      INSTALL_INCLUDE_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install/include"
+      INSTALL_SYMLINK: "{{.INSTALL_INCLUDE_DIR}}/{{.LIB_NAME}}"
       SRC_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
     run: "once"
     deps:
@@ -188,12 +188,12 @@ tasks:
             - "*/single-header"
           OUTPUT_DIR: "{{.SRC_DIR}}"
           URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.9.tar.gz"
-      - "mkdir -p '{{.INSTALL_INCLUDES_DIR}}'"
+      - "mkdir -p '{{.INSTALL_INCLUDE_DIR}}'"
       - "rm -f '{{.INSTALL_SYMLINK}}'"
       - "ln -s '{{.SRC_DIR}}/single-header' '{{.INSTALL_SYMLINK}}'"
       - >-
         echo "set(
-        CLP_OUTCOME_INCLUDES_DIRECTORY \"{{.INSTALL_INCLUDES_DIR}}\"
+        CLP_OUTCOME_INCLUDE_DIRECTORY \"{{.INSTALL_INCLUDE_DIR}}\"
         )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   simdjson:
@@ -216,8 +216,8 @@ tasks:
 
       # Paths
       EXTRACTION_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
-      INSTALL_INCLUDES_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install/includes"
-      INSTALL_SYMLINK: "{{.INSTALL_INCLUDES_DIR}}/{{.LIB_NAME}}"
+      INSTALL_INCLUDE_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install/include"
+      INSTALL_SYMLINK: "{{.INSTALL_INCLUDE_DIR}}/{{.LIB_NAME}}"
       ZIP_FILENAME_STEM: "sqlite-amalgamation-3360000"
       SRC_DIR: "{{.EXTRACTION_DIR}}/{{.ZIP_FILENAME_STEM}}"
     run: "once"
@@ -230,13 +230,13 @@ tasks:
           FILE_SHA256: "999826fe4c871f18919fdb8ed7ec9dd8217180854dd1fe21eea96aed36186729"
           OUTPUT_DIR: "{{.EXTRACTION_DIR}}"
           URL: "https://www.sqlite.org/2021/{{.ZIP_FILENAME_STEM}}.zip"
-      - "mkdir -p '{{.INSTALL_INCLUDES_DIR}}'"
+      - "mkdir -p '{{.INSTALL_INCLUDE_DIR}}'"
       - "rm -f '{{.INSTALL_SYMLINK}}'"
       - "ln -s '{{.SRC_DIR}}' '{{.INSTALL_SYMLINK}}'"
       - |-
         echo "set(CLP_SQLITE3_SOURCE_DIRECTORY \"{{.SRC_DIR}}\")" \
         > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
-        echo "set(CLP_SQLITE3_INCLUDES_DIRECTORY \"{{.INSTALL_INCLUDES_DIR}}\")" \
+        echo "set(CLP_SQLITE3_INCLUDE_DIRECTORY \"{{.INSTALL_INCLUDE_DIR}}\")" \
         >> "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   utfcpp:
@@ -256,7 +256,7 @@ tasks:
           URL: "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.6.tar.gz"
       - >-
         echo "set(
-        CLP_UTFCPP_INCLUDES_DIRECTORY \"{{.UTFCPP_OUTPUT_DIR}}\"
+        CLP_UTFCPP_INCLUDE_DIRECTORY \"{{.UTFCPP_OUTPUT_DIR}}\"
         )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   yaml-cpp:

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -159,33 +159,16 @@ tasks:
 
   log-surgeon:
     internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/log-surgeon.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/log-surgeon"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "utils:install-remote-cmake-lib"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "log-surgeon-f801a3f369bb14919d82a928d9a3812006245aa0"
-          SRC_URL: "https://github.com/y-scope/log-surgeon/archive/f801a3f.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CMAKE_GEN_ARGS:
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+          LIB_NAME: "log_surgeon"
+          TARBALL_SHA256: "169b56714b620c3f8f07bf7975aba8573b9bd25e423e5c4f0cc9b52450a2403d"
+          TARBALL_URL: "https://github.com/y-scope/log-surgeon/archive/f801a3f.tar.gz"
 
   nlohmann_json:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -269,32 +269,26 @@ tasks:
   outcome:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/outcome.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/outcome"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
+      LIB_NAME: "outcome"
+      OUTPUT_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
+    run: "once"
     deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+      - task: "utils:init"
     cmds:
-      - task: "download-dependency"
+      - task: "yscope-dev-utils:remote:download-and-extract-tar"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "outcome-2.2.9"
-          SRC_URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.9.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
+          FILE_SHA256: "9588c01465b287296ab647b2caf50d5137e3eeaf662e3105b858d5c5c7579428"
+          INCLUDE_PATTERNS:
+            - "outcome/single-header"
+          NUM_COMPONENTS_TO_STRIP: 2
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
+          URL: "https://github.com/ned14/outcome/releases/download/v2.2.9\
+          /outcome-v2-all-sources-571f9c930e672950e99d5d30f743603aaaf8014c.tar.xz"
+      - >-
+        echo "set(
+        CLP_OUTCOME_SOURCE_DIRECTORY \"{{.OUTPUT_DIR}}\"
+        )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   simdjson:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -80,7 +80,7 @@ tasks:
       - task: "sqlite3"
       - task: "utfcpp"
       - task: "yaml-cpp"
-      - task: "ystdlib-cpp"
+      - task: "ystdlib"
 
   absl:
     internal: true
@@ -275,35 +275,25 @@ tasks:
           TARBALL_SHA256: "43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3"
           TARBALL_URL: "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz"
 
-  ystdlib-cpp:
+  ystdlib:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/ystdlib-cpp.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/ystdlib-cpp"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
+      LIB_NAME: "ystdlib"
+      YSTDLIB_OUTPUT_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
+    run: "once"
     deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+      - task: "utils:init"
     cmds:
-      - task: "download-dependency"
+      - task: "yscope-dev-utils:remote:download-and-extract-tar"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "ystdlib-cpp-2ac17579d12c48e2f45d4688a10bcabb5becb466"
-          SRC_URL: "https://github.com/y-scope/ystdlib-cpp/archive/2ac1757.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
+          FILE_SHA256: "d47c703c0d1c5e755c1bfb984b68c85967683a09dadbe23772d9eb69f822d040"
+          OUTPUT_DIR: "{{.YSTDLIB_OUTPUT_DIR}}"
+          URL: "https://github.com/y-scope/ystdlib-cpp/archive/2ac1757.tar.gz"
+      - >-
+        echo "set(
+        CLP_YSTDLIB_SOURCE_DIRECTORY \"{{.YSTDLIB_OUTPUT_DIR}}\"
+        )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
 
   download-dependency:

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -188,7 +188,7 @@ tasks:
           /outcome-v2-all-sources-571f9c930e672950e99d5d30f743603aaaf8014c.tar.xz"
       - >-
         echo "set(
-        CLP_OUTCOME_SOURCE_DIRECTORY \"{{.OUTPUT_DIR}}\"
+        CLP_OUTCOME_INCLUDES_DIRECTORY \"{{.OUTPUT_DIR}}\"
         )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   simdjson:
@@ -241,7 +241,7 @@ tasks:
           URL: "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.6.tar.gz"
       - >-
         echo "set(
-        CLP_UTFCPP_SOURCE_DIRECTORY \"{{.UTFCPP_OUTPUT_DIR}}\"
+        CLP_UTFCPP_INCLUDES_DIRECTORY \"{{.UTFCPP_OUTPUT_DIR}}\"
         )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   yaml-cpp:

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -217,6 +217,8 @@ tasks:
 
       # Paths
       EXTRACTION_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
+      INSTALL_INCLUDES_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install/includes"
+      INSTALL_SYMLINK: "{{.INSTALL_INCLUDES_DIR}}/{{.LIB_NAME}}"
       ZIP_FILENAME_STEM: "sqlite-amalgamation-3360000"
       SRC_DIR: "{{.EXTRACTION_DIR}}/{{.ZIP_FILENAME_STEM}}"
     run: "once"
@@ -227,10 +229,14 @@ tasks:
           FILE_SHA256: "999826fe4c871f18919fdb8ed7ec9dd8217180854dd1fe21eea96aed36186729"
           OUTPUT_DIR: "{{.EXTRACTION_DIR}}"
           URL: "https://www.sqlite.org/2021/{{.ZIP_FILENAME_STEM}}.zip"
-      - >-
-        echo "set(
-        CLP_SQLITE3_SOURCE_DIRECTORY \"{{.SRC_DIR}}\"
-        )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
+      - "mkdir -p '{{.INSTALL_INCLUDES_DIR}}'"
+      - "rm -f '{{.INSTALL_SYMLINK}}'"
+      - "ln -s '{{.SRC_DIR}}' '{{.INSTALL_SYMLINK}}'"
+      - |-
+        echo "set(CLP_SQLITE3_SOURCE_DIRECTORY \"{{.SRC_DIR}}\")" \
+        > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
+        echo "set(CLP_SQLITE3_INCLUDES_DIRECTORY \"{{.INSTALL_INCLUDES_DIR}}\")" \
+        >> "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   utfcpp:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -345,32 +345,20 @@ tasks:
   utfcpp:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/utfcpp.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/utfcpp"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+      LIB_NAME: "utfcpp"
+      UTFCPP_OUTPUT_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "yscope-dev-utils:remote:download-and-extract-tar"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "utfcpp-4.0.6"
-          SRC_URL: "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.6.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
+          FILE_SHA256: "6920a6a5d6a04b9a89b2a89af7132f8acefd46e0c2a7b190350539e9213816c0"
+          OUTPUT_DIR: "{{.UTFCPP_OUTPUT_DIR}}"
+          URL: "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.6.tar.gz"
+      - >-
+        echo "set(
+        CLP_UTFCPP_SOURCE_DIRECTORY \"{{.UTFCPP_OUTPUT_DIR}}\"
+        )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   yaml-cpp:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -73,8 +73,8 @@ tasks:
       - task: "antlr"
       - task: "catch2"
       - task: "date"
-      - task: "json"
       - task: "log-surgeon"
+      - task: "nlohmann_json"
       - task: "outcome"
       - task: "simdjson"
       - task: "sqlite3"
@@ -174,36 +174,6 @@ tasks:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           INCLUDE_PATTERNS: ["{{.DEST}}"]
 
-  json:
-    internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/json.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/json"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
-    cmds:
-      - task: "download-dependency"
-        vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "json-3.11.3"
-          SRC_URL: "https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
-
   log-surgeon:
     internal: true
     vars:
@@ -233,6 +203,20 @@ tasks:
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           INCLUDE_PATTERNS: ["{{.DEST}}"]
+
+  nlohmann_json:
+    internal: true
+    run: "once"
+    cmds:
+      - task: "utils:install-remote-cmake-lib"
+        vars:
+          CMAKE_GEN_ARGS:
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+            - "-DJSON_BuildTests=OFF"
+          LIB_NAME: "nlohmann_json"
+          TARBALL_SHA256: "d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d"
+          TARBALL_URL: "https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz"
 
   outcome:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -34,7 +34,7 @@ tasks:
       - task: "yscope-dev-utils:cmake:install-deps-and-generate-settings"
         vars:
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}"
-          DEP_TASK: "all-internal-deps"
+          DEP_TASK: "core-all-parallel"
       - task: "utils:combine-core-checksum-files"
 
   log-viewer:
@@ -49,23 +49,10 @@ tasks:
           TAR_FILE: "{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz"
           URL: "https://github.com/y-scope/yscope-log-viewer/archive/969ff35.tar.gz"
 
-  # NOTE: `git submodule update` doesn't support parallel invocations, so we can't use it to
-  # download submodules in parallel. This means:
-  # 1. the submodule tasks cannot be specified as a list of `deps`, because `task` always runs
-  #   `deps` tasks in parallel.
-  # 2. we need to force higher level tasks, like `core` and `log-viewer`, to run their submodule
-  #    download tasks serially.
-  #
-  # As a solution, the `all-internal-deps` task below:
-  # 1. uses `cmds` to sequentially download `ALL` submodules required by the clp-package.
-  # 2. uses `run: once`, so it executes once even if multiple higher level targets depend on it.
-  #
-  # All higher level tasks must depend on this task instead of depending on the individual
-  # submodule tasks in this file.
-  all-internal-deps:
+  core-all-parallel:
     internal: true
     run: "once"
-    cmds:
+    deps:
       - task: "absl"
       - task: "antlr"
       - task: "catch2"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -69,7 +69,7 @@ tasks:
     internal: true
     run: "once"
     cmds:
-      - task: "abseil-cpp"
+      - task: "absl"
       - task: "antlr"
       - task: "Catch2"
       - task: "date"
@@ -82,35 +82,19 @@ tasks:
       - task: "yaml-cpp"
       - task: "ystdlib-cpp"
 
-  abseil-cpp:
+  absl:
     internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/abseil-cpp.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/abseil-cpp"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "utils:install-remote-cmake-lib"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "abseil-cpp-20230802.1"
-          SRC_URL: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CMAKE_GEN_ARGS:
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_CXX_STANDARD=20"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+          LIB_NAME: "absl"
+          TARBALL_SHA256: "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed"
+          TARBALL_URL: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"
 
   antlr:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -320,37 +320,27 @@ tasks:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           INCLUDE_PATTERNS: ["{{.DEST}}"]
 
-  # We don't use a git submodule for sqlite3 since that would require building the sqlite
-  # amalgamation
   sqlite3:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/sqlite3.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/sqlite3"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+      LIB_NAME: "sqlite3"
+
+      # Paths
+      EXTRACTION_DIR: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-src"
+      ZIP_FILENAME_STEM: "sqlite-amalgamation-3360000"
+      SRC_DIR: "{{.EXTRACTION_DIR}}/{{.ZIP_FILENAME_STEM}}"
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "yscope-dev-utils:remote:download-and-extract-zip"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract --no-submodule"
-          SRC_NAME: "sqlite-amalgamation-3360000"
-          SRC_URL: "https://www.sqlite.org/2021/sqlite-amalgamation-3360000.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
+          FILE_SHA256: "999826fe4c871f18919fdb8ed7ec9dd8217180854dd1fe21eea96aed36186729"
+          OUTPUT_DIR: "{{.EXTRACTION_DIR}}"
+          URL: "https://www.sqlite.org/2021/{{.ZIP_FILENAME_STEM}}.zip"
+      - >-
+        echo "set(
+        CLP_SQLITE3_SOURCE_DIRECTORY \"{{.SRC_DIR}}\"
+        )" > "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   utfcpp:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -183,12 +183,11 @@ tasks:
       - task: "yscope-dev-utils:remote:download-and-extract-tar"
         vars:
           CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
-          FILE_SHA256: "9588c01465b287296ab647b2caf50d5137e3eeaf662e3105b858d5c5c7579428"
+          FILE_SHA256: "2840e403b1d7a0d3a75ecc4df574ab0674284bb21d76ac5f817695f2b56905f2"
           INCLUDE_PATTERNS:
-            - "outcome/single-header"
+            - "*/single-header"
           OUTPUT_DIR: "{{.SRC_DIR}}"
-          URL: "https://github.com/ned14/outcome/releases/download/v2.2.9\
-          /outcome-v2-all-sources-571f9c930e672950e99d5d30f743603aaaf8014c.tar.xz"
+          URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.9.tar.gz"
       - "mkdir -p '{{.INSTALL_INCLUDES_DIR}}'"
       - "rm -f '{{.INSTALL_SYMLINK}}'"
       - "ln -s '{{.SRC_DIR}}/single-header' '{{.INSTALL_SYMLINK}}'"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -1,30 +1,21 @@
 version: "3"
 
 includes:
+  utils: "./utils.yaml"
   yscope-dev-utils: "../../tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
 vars:
+  # Directories
+  G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
+  G_DEPS_CORE_DIR: "{{.G_DEPS_DIR}}/core"
+  G_DEPS_CORE_CHECKSUMS_DIR: "{{.G_DEPS_CORE_DIR}}/checksums"
+
+  # Checksum file paths
+  G_DEPS_CORE_CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/all.md5"
+  G_DEPS_LOG_VIEWER_CHECKSUM_FILE: "{{.G_DEPS_DIR}}/log-viewer.md5"
+
   # Utility script path
   G_DEP_DOWNLOAD_SCRIPT: "{{.ROOT_DIR}}/tools/scripts/deps-download/download-dep.py"
-
-  # Target checksum files
-  G_DEPS_CORE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#core.md5"
-  G_DEPS_LOG_VIEWER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#log-viewer.md5"
-
-  # Submodule checksum files
-  G_ABSEIL_CPP_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#abseil-cpp.md5"
-  G_ANTLR4_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#antlr4.md5"
-  G_CATCH2_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#Catch2.md5"
-  G_DATE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#date.md5"
-  G_JSON_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#json.md5"
-  G_LOG_SURGEON_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#log-surgeon.md5"
-  G_OUTCOME_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#outcome.md5"
-  G_SIMDJSON_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#simdjson.md5"
-  G_SQLITE3_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#sqlite3.md5"
-  G_UTFCPP_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#utfcpp.md5"
-  G_YAML_CPP_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#yaml-cpp.md5"
-  G_YSCOPE_LOG_VIEWER_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#yscope-log-viewer.md5"
-  G_YSTDLIB_CPP_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/deps#ystdlib-cpp.md5"
 
 tasks:
   default:
@@ -33,40 +24,16 @@ tasks:
       - "log-viewer"
 
   core:
-    vars:
-    sources:
-      - "{{.G_ABSEIL_CPP_CHECKSUM_FILE}}"
-      - "{{.G_ANTLR4_CHECKSUM_FILE}}"
-      - "{{.G_CATCH2_CHECKSUM_FILE}}"
-      - "{{.G_DATE_CHECKSUM_FILE}}"
-      - "{{.G_JSON_CHECKSUM_FILE}}"
-      - "{{.G_LOG_SURGEON_CHECKSUM_FILE}}"
-      - "{{.G_OUTCOME_CHECKSUM_FILE}}"
-      - "{{.G_SIMDJSON_CHECKSUM_FILE}}"
-      - "{{.G_SQLITE3_CHECKSUM_FILE}}"
-      - "{{.G_UTFCPP_CHECKSUM_FILE}}"
-      - "{{.G_YAML_CPP_CHECKSUM_FILE}}"
-      - "{{.G_YSTDLIB_CPP_CHECKSUM_FILE}}"
-    generates: ["{{.G_DEPS_CORE_CHECKSUM_FILE}}"]
-    deps: ["all-internal-deps"]
+    deps:
+      - "utils:clean-old-core-checksum-files"
+      - "utils:init"
     cmds:
-      - >-
-        cat
-        "{{.G_ABSEIL_CPP_CHECKSUM_FILE}}"
-        "{{.G_ANTLR4_CHECKSUM_FILE}}"
-        "{{.G_CATCH2_CHECKSUM_FILE}}"
-        "{{.G_DATE_CHECKSUM_FILE}}"
-        "{{.G_JSON_CHECKSUM_FILE}}"
-        "{{.G_LOG_SURGEON_CHECKSUM_FILE}}"
-        "{{.G_OUTCOME_CHECKSUM_FILE}}"
-        "{{.G_SIMDJSON_CHECKSUM_FILE}}"
-        "{{.G_SQLITE3_CHECKSUM_FILE}}"
-        "{{.G_UTFCPP_CHECKSUM_FILE}}"
-        "{{.G_YAML_CPP_CHECKSUM_FILE}}"
-        "{{.G_YSTDLIB_CPP_CHECKSUM_FILE}}"
-        >> "{{.G_DEPS_CORE_CHECKSUM_FILE}}"
+      - task: "all-internal-deps"
+      - task: "utils:combine-core-checksum-files"
 
   log-viewer:
+    deps:
+      - "utils:init"
     cmds:
       - task: "yscope-dev-utils:remote:download-and-extract-tar"
         vars:
@@ -109,7 +76,7 @@ tasks:
   abseil-cpp:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_ABSEIL_CPP_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/abseil-cpp.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/abseil-cpp"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -118,7 +85,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -139,7 +106,7 @@ tasks:
   antlr4:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_ANTLR4_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/antlr4.md5"
       DEST_DIR: "{{.G_CORE_COMPONENT_DIR}}/third-party/antlr"
       DEST: "{{.DEST_DIR}}/antlr-4.13.1-complete.jar"
     sources:
@@ -149,7 +116,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -170,7 +137,7 @@ tasks:
   Catch2:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_CATCH2_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/Catch2.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/Catch2"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -179,7 +146,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -200,7 +167,7 @@ tasks:
   date:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_DATE_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/date.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/date"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -209,7 +176,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -230,7 +197,7 @@ tasks:
   json:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_JSON_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/json.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/json"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -239,7 +206,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -260,7 +227,7 @@ tasks:
   log-surgeon:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_LOG_SURGEON_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/log-surgeon.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/log-surgeon"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -269,7 +236,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -290,7 +257,7 @@ tasks:
   outcome:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_OUTCOME_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/outcome.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/outcome"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -299,7 +266,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -320,7 +287,7 @@ tasks:
   simdjson:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_SIMDJSON_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/simdjson.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/simdjson"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -329,7 +296,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -352,7 +319,7 @@ tasks:
   sqlite3:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_SQLITE3_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/sqlite3.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/sqlite3"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -361,7 +328,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -382,7 +349,7 @@ tasks:
   utfcpp:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_UTFCPP_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/utfcpp.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/utfcpp"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -391,7 +358,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -412,7 +379,7 @@ tasks:
   yaml-cpp:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_YAML_CPP_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/yaml-cpp.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/yaml-cpp"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -421,7 +388,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -442,7 +409,7 @@ tasks:
   ystdlib-cpp:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_YSTDLIB_CPP_CHECKSUM_FILE}}"
+      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/ystdlib-cpp.md5"
       DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/ystdlib-cpp"
     sources:
       - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
@@ -451,7 +418,7 @@ tasks:
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - ":init"
+      - "utils:init"
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
@@ -476,7 +443,7 @@ tasks:
     requires:
       vars: ["DEST", "FLAGS", "SRC_NAME", "SRC_URL"]
     deps:
-      - ":init"
+      - "utils:init"
     cmds:
       - >-
         python3 "{{.G_DEP_DOWNLOAD_SCRIPT}}"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -227,33 +227,16 @@ tasks:
 
   simdjson:
     internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/simdjson.md5"
-      DEST: "{{.G_CORE_COMPONENT_SUBMODULES_DIR}}/simdjson"
-    sources:
-      - "{{.G_DEP_DOWNLOAD_SCRIPT}}"
-      - "{{.G_UTILS_TASKFILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - "utils:init"
-      - task: ":utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+    run: "once"
     cmds:
-      - task: "download-dependency"
+      - task: "utils:install-remote-cmake-lib"
         vars:
-          DEST: "{{.DEST}}"
-          FLAGS: "--extract"
-          SRC_NAME: "simdjson-3.6.3"
-          SRC_URL: "https://github.com/simdjson/simdjson/archive/refs/tags/v3.6.3.zip"
-      # This command must be last
-      - task: ":utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.DEST}}"]
+          CMAKE_GEN_ARGS:
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+          LIB_NAME: "simdjson"
+          TARBALL_SHA256: "afd8201cfb1abe927737d876441bb1f21730a9ee6078a1b8c6174e6463981fa3"
+          TARBALL_URL: "https://github.com/simdjson/simdjson/archive/refs/tags/v3.6.3.tar.gz"
 
   sqlite3:
     internal: true

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -168,7 +168,7 @@ tasks:
 
           # NOTE: We use the GitHub-generated source tarball for this version rather than the
           # release tarball, since the latter is served from githubusercontent.com which is blocked
-          # by some developer's firewalls. The contents of the former are a superset of the latter.
+          # by some developers' firewalls. The contents of the former are a superset of the latter.
           TARBALL_URL: "https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz"
 
   outcome:
@@ -194,7 +194,7 @@ tasks:
 
           # NOTE: We use the GitHub-generated source tarball for this version rather than the
           # release tarball, since the latter is served from githubusercontent.com which is blocked
-          # by some developer's firewalls. The source files we use are identical between the two
+          # by some developers' firewalls. The source files we use are identical between the two
           # tarballs.
           URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.9.tar.gz"
       - "mkdir -p '{{.INSTALL_INCLUDE_DIR}}'"

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -17,8 +17,7 @@ tasks:
       - "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/**/*.yaml"
     cmd: "rm -f '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'/*"
 
-  # Generates the combined checksum file `G_DEPS_CORE_CHECKSUM_FILE` by concatenating all the core
-  # checksum files.
+  # Combines all of core's checksum files into `G_DEPS_CORE_CHECKSUM_FILE`.
   combine-core-checksum-files:
     internal: true
     cmds:

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -35,3 +35,4 @@ tasks:
       - "mkdir -p '{{.G_DEPS_DIR}}'"
       - "mkdir -p '{{.G_DEPS_CORE_DIR}}'"
       - "mkdir -p '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'"
+      - "mkdir -p '{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}'"

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -8,7 +8,7 @@ tasks:
   # of core's dependencies are removed from the taskfiles, then the checksum files for the removed
   # dependencies will also be removed. Since we can't easily remove just the checksum files for the
   # removed dependencies, we remove all of them.
-  clean-old-core-checksum-files:
+  clean-outdated-core-checksum-files:
     internal: true
     run: "once"
     sources:

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -39,7 +39,7 @@ tasks:
       - "mkdir -p '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'"
       - "mkdir -p '{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}'"
 
-    # Installs a CMake-based library from a remote tarball, generates a corresponding settings file,
+  # Installs a CMake-based library from a remote tarball, generates a corresponding settings file,
   # and computes a checksum for the installation directory.
   #
   # @param {string} LIB_NAME

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -53,6 +53,7 @@ tasks:
       INSTALL_PREFIX: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install"
       INSTALL_DIR_CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
     deps:
+      - task: "init"
       - task: "yscope-dev-utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.INSTALL_DIR_CHECKSUM_FILE}}"

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -1,0 +1,37 @@
+version: "3"
+
+includes:
+  yscope-dev-utils: "../../tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
+
+tasks:
+  # Cleans up the core checksum files any time the taskfiles change. This is to ensure that if any
+  # of core's dependencies are removed from the taskfiles, then the checksum files for the removed
+  # dependencies will also be removed. Since we can't easily remove just the checksum files for the
+  # removed dependencies, we remove all of them.
+  clean-old-core-checksum-files:
+    internal: true
+    run: "once"
+    sources:
+      - "{{.ROOT_DIR}}/Taskfile.yaml"
+      - "{{.ROOT_DIR}}/taskfiles/**/*.yaml"
+      - "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/**/*.yaml"
+    cmd: "rm -f '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'/*"
+
+  combine-core-checksum-files:
+    internal: true
+    cmds:
+      - "rm -f '{{.G_DEPS_CORE_CHECKSUM_FILE}}'"
+      - |-
+        for file in "{{.G_DEPS_CORE_CHECKSUMS_DIR}}"/*.md5; do
+          if [[ "$file" != "{{.G_DEPS_CORE_CHECKSUM_FILE}}" ]]; then
+            cat "$file" >> "{{.G_DEPS_CORE_CHECKSUM_FILE}}"
+          fi
+        done
+
+  init:
+    internal: true
+    run: "once"
+    cmds:
+      - "mkdir -p '{{.G_DEPS_DIR}}'"
+      - "mkdir -p '{{.G_DEPS_CORE_DIR}}'"
+      - "mkdir -p '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'"

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -36,3 +36,42 @@ tasks:
       - "mkdir -p '{{.G_DEPS_CORE_DIR}}'"
       - "mkdir -p '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'"
       - "mkdir -p '{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}'"
+
+  # Installs a CMake-based library from a remote tarball, generates a settings file for it, and
+  # computes a checksum for the installation directory.
+  #
+  # @param {string} LIB_NAME
+  # @param {string} TARBALL_SHA256
+  # @param {string} TARBALL_URL
+  # @param {string[]} [CMAKE_GEN_ARGS] Any additional arguments to pass to the CMake generate
+  # command.
+  install-remote-cmake-lib:
+    internal: true
+    vars:
+      CMAKE_GEN_ARGS:
+        ref: "default (list) .CMAKE_GEN_ARGS"
+      INSTALL_PREFIX: "{{.G_DEPS_CORE_DIR}}/{{.LIB_NAME}}-install"
+      INSTALL_DIR_CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
+    deps:
+      - task: "yscope-dev-utils:checksum:validate"
+        vars:
+          CHECKSUM_FILE: "{{.INSTALL_DIR_CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS:
+            - "{{.INSTALL_PREFIX}}"
+    cmds:
+      - task: "yscope-dev-utils:cmake:install-remote-tar"
+        vars:
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}"
+          FILE_SHA256: "{{.TARBALL_SHA256}}"
+          GEN_ARGS:
+            ref: ".CMAKE_GEN_ARGS"
+          NAME: "{{.LIB_NAME}}"
+          URL: "{{.TARBALL_URL}}"
+          WORK_DIR: "{{.G_DEPS_CORE_DIR}}"
+
+      # This command must be last
+      - task: "yscope-dev-utils:checksum:compute"
+        vars:
+          CHECKSUM_FILE: "{{.INSTALL_DIR_CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS:
+            - "{{.INSTALL_PREFIX}}"

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -17,6 +17,8 @@ tasks:
       - "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/**/*.yaml"
     cmd: "rm -f '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'/*"
 
+  # Generates the combined checksum file `G_DEPS_CORE_CHECKSUM_FILE` by concatenating all the core
+  # checksum files.
   combine-core-checksum-files:
     internal: true
     cmds:
@@ -37,8 +39,8 @@ tasks:
       - "mkdir -p '{{.G_DEPS_CORE_CHECKSUMS_DIR}}'"
       - "mkdir -p '{{.G_DEPS_CORE_CMAKE_SETTINGS_DIR}}'"
 
-  # Installs a CMake-based library from a remote tarball, generates a settings file for it, and
-  # computes a checksum for the installation directory.
+    # Installs a CMake-based library from a remote tarball, generates a corresponding settings file,
+  # and computes a checksum for the installation directory.
   #
   # @param {string} LIB_NAME
   # @param {string} TARBALL_SHA256

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -118,7 +118,7 @@ tasks:
           components/package-template/src/etc \
           docs \
           taskfile.yaml \
-          taskfiles/deps.yaml \
+          taskfiles/deps/main.yaml \
           taskfiles/lint.yaml
 
   check-cpp-format:

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -118,8 +118,7 @@ tasks:
           components/package-template/src/etc \
           docs \
           taskfile.yaml \
-          taskfiles/deps/main.yaml \
-          taskfiles/lint.yaml
+          taskfiles
 
   check-cpp-format:
     sources: &cpp_source_files

--- a/tools/scripts/deps-download/init.sh
+++ b/tools/scripts/deps-download/init.sh
@@ -11,7 +11,7 @@ project_root_dir="$script_dir/../../../"
 download_dep_script="$script_dir/download-dep.py"
 
 python3 "${download_dep_script}" \
-    https://github.com/y-scope/yscope-dev-utils/archive/30640b0.zip \
-    yscope-dev-utils-30640b0af5a8d344ae57afe02e8ae88a79233809 \
+    https://github.com/y-scope/yscope-dev-utils/archive/e300d1b.zip \
+    yscope-dev-utils-e300d1bab4c2f33cbf9ddf9f0c08185faf035070 \
     "${project_root_dir}/tools/yscope-dev-utils" \
     --extract


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Continuing the effort started in #835, this PR migrates core's submodule-based dependencies to task-based installation.

This is similar to the work done in https://github.com/y-scope/spider/pull/115

There are three types of dependencies:

* CMake-based libraries
* Non-CMake-based libraries
* Files

For each dependency, we download it, extract it (if necessary), install it, and then generate a CMake-settings file that contains any CMake variables necessary to reference it. After all dependencies are installed, we generate a single CMake-settings file, that includes all the other settings files, and include this single settings file in core's CMakeLists.txt.

For each dependency, we also generate a checksum file and amalgamate all of these checksum files into a single checksum file that the package build can depend on to detect changes in any of the dependencies.

For CMake-based libraries, we reference them in core's CMakeLists.txt using `find_package`.

For non-CMake-based libraries, we reference them in core's CMakeLists files either using `add_subdirectory`, or if the library is header-only, by adding them as include directories in `target_include_directories`.

Below are the dependencies migrated and any nuances of the migration:

* absl (CMake-based)
  * Included in core's CMakeLists.txt using `find_package` rather than `add_subdirectory`.
  * Installation task renamed from `abseil-cpp` to `absl` to match the name of the CMake target.
  * Removed the submodule.
* ANTLR (JAR)
  * Moved the `ANTLR_EXECUTABLE` CMake variable to the dependency's CMake settings file.
  * Removed the `components/core/third-party` directory from `.gitignore` since it's no longer used.
  * Renamed the installation task to remove the version number.
* Catch2 (CMake-based)
  * Included in core's CMakeLists.txt using `find_package`.
  * Changed include path from Catch2/single_include/catch2/catch.hpp to catch2/catch.hpp.
  * Removed the submodule.
  * Installation task renamed from `Catch2` to `catch2` to be consistent with our task-naming conventions.
* date (CMake-based)
  * Included in core's CMakeLists.txt using `find_package`.
  * Switched to using date::date CMake target rather than including date.h directly. 
  * Changed include path from date/include/date.h to date/date.h.
  * Removed its submodule.
* log-surgeon (CMake-based)
  * Included in core's CMakeLists.txt using `find_package` rather than `add_subdirectory`.
  * Removed its submodule.
* nlohmann_json
  * Included in core's CMakeLists.txt using `find_package`.
  * Changed include path from json/single_include/nlohmann/json.hpp to nlohmann/json.hpp.
  * Addressed new misc-include-cleaner clang-tidy violations caused by not using the single-header include.
  * Replaced `json` with `nlohmann_json` in .clang-format.
  * Removed its submodule.
  * Added `unzip` and `xz` to the core dependency container images that require it.
  * Renamed its installation task from `json` to `nlohmann_json` to match the name of the CMake target.
* outcome (non-CMake-based)
  * Added to CMakeLists files using source-directory variable in target_include_directories.
  * Removed its submodule.
  * NOTE: outcome can be installed through CMake but requires quickcpplib which causes issues with absl in Debug builds. This can be addressed by switching to boost's version of outcome.
* simdjson (CMake-based)
  * Included in core's CMakeLists.txt using `find_package` rather than `add_subdirectory`.
  * Changed cmake-target from simdjson to simdjson:: simdjson.
  * Removed submodule.
* sqlite3 (non-CMake based)
  * Added to CMakeLists files using source-directory variable in target_include_directories.
  * Changed include path from sqlite3/sqlite3.h to sqlite3.h.
  * Removed from .gitignore since it's now downloaded into the build directory.
* utfcpp (non-CMake based)
  * Removed its submodule.
* yaml-cpp
  * Included in core's CMakeLists.txt using `find_package` rather than `add_subdirectory`.
  * Changed CMake-target from yaml-cpp:: yaml-cpp to yaml-cpp to resolve this error:
    ```text
    CMake Error at src/clp/clg/CMakeLists.txt:136 (target_link_libraries):
      Target "clg" links to:

        yaml-cpp::yaml-cpp

      but the target was not found.  Possible reasons include:

        * There is a typo in the target name.
        * A find_package call is missing for an IMPORTED target.
        * An ALIAS target is missing.
    ```

  * Changed include path from yaml-cpp/include/yaml-cpp/yaml.h to yaml-cpp/yaml.h.
  * Removed its submodule.
* ystdlib-cpp:
  * Changed path passed to add_subdirectory and added the directory where it would be built since we're building outside its source directory.
  * Removed its submodule.
  * Installation task renamed from `ystdlib-cpp` to `ystdlib` to match the name of the CMake target.

To support the above, we also:

* Update yscope-dev-utils to the latest version.
* Move `taskfiles/deps.yaml` to `taskfiles/deps/main.yaml` and split any utilities into `taskfiles/deps/utils.yaml`.
* Build all CMake-based libraries in Release mode and with `LAZY` install messages to reduce the installation output.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* GH workflows succeed.
* Tested that each dependency's task didn't download and extract the dependency if it had already been downloaded and extracted.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Migrated from embedded submodules to external dependency management for core libraries, removing bundled third-party code.
  - Updated build scripts and configuration files to use external package discovery and installation for dependencies.
  - Introduced new, modular taskfiles for dependency management with improved checksum validation and parallel execution.
  - Updated installation scripts to include additional required packages (`unzip`, `xz`).
  - Adjusted workflow triggers and linting to cover all relevant files and directories.
- **Refactor**
  - Standardized include paths for third-party libraries across the codebase.
  - Updated build and test configurations to align with new dependency management approach.
- **Style**
  - Simplified and unified include directives for external libraries in source and test files.
- **Documentation**
  - Improved clarity and structure in task and utility YAML files for dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->