### PR TITLE
feat(kv-ir): Add a function signature C++ concept for the callback called when a new projected schema-tree node is read.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -433,6 +433,7 @@ set(SOURCE_FILES_unitTest
         src/clp/ffi/ir_stream/protocol_constants.hpp
         src/clp/ffi/ir_stream/Serializer.cpp
         src/clp/ffi/ir_stream/Serializer.hpp
+        src/clp/ffi/ir_stream/search/ProjectionResolutionCallbackReq.hpp
         src/clp/ffi/ir_stream/utils.cpp
         src/clp/ffi/ir_stream/utils.hpp
         src/clp/ffi/KeyValuePairLogEvent.cpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -433,7 +433,7 @@ set(SOURCE_FILES_unitTest
         src/clp/ffi/ir_stream/protocol_constants.hpp
         src/clp/ffi/ir_stream/Serializer.cpp
         src/clp/ffi/ir_stream/Serializer.hpp
-        src/clp/ffi/ir_stream/search/ProjectionResolutionCallbackReq.hpp
+        src/clp/ffi/ir_stream/search/NewProjectedSchemaTreeNodeCallbackReq.hpp
         src/clp/ffi/ir_stream/utils.cpp
         src/clp/ffi/ir_stream/utils.hpp
         src/clp/ffi/KeyValuePairLogEvent.cpp

--- a/components/core/src/clp/ffi/ir_stream/search/NewProjectedSchemaTreeNodeCallbackReq.hpp
+++ b/components/core/src/clp/ffi/ir_stream/search/NewProjectedSchemaTreeNodeCallbackReq.hpp
@@ -1,5 +1,5 @@
-#ifndef CLP_FFI_IR_STREAM_SEARCH_PROJECTIONRESOLUTIONCALLBACKREQ_HPP
-#define CLP_FFI_IR_STREAM_SEARCH_PROJECTIONRESOLUTIONCALLBACKREQ_HPP
+#ifndef CLP_FFI_IR_STREAM_SEARCH_NEWPROJECTEDSCHEMATREENODECALLBACKREQ_HPP
+#define CLP_FFI_IR_STREAM_SEARCH_NEWPROJECTEDSCHEMATREENODECALLBACKREQ_HPP
 
 #include <string_view>
 #include <type_traits>
@@ -12,22 +12,22 @@ namespace clp::ffi::ir_stream::search {
 /**
  * Requirements for a callback that's called whenever:
  *
- * 1. a new schema-tree node is read from the IR stream; and
+ * 1. a new schema-tree node is deserialized from the IR stream; and
  * 2. that node corresponds to one of the projected key paths in the query.
  *
- * @tparam ProjectionResolutionCallbackType
+ * @tparam NewProjectedSchemaTreeNodeCallbackType
  * @param arg_0 Whether the schema-tree node is for an auto-generated kv-pair.
  * @param arg_1 The ID of the schema-tree node.
  * @param arg_2 The projected key path.
  * @return A void result on success or a user-defined error code indicating the failure.
  */
-template <typename ProjectionResolutionCallbackType>
-concept ProjectionResolutionCallbackReq = std::is_invocable_r_v<
+template <typename NewProjectedSchemaTreeNodeCallbackType>
+concept NewProjectedSchemaTreeNodeCallbackReq = std::is_invocable_r_v<
         outcome_v2::std_result<void>,
-        ProjectionResolutionCallbackType,
+        NewProjectedSchemaTreeNodeCallbackType,
         bool,
         SchemaTree::Node::id_t,
         std::string_view>;
 }  // namespace clp::ffi::ir_stream::search
 
-#endif  // CLP_FFI_IR_STREAM_SEARCH_PROJECTIONRESOLUTIONCALLBACKREQ_HPP
+#endif  // CLP_FFI_IR_STREAM_SEARCH_NEWPROJECTEDSCHEMATREENODECALLBACKREQ_HPP

--- a/components/core/src/clp/ffi/ir_stream/search/ProjectionResolutionCallbackReq.hpp
+++ b/components/core/src/clp/ffi/ir_stream/search/ProjectionResolutionCallbackReq.hpp
@@ -1,0 +1,34 @@
+#ifndef CLP_FFI_IR_STREAM_SEARCH_PROJECTIONRESOLUTIONCALLBACKREQ_HPP
+#define CLP_FFI_IR_STREAM_SEARCH_PROJECTIONRESOLUTIONCALLBACKREQ_HPP
+
+#include <string_view>
+#include <type_traits>
+
+#include <outcome/single-header/outcome.hpp>
+
+#include "../../SchemaTree.hpp"
+
+namespace clp::ffi::ir_stream::search {
+/**
+ * Concept that defines the callback function signature for projection resolution.
+ * @tparam ProjectionResolutionCallbackType
+ *
+ * Callback parameters:
+ * - `bool is_auto_generated`: Whether the schema tree node is auto-generated.
+ * - `SchemaTree::Node::id_t schema_tree_node_id`: The ID of the resolved schema tree node.
+ * - `std::string_view key_path`: The key path of the resolved projection.
+ *
+ * Callback return values:
+ * - A void result on success.
+ * - A user-defined error code indicating the failure.
+ */
+template <typename ProjectionResolutionCallbackType>
+concept ProjectionResolutionCallbackReq = std::is_invocable_r_v<
+        outcome_v2::std_result<void>,
+        ProjectionResolutionCallbackType,
+        bool,
+        SchemaTree::Node::id_t,
+        std::string_view>;
+}  // namespace clp::ffi::ir_stream::search
+
+#endif  // CLP_FFI_IR_STREAM_SEARCH_PROJECTIONRESOLUTIONCALLBACKREQ_HPP

--- a/components/core/src/clp/ffi/ir_stream/search/ProjectionResolutionCallbackReq.hpp
+++ b/components/core/src/clp/ffi/ir_stream/search/ProjectionResolutionCallbackReq.hpp
@@ -10,17 +10,16 @@
 
 namespace clp::ffi::ir_stream::search {
 /**
- * Concept that defines the callback function signature for projection resolution.
+ * Requirements for a callback that's called whenever:
+ *
+ * 1. a new schema-tree node is read from the IR stream; and
+ * 2. that node corresponds to one of the projected key paths in the query.
+ *
  * @tparam ProjectionResolutionCallbackType
- *
- * Callback parameters:
- * - `bool is_auto_generated`: Whether the schema tree node is auto-generated.
- * - `SchemaTree::Node::id_t schema_tree_node_id`: The ID of the resolved schema tree node.
- * - `std::string_view key_path`: The key path of the resolved projection.
- *
- * Callback return values:
- * - A void result on success.
- * - A user-defined error code indicating the failure.
+ * @param arg_0 Whether the schema-tree node is for an auto-generated kv-pair.
+ * @param arg_1 The ID of the schema-tree node.
+ * @param arg_2 The projected key path.
+ * @return A void result on success or a user-defined error code indicating the failure.
  */
 template <typename ProjectionResolutionCallbackType>
 concept ProjectionResolutionCallbackReq = std::is_invocable_r_v<


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

feat(ffi): Add a concept to define the projection resolution callback's signature.

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is one of the series #840.

This PR implements the projection resolution callback's signature as a concept. Unlike the prototype implementation, this callback signature is defined as a standalone concept instead of inside `IrUnitHandlerInterface`, since it is not designed to handle any IR unit.

The signature is documented in the docstring.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Ensure all workflows passed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new callback concept to enhance handling of projected schema-tree nodes in search functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->