### PR TITLE
fix(docker): Change "base" image reference to lowercase in Dockerfiles (fixes #798).

### DIFF
--- a/components/core/tools/docker-images/clp-core-ubuntu-jammy/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy AS BASE
+FROM ubuntu:jammy AS base
 
 # Install runtime dependencies
 # TODO: Investigate why libssl-dev is a hidden dependency of clp-s
@@ -22,7 +22,7 @@ ADD ./make-dictionaries-readable ./
 
 # Flatten the image
 FROM scratch
-COPY --from=BASE / /
+COPY --from=base / /
 
 WORKDIR /clp
 

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy AS BASE
+FROM ubuntu:jammy AS base
 
 WORKDIR /root
 
@@ -19,4 +19,4 @@ RUN apt-get clean \
 
 # Flatten the image
 FROM scratch
-COPY --from=BASE / /
+COPY --from=base / /

--- a/tools/docker-images/clp-execution-base-ubuntu-jammy/Dockerfile
+++ b/tools/docker-images/clp-execution-base-ubuntu-jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy AS BASE
+FROM ubuntu:jammy AS base
 
 WORKDIR /root
 
@@ -13,4 +13,4 @@ RUN apt-get clean \
 
 # Flatten the image
 FROM scratch
-COPY --from=BASE / /
+COPY --from=base / /


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
According to https://docs.docker.com/reference/build-checks/stage-name-casing/ normalize base image reference to lowercase in Dockerfiles.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Opened the modified files in VSCode with the Docker plugin installed, and found no warning regarding StageNameCasing as reported in #798 .


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal naming conventions in several Dockerfiles. No changes to features or user-facing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->