### PR TITLE
fix(new-webui): Configure Vite `base` parameter to allow hosting in subdirectories (fixes #867).

### DIFF
--- a/components/log-viewer-webui/client/vite.config.ts
+++ b/components/log-viewer-webui/client/vite.config.ts
@@ -17,4 +17,5 @@ export default defineConfig({
         },
     },
     publicDir: "public",
+    base: "./",
 });

--- a/components/log-viewer-webui/client/vite.config.ts
+++ b/components/log-viewer-webui/client/vite.config.ts
@@ -4,7 +4,9 @@ import {defineConfig} from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({
+    base: "./",
     plugins: [react()],
+    publicDir: "public",
     server: {
         port: 8080,
         proxy: {
@@ -16,6 +18,4 @@ export default defineConfig({
             },
         },
     },
-    publicDir: "public",
-    base: "./",
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Fixes issue #867.

Adds base to the client Vite config.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Verified that the individual resources from the index.html in the list directory.

Started the webui, compressed and searched a file, and verified that the links froth search results directed correctly to the log viewer.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated asset paths to be relative to the current directory for improved compatibility when deploying built files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->