### PR TITLE
build(deps): Upgrade to `outcome` v2.2.12.

### DIFF
--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -207,7 +207,7 @@ tasks:
       - task: "yscope-dev-utils:remote:download-and-extract-tar"
         vars:
           CHECKSUM_FILE: "{{.G_DEPS_CORE_CHECKSUMS_DIR}}/{{.LIB_NAME}}.md5"
-          FILE_SHA256: "2840e403b1d7a0d3a75ecc4df574ab0674284bb21d76ac5f817695f2b56905f2"
+          FILE_SHA256: "14e15bda4e7c26ee42b0329d7ff746235f67bda084305c9d61297e9a521deb18"
           INCLUDE_PATTERNS:
             - "*/single-header"
           OUTPUT_DIR: "{{.SRC_DIR}}"
@@ -216,7 +216,7 @@ tasks:
           # release tarball, since the latter is served from githubusercontent.com which is blocked
           # by some developers' firewalls. The source files we use are identical between the two
           # tarballs.
-          URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.9.tar.gz"
+          URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.12.tar.gz"
       - "mkdir -p '{{.INSTALL_INCLUDE_DIR}}'"
       - "rm -f '{{.INSTALL_SYMLINK}}'"
       - "ln -s '{{.SRC_DIR}}/single-header' '{{.INSTALL_SYMLINK}}'"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR updates `outcome` to the latest release to fix the clang-tidy issue discussed [here](https://github.com/ned14/outcome/issues/311).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows passed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the outcome dependency to version v2.2.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->