### PR TITLE
refactor(core): Apply formatting updates for clang-format v20.1.4.

### DIFF
--- a/components/core/src/clp/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/clp/GlobalSQLiteMetadataDB.cpp
@@ -425,9 +425,9 @@ void GlobalSQLiteMetadataDB::open() {
             m_db.prepare_statement(statement_buffer.data(), statement_buffer.size())
     );
 
-    m_upsert_files_transaction_begin_statement
-            = std::make_unique<SQLitePreparedStatement>(m_db.prepare_statement("BEGIN TRANSACTION")
-            );
+    m_upsert_files_transaction_begin_statement = std::make_unique<SQLitePreparedStatement>(
+            m_db.prepare_statement("BEGIN TRANSACTION")
+    );
     m_upsert_files_transaction_end_statement
             = std::make_unique<SQLitePreparedStatement>(m_db.prepare_statement("END TRANSACTION"));
 

--- a/components/core/src/clp/Grep.cpp
+++ b/components/core/src/clp/Grep.cpp
@@ -937,8 +937,8 @@ size_t Grep::search_and_output(
         // - Sub-query requires wildcard match, or
         // - no subqueries exist and the search string is not a match-all
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required())
-            || (query.contains_sub_queries() == false && query.search_string_matches_all() == false
-            ))
+            || (query.contains_sub_queries() == false
+                && query.search_string_matches_all() == false))
         {
             bool matched = wildcard_match_unsafe(
                     decompressed_msg,
@@ -994,8 +994,8 @@ bool Grep::search_and_decompress(
         // - Sub-query requires wildcard match, or
         // - no subqueries exist and the search string is not a match-all
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required())
-            || (query.contains_sub_queries() == false && query.search_string_matches_all() == false
-            ))
+            || (query.contains_sub_queries() == false
+                && query.search_string_matches_all() == false))
         {
             matched = wildcard_match_unsafe(
                     decompressed_msg,
@@ -1036,8 +1036,8 @@ size_t Grep::search(Query const& query, size_t limit, Archive& archive, File& co
         // - Sub-query requires wildcard match, or
         // - no subqueries exist and the search string is not a match-all
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required())
-            || (query.contains_sub_queries() == false && query.search_string_matches_all() == false
-            ))
+            || (query.contains_sub_queries() == false
+                && query.search_string_matches_all() == false))
         {
             // Decompress match
             bool decompress_successful

--- a/components/core/src/clp/Query.hpp
+++ b/components/core/src/clp/Query.hpp
@@ -45,8 +45,8 @@ public:
 
     VariableDictionaryEntry const* get_var_dict_entry() const { return m_var_dict_entry; }
 
-    std::unordered_set<VariableDictionaryEntry const*> const& get_possible_var_dict_entries(
-    ) const {
+    std::unordered_set<VariableDictionaryEntry const*> const&
+    get_possible_var_dict_entries() const {
         return m_possible_var_dict_entries;
     }
 

--- a/components/core/src/clp/SQLitePreparedStatement.cpp
+++ b/components/core/src/clp/SQLitePreparedStatement.cpp
@@ -47,7 +47,8 @@ SQLitePreparedStatement::SQLitePreparedStatement(SQLitePreparedStatement&& rhs) 
     *this = std::move(rhs);
 }
 
-SQLitePreparedStatement& SQLitePreparedStatement::operator=(SQLitePreparedStatement&& rhs
+SQLitePreparedStatement& SQLitePreparedStatement::operator=(
+        SQLitePreparedStatement&& rhs
 ) noexcept {
     if (this != &rhs) {
         if (nullptr != m_statement_handle) {

--- a/components/core/src/clp/TimestampPattern.cpp
+++ b/components/core/src/clp/TimestampPattern.cpp
@@ -937,8 +937,8 @@ void TimestampPattern::insert_formatted_timestamp(epochtime_t const timestamp, s
 }
 
 bool operator==(TimestampPattern const& lhs, TimestampPattern const& rhs) {
-    return (lhs.m_num_spaces_before_ts == rhs.m_num_spaces_before_ts && lhs.m_format == rhs.m_format
-    );
+    return (lhs.m_num_spaces_before_ts == rhs.m_num_spaces_before_ts
+            && lhs.m_format == rhs.m_format);
 }
 
 bool operator!=(TimestampPattern const& lhs, TimestampPattern const& rhs) {

--- a/components/core/src/clp/clg/clg.cpp
+++ b/components/core/src/clp/clg/clg.cpp
@@ -524,9 +524,9 @@ int main(int argc, char const* argv[]) {
         case GlobalMetadataDBConfig::MetadataDBType::SQLite: {
             auto global_metadata_db_path
                     = archives_dir / clp::streaming_archive::cMetadataDBFileName;
-            global_metadata_db
-                    = std::make_unique<clp::GlobalSQLiteMetadataDB>(global_metadata_db_path.string()
-                    );
+            global_metadata_db = std::make_unique<clp::GlobalSQLiteMetadataDB>(
+                    global_metadata_db_path.string()
+            );
             break;
         }
         case GlobalMetadataDBConfig::MetadataDBType::MySQL:

--- a/components/core/src/clp/clp/compression.cpp
+++ b/components/core/src/clp/clp/compression.cpp
@@ -131,8 +131,9 @@ bool compress(
         num_files_to_compress = files_to_compress.size() + grouped_files_to_compress.size();
     }
     if (command_line_args.sort_input_files()) {
-        sort(files_to_compress.begin(), files_to_compress.end(), file_gt_last_write_time_comparator
-        );
+        sort(files_to_compress.begin(),
+             files_to_compress.end(),
+             file_gt_last_write_time_comparator);
     }
     for (auto it = files_to_compress.cbegin(); it != files_to_compress.cend(); ++it) {
         if (archive_writer.get_data_size_of_dictionaries() >= target_data_size_of_dictionaries) {

--- a/components/core/src/clp/clp/run.cpp
+++ b/components/core/src/clp/clp/run.cpp
@@ -63,7 +63,8 @@ int run(int argc, char const* argv[]) {
             reader_parser = std::make_unique<log_surgeon::ReaderParser>(schema_file_path);
         }
 
-        boost::filesystem::path path_prefix_to_remove(command_line_args.get_path_prefix_to_remove()
+        boost::filesystem::path path_prefix_to_remove(
+                command_line_args.get_path_prefix_to_remove()
         );
 
         // Validate input paths exist

--- a/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
+++ b/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
@@ -437,8 +437,10 @@ auto serialize_node_id_value_pairs_to_json(
     }
 
     bool json_exception_captured{false};
-    auto json_exception_handler = [&]([[maybe_unused]] nlohmann::json::exception const& ex
-                                  ) -> void { json_exception_captured = true; };
+    auto json_exception_handler
+            = [&]([[maybe_unused]] nlohmann::json::exception const& ex) -> void {
+        json_exception_captured = true;
+    };
     using DfsIterator = JsonSerializationIterator<decltype(json_exception_handler)>;
 
     // NOTE: We use a `std::stack` (which uses `std::deque` as the underlying container) instead of
@@ -573,8 +575,9 @@ auto KeyValuePairLogEvent::get_user_gen_keys_schema_subtree_bitmap() const
 
 auto KeyValuePairLogEvent::serialize_to_json() const
         -> OUTCOME_V2_NAMESPACE::std_result<std::pair<nlohmann::json, nlohmann::json>> {
-    auto const auto_gen_keys_schema_subtree_bitmap_result{get_auto_gen_keys_schema_subtree_bitmap(
-    )};
+    auto const auto_gen_keys_schema_subtree_bitmap_result{
+            get_auto_gen_keys_schema_subtree_bitmap()
+    };
     if (auto_gen_keys_schema_subtree_bitmap_result.has_error()) {
         return auto_gen_keys_schema_subtree_bitmap_result.error();
     }
@@ -587,8 +590,9 @@ auto KeyValuePairLogEvent::serialize_to_json() const
         return serialized_auto_gen_kv_pairs_result.error();
     }
 
-    auto const user_gen_keys_schema_subtree_bitmap_result{get_user_gen_keys_schema_subtree_bitmap(
-    )};
+    auto const user_gen_keys_schema_subtree_bitmap_result{
+            get_user_gen_keys_schema_subtree_bitmap()
+    };
     if (user_gen_keys_schema_subtree_bitmap_result.has_error()) {
         return user_gen_keys_schema_subtree_bitmap_result.error();
     }

--- a/components/core/src/clp/ffi/ir_stream/search/test/test_QueryHandlerImpl.cpp
+++ b/components/core/src/clp/ffi/ir_stream/search/test/test_QueryHandlerImpl.cpp
@@ -412,8 +412,9 @@ TEST_CASE("query_handler_handle_projection", "[ffi][ir_stream][search][QueryHand
     SchemaTree::Node::id_t node_id{1};
     std::map<std::string, std::set<SchemaTree::Node::id_t>> actual_resolved_projections;
     auto new_projected_schema_tree_node_callback
-            = [&](bool is_auto_gen, SchemaTree::Node::id_t node_id, std::string_view key
-              ) -> outcome_v2::std_result<void> {
+            = [&](bool is_auto_gen,
+                  SchemaTree::Node::id_t node_id,
+                  std::string_view key) -> outcome_v2::std_result<void> {
         REQUIRE((is_auto_generated == is_auto_gen));
         auto [column_it, column_inserted] = actual_resolved_projections.try_emplace(
                 std::string{key},

--- a/components/core/src/clp/ffi/ir_stream/utils.hpp
+++ b/components/core/src/clp/ffi/ir_stream/utils.hpp
@@ -216,14 +216,17 @@ auto encode_and_serialize_schema_tree_node_id(
     };
 
     if (node_id <= static_cast<SchemaTree::Node::id_t>(INT8_MAX)) {
-        size_dependent_encode_and_serialize_schema_tree_node_id.template operator(
-        )<int8_t>(one_byte_length_indicator_tag);
+        size_dependent_encode_and_serialize_schema_tree_node_id.template operator()<int8_t>(
+                one_byte_length_indicator_tag
+        );
     } else if (node_id <= static_cast<SchemaTree::Node::id_t>(INT16_MAX)) {
-        size_dependent_encode_and_serialize_schema_tree_node_id.template operator(
-        )<int16_t>(two_byte_length_indicator_tag);
+        size_dependent_encode_and_serialize_schema_tree_node_id.template operator()<int16_t>(
+                two_byte_length_indicator_tag
+        );
     } else if (node_id <= static_cast<SchemaTree::Node::id_t>(INT32_MAX)) {
-        size_dependent_encode_and_serialize_schema_tree_node_id.template operator(
-        )<int32_t>(four_byte_length_indicator_tag);
+        size_dependent_encode_and_serialize_schema_tree_node_id.template operator()<int32_t>(
+                four_byte_length_indicator_tag
+        );
     } else {
         return false;
     }
@@ -239,8 +242,8 @@ auto deserialize_and_decode_schema_tree_node_id(
         ReaderInterface& reader
 ) -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::Node::id_t>> {
     auto size_dependent_deserialize_and_decode_schema_tree_node_id
-            = [&reader]<SignedIntegerType encoded_node_id_t>(
-              ) -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::Node::id_t>> {
+            = [&reader]<SignedIntegerType encoded_node_id_t>()
+            -> OUTCOME_V2_NAMESPACE::std_result<std::pair<bool, SchemaTree::Node::id_t>> {
         encoded_node_id_t encoded_node_id{};
         if (false == deserialize_int(reader, encoded_node_id)) {
             return std::errc::result_out_of_range;
@@ -253,16 +256,16 @@ auto deserialize_and_decode_schema_tree_node_id(
     };
 
     if (one_byte_length_indicator_tag == length_indicator_tag) {
-        return size_dependent_deserialize_and_decode_schema_tree_node_id.template operator(
-        )<int8_t>();
+        return size_dependent_deserialize_and_decode_schema_tree_node_id
+                .template operator()<int8_t>();
     }
     if (two_byte_length_indicator_tag == length_indicator_tag) {
-        return size_dependent_deserialize_and_decode_schema_tree_node_id.template operator(
-        )<int16_t>();
+        return size_dependent_deserialize_and_decode_schema_tree_node_id
+                .template operator()<int16_t>();
     }
     if (four_byte_length_indicator_tag == length_indicator_tag) {
-        return size_dependent_deserialize_and_decode_schema_tree_node_id.template operator(
-        )<int32_t>();
+        return size_dependent_deserialize_and_decode_schema_tree_node_id
+                .template operator()<int32_t>();
     }
     return std::errc::protocol_error;
 }

--- a/components/core/src/clp/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/clp/streaming_archive/MetadataDB.cpp
@@ -362,7 +362,8 @@ void MetadataDB::FileIterator::get_path(string& path) const {
 }
 
 epochtime_t MetadataDB::FileIterator::get_begin_ts() const {
-    return m_statement.column_int64(enum_to_underlying_type(FilesTableFieldIndexes::BeginTimestamp)
+    return m_statement.column_int64(
+            enum_to_underlying_type(FilesTableFieldIndexes::BeginTimestamp)
     );
 }
 
@@ -384,7 +385,8 @@ size_t MetadataDB::FileIterator::get_num_uncompressed_bytes() const {
 }
 
 size_t MetadataDB::FileIterator::get_begin_message_ix() const {
-    return m_statement.column_int64(enum_to_underlying_type(FilesTableFieldIndexes::BeginMessageIx)
+    return m_statement.column_int64(
+            enum_to_underlying_type(FilesTableFieldIndexes::BeginMessageIx)
     );
 }
 

--- a/components/core/src/clp_s/TimestampPattern.cpp
+++ b/components/core/src/clp_s/TimestampPattern.cpp
@@ -1101,8 +1101,8 @@ void TimestampPattern::insert_formatted_timestamp(epochtime_t timestamp, string&
 }
 
 bool operator==(TimestampPattern const& lhs, TimestampPattern const& rhs) {
-    return (lhs.m_num_spaces_before_ts == rhs.m_num_spaces_before_ts && lhs.m_format == rhs.m_format
-    );
+    return (lhs.m_num_spaces_before_ts == rhs.m_num_spaces_before_ts
+            && lhs.m_format == rhs.m_format);
 }
 
 bool operator!=(TimestampPattern const& lhs, TimestampPattern const& rhs) {

--- a/components/core/src/clp_s/ZstdDecompressor.cpp
+++ b/components/core/src/clp_s/ZstdDecompressor.cpp
@@ -266,8 +266,9 @@ ErrorCode ZstdDecompressor::open(std::string const& compressed_file_path) {
     memory_map_params.path = compressed_file_path;
     memory_map_params.flags = boost::iostreams::mapped_file::readonly;
     memory_map_params.length = compressed_file_size;
-    memory_map_params.hint = m_memory_mapped_compressed_file.data(
-    );  // Try to map it to the same memory location as previous memory mapped file
+    memory_map_params.hint
+            = m_memory_mapped_compressed_file.data();  // Try to map it to the same memory location
+                                                       // as previous memory mapped file
     m_memory_mapped_compressed_file.open(memory_map_params);
     if (false == m_memory_mapped_compressed_file.is_open()) {
         SPDLOG_ERROR(
@@ -299,8 +300,8 @@ void ZstdDecompressor::reset_stream() {
         m_file_read_buffer_length = 0;
         m_compressed_stream_block.size = m_file_read_buffer_length;
         if (false
-            == (clp::ErrorCode::ErrorCode_Success == rc || clp::ErrorCode::ErrorCode_EndOfFile == rc
-            ))
+            == (clp::ErrorCode::ErrorCode_Success == rc
+                || clp::ErrorCode::ErrorCode_EndOfFile == rc))
         {
             throw OperationFailed(static_cast<ErrorCode>(rc), __FILENAME__, __LINE__);
         }

--- a/components/core/src/clp_s/search/ast/ColumnDescriptor.cpp
+++ b/components/core/src/clp_s/search/ast/ColumnDescriptor.cpp
@@ -59,7 +59,8 @@ std::shared_ptr<ColumnDescriptor> ColumnDescriptor::create_from_descriptors(
         DescriptorList const& descriptors,
         std::string_view descriptor_namespace
 ) {
-    return std::shared_ptr<ColumnDescriptor>(new ColumnDescriptor(descriptors, descriptor_namespace)
+    return std::shared_ptr<ColumnDescriptor>(
+            new ColumnDescriptor(descriptors, descriptor_namespace)
     );
 }
 

--- a/components/core/src/clp_s/search/clp_search/Query.hpp
+++ b/components/core/src/clp_s/search/clp_search/Query.hpp
@@ -42,8 +42,8 @@ public:
 
     VariableDictionaryEntry const* get_var_dict_entry() const { return m_var_dict_entry; }
 
-    std::unordered_set<VariableDictionaryEntry const*> const& get_possible_var_dict_entries(
-    ) const {
+    std::unordered_set<VariableDictionaryEntry const*> const&
+    get_possible_var_dict_entries() const {
         return m_possible_var_dict_entries;
     }
 

--- a/components/core/src/glt/GlobalSQLiteMetadataDB.cpp
+++ b/components/core/src/glt/GlobalSQLiteMetadataDB.cpp
@@ -382,9 +382,9 @@ void GlobalSQLiteMetadataDB::open() {
             m_db.prepare_statement(statement_buffer.data(), statement_buffer.size())
     );
 
-    m_upsert_files_transaction_begin_statement
-            = std::make_unique<SQLitePreparedStatement>(m_db.prepare_statement("BEGIN TRANSACTION")
-            );
+    m_upsert_files_transaction_begin_statement = std::make_unique<SQLitePreparedStatement>(
+            m_db.prepare_statement("BEGIN TRANSACTION")
+    );
     m_upsert_files_transaction_end_statement
             = std::make_unique<SQLitePreparedStatement>(m_db.prepare_statement("END TRANSACTION"));
 

--- a/components/core/src/glt/Grep.cpp
+++ b/components/core/src/glt/Grep.cpp
@@ -763,8 +763,8 @@ size_t Grep::search_and_output(
         // - Sub-query requires wildcard match, or
         // - no subqueries exist and the search string is not a match-all
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required())
-            || (query.contains_sub_queries() == false && query.search_string_matches_all() == false
-            ))
+            || (query.contains_sub_queries() == false
+                && query.search_string_matches_all() == false))
         {
             bool matched = wildcard_match_unsafe(
                     decompressed_msg,
@@ -820,8 +820,8 @@ bool Grep::search_and_decompress(
         // - Sub-query requires wildcard match, or
         // - no subqueries exist and the search string is not a match-all
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required())
-            || (query.contains_sub_queries() == false && query.search_string_matches_all() == false
-            ))
+            || (query.contains_sub_queries() == false
+                && query.search_string_matches_all() == false))
         {
             matched = wildcard_match_unsafe(
                     decompressed_msg,
@@ -862,8 +862,8 @@ size_t Grep::search(Query const& query, size_t limit, Archive& archive, File& co
         // - Sub-query requires wildcard match, or
         // - no subqueries exist and the search string is not a match-all
         if ((query.contains_sub_queries() && matching_sub_query->wildcard_match_required())
-            || (query.contains_sub_queries() == false && query.search_string_matches_all() == false
-            ))
+            || (query.contains_sub_queries() == false
+                && query.search_string_matches_all() == false))
         {
             // Decompress match
             bool decompress_successful

--- a/components/core/src/glt/Query.hpp
+++ b/components/core/src/glt/Query.hpp
@@ -45,8 +45,8 @@ public:
 
     VariableDictionaryEntry const* get_var_dict_entry() const { return m_var_dict_entry; }
 
-    std::unordered_set<VariableDictionaryEntry const*> const& get_possible_var_dict_entries(
-    ) const {
+    std::unordered_set<VariableDictionaryEntry const*> const&
+    get_possible_var_dict_entries() const {
         return m_possible_var_dict_entries;
     }
 

--- a/components/core/src/glt/SQLitePreparedStatement.cpp
+++ b/components/core/src/glt/SQLitePreparedStatement.cpp
@@ -47,7 +47,8 @@ SQLitePreparedStatement::SQLitePreparedStatement(SQLitePreparedStatement&& rhs) 
     *this = std::move(rhs);
 }
 
-SQLitePreparedStatement& SQLitePreparedStatement::operator=(SQLitePreparedStatement&& rhs
+SQLitePreparedStatement& SQLitePreparedStatement::operator=(
+        SQLitePreparedStatement&& rhs
 ) noexcept {
     if (this != &rhs) {
         if (nullptr != m_statement_handle) {

--- a/components/core/src/glt/TimestampPattern.cpp
+++ b/components/core/src/glt/TimestampPattern.cpp
@@ -937,8 +937,8 @@ void TimestampPattern::insert_formatted_timestamp(epochtime_t const timestamp, s
 }
 
 bool operator==(TimestampPattern const& lhs, TimestampPattern const& rhs) {
-    return (lhs.m_num_spaces_before_ts == rhs.m_num_spaces_before_ts && lhs.m_format == rhs.m_format
-    );
+    return (lhs.m_num_spaces_before_ts == rhs.m_num_spaces_before_ts
+            && lhs.m_format == rhs.m_format);
 }
 
 bool operator!=(TimestampPattern const& lhs, TimestampPattern const& rhs) {

--- a/components/core/src/glt/glt/decompression.cpp
+++ b/components/core/src/glt/glt/decompression.cpp
@@ -46,9 +46,9 @@ bool decompress(
             case GlobalMetadataDBConfig::MetadataDBType::SQLite: {
                 auto global_metadata_db_path
                         = archives_dir / streaming_archive::cMetadataDBFileName;
-                global_metadata_db
-                        = std::make_unique<GlobalSQLiteMetadataDB>(global_metadata_db_path.string()
-                        );
+                global_metadata_db = std::make_unique<GlobalSQLiteMetadataDB>(
+                        global_metadata_db_path.string()
+                );
                 break;
             }
             case GlobalMetadataDBConfig::MetadataDBType::MySQL:

--- a/components/core/src/glt/glt/run.cpp
+++ b/components/core/src/glt/glt/run.cpp
@@ -62,7 +62,8 @@ int run(int argc, char const* argv[]) {
         if (false == obtain_input_paths(command_line_args, input_paths)) {
             return -1;
         }
-        boost::filesystem::path path_prefix_to_remove(command_line_args.get_path_prefix_to_remove()
+        boost::filesystem::path path_prefix_to_remove(
+                command_line_args.get_path_prefix_to_remove()
         );
 
         // Validate input paths exist

--- a/components/core/src/glt/streaming_archive/MetadataDB.cpp
+++ b/components/core/src/glt/streaming_archive/MetadataDB.cpp
@@ -323,7 +323,8 @@ void MetadataDB::FileIterator::get_path(string& path) const {
 }
 
 epochtime_t MetadataDB::FileIterator::get_begin_ts() const {
-    return m_statement.column_int64(enum_to_underlying_type(FilesTableFieldIndexes::BeginTimestamp)
+    return m_statement.column_int64(
+            enum_to_underlying_type(FilesTableFieldIndexes::BeginTimestamp)
     );
 }
 

--- a/components/core/src/glt/streaming_archive/reader/Archive.cpp
+++ b/components/core/src/glt/streaming_archive/reader/Archive.cpp
@@ -465,8 +465,8 @@ size_t Archive::decompress_messages_and_output(
         // - Sub-query requires wildcard match, or
         // - no subqueries exist and the search string is not a match-all
         if ((query.contains_sub_queries() && wildcard_required[ix])
-            || (query.contains_sub_queries() == false && query.search_string_matches_all() == false
-            ))
+            || (query.contains_sub_queries() == false
+                && query.search_string_matches_all() == false))
         {
             bool matched = wildcard_match_unsafe(
                     decompressed_msg,

--- a/components/core/src/glt/streaming_archive/reader/LogtypeTableManager.cpp
+++ b/components/core/src/glt/streaming_archive/reader/LogtypeTableManager.cpp
@@ -46,8 +46,9 @@ void LogtypeTableManager::load_variables_segment() {
     memory_map_params.path = column_file;
     memory_map_params.flags = boost::iostreams::mapped_file::readonly;
     memory_map_params.length = column_file_size;
-    memory_map_params.hint = m_memory_mapped_segment_file.data(
-    );  // try to map it to the same memory location as previous memory mapped file
+    memory_map_params.hint
+            = m_memory_mapped_segment_file.data();  // try to map it to the same memory location as
+                                                    // previous memory mapped file
     m_memory_mapped_segment_file.open(memory_map_params);
     if (!m_memory_mapped_segment_file.is_open()) {
         SPDLOG_ERROR(
@@ -85,8 +86,9 @@ void LogtypeTableManager::load_metadata() {
     memory_map_params.path = metadata_path;
     memory_map_params.flags = boost::iostreams::mapped_file::readonly;
     memory_map_params.length = metadata_file_size;
-    memory_map_params.hint = memory_mapped_segment_file.data(
-    );  // try to map it to the same memory location as previous memory mapped file
+    memory_map_params.hint
+            = memory_mapped_segment_file.data();  // try to map it to the same memory location as
+                                                  // previous memory mapped file
     memory_mapped_segment_file.open(memory_map_params);
     if (!memory_mapped_segment_file.is_open()) {
         SPDLOG_ERROR(

--- a/components/core/src/reducer/Record.hpp
+++ b/components/core/src/reducer/Record.hpp
@@ -18,7 +18,8 @@ class Record {
 public:
     virtual ~Record() = default;
 
-    [[nodiscard]] virtual std::string_view get_string_view([[maybe_unused]] std::string_view key
+    [[nodiscard]] virtual std::string_view get_string_view(
+            [[maybe_unused]] std::string_view key
     ) const {
         return {};
     }

--- a/components/core/src/reducer/RecordGroupIterator.hpp
+++ b/components/core/src/reducer/RecordGroupIterator.hpp
@@ -121,7 +121,8 @@ public:
     FilteredInt64MapRecordGroupIterator(FilteredInt64MapRecordGroupIterator const&&) = delete;
     FilteredInt64MapRecordGroupIterator const& operator=(FilteredInt64MapRecordGroupIterator const&)
             = delete;
-    FilteredInt64MapRecordGroupIterator const& operator=(FilteredInt64MapRecordGroupIterator const&&
+    FilteredInt64MapRecordGroupIterator const& operator=(
+            FilteredInt64MapRecordGroupIterator const&&
     ) = delete;
 
     RecordGroup& get() override {

--- a/components/core/src/reducer/ServerContext.cpp
+++ b/components/core/src/reducer/ServerContext.cpp
@@ -215,7 +215,8 @@ bool ServerContext::publish_pipeline_results() {
     vector<bsoncxx::document::view> result_documents;
     for (auto group_it = m_pipeline->finish(); false == group_it->done(); group_it->next()) {
         auto& group = group_it->get();
-        results.push_back(serialize(group.get_tags(), group.record_iter(), nlohmann::json::to_bson)
+        results.push_back(
+                serialize(group.get_tags(), group.record_iter(), nlohmann::json::to_bson)
         );
 
         vector<uint8_t>& encoded_result = results.back();


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The new clang-format 20.1.4 release seems to change how some of our c++ code should be formatted even without any changes to our formatting config. This PR runs clang-format 20.1.4 on our existing c++ code to unblock PRs failing due to CI formatting checks (`lint:check-cpp-full`) on files they do not touch.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that `lint:check-cpp-full` succeeds after this change


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved code readability and consistency through formatting and stylistic adjustments across multiple components. No changes to application logic or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->