### PR TITLE
build(deps): Lock snowballstemmer to v2.* to work around #886.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,6 @@ sphinx>=8.1.3
 sphinx_design>=0.6.1
 sphinx-copybutton>=0.5.2
 sphinxcontrib-mermaid>=1.0.0
+
+# Lock to v2.* to work around https://github.com/sphinx-doc/sphinx/issues/13533
+snowballstemmer~=2.2


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says, this mitigates #886 until a fix is available for https://github.com/sphinx-doc/sphinx/issues/13533.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Workflows succeed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added the snowballstemmer dependency to documentation requirements to address a known compatibility issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->