### PR TITLE
feat(clp-s): Add the read-side implementation for the archive range index.

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -633,6 +633,7 @@ set(SOURCE_FILES_unitTest
         tests/test-BoundedReader.cpp
         tests/test-BufferedFileReader.cpp
         tests/test-clp_s-end_to_end.cpp
+        tests/test-clp_s-range_index.cpp
         tests/test-clp_s-search.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -117,6 +117,10 @@ public:
 
     std::shared_ptr<ReaderUtils::SchemaMap> get_schema_map() { return m_schema_map; }
 
+    auto get_range_index() const -> std::vector<ArchiveReaderAdaptor::RangeIndexEntry> const& {
+        return m_archive_reader_adaptor->get_range_index();
+    }
+
     /**
      * Writes decoded messages to a file.
      * @param writer

--- a/components/core/tests/test-clp_s-range_index.cpp
+++ b/components/core/tests/test-clp_s-range_index.cpp
@@ -1,0 +1,222 @@
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+#include <catch2/catch.hpp>
+#include <fmt/format.h>
+#include <msgpack.hpp>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
+
+#include "../src/clp/ffi/ir_stream/protocol_constants.hpp"
+#include "../src/clp/ffi/ir_stream/Serializer.hpp"
+#include "../src/clp/FileReader.hpp"
+#include "../src/clp/FileWriter.hpp"
+#include "../src/clp/ir/types.hpp"
+#include "../src/clp/streaming_compression/zstd/Compressor.hpp"
+#include "../src/clp_s/ArchiveReader.hpp"
+#include "../src/clp_s/InputConfig.hpp"
+#include "../src/clp_s/JsonParser.hpp"
+#include "TestOutputCleaner.hpp"
+
+constexpr std::string_view cTestRangeIndexArchiveDirectory{"test-range-index-archive"};
+constexpr std::string_view cTestRangeIndexIRDirectory{"test-range-index-ir"};
+constexpr std::string_view cTestRangeIndexInputFileDirectory{"test_log_files"};
+constexpr std::string_view cTestRangeIndexInputFile{"test_no_floats_sorted.jsonl"};
+constexpr std::string_view cTestRangeIndexIRInputFile{"test_no_floats_sorted.ir"};
+constexpr std::string_view cTestRangeIndexIRMetadataKey{"test_key"};
+constexpr std::string_view cTestRangeIndexIRMetadataValue{"test_value"};
+
+namespace {
+auto get_test_input_path_relative_to_tests_dir() -> std::filesystem::path;
+auto get_test_input_local_path() -> std::string;
+void serialize_record(
+        nlohmann::json const& auto_gen,
+        nlohmann::json const& user_gen,
+        clp::ffi::ir_stream::Serializer<clp::ir::eight_byte_encoded_variable_t>& serializer
+);
+void compress_ir();
+void compress(bool single_file_archive, bool from_ir);
+void check_archive_metadata(bool from_ir);
+
+auto get_test_input_path_relative_to_tests_dir() -> std::filesystem::path {
+    return std::filesystem::path{cTestRangeIndexInputFileDirectory} / cTestRangeIndexInputFile;
+}
+
+auto get_test_input_local_path() -> std::string {
+    std::filesystem::path const current_file_path{__FILE__};
+    auto const tests_dir{current_file_path.parent_path()};
+    return (tests_dir / get_test_input_path_relative_to_tests_dir()).string();
+}
+
+auto get_ir_test_input_relative_path() -> std::string {
+    return (std::filesystem::path{cTestRangeIndexIRDirectory} / cTestRangeIndexIRInputFile)
+            .string();
+}
+
+void serialize_record(
+        nlohmann::json const& auto_gen,
+        nlohmann::json const& user_gen,
+        clp::ffi::ir_stream::Serializer<clp::ir::eight_byte_encoded_variable_t>& serializer
+) {
+    auto const auto_gen_bytes{nlohmann::json::to_msgpack(auto_gen)};
+    auto const user_gen_bytes{nlohmann::json::to_msgpack(user_gen)};
+    auto const auto_gen_handle{msgpack::unpack(
+            reinterpret_cast<char const*>(auto_gen_bytes.data()),
+            auto_gen_bytes.size()
+    )};
+    auto const user_gen_handle{msgpack::unpack(
+            reinterpret_cast<char const*>(user_gen_bytes.data()),
+            user_gen_bytes.size()
+    )};
+    auto const auto_gen_obj{auto_gen_handle.get()};
+    auto const user_gen_obj{user_gen_handle.get()};
+    REQUIRE(msgpack::type::MAP == auto_gen_obj.type);
+    REQUIRE(msgpack::type::MAP == user_gen_obj.type);
+    REQUIRE(serializer.serialize_msgpack_map(auto_gen_obj.via.map, user_gen_obj.via.map));
+}
+
+void compress_ir() {
+    std::filesystem::create_directory(cTestRangeIndexIRDirectory);
+    REQUIRE(std::filesystem::is_directory(cTestRangeIndexIRDirectory));
+
+    nlohmann::json ir_metadata = {{cTestRangeIndexIRMetadataKey, cTestRangeIndexIRMetadataValue}};
+
+    auto result{clp::ffi::ir_stream::Serializer<clp::ir::eight_byte_encoded_variable_t>::create(
+            ir_metadata
+    )};
+    REQUIRE(false == result.has_error());
+    auto& serializer = result.value();
+
+    auto empty_object = nlohmann::json::parse("{}");
+    clp::FileReader reader(get_test_input_local_path());
+    std::string line;
+    while (clp::ErrorCode::ErrorCode_Success
+           == reader.try_read_to_delimiter('\n', false, false, line))
+    {
+        auto json_line = nlohmann::json::parse(line);
+        serialize_record(empty_object, json_line, serializer);
+    }
+
+    clp::FileWriter writer;
+    REQUIRE_NOTHROW(writer.open(
+            get_ir_test_input_relative_path(),
+            clp::FileWriter::OpenMode::CREATE_FOR_WRITING
+    ));
+    clp::streaming_compression::zstd::Compressor compressor;
+    compressor.open(writer);
+
+    auto const eof_packet{clp::ffi::ir_stream::cProtocol::Eof};
+    auto const ir_buf{serializer.get_ir_buf_view()};
+    compressor.write(reinterpret_cast<char const*>(ir_buf.data()), ir_buf.size());
+    compressor.write(reinterpret_cast<char const*>(&eof_packet), sizeof(eof_packet));
+    compressor.close();
+    writer.close();
+}
+
+void compress(bool single_file_archive, bool from_ir) {
+    constexpr auto cDefaultTargetEncodedSize = 8ULL * 1024 * 1024 * 1024;  // 8 GiB
+    constexpr auto cDefaultMaxDocumentSize = 512ULL * 1024 * 1024;  // 512 MiB
+    constexpr auto cDefaultMinTableSize = 1ULL * 1024 * 1024;  // 1 MiB
+    constexpr auto cDefaultCompressionLevel = 3;
+    constexpr auto cDefaultPrintArchiveStats = false;
+    constexpr auto cDefaultStructurizeArrays = false;
+    auto const input_file_path{
+            from_ir ? get_ir_test_input_relative_path() : get_test_input_local_path()
+    };
+    auto const input_file_type{
+            from_ir ? clp_s::CommandLineArguments::FileType::KeyValueIr
+                    : clp_s::CommandLineArguments::FileType::Json
+    };
+
+    if (from_ir) {
+        compress_ir();
+    }
+
+    std::filesystem::create_directory(cTestRangeIndexArchiveDirectory);
+    REQUIRE((std::filesystem::is_directory(cTestRangeIndexArchiveDirectory)));
+
+    clp_s::JsonParserOption parser_option{};
+    parser_option.input_paths.emplace_back(
+            clp_s::Path{.source = clp_s::InputSource::Filesystem, .path = input_file_path}
+    );
+    parser_option.archives_dir = cTestRangeIndexArchiveDirectory;
+    parser_option.target_encoded_size = cDefaultTargetEncodedSize;
+    parser_option.max_document_size = cDefaultMaxDocumentSize;
+    parser_option.min_table_size = cDefaultMinTableSize;
+    parser_option.compression_level = cDefaultCompressionLevel;
+    parser_option.print_archive_stats = cDefaultPrintArchiveStats;
+    parser_option.structurize_arrays = cDefaultStructurizeArrays;
+    parser_option.single_file_archive = single_file_archive;
+    parser_option.input_file_type = input_file_type;
+
+    clp_s::JsonParser parser{parser_option};
+    if (from_ir) {
+        REQUIRE(parser.parse_from_ir());
+    } else {
+        REQUIRE(parser.parse());
+    }
+    parser.store();
+
+    REQUIRE((false == std::filesystem::is_empty(cTestRangeIndexArchiveDirectory)));
+}
+
+void check_archive_metadata(bool from_ir) {
+    clp_s::ArchiveReader archive_reader;
+    auto const expected_input_path{
+            from_ir ? get_ir_test_input_relative_path() : get_test_input_local_path()
+    };
+    for (auto const& entry : std::filesystem::directory_iterator(cTestRangeIndexArchiveDirectory)) {
+        clp_s::Path archive_path{
+                .source{clp_s::InputSource::Filesystem},
+                .path{entry.path().string()}
+        };
+        REQUIRE_NOTHROW(archive_reader.open(archive_path, clp_s::NetworkAuthOption{}));
+        auto const& range_index = archive_reader.get_range_index();
+        REQUIRE(1ULL == range_index.size());
+        auto const& range_index_entry = range_index.front();
+        REQUIRE(0ULL == range_index_entry.start_index);
+        REQUIRE(4ULL == range_index_entry.end_index);
+        auto const& metadata_fields = range_index_entry.fields;
+        REQUIRE(metadata_fields.contains(clp_s::constants::range_index::cArchiveCreatorId));
+        REQUIRE(metadata_fields.at(clp_s::constants::range_index::cArchiveCreatorId).is_string());
+        REQUIRE(false
+                == metadata_fields.at(clp_s::constants::range_index::cArchiveCreatorId)
+                           .template get<std::string>()
+                           .empty());
+        REQUIRE(metadata_fields.contains(clp_s::constants::range_index::cFilename));
+        REQUIRE(metadata_fields.at(clp_s::constants::range_index::cFilename).is_string());
+        REQUIRE(expected_input_path
+                == metadata_fields.at(clp_s::constants::range_index::cFilename)
+                           .template get<std::string>());
+        REQUIRE(metadata_fields.contains(clp_s::constants::range_index::cFileSplitNumber));
+        REQUIRE(metadata_fields.at(clp_s::constants::range_index::cFileSplitNumber)
+                        .is_number_integer());
+        REQUIRE(0ULL
+                == metadata_fields.at(clp_s::constants::range_index::cFileSplitNumber)
+                           .template get<size_t>());
+        if (from_ir) {
+            REQUIRE(metadata_fields.contains(cTestRangeIndexIRMetadataKey));
+            REQUIRE(metadata_fields.at(cTestRangeIndexIRMetadataKey).is_string());
+            REQUIRE(
+                    cTestRangeIndexIRMetadataValue
+                    == metadata_fields.at(cTestRangeIndexIRMetadataKey).template get<std::string>()
+            );
+        }
+        REQUIRE_NOTHROW(archive_reader.close());
+    }
+}
+}  // namespace
+
+TEST_CASE("clp-s-range-index", "[clp-s][range-index]") {
+    auto single_file_archive = GENERATE(true, false);
+    auto from_ir = GENERATE(true, false);
+
+    TestOutputCleaner const test_cleanup{
+            {std::string{cTestRangeIndexArchiveDirectory}, std::string{cTestRangeIndexIRDirectory}}
+    };
+
+    compress(single_file_archive, from_ir);
+    check_archive_metadata(from_ir);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR follows up on #847 and implements the read side of the archive range index, and also adds end to end tests for this feature across both the JSON and kv-ir ingestion paths.

The code for reading the range index metdata packet lives in `ArchiveReaderAdaptor`, and access to the range index is forwarded to readers through `ArchiveReader`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Added end to end tests that verify that the archive range index acts as expected when ingesting JSON and kv-ir files


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
