### PR TITLE
refactor(kv-ir): Rename `IrUnitHandlerInterface` to `IrUnitHandlerInterfaceReq`; Add `IrUnitHandlerReq` to include all type constraints (resolves #901).

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -447,7 +447,7 @@ set(SOURCE_FILES_unitTest
         src/clp/ffi/ir_stream/encoding_methods.hpp
         src/clp/ffi/ir_stream/IrErrorCode.cpp
         src/clp/ffi/ir_stream/IrErrorCode.hpp
-        src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp
+        src/clp/ffi/ir_stream/IrUnitHandlerReq.hpp
         src/clp/ffi/ir_stream/IrUnitType.hpp
         src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
         src/clp/ffi/ir_stream/ir_unit_deserialization_methods.hpp
@@ -638,7 +638,7 @@ set(SOURCE_FILES_unitTest
         tests/test-clp_s-search.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp
-        tests/test-ffi_IrUnitHandlerInterface.cpp
+        tests/test-ffi_IrUnitHandlerReq.cpp
         tests/test-ffi_KeyValuePairLogEvent.cpp
         tests/test-ffi_SchemaTree.cpp
         tests/test-FileDescriptorReader.cpp

--- a/components/core/src/clp/ffi/ir_stream/IrUnitHandlerReq.hpp
+++ b/components/core/src/clp/ffi/ir_stream/IrUnitHandlerReq.hpp
@@ -1,5 +1,5 @@
-#ifndef CLP_FFI_IR_STREAM_IRUNITHANDLERINTERFACE_HPP
-#define CLP_FFI_IR_STREAM_IRUNITHANDLERINTERFACE_HPP
+#ifndef CLP_FFI_IR_STREAM_IRUNITHANDLERREQ_HPP
+#define CLP_FFI_IR_STREAM_IRUNITHANDLERREQ_HPP
 
 #include <concepts>
 #include <memory>
@@ -12,11 +12,12 @@
 
 namespace clp::ffi::ir_stream {
 /**
- * Concept that defines the IR unit handler interface.
+ * Requirement for the IR unit handler interface.
+ * @tparam IrUnitHandlerType The type of the IR unit handler.
  */
-template <typename Handler>
-concept IrUnitHandlerInterface = requires(
-        Handler handler,
+template <typename IrUnitHandlerType>
+concept IrUnitHandlerInterfaceReq = requires(
+        IrUnitHandlerType handler,
         KeyValuePairLogEvent&& log_event,
         bool is_auto_generated,
         UtcOffset utc_offset_old,
@@ -66,6 +67,14 @@ concept IrUnitHandlerInterface = requires(
         handler.handle_end_of_stream()
     } -> std::same_as<IRErrorCode>;
 };
+
+/**
+ * Requirement for an IR unit handler.
+ * @tparam IrUnitHandlerType The type of the IR unit handler.
+ */
+template <typename IrUnitHandlerType>
+concept IrUnitHandlerReq = std::move_constructible<IrUnitHandlerType>
+                           && IrUnitHandlerInterfaceReq<IrUnitHandlerType>;
 }  // namespace clp::ffi::ir_stream
 
-#endif  // CLP_FFI_IR_STREAM_IRUNITHANDLERINTERFACE_HPP
+#endif  // CLP_FFI_IR_STREAM_IRUNITHANDLERREQ_HPP

--- a/components/core/src/clp/ffi/ir_stream/search/test/test_deserializer_integration.cpp
+++ b/components/core/src/clp/ffi/ir_stream/search/test/test_deserializer_integration.cpp
@@ -34,7 +34,7 @@ namespace {
 using JsonPair = std::pair<nlohmann::json, nlohmann::json>;
 
 /**
- * Implementation of `clp::ffi::ir_stream::IrUnitHandlerInterface` for testing purposes.
+ * Implementation of `clp::ffi::ir_stream::IrUnitHandlerReq` for testing purposes.
  */
 class IrUnitHandler {
 public:

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -40,7 +40,7 @@ using clp::UtcOffset;
 
 namespace clp_s {
 /**
- * Class that implements `clp::ffi::ir_stream::IrUnitHandlerInterface` for Key-Value IR compression.
+ * Class that implements `clp::ffi::ir_stream::IrUnitHandlerReq` for Key-Value IR compression.
  */
 class IrUnitHandler {
 public:

--- a/components/core/tests/test-ffi_IrUnitHandlerReq.cpp
+++ b/components/core/tests/test-ffi_IrUnitHandlerReq.cpp
@@ -6,7 +6,7 @@
 #include <catch2/catch.hpp>
 
 #include "../src/clp/ffi/ir_stream/decoding_methods.hpp"
-#include "../src/clp/ffi/ir_stream/IrUnitHandlerInterface.hpp"
+#include "../src/clp/ffi/ir_stream/IrUnitHandlerReq.hpp"
 #include "../src/clp/ffi/KeyValuePairLogEvent.hpp"
 #include "../src/clp/ffi/SchemaTree.hpp"
 #include "../src/clp/time_types.hpp"
@@ -22,11 +22,11 @@ constexpr UtcOffset cTestUtcOffsetDelta{1000};
 constexpr std::string_view cTestSchemaTreeNodeKeyName{"test_key"};
 
 /**
- * Class that implements `clp::ffi::ir_stream::IrUnitHandlerInterface` for testing purposes.
+ * Class that implements `clp::ffi::ir_stream::IrUnitHandlerReq` for testing purposes.
  */
 class TrivialIrUnitHandler {
 public:
-    // Implements `clp::ffi::ir_stream::IrUnitHandlerInterface` interface
+    // Implements `clp::ffi::ir_stream::IrUnitHandlerReq`
     [[nodiscard]] auto handle_log_event(KeyValuePairLogEvent&& log_event) -> IRErrorCode {
         m_log_event.emplace(std::move(log_event));
         return IRErrorCode::IRErrorCode_Success;
@@ -75,20 +75,18 @@ private:
 
 /**
  * Class that inherits `TrivialIrUnitHandler` which also implements
- * `clp::ffi::ir_stream::IrUnitHandlerInterface`.
+ * `clp::ffi::ir_stream::IrUnitHandlerReq`.
  */
 class TriviallyInheritedIrUnitHandler : public TrivialIrUnitHandler {};
 
 /**
  * Simulates the use of an IR unit handler. It calls every method required by
- * `clp::ffi::ir_stream::IrUnitHandlerInterface` and ensure they don't return errors.
+ * `clp::ffi::ir_stream::IrUnitHandlerReq` and ensure they don't return errors.
  * @param handler
  */
-auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface auto& handler)
-        -> void;
+auto test_ir_unit_handler_req(clp::ffi::ir_stream::IrUnitHandlerReq auto& handler) -> void;
 
-auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface auto& handler)
-        -> void {
+auto test_ir_unit_handler_req(clp::ffi::ir_stream::IrUnitHandlerReq auto& handler) -> void {
     auto test_log_event_result{KeyValuePairLogEvent::create(
             std::make_shared<SchemaTree>(),
             std::make_shared<SchemaTree>(),
@@ -121,14 +119,14 @@ auto test_ir_unit_handler_interface(clp::ffi::ir_stream::IrUnitHandlerInterface 
 }  // namespace
 
 TEMPLATE_TEST_CASE(
-        "test_ir_unit_handler_interface_basic",
+        "test_ir_unit_handler_req_basic",
         "[ffi][ir_stream]",
         TrivialIrUnitHandler,
         TriviallyInheritedIrUnitHandler
 ) {
     TestType handler;
     REQUIRE_FALSE(handler.is_complete());
-    test_ir_unit_handler_interface(handler);
+    test_ir_unit_handler_req(handler);
 
     REQUIRE((handler.get_utc_offset_delta() == cTestUtcOffsetDelta));
     auto const& optional_log_event{handler.get_log_event()};

--- a/components/core/tests/test-ir_encoding_methods.cpp
+++ b/components/core/tests/test-ir_encoding_methods.cpp
@@ -96,11 +96,11 @@ private:
 };
 
 /**
- * Class that implements `clp::ffi::ir_stream::IrUnitHandlerInterface` for testing purposes.
+ * Class that implements `clp::ffi::ir_stream::IrUnitHandlerReq` for testing purposes.
  */
 class IrUnitHandler {
 public:
-    // Implements `clp::ffi::ir_stream::IrUnitHandlerInterface` interface
+    // Implements `clp::ffi::ir_stream::IrUnitHandlerReq`
     [[nodiscard]] auto handle_log_event(KeyValuePairLogEvent&& log_event) -> IRErrorCode {
         m_deserialized_log_events.emplace_back(std::move(log_event));
         return IRErrorCode::IRErrorCode_Success;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## References

This PR resolves #901.

## Overview

* This PR renames  `IrUnitHandlerInterface` to `IrUnitHandlerInterfaceReq` to meet our latest concept naming guideline.
* This PR adds a new concept `IrUnitHandlerReq` to cover all type constraints (including move cosntructable check). As a result `Deserializer` now shall use `IrUnitHandlerReq` instead to avoid explicitly checking whether the unit handler is move-constructible.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows passed.
* [x] Ensure `IrUnitHandlerInterface` symbols are all renamed in our source code.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated naming conventions and documentation to clarify requirements for IR unit handler types, replacing "Interface" with "Req" for improved clarity and consistency.
  - Adjusted template parameter names and constraints in deserialization components for better readability and maintainability.
  - Replaced references to IR unit handler interface in comments and documentation to align with new naming.

- **Tests**
  - Updated test files to reflect new naming conventions and requirements, ensuring alignment with the refactored codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->