### PR TITLE
build(deps): Unlock snowballstemmer since #886 has been resolved upstream (resolves #886).

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,3 @@ sphinx>=8.1.3
 sphinx_design>=0.6.1
 sphinx-copybutton>=0.5.2
 sphinxcontrib-mermaid>=1.0.0
-
-# Lock to v2.* to work around https://github.com/sphinx-doc/sphinx/issues/13533
-snowballstemmer~=2.2


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

#886 has been resolved [upstream](https://github.com/sphinx-doc/sphinx/issues/13533), so we no longer need to lock to a specific version of snowballstemmer.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

[clp-docs](https://github.com/y-scope/clp/blob/c097b2e9397c3bf9b28dd53348b1bf2aa946ca9e/.github/workflows/clp-docs.yaml) workflow succeeds.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated documentation dependencies by removing the version restriction on the snowballstemmer package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->