### PR TITLE
fix(new-webui): Read host environment variable when starting fastify app (fixes #951).

### DIFF
--- a/components/log-viewer-webui/server/src/main.ts
+++ b/components/log-viewer-webui/server/src/main.ts
@@ -8,7 +8,6 @@ import serviceApp from "./fastify-v2/app.js";
 
 
 const DEFAULT_FASTIFY_CLOSE_GRACE_DELAY = 500;
-const DEFAULT_PORT = 3000;
 
 /**
  * Generates logger configuration options based on the environment.
@@ -57,9 +56,10 @@ const init = async (): Promise<void> => {
     );
 
     await app.ready();
+    app.config
 
     try {
-        await app.listen({port: Number(process.env.PORT || DEFAULT_PORT)});
+        await app.listen({host: app.config.HOST, port: app.config.PORT});
     } catch (err) {
         app.log.error(err);
         process.exit(1);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

When moving to new fastify setup, we replaced script with one from demo app. Demo app did not load the host name. 

Note this fix will only work for production setup. We should change environment variable names to FASTIFY_HOST, FASTIFY_PORT,... etc, so the dev scripts also load these variables. I cannot do that in this PR, it will need to be part of package replacement and ideally done in #939.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Started server with 0.0.0.0 hostname and it started


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
