### PR TITLE
feat(new-webui):  Display sizes using binary units (resolves #947).

### DIFF
--- a/components/log-viewer-webui/client/src/pages/IngestPage/Jobs/utils.ts
+++ b/components/log-viewer-webui/client/src/pages/IngestPage/Jobs/utils.ts
@@ -51,12 +51,12 @@ const convertQueryJobsItemToJobData = (job: QueryJobsItem): JobData => {
 
     const uncompressedSize = Number(job.uncompressed_size);
     if (false === isNaN(uncompressedSize) && 0 !== uncompressedSize) {
-        uncompressedSizeText = formatSizeInBytes(uncompressedSize);
+        uncompressedSizeText = formatSizeInBytes(uncompressedSize, false);
     }
 
     const compressedSize = Number(job.compressed_size);
     if (false === isNaN(compressedSize) && 0 !== compressedSize) {
-        compressedSizeText = formatSizeInBytes(compressedSize);
+        compressedSizeText = formatSizeInBytes(compressedSize, false);
     }
 
     if (false === isNaN(uncompressedSize) &&
@@ -64,7 +64,7 @@ const convertQueryJobsItemToJobData = (job: QueryJobsItem): JobData => {
         null !== job.duration &&
         0 < job.duration
     ) {
-        speedText = `${formatSizeInBytes(uncompressedSize / job.duration)}/s`;
+        speedText = `${formatSizeInBytes(uncompressedSize / job.duration, false)}/s`;
     }
 
     return {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
move to binary units
Resolves #947.
 
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Now in binary units
<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
