### PR TITLE
feat(core): Add environment variable to limit parallelism for core's build tasks.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -74,7 +74,7 @@ jobs:
       - run: "./tools/scripts/deps-download/init.sh"
         shell: "bash"
 
-      - run: "task deps:core"
+      - run: "CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN) task deps:core"
         shell: "bash"
 
       - name: "Build CLP-core and run unit tests"

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -179,7 +179,7 @@ jobs:
             ${{needs.filter-relevant-changes.outputs.centos_stream_9_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
           run_command: >-
-            task deps:core
+            CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN) task deps:core
             && python3 /mnt/repo/components/core/tools/scripts/utils/build-and-run-unit-tests.py
             ${{matrix.use_shared_libs == true && '--use-shared-libs' || ''}}
             --source-dir /mnt/repo/components/core
@@ -222,7 +222,7 @@ jobs:
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
           run_command: >-
-            task deps:core
+            CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN) task deps:core
             && python3 /mnt/repo/components/core/tools/scripts/utils/build-and-run-unit-tests.py
             ${{matrix.use_shared_libs == true && '--use-shared-libs' || ''}}
             --source-dir /mnt/repo/components/core

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -35,6 +35,10 @@ vars:
   # Versions
   G_PACKAGE_VERSION: "0.2.0-dev"
 
+  # Build parameters
+  G_CORE_MAX_PARALLELISM_PER_BUILD_TASK: >-
+    {{default "" (env  "CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK")}}
+
 tasks:
   default:
     deps: ["package"]
@@ -212,6 +216,7 @@ tasks:
       - task: "utils:cmake:build"
         vars:
           BUILD_DIR: "{{.G_CORE_COMPONENT_BUILD_DIR}}"
+          JOBS: "{{.G_CORE_MAX_PARALLELISM_PER_BUILD_TASK}}"
           TARGETS: ["clg", "clo", "clp", "clp-s", "indexer", "reducer-server"]
 
   clp-package-utils:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -37,7 +37,7 @@ vars:
 
   # Build parameters
   G_CORE_MAX_PARALLELISM_PER_BUILD_TASK: >-
-    {{default "" (env  "CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK")}}
+    {{default "" (env "CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK")}}
 
 tasks:
   default:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -36,6 +36,7 @@ vars:
   G_PACKAGE_VERSION: "0.2.0-dev"
 
   # Build parameters
+  # NOTE: Defaulting to an empty string is safe since CMake ignores an empty string.
   G_CORE_MAX_PARALLELISM_PER_BUILD_TASK: >-
     {{default "" (env "CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK")}}
 

--- a/taskfiles/deps/utils.yaml
+++ b/taskfiles/deps/utils.yaml
@@ -67,6 +67,7 @@ tasks:
           FILE_SHA256: "{{.TARBALL_SHA256}}"
           GEN_ARGS:
             ref: ".CMAKE_GEN_ARGS"
+          JOBS: "{{.G_CORE_MAX_PARALLELISM_PER_BUILD_TASK}}"
           NAME: "{{.LIB_NAME}}"
           URL: "{{.TARBALL_URL}}"
           WORK_DIR: "{{.G_DEPS_CORE_DIR}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

When building the dependencies for `core` as well as core itself, a machine can run out of memory if the build parallelism isn't restricted. We've been seeing something like this happen in the GH workflows for #925. Thus, this PR adds an environment variable `CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK` that, as the name suggests, when set, it limit the parallelism of each build task.

Of course, if we run many concurrent tasks then a machine could still run out of memory; however, in our testing, it seems like it's just specific builds like `core`'s and `antlr-runtime`'s that can exceed the capacity of a single machine, probably because they have many source files they can compile concurrently. So until the number of concurrent tasks we can run matches the number of concurrent files they can compile, task-level concurrency is probably a non-issue.

For now, this environment variable is undocumented. Once we add proper tasks to build & test `core`, we can document the environment variable on the page that describes those tasks.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Compared the runtime of the following commands on a 12-core machine and observed the former was proportionally faster than the latter:
  ```bash
  task clean && rm -r .task && task core
  ```
  and
  ```bash
  task clean && rm -r .task && CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=6 task core
  ```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced build workflows to automatically adjust parallelism according to available processors, improving efficiency of dependency processing and build tasks on macOS, CentOS, and Ubuntu systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->