### PR TITLE
fix(ci): Limit `core`'s build parallelism for macOS & ubuntu-jammy lint GH workflow jobs (fixes #965).

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -108,7 +108,9 @@ jobs:
       # TODO: When enough files are passing clang-tidy, switch to a full pass on schedule only.
       # - run: >-
       #     task lint:check-cpp-${{(github.event_name == 'schedule') && 'full' || 'diff'}}
-      - run: "task lint:check-cpp-full"
+      - run: >-
+          CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN)
+          task lint:check-cpp-full
         shell: "bash"
 
       # Cache the source file checksums and the generated files (logs) for the

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -360,7 +360,7 @@ jobs:
           #   task lint:check-cpp-${{(github.event_name == 'schedule') && 'full' || 'diff'}}
           run_command: >-
             CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN)
-            task lint:check-cpp-full"
+            task lint:check-cpp-full
 
       # Cache the source file checksums and the generated files (logs) for the
       # lint:check-cpp-static-full task, but only if it runs successfully on the main branch.

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -358,7 +358,9 @@ jobs:
           # TODO: When enough files are passing clang-tidy, switch to a full pass on schedule only.
           # run_command: >-
           #   task lint:check-cpp-${{(github.event_name == 'schedule') && 'full' || 'diff'}}
-          run_command: "task lint:check-cpp-full"
+          run_command: >-
+            CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN)
+            task lint:check-cpp-full"
 
       # Cache the source file checksums and the generated files (logs) for the
       # lint:check-cpp-static-full task, but only if it runs successfully on the main branch.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Workflows succeeded.
* Checked the workflow logs to ensure that CMake's `--parallel` flag had an argument that roughly corresponded to the expected number of cores on a GH runner.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build workflow efficiency by dynamically configuring parallelism for C++ lint checks based on available processors during automated builds on Ubuntu and macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->