### PR TITLE
feat: Add support for building core and core-deps images for ubuntu-noble

### DIFF
--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -46,6 +46,7 @@ jobs:
     outputs:
       centos_stream_9_image_changed: "${{steps.filter.outputs.centos_stream_9_image}}"
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
+      ubuntu_noble_image_changed: "${{steps.filter.outputs.ubuntu_noble_image}}"
       clp_changed: "${{steps.filter.outputs.clp}}"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
@@ -82,6 +83,12 @@ jobs:
               - "components/core/tools/scripts/lib_install/*.sh"
               - "components/core/tools/docker-images/clp-env-base-ubuntu-jammy/**"
               - "components/core/tools/scripts/lib_install/ubuntu-jammy/**"
+            ubuntu_noble_image:
+              - ".github/actions/**"
+              - ".github/workflows/clp-core-build.yaml"
+              - "components/core/tools/scripts/lib_install/*.sh"
+              - "components/core/tools/docker-images/clp-env-base-ubuntu-noble/**"
+              - "components/core/tools/scripts/lib_install/ubuntu-noble/**"
             clp:
               - ".github/actions/**"
               - ".github/workflows/clp-core-build.yaml"
@@ -138,6 +145,32 @@ jobs:
       - uses: "./.github/actions/clp-core-build-containers"
         env:
           OS_NAME: "ubuntu-jammy"
+        with:
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          docker_context: "components/core"
+          docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}\
+            /Dockerfile"
+          push_deps_image: >-
+            ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
+          token: "${{secrets.GITHUB_TOKEN}}"
+
+  ubuntu-noble-deps-image:
+    name: "ubuntu-noble-deps-image"
+    if: "needs.filter-relevant-changes.outputs.ubuntu_noble_image_changed == 'true'"
+    needs: "filter-relevant-changes"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          submodules: "recursive"
+
+      - name: "Work around actions/runner-images/issues/6775"
+        run: "chown $(id -u):$(id -g) -R ."
+        shell: "bash"
+
+      - uses: "./.github/actions/clp-core-build-containers"
+        env:
+          OS_NAME: "ubuntu-noble"
         with:
           image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
@@ -246,6 +279,45 @@ jobs:
           name: "${{env.BINARIES_ARTIFACT_NAME_PREFIX}}${{env.OS_NAME}}"
           path: "${{steps.copy_binaries.outputs.output_dir}}"
           retention-days: 1
+
+  ubuntu-noble-binaries:
+    # Run if the ancestor jobs succeeded OR they were skipped and clp was changed.
+    if: >-
+      success()
+      || (!cancelled() && !failure() && needs.filter-relevant-changes.outputs.clp_changed == 'true')
+    needs:
+      - "ubuntu-noble-deps-image"
+      - "filter-relevant-changes"
+    strategy:
+      matrix:
+        use_shared_libs: [true, false]
+    name: "ubuntu-noble-${{matrix.use_shared_libs == true && 'dynamic' || 'static'}}-linked-bins"
+    continue-on-error: true
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          submodules: "recursive"
+
+      - name: "Work around actions/runner-images/issues/6775"
+        run: "chown $(id -u):$(id -g) -R ."
+        shell: "bash"
+
+      - uses: "./.github/actions/run-on-image"
+        env:
+          OS_NAME: "ubuntu-noble"
+        with:
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          use_published_image: >-
+            ${{needs.filter-relevant-changes.outputs.ubuntu_noble_image_changed == 'false'
+            || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
+          run_command: >-
+            CLP_CORE_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN) task deps:core
+            && python3 /mnt/repo/components/core/tools/scripts/utils/build-and-run-unit-tests.py
+            ${{matrix.use_shared_libs == true && '--use-shared-libs' || ''}}
+            --source-dir /mnt/repo/components/core
+            --build-dir /mnt/repo/components/core/build
+            --num-jobs $(getconf _NPROCESSORS_ONLN)
 
   ubuntu-jammy-binaries-image:
     name: "ubuntu-jammy-binaries-image"

--- a/components/core/tools/docker-images/clp-core-ubuntu-noble/Dockerfile
+++ b/components/core/tools/docker-images/clp-core-ubuntu-noble/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:noble AS base
+
+# Install runtime dependencies
+# TODO: Investigate why libssl-dev is a hidden dependency of clp-s
+RUN apt-get update \
+    && apt-get install -y \
+    libcurl4 \
+    libmariadb-dev \
+    libssl-dev
+
+# Remove cached files
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /clp
+
+COPY ./clg ./
+COPY ./clp ./
+COPY ./clp-s ./
+COPY ./glt ./
+COPY ./make-dictionaries-readable ./
+
+# Flatten the image
+FROM scratch
+COPY --from=base / /
+
+WORKDIR /clp
+
+CMD ["bash"]

--- a/components/core/tools/docker-images/clp-core-ubuntu-noble/build.sh
+++ b/components/core/tools/docker-images/clp-core-ubuntu-noble/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+set -o pipefail
+
+cUsage="Usage: ${BASH_SOURCE[0]} <clp-core-build-dir>"
+if [ "$#" -lt 1 ]; then
+    echo "${cUsage}" >&2
+    exit 1
+fi
+build_dir="$1"
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+build_cmd=(
+    docker build
+    --pull
+    --tag clp-core-x86-ubuntu-noble:dev
+    "$build_dir"
+    --file "${script_dir}/Dockerfile"
+)
+
+if command -v git >/dev/null && git -C "$script_dir" rev-parse --is-inside-work-tree >/dev/null ;
+then
+    build_cmd+=(
+        --label "org.opencontainers.image.revision=$(git -C "$script_dir" rev-parse HEAD)"
+        --label "org.opencontainers.image.source=$(git -C "$script_dir" remote get-url origin)"
+    )
+fi
+
+"${build_cmd[@]}"

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-noble/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-noble/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:noble AS base
+
+WORKDIR /root
+
+RUN mkdir -p ./tools/scripts/lib_install
+COPY ./tools/scripts/lib_install ./tools/scripts/lib_install
+
+RUN ./tools/scripts/lib_install/ubuntu-noble/install-all.sh
+
+# Remove cached files
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Flatten the image
+FROM scratch
+COPY --from=base / /

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-noble/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-noble/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+component_root=${script_dir}/../../../
+
+build_cmd=(
+    docker build
+    --pull
+    --tag clp-core-dependencies-x86-ubuntu-noble:dev
+    "$component_root"
+    --file "${script_dir}/Dockerfile"
+)
+
+if command -v git >/dev/null && git -C "$script_dir" rev-parse --is-inside-work-tree >/dev/null ;
+then
+    build_cmd+=(
+        --label "org.opencontainers.image.revision=$(git -C "$script_dir" rev-parse HEAD)"
+        --label "org.opencontainers.image.source=$(git -C "$script_dir" remote get-url origin)"
+    )
+fi
+
+"${build_cmd[@]}"

--- a/components/core/tools/scripts/lib_install/ubuntu-noble/install-all.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-noble/install-all.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+set -o pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+echo "Installing prebuilt packages…"
+"${script_dir}/install-prebuilt-packages.sh"
+
+echo "Installing packages from source…"
+"${script_dir}/install-packages-from-source.sh"
+
+# TODO: remove this workaround when CMake >= 3.22 is packaged (see issue #795)
+"${script_dir}/../check-cmake-version.sh"

--- a/components/core/tools/scripts/lib_install/ubuntu-noble/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-noble/install-packages-from-source.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+set -o pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+lib_install_scripts_dir=$script_dir/..
+
+# NOTE: boost must be installed first since the remaining packages depend on it
+"$lib_install_scripts_dir"/install-boost.sh 1.87.0
+
+"$lib_install_scripts_dir"/libarchive.sh 3.5.1
+"$lib_install_scripts_dir"/liblzma.sh 5.4.6
+"$lib_install_scripts_dir"/lz4.sh 1.8.2
+"$lib_install_scripts_dir"/mongocxx.sh 3.10.2
+"$lib_install_scripts_dir"/msgpack.sh 7.0.0
+"$lib_install_scripts_dir"/zstandard.sh 1.4.9

--- a/components/core/tools/scripts/lib_install/ubuntu-noble/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-noble/install-prebuilt-packages.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+set -o pipefail
+
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  ca-certificates \
+  checkinstall \
+  cmake \
+  curl \
+  build-essential \
+  git \
+  jq \
+  libcurl4 \
+  libcurl4-openssl-dev \
+  liblzma-dev \
+  libmariadb-dev \
+  libssl-dev \
+  openjdk-11-jdk \
+  pkg-config \
+  python3 \
+  python3-pip \
+  python3-venv \
+  software-properties-common \
+  unzip
+
+# Install `task`
+# NOTE: We lock `task` to a version < 3.43 to avoid https://github.com/y-scope/clp/issues/872
+task_pkg_arch=$(dpkg --print-architecture)
+task_pkg_path="$(mktemp -t --suffix ".deb" task-pkg.XXXXXXXXXX)"
+curl \
+    --fail \
+    --location \
+    --output "$task_pkg_path" \
+    --show-error \
+    "https://github.com/go-task/task/releases/download/v3.42.1/task_linux_${task_pkg_arch}.deb"
+dpkg --install "$task_pkg_path"
+rm "$task_pkg_path"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Core and core-deps images are now built for Ubuntu Noble by adding ` is now built by adding `ubuntu-noble-deps-image` and `ubuntu-noble-binaries` jobs to `clp-core-build` workflow. Core image for noble will not be published.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All workflows passed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
