### PR TITLE
feat(new-webui): Limit search results to 1k entries.

### DIFF
--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/index.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/index.tsx
@@ -30,8 +30,6 @@ const SearchResultsTable = () => {
             searchResults.length :
             0;
 
-        console.log(num);
-
         updateNumSearchResultsTable(num);
     }, [
         searchResults,

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/index.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/index.tsx
@@ -30,6 +30,8 @@ const SearchResultsTable = () => {
             searchResults.length :
             0;
 
+        console.log(num);
+
         updateNumSearchResultsTable(num);
     }, [
         searchResults,

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/typings.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/typings.tsx
@@ -30,10 +30,16 @@ interface SearchResult {
 const searchResultsTableColumns: NonNullable<TableProps<SearchResult>["columns"]> = [
     {
         dataIndex: "timestamp",
-        defaultSortOrder: "ascend",
+        defaultSortOrder: "descend",
         key: "timestamp",
         render: (timestamp: number) => dayjs(timestamp).format(DATETIME_FORMAT_TEMPLATE),
-        sorter: (a, b) => a.timestamp - b.timestamp,
+        sorter: (a, b) => {
+            const timestampDiff = a.timestamp - b.timestamp;
+            if (timestampDiff !== 0) {
+                return timestampDiff;
+            }
+            return a._id.localeCompare(b._id);
+        },
 
         // Specifying a third sort direction removes ability for user to cancel sorting.
         sortDirections: [
@@ -68,8 +74,15 @@ const searchResultsTableColumns: NonNullable<TableProps<SearchResult>["columns"]
  */
 const TABLE_BOTTOM_PADDING = 75;
 
+/**
+ * The maximum number of results to retrieve for a search.
+ */
+const SEARCH_MAX_NUM_RESULTS = 1000;
+
 
 export type {SearchResult};
 export {
-    searchResultsTableColumns, TABLE_BOTTOM_PADDING,
+    searchResultsTableColumns,
+    TABLE_BOTTOM_PADDING,
+    SEARCH_MAX_NUM_RESULTS
 };

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/typings.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/typings.tsx
@@ -35,9 +35,10 @@ const searchResultsTableColumns: NonNullable<TableProps<SearchResult>["columns"]
         render: (timestamp: number) => dayjs(timestamp).format(DATETIME_FORMAT_TEMPLATE),
         sorter: (a, b) => {
             const timestampDiff = a.timestamp - b.timestamp;
-            if (timestampDiff !== 0) {
+            if (0 !== timestampDiff) {
                 return timestampDiff;
             }
+
             return a._id.localeCompare(b._id);
         },
 
@@ -82,7 +83,7 @@ const SEARCH_MAX_NUM_RESULTS = 1000;
 
 export type {SearchResult};
 export {
+    SEARCH_MAX_NUM_RESULTS,
     searchResultsTableColumns,
     TABLE_BOTTOM_PADDING,
-    SEARCH_MAX_NUM_RESULTS
 };

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/useSearchResults.ts
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/useSearchResults.ts
@@ -1,7 +1,7 @@
 import MongoCollectionSocket from "../../../../api/socket/MongoCollectionSocket";
 import {useCursor} from "../../../../api/socket/useCursor";
 import useSearchStore, {SEARCH_STATE_DEFAULT} from "../../SearchState/index";
-import {SearchResult} from "./typings";
+import {SearchResult, SEARCH_MAX_NUM_RESULTS} from "./typings";
 
 
 /**
@@ -20,8 +20,14 @@ const useSearchResults = () => {
                 return null;
             }
 
+            //Retrieve 1k most recent results.
+            const findOptions = {
+                sort:[["timestamp", "desc"], ["id", "desc"]],
+                limit: SEARCH_MAX_NUM_RESULTS,
+            };
+
             const collection = new MongoCollectionSocket(searchJobId.toString());
-            return collection.find({}, {});
+            return collection.find({}, findOptions);
         },
         [searchJobId]
     );

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/useSearchResults.ts
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/useSearchResults.ts
@@ -1,7 +1,10 @@
 import MongoCollectionSocket from "../../../../api/socket/MongoCollectionSocket";
 import {useCursor} from "../../../../api/socket/useCursor";
 import useSearchStore, {SEARCH_STATE_DEFAULT} from "../../SearchState/index";
-import {SearchResult, SEARCH_MAX_NUM_RESULTS} from "./typings";
+import {
+    SEARCH_MAX_NUM_RESULTS,
+    SearchResult,
+} from "./typings";
 
 
 /**
@@ -20,14 +23,23 @@ const useSearchResults = () => {
                 return null;
             }
 
-            //Retrieve 1k most recent results.
-            const findOptions = {
-                sort:[["timestamp", "desc"], ["id", "desc"]],
+            // Retrieve 1k most recent results.
+            const options = {
+                sort: [
+                    [
+                        "timestamp",
+                        "desc",
+                    ],
+                    [
+                        "id",
+                        "desc",
+                    ],
+                ],
                 limit: SEARCH_MAX_NUM_RESULTS,
             };
 
             const collection = new MongoCollectionSocket(searchJobId.toString());
-            return collection.find({}, findOptions);
+            return collection.find({}, options);
         },
         [searchJobId]
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Per discussion, results cache can actually have >1000 entries. 

PR limits search results to 1000 most recent entries. Data is still sorted client side, but we only sort 1000 recent entries.

I also added fallback to sort by mongoID when there are ties. 

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Only retrieves 1000 results.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
