### PR TITLE
fix(new-webui): Modify all timestamps to UTC timezone.

### DIFF
--- a/components/log-viewer-webui/client/src/pages/IngestPage/Details/TimeRange.tsx
+++ b/components/log-viewer-webui/client/src/pages/IngestPage/Details/TimeRange.tsx
@@ -21,7 +21,7 @@ interface TimeRangeProps {
 const TimeRange = ({beginDate, endDate}: TimeRangeProps) => {
     let stat;
     if (beginDate.isValid() && endDate.isValid()) {
-        stat = `${beginDate.format(DATE_FORMAT)} - ${endDate.format(DATE_FORMAT)}`;
+        stat = `${beginDate.utc().format(DATE_FORMAT)} - ${endDate.utc().format(DATE_FORMAT)}`;
     } else {
         stat = "No timestamp data";
     }

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchControls/TimeRangeInput/index.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchControls/TimeRangeInput/index.tsx
@@ -14,6 +14,7 @@ import {
     TIME_RANGE_OPTION_NAMES,
 } from "./utils";
 
+
 /**
  * Renders controls for selecting a time range for queries. By default, the component is
  * a select dropdown with a list of preset time ranges. If the user selects "Custom",

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchControls/TimeRangeInput/index.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchControls/TimeRangeInput/index.tsx
@@ -14,7 +14,6 @@ import {
     TIME_RANGE_OPTION_NAMES,
 } from "./utils";
 
-
 /**
  * Renders controls for selecting a time range for queries. By default, the component is
  * a select dropdown with a list of preset time ranges. If the user selects "Custom",
@@ -45,6 +44,12 @@ const TimeRangeInput = () => {
         if (!isValidDateRange(dates)) {
             return;
         }
+
+        console.debug('Selected date range:', {
+            start: dates?.[0]?.format('YYYY-MM-DD HH:mm:ss Z'),
+            end: dates?.[1]?.format('YYYY-MM-DD HH:mm:ss Z')
+        });
+
         updateTimeRange(dates);
     };
 

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchControls/TimeRangeInput/utils.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchControls/TimeRangeInput/utils.tsx
@@ -1,5 +1,7 @@
 import dayjs from "dayjs";
 
+import DayjsUtc from "dayjs/plugin/utc";
+dayjs.extend(DayjsUtc);
 
 /**
  * Time range options.
@@ -22,31 +24,31 @@ const DEFAULT_TIME_RANGE = TIME_RANGE_OPTION.ALL_TIME;
 
 /* eslint-disable no-magic-numbers */
 const TIME_RANGE_OPTION_DAYJS_MAP: Record<TIME_RANGE_OPTION, [dayjs.Dayjs, dayjs.Dayjs]> = {
-    [TIME_RANGE_OPTION.LAST_15_MINUTES]: [dayjs().subtract(15, "minute"),
-        dayjs()],
-    [TIME_RANGE_OPTION.LAST_HOUR]: [dayjs().subtract(1, "hour"),
-        dayjs()],
-    [TIME_RANGE_OPTION.TODAY]: [dayjs().startOf("day"),
-        dayjs().endOf("day")],
-    [TIME_RANGE_OPTION.YESTERDAY]: [dayjs().subtract(1, "d"),
-        dayjs().subtract(2, "d")],
-    [TIME_RANGE_OPTION.LAST_7_DAYS]: [dayjs().subtract(7, "d"),
-        dayjs()],
-    [TIME_RANGE_OPTION.LAST_30_DAYS]: [dayjs().subtract(30, "d"),
-        dayjs()],
-    [TIME_RANGE_OPTION.LAST_12_MONTHS]: [dayjs().subtract(12, "month"),
-        dayjs()],
-    [TIME_RANGE_OPTION.MONTH_TO_DATE]: [dayjs().startOf("month"),
-        dayjs()],
-    [TIME_RANGE_OPTION.YEAR_TO_DATE]: [dayjs().startOf("year"),
-        dayjs()],
-    [TIME_RANGE_OPTION.ALL_TIME]: [dayjs(0),
-        dayjs().add(1, "year")],
+    [TIME_RANGE_OPTION.LAST_15_MINUTES]: [dayjs.utc().subtract(15, "minute"),
+        dayjs.utc()],
+    [TIME_RANGE_OPTION.LAST_HOUR]: [dayjs.utc().subtract(1, "hour"),
+        dayjs.utc()],
+    [TIME_RANGE_OPTION.TODAY]: [dayjs.utc().startOf("day"),
+        dayjs.utc().endOf("day")],
+    [TIME_RANGE_OPTION.YESTERDAY]: [dayjs.utc().subtract(1, "d").startOf("day"),
+        dayjs.utc().subtract(1, "d").endOf("day")],
+    [TIME_RANGE_OPTION.LAST_7_DAYS]: [dayjs.utc().subtract(7, "d"),
+        dayjs.utc()],
+    [TIME_RANGE_OPTION.LAST_30_DAYS]: [dayjs.utc().subtract(30, "d"),
+        dayjs.utc()],
+    [TIME_RANGE_OPTION.LAST_12_MONTHS]: [dayjs.utc().subtract(12, "month"),
+        dayjs.utc()],
+    [TIME_RANGE_OPTION.MONTH_TO_DATE]: [dayjs.utc().startOf("month"),
+        dayjs.utc()],
+    [TIME_RANGE_OPTION.YEAR_TO_DATE]: [dayjs.utc().startOf("year"),
+        dayjs.utc()],
+    [TIME_RANGE_OPTION.ALL_TIME]: [dayjs.utc(0),
+        dayjs.utc().add(1, "year")],
 
     // Custom option is just a placeholder for typing purposes, its DayJs values should not
     // be used.
-    [TIME_RANGE_OPTION.CUSTOM]: [dayjs(),
-        dayjs()],
+    [TIME_RANGE_OPTION.CUSTOM]: [dayjs.utc(),
+        dayjs.utc()],
 };
 
 

--- a/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/typings.tsx
+++ b/components/log-viewer-webui/client/src/pages/SearchPage/SearchResults/SearchResultsTable/typings.tsx
@@ -32,7 +32,7 @@ const searchResultsTableColumns: NonNullable<TableProps<SearchResult>["columns"]
         dataIndex: "timestamp",
         defaultSortOrder: "ascend",
         key: "timestamp",
-        render: (timestamp: number) => dayjs(timestamp).format(DATETIME_FORMAT_TEMPLATE),
+        render: (timestamp: number) => dayjs.utc(timestamp).format(DATETIME_FORMAT_TEMPLATE),
         sorter: (a, b) => a.timestamp - b.timestamp,
 
         // Specifying a third sort direction removes ability for user to cancel sorting.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Previously some timestamps were in user timezone. Now they are all in utc.

It appears that range picker will adopt timezone of the default option. So as long as the default is in utc,
all the new changes will also be in utc.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Printed timestamps they appear in utc

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
