### PR TITLE
fix(new-webui): Hide the Messages and Files panels when using the clp-s storage engine (resolves #945).

### DIFF
--- a/components/log-viewer-webui/client/src/pages/IngestPage/Details/index.tsx
+++ b/components/log-viewer-webui/client/src/pages/IngestPage/Details/index.tsx
@@ -7,6 +7,10 @@ import {
 import dayjs, {Dayjs} from "dayjs";
 import {Nullable} from "src/typings/common";
 
+import {
+    CLP_STORAGE_ENGINES,
+    SETTINGS_STORAGE_ENGINE,
+} from "../../../config";
 import useIngestStatsStore from "../ingestStatsStore";
 import {querySql} from "../sqlConfig";
 import Files from "./Files";
@@ -76,16 +80,25 @@ const Details = () => {
         fetchDetailsStats,
     ]);
 
+    if (CLP_STORAGE_ENGINES.CLP === SETTINGS_STORAGE_ENGINE) {
+        return (
+            <div className={styles["detailsGrid"]}>
+                <div className={styles["timeRange"]}>
+                    <TimeRange
+                        beginDate={beginDate}
+                        endDate={endDate}/>
+                </div>
+                <Messages numMessages={numMessages}/>
+                <Files numFiles={numFiles}/>
+            </div>
+        );
+    }
 
     return (
-        <div className={styles["detailsGrid"]}>
-            <div className={styles["timeRange"]}>
-                <TimeRange
-                    beginDate={beginDate}
-                    endDate={endDate}/>
-            </div>
-            <Messages numMessages={numMessages}/>
-            <Files numFiles={numFiles}/>
+        <div>
+            <TimeRange
+                beginDate={beginDate}
+                endDate={endDate}/>
         </div>
     );
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

hides Messages and Files cards when using clp-s



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Cards changed when settings where modified 



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
