### PR TITLE
feat(new-webui): Enable configuration override in Fastify dotenv settings (fixes #1010).

### DIFF
--- a/components/log-viewer-webui/server/src/fastify-v2/plugins/external/env.ts
+++ b/components/log-viewer-webui/server/src/fastify-v2/plugins/external/env.ts
@@ -65,6 +65,7 @@ export const autoConfig = {
             ".env",
             ".env.local",
         ],
+        override: true,
     },
 
     // Source for the configuration data


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Set `override: true` in dotenv settings to let the values in the last file specified in `path` to override any previous values set.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Start CLP pacakage. Then `./stop-clp.sh log_viewer_webui`.
2. `cd components/log-viewer-webui/server`
3. `cp .env .env.local`. Then modify value of `CLP_DB_PASS` in `.env.local` to match `clp-package/etc/credentials.yml`.
4. `npm run start` and observed the server was able to start up successfully, which means the `CLP_DB_PASS` value specified in `.env.local` was correctly read.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
