### PR TITLE
fix(new-webui): Ensure SUM results fallback to 0 to prevent null values in space savings query (fixes #1012).

### DIFF
--- a/components/log-viewer-webui/client/src/pages/IngestPage/SpaceSavings/sql.ts
+++ b/components/log-viewer-webui/client/src/pages/IngestPage/SpaceSavings/sql.ts
@@ -11,8 +11,18 @@ import {
  */
 const getSpaceSavingsSql = () => `
 SELECT
-    SUM(${CLP_ARCHIVES_TABLE_COLUMN_NAMES.UNCOMPRESSED_SIZE}) AS total_uncompressed_size,
-    SUM(${CLP_ARCHIVES_TABLE_COLUMN_NAMES.SIZE})              AS total_compressed_size
+    CAST(
+        COALESCE(
+            SUM(${CLP_ARCHIVES_TABLE_COLUMN_NAMES.UNCOMPRESSED_SIZE}),
+            0
+        ) AS UNSIGNED
+    ) AS total_uncompressed_size,
+    CAST(
+        COALESCE(
+            SUM(${CLP_ARCHIVES_TABLE_COLUMN_NAMES.SIZE}),
+            0
+        ) AS UNSIGNED
+    ) AS total_compressed_size
 FROM ${SQL_CONFIG.SqlDbClpArchivesTableName}
 `;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
In the space savings SQL query, ensure:
1. the values fallback to 0 SUM() gives null
2. the values are always `UNSIGNED` instead of string "0" for example.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Start CLP package without compressing any files.
2. `cd components/log-viewer-client/client; npm run antd`
3. Accessed `http://localhost:3000` in the browser and observed the app did not crash. Instead the uncompressed and compressed sizes were displayed as 0 as expected.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display of space savings totals to always show zero instead of blank when no data is available. Totals are now consistently shown as non-negative numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->