### PR TITLE
refactor(clp-s): Resolve clang-tidy violations in `clp_s/search/kql/kql.{cpp,hpp}` and apply our latest coding guidelines.

### DIFF
--- a/components/core/src/clp_s/search/kql/kql.hpp
+++ b/components/core/src/clp_s/search/kql/kql.hpp
@@ -7,11 +7,12 @@
 
 namespace clp_s::search::kql {
 /**
- * Generate a search AST from a Kibana expression in an input stream
- * @param in input stream containing a Kibana expression followed by EOF
- * @return a search AST on success, nullptr otherwise
+ * Generates a search AST from a Kibana Query Language (KQL) expression.
+ * @param in An input stream containing a KQL expression followed by EOF.
+ * @return A search AST on success or nullptr on failure.
  */
-std::shared_ptr<clp_s::search::ast::Expression> parse_kql_expression(std::istream& in);
+[[nodiscard]] auto parse_kql_expression(std::istream& in)
+        -> std::shared_ptr<clp_s::search::ast::Expression>;
 }  // namespace clp_s::search::kql
 
 #endif  // CLP_S_SEARCH_KQL_KQL_HPP

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -497,8 +497,6 @@ tasks:
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/EvaluateTimestampIndex.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/EvaluateTimestampIndex.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/kql/generated/*"
-            - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/kql/kql.cpp"
-            - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/kql/kql.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/Output.cpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/Output.hpp"
             - "{{.G_CORE_COMPONENT_DIR}}/src/clp_s/search/Projection.cpp"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR is part of the #764 series to refactor code in order to pass our clang-tidy checks. This PR updates our kql parsing code to pass clang-tidy as well as comply with our latest coding guidelines.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that tests still pass


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
