### PR TITLE
refactor(new-webui): Migrate archive metadata SQL query route to new Fastify architecture. 

### DIFF
--- a/components/log-viewer-webui/client/src/pages/IngestPage/sqlConfig.ts
+++ b/components/log-viewer-webui/client/src/pages/IngestPage/sqlConfig.ts
@@ -52,7 +52,7 @@ enum COMPRESSION_JOBS_TABLE_COLUMN_NAMES {
  * @return
  */
 const querySql = async <T>(queryString: string) => {
-    return axios.post<T>("/query/sql", {queryString});
+    return axios.post<T>("/api/archive-metadata/sql", {queryString});
 };
 
 export {

--- a/components/log-viewer-webui/server/src/fastify-v2/routes/api/archive-metadata/index.ts
+++ b/components/log-viewer-webui/server/src/fastify-v2/routes/api/archive-metadata/index.ts
@@ -1,0 +1,36 @@
+import {
+    FastifyPluginAsyncTypebox,
+    Type,
+} from "@fastify/type-provider-typebox";
+import {StatusCodes} from "http-status-codes";
+
+import {SqlSchema} from "../../../schemas/archive-metadata.js";
+/**
+ * Search API routes.
+ *
+ * @param fastify
+ */
+// eslint-disable-next-line max-lines-per-function
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
+    const mysqlConnectionPool = fastify.mysql.pool;
+
+    fastify.post(
+        "/sql",
+        {
+            schema: {
+                body: SqlSchema,
+                response: {
+                    [StatusCodes.OK]: Type.Any(),
+                },
+                tags: ["Archive Metadata"],
+            },
+        },
+        async (req, reply) => {
+            const {queryString} = req.body;
+            reply.code(StatusCodes.OK);
+            return await mysqlConnectionPool.query(queryString);
+        },
+    );
+};
+
+export default plugin;

--- a/components/log-viewer-webui/server/src/fastify-v2/routes/api/archive-metadata/index.ts
+++ b/components/log-viewer-webui/server/src/fastify-v2/routes/api/archive-metadata/index.ts
@@ -5,12 +5,13 @@ import {
 import {StatusCodes} from "http-status-codes";
 
 import {SqlSchema} from "../../../schemas/archive-metadata.js";
+
+
 /**
- * Search API routes.
+ * Archive metadata API routes.
  *
  * @param fastify
  */
-// eslint-disable-next-line max-lines-per-function
 const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     const mysqlConnectionPool = fastify.mysql.pool;
 
@@ -28,7 +29,8 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         async (req, reply) => {
             const {queryString} = req.body;
             reply.code(StatusCodes.OK);
-            return await mysqlConnectionPool.query(queryString);
+            const [result] = await mysqlConnectionPool.query(queryString);
+            return result;
         },
     );
 };

--- a/components/log-viewer-webui/server/src/fastify-v2/schemas/archive-metadata.ts
+++ b/components/log-viewer-webui/server/src/fastify-v2/schemas/archive-metadata.ts
@@ -1,0 +1,14 @@
+import {Type} from "@sinclair/typebox";
+
+import {StringSchema} from "./common.js";
+
+/**
+ * Schema for SQL query request.
+ */
+const SqlSchema = Type.Object({
+    queryString: StringSchema,
+});
+
+export {
+    SqlSchema,
+};

--- a/components/log-viewer-webui/server/src/plugins/DbManager.ts
+++ b/components/log-viewer-webui/server/src/plugins/DbManager.ts
@@ -83,18 +83,6 @@ class DbManager {
     }
 
     /**
-     * Submits a query to MySQL.
-     *
-     * @param queryString
-     * @return The result from MySQL.
-     */
-    async queryMySql (queryString: string) {
-        const [result] = await this.#mysqlConnectionPool.query(queryString);
-        return result;
-    }
-
-
-    /**
      * Submits a stream extraction job to the scheduler and waits for it to finish.
      *
      * @param props

--- a/components/log-viewer-webui/server/src/routes/query.ts
+++ b/components/log-viewer-webui/server/src/routes/query.ts
@@ -20,21 +20,6 @@ import {
 const routes: FastifyPluginAsync = async (app) => {
     const fastify = app.withTypeProvider<TypeBoxTypeProvider>();
 
-    fastify.post(
-        "/query/sql",
-        {
-            schema: {
-                body: Type.Object({
-                    queryString: Type.String({minLength: 1}),
-                }),
-            },
-        },
-        async (req) => {
-            const {queryString} = req.body;
-            return await fastify.dbManager.queryMySql(queryString);
-        },
-    );
-
     fastify.post("/query/extract-stream", {
         schema: {
             body: Type.Object({


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

PR moves sql query route into new fastify architecture. This is a chain of PRs which started with #1027 

In addition, I just removed the querySql function out of dbManager. It can just be declared in route which in simpler.

I also renamed the route, and did some minor refactor.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
