### PR TITLE
fix(package): Remove storage_type column from the datasets table. (fix #1023)

### DIFF
--- a/components/clp-py-utils/clp_py_utils/clp_metadata_db_utils.py
+++ b/components/clp-py-utils/clp_py_utils/clp_metadata_db_utils.py
@@ -110,7 +110,6 @@ def create_datasets_table(db_cursor, table_prefix: str) -> None:
         f"""
         CREATE TABLE IF NOT EXISTS `{table_prefix}{DATASETS_TABLE_SUFFIX}` (
             `name` VARCHAR(255) NOT NULL,
-            `archive_storage_type` VARCHAR(64) NOT NULL,
             `archive_storage_directory` VARCHAR(4096) NOT NULL,
             PRIMARY KEY (`name`)
         )
@@ -123,7 +122,6 @@ def add_dataset(
     db_cursor,
     table_prefix: str,
     dataset_name: str,
-    archive_storage_type: StorageType,
     dataset_archive_storage_directory: Path,
 ) -> None:
     """
@@ -134,15 +132,14 @@ def add_dataset(
     :param db_cursor: The database cursor to execute the table row insertion.
     :param table_prefix: A string to prepend to the table name.
     :param dataset_name:
-    :param archive_storage_type:
     :param dataset_archive_storage_directory:
     """
     query = f"""INSERT INTO `{table_prefix}{DATASETS_TABLE_SUFFIX}`
-                (name, archive_storage_type, archive_storage_directory)
-                VALUES (%s, %s, %s)
+                (name, archive_storage_directory)
+                VALUES (%s, %s)
                 """
     db_cursor.execute(
-        query, (dataset_name, archive_storage_type, str(dataset_archive_storage_directory))
+        query, (dataset_name, str(dataset_archive_storage_directory))
     )
     create_metadata_db_tables(db_cursor, table_prefix, dataset_name)
     db_conn.commit()

--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -200,7 +200,6 @@ def search_and_schedule_new_tasks(
                     db_cursor,
                     table_prefix,
                     dataset_name,
-                    clp_archive_output.storage.type,
                     archive_storage_directory,
                 )
                 existing_datasets.add(dataset_name)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR removes the storage_type column from the datasets table beause: 
1. The storage type can be inferred from the package config.
2. Keeping the column may confuses user and make them feel that CLP supports datasets from different storage type at the sametime, which is not true.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
- Started a clp-s package with default settings. Compressed and viewed a log and confirmed there is no error.
- Manually checked the database with gui viewer and confirmed that the column is removed.
- Searched for `archive_storage_type` in the codebase to ensure no other code references to it.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
