### PR TITLE
fix(package): Explicilty specify required fields for update in `update_archive_metadata` method. (fixes #1039)

### DIFF
--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -92,30 +92,30 @@ def update_job_metadata_and_tags(db_cursor, job_id, table_prefix, tag_ids, archi
 
 
 def update_archive_metadata(db_cursor, table_prefix, archive_stats):
-    archive_stats_defaults = {
-        "creator_id": "",
+    default_creation_stats = {
         "creation_ix": 0,
+        "creator_id": "",
     }
-    for k, v in archive_stats_defaults.items():
-        if k in archive_stats:
-            raise ValueError(f"Unexpected key '{k}' in archive stats")
-        archive_stats[k] = v
+    for key, default_value in default_creation_stats.items():
+        if key in archive_stats:
+            raise ValueError(f"Unexpected key '{key}' in archive stats")
+        archive_stats[key] = default_value
 
-    fields_to_update = [
+    stats_to_update = [
         "begin_timestamp",
         "end_timestamp",
         "id",
         "size",
         "uncompressed_size",
     ]
-    fields_to_update.extend(archive_stats_defaults.keys())
+    stats_to_update.extend(default_creation_stats.keys())
 
-    keys = ", ".join(fields_to_update)
-    value_placeholders = ", ".join(["%s"] * len(fields_to_update))
+    keys = ", ".join(stats_to_update)
+    value_placeholders = ", ".join(["%s"] * len(stats_to_update))
     query = (
         f"INSERT INTO {table_prefix}{ARCHIVES_TABLE_SUFFIX} ({keys}) VALUES ({value_placeholders})"
     )
-    db_cursor.execute(query, [archive_stats[key] for key in fields_to_update])
+    db_cursor.execute(query, [archive_stats[key] for key in stats_to_update])
 
 
 def _generate_fs_logs_list(


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As described in #1039 , the current `update_archive_metadata` relies on clp-s to output the exact fields for metadata update. However, this assumption is not always true and has been broken by a recent change.

This pr updates `update_archive_metadata` so it expliclity specifies the required fields from the clp-s's archive_stats.
This pr also updates the logic for handling the `default_fields`. We removed begin_ts and end_ts from the default list since they will be output by clp-s (when timestamp is not found, those fields will be 0). We also add a strict check to ensure the fields to add does not exist in the clp-s's archive stats.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Ran package with storage_engine = clp-s.
Confirmed that a single input file can be compressed without error.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
