### PR TITLE
feat(core): Add support for building and running on musllinux_1_2; Add musllinux_1_2 dependency container images.

### DIFF
--- a/components/core/src/clp/SQLitePreparedStatement.hpp
+++ b/components/core/src/clp/SQLitePreparedStatement.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_SQLITEPREPAREDSTATEMENT_HPP
 #define CLP_SQLITEPREPAREDSTATEMENT_HPP
 
+#include <cstdint>
 #include <string>
 
 #include <sqlite3/sqlite3.h>

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <charconv>
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <string>

--- a/components/core/src/glt/SQLitePreparedStatement.hpp
+++ b/components/core/src/glt/SQLitePreparedStatement.hpp
@@ -1,6 +1,7 @@
 #ifndef GLT_SQLITEPREPAREDSTATEMENT_HPP
 #define GLT_SQLITEPREPAREDSTATEMENT_HPP
 
+#include <cstdint>
 #include <string>
 
 #include <sqlite3/sqlite3.h>

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/Dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/pypa/musllinux_1_2_aarch64
+
+WORKDIR /root
+
+RUN mkdir -p ./tools/scripts/lib_install
+COPY ./tools/scripts/lib_install ./tools/scripts/lib_install
+
+RUN ./tools/scripts/lib_install/musllinux_1_2/install-all.sh
+
+# Remove cached files
+RUN apk cache clean && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+
+# NOTE: Don't flatten the image or else we'll lose any environment modifications from the base
+# image.

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+component_root="${script_dir}/../../../"
+
+build_cmd=(
+    docker buildx build
+    --platform linux/arm64
+    --tag clp-core-dependencies-arm64-musllinux_1_2:dev
+    "$component_root"
+    --file "${script_dir}/Dockerfile"
+    --load
+)
+
+if command -v git >/dev/null && git -C "$script_dir" rev-parse --is-inside-work-tree >/dev/null ;
+then
+    build_cmd+=(
+        --label "org.opencontainers.image.revision=$(git -C "$script_dir" rev-parse HEAD)"
+        --label "org.opencontainers.image.source=$(git -C "$script_dir" remote get-url origin)"
+    )
+fi
+
+echo "Running: ${build_cmd[*]}"
+"${build_cmd[@]}"

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86/Dockerfile
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86/Dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/pypa/musllinux_1_2_x86_64
+
+WORKDIR /root
+
+RUN mkdir -p ./tools/scripts/lib_install
+COPY ./tools/scripts/lib_install ./tools/scripts/lib_install
+
+RUN ./tools/scripts/lib_install/musllinux_1_2/install-all.sh
+
+# Remove cached files
+RUN apk cache clean && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+
+# NOTE: Don't flatten the image or else we'll lose any environment modifications from the base
+# image.

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+component_root="${script_dir}/../../../"
+
+build_cmd=(
+    docker buildx build
+    --platform linux/amd64
+    --tag clp-core-dependencies-x86-musllinux_1_2:dev
+    "$component_root"
+    --file "${script_dir}/Dockerfile"
+    --load
+)
+
+if command -v git >/dev/null && git -C "$script_dir" rev-parse --is-inside-work-tree >/dev/null ;
+then
+    build_cmd+=(
+        --label "org.opencontainers.image.revision=$(git -C "$script_dir" rev-parse HEAD)"
+        --label "org.opencontainers.image.source=$(git -C "$script_dir" remote get-url origin)"
+    )
+fi
+
+echo "Running: ${build_cmd[*]}"
+"${build_cmd[@]}"

--- a/components/core/tools/scripts/lib_install/musllinux_1_2/install-all.sh
+++ b/components/core/tools/scripts/lib_install/musllinux_1_2/install-all.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+"${script_dir}/install-prebuilt-packages.sh"
+"${script_dir}/install-packages-from-source.sh"
+
+# TODO: https://github.com/y-scope/clp/issues/795
+"${script_dir}/../check-cmake-version.sh"

--- a/components/core/tools/scripts/lib_install/musllinux_1_2/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/musllinux_1_2/install-packages-from-source.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+lib_install_scripts_dir="${script_dir}/.."
+
+# NOTE: The remaining installation scripts depend on boost, so we install it beforehand.
+"${lib_install_scripts_dir}/install-boost.sh" 1.87.0
+
+# NOTE:
+# 1. libarchive may statically link with LZMA, LZ4, and Zstandard, so we install them beforehand.
+# 2. The versions of libarchive, LZMA, LZ4, and Zstandard available in manylinux_2_28's package
+#    repositories are either dated or don't include static libraries, so we install more recent
+#    versions from source.
+"${lib_install_scripts_dir}/liblzma.sh" 5.8.1
+"${lib_install_scripts_dir}/lz4.sh" 1.10.0
+"${lib_install_scripts_dir}/zstandard.sh" 1.5.7
+"${lib_install_scripts_dir}/libarchive.sh" 3.8.0
+
+"${lib_install_scripts_dir}/msgpack.sh" 7.0.0

--- a/components/core/tools/scripts/lib_install/musllinux_1_2/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/musllinux_1_2/install-prebuilt-packages.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+apk update &&  apk add \
+    openjdk11-jdk \
+    jq \
+    curl-dev \
+    bzip2-dev \
+    bzip2-static \
+    mariadb-connector-c-dev \
+    openssl-dev \
+    zlib-dev \
+    zlib-static
+
+# Install `task`
+# NOTE: We lock `task` to a version < 3.43 to avoid https://github.com/y-scope/clp/issues/
+VERSION=3.42.1
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64) ARCH=amd64 ;;
+    aarch64) ARCH=arm64 ;;
+    *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+wget -O /tmp/task.tar.gz \
+    "https://github.com/go-task/task/releases/download/v${VERSION}/task_linux_${ARCH}.tar.gz"
+
+tar -C /usr/local/bin -xzf /tmp/task.tar.gz task
+chmod +x /usr/local/bin/task
+rm /tmp/task.tar.gz
+
+# Downgrade to CMake v3 to work around https://github.com/y-scope/clp/issues/795
+pipx uninstall cmake
+pipx install cmake~=3.31

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -214,8 +214,8 @@ tasks:
             - "-DFMT_DOC=OFF"
             - "-DFMT_TEST=OFF"
           LIB_NAME: "{{.G_FMT_LIB_NAME}}"
-          TARBALL_SHA256: "b06ca3130158c625848f3fb7418f235155a4d389b2abc3a6245fb01cb0eb1e01"
-          TARBALL_URL: "https://github.com/fmtlib/fmt/archive/refs/tags/8.0.1.tar.gz"
+          TARBALL_SHA256: "ede1b6b42188163a3f2e0f25ad5c0637eca564bd8df74d02e31a311dd6b37ad8"
+          TARBALL_URL: "https://github.com/fmtlib/fmt/archive/refs/tags/10.0.0.tar.gz"
 
   log-surgeon:
     internal: true
@@ -302,11 +302,11 @@ tasks:
             - "-DSPDLOG_BUILD_EXAMPLE_HO=OFF"
             - "-DSPDLOG_FMT_EXTERNAL=ON"
           LIB_NAME: "spdlog"
-          TARBALL_SHA256: "6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38"
+          TARBALL_SHA256: "4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9"
 
           # NOTE: Since spdlog depends on fmt, we need to choose a version of spdlog that's
           # compatible with the version of fmt we use.
-          TARBALL_URL: "https://github.com/gabime/spdlog/archive/refs/tags/v1.9.2.tar.gz"
+          TARBALL_URL: "https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz"
 
   sqlite3:
     internal: true


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds support for building on musllinux1_2. musllinux is part of the manylinux project, which provides standardized, portable Linux build environments for Python wheels, ensuring broad compatibility with musl-based distributions such as Alpine Linux (commonly used in Kubernetes). The resulting binaries should work on Alpine Linux 3.13+ and any distribution based on musl 1.2 or newer.

Note 1:  Spdlog has been upgraded from version 1.9.2 to 1.12.0 to ensure successful compilation in musl-based Linux environments. Additionally, fmtlib has been updated from 8.0.1 to 10.0.0 to satisfy spdlog's dependency requirements. Basic testing suggest no compilation and execution regression for the upgrade.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Invoked `build.sh` to build x86_64 and aarch64 containers, and use them to build CLP binaries.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
