### PR TITLE
fix(clp-s): Expose msgpack-cxx publicly via clp_s_archive_reader and clp_s_archive_writer; Add CLP_NEED_MSGPACKCXX flag when enabling clp_s_clp_dependencies target.

### DIFF
--- a/components/core/cmake/Options/options.cmake
+++ b/components/core/cmake/Options/options.cmake
@@ -248,6 +248,7 @@ function(set_clp_s_clp_dependencies_dependencies)
         CLP_NEED_BOOST
         CLP_NEED_CURL
         CLP_NEED_FMT
+        CLP_NEED_MSGPACKCXX
         CLP_NEED_NLOHMANN_JSON
         CLP_NEED_OPENSSL
         CLP_NEED_SPDLOG

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -303,6 +303,7 @@ if(CLP_BUILD_CLP_S_ARCHIVEREADER)
                 PUBLIC
                 absl::flat_hash_map
                 clp_s::io
+                msgpack-cxx
                 nlohmann_json::nlohmann_json
                 PRIVATE
                 Boost::url
@@ -310,7 +311,6 @@ if(CLP_BUILD_CLP_S_ARCHIVEREADER)
                 clp_s::timestamp_pattern
                 ${CURL_LIBRARIES}
                 fmt::fmt
-                msgpack-cxx
                 spdlog::spdlog
         )
 endif()

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -240,6 +240,7 @@ if(CLP_BUILD_CLP_S_ARCHIVEWRITER)
                 PUBLIC
                 absl::flat_hash_map
                 clp_s::io
+                msgpack-cxx
                 nlohmann_json::nlohmann_json
                 simdjson::simdjson
                 PRIVATE
@@ -248,7 +249,6 @@ if(CLP_BUILD_CLP_S_ARCHIVEWRITER)
                 clp_s::timestamp_pattern
                 ${CURL_LIBRARIES}
                 fmt::fmt
-                msgpack-cxx
                 spdlog::spdlog
         )
 endif()

--- a/components/core/src/clp_s/search/CMakeLists.txt
+++ b/components/core/src/clp_s/search/CMakeLists.txt
@@ -47,7 +47,6 @@ if(CLP_BUILD_CLP_S_SEARCH)
                 simdjson::simdjson
                 PRIVATE
                 clp_s::clp_dependencies
-                msgpack-cxx
                 spdlog::spdlog
         )
 endif()

--- a/components/core/src/clp_s/search/CMakeLists.txt
+++ b/components/core/src/clp_s/search/CMakeLists.txt
@@ -47,6 +47,7 @@ if(CLP_BUILD_CLP_S_SEARCH)
                 simdjson::simdjson
                 PRIVATE
                 clp_s::clp_dependencies
+                msgpack-cxx
                 spdlog::spdlog
         )
 endif()


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
The target `clp_s_archive_reader` and `clp_s_archive_writer` did not publicly expose `msgpack-cxx`, which led to missing header errors when other targets included its headers. This PR fixes the issue by publicly linking `msgpack-cxx` to `clp_s_archive_reader`. Additionally, it adds the `CLP_NEED_MSGPACKCXX` flag when enabling the `clp_s_clp_dependencies` target—an omission from PR #1049.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

+ Install `msgpack-cxx` to a custom (non-system) path
+ Without this change, it reports the error
```
src/components/core/src/clp_s/search/clp_search/Grep.hpp:11,
                 from /home/yscope/actions-runner/_work/velox/velox/velox/_build/release/_deps/clp-src/components/core/src/clp_s/search/clp_search/Grep.cpp:3:
/home/yscope/actions-runner/_work/velox/velox/velox/_build/release/_deps/clp-src/components/core/src/clp_s/search/clp_search/../../SingleFileArchiveDefs.hpp:8:10: fatal error: msgpack.hpp: No such file or directory
    8 | #include "msgpack.hpp"
```
+ With this change, `clp_s_clp_dependencies` is built successfully


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configuration to include an additional required library.
  * Adjusted the order of linked libraries for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->