### PR TITLE
fix(webui): Respect case sensitivity setting in search queries (fixes #1060); refactor Zustand usages.

### DIFF
--- a/components/webui/client/src/pages/SearchPage/SearchControls/QueryInput/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchControls/QueryInput/index.tsx
@@ -1,4 +1,6 @@
 import {
+    ChangeEvent,
+    useCallback,
     useEffect,
     useRef,
     useState,
@@ -21,10 +23,8 @@ import {
  * @return
  */
 const QueryInput = () => {
-    const queryString = useSearchStore((state) => state.queryString);
     const queryIsCaseSensitive = useSearchStore((state) => state.queryIsCaseSensitive);
-    const updateQueryString = useSearchStore((state) => state.updateQueryString);
-    const updateQueryIsCaseSensitive = useSearchStore((state) => state.updateQueryIsCaseSensitive);
+    const queryString = useSearchStore((state) => state.queryString);
     const searchUiState = useSearchStore((state) => state.searchUiState);
     const [pseudoProgress, setPseudoProgress] = useState<Nullable<number>>(null);
     const intervalIdRef = useRef<number>(0);
@@ -57,6 +57,16 @@ const QueryInput = () => {
         clearInterval(intervalIdRef.current);
     }, []);
 
+    const handleCaseSensitiveChange = useCallback((newValue: boolean) => {
+        const {updateQueryIsCaseSensitive} = useSearchStore.getState();
+        updateQueryIsCaseSensitive(newValue);
+    }, []);
+
+    const handleChange = useCallback((ev: ChangeEvent<HTMLInputElement>) => {
+        const {updateQueryString} = useSearchStore.getState();
+        updateQueryString(ev.target.value);
+    }, []);
+
     return (
         <QueryBox
             isCaseSensitive={queryIsCaseSensitive}
@@ -68,12 +78,8 @@ const QueryInput = () => {
                 searchUiState === SEARCH_UI_STATE.QUERY_ID_PENDING ||
                 searchUiState === SEARCH_UI_STATE.QUERYING
             }
-            onCaseSensitiveChange={(newValue) => {
-                updateQueryIsCaseSensitive(newValue);
-            }}
-            onChange={(e) => {
-                updateQueryString(e.target.value);
-            }}/>
+            onCaseSensitiveChange={handleCaseSensitiveChange}
+            onChange={handleChange}/>
     );
 };
 

--- a/components/webui/client/src/pages/SearchPage/SearchControls/QueryInput/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchControls/QueryInput/index.tsx
@@ -21,13 +21,11 @@ import {
  * @return
  */
 const QueryInput = () => {
-    const {
-        queryString,
-        queryIsCaseSensitive,
-        updateQueryString,
-        updateQueryIsCaseSensitive,
-        searchUiState,
-    } = useSearchStore();
+    const queryString = useSearchStore((state) => state.queryString);
+    const queryIsCaseSensitive = useSearchStore((state) => state.queryIsCaseSensitive);
+    const updateQueryString = useSearchStore((state) => state.updateQueryString);
+    const updateQueryIsCaseSensitive = useSearchStore((state) => state.updateQueryIsCaseSensitive);
+    const searchUiState = useSearchStore((state) => state.searchUiState);
     const [pseudoProgress, setPseudoProgress] = useState<Nullable<number>>(null);
     const intervalIdRef = useRef<number>(0);
 

--- a/components/webui/client/src/pages/SearchPage/SearchControls/QueryInput/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchControls/QueryInput/index.tsx
@@ -29,6 +29,16 @@ const QueryInput = () => {
     const [pseudoProgress, setPseudoProgress] = useState<Nullable<number>>(null);
     const intervalIdRef = useRef<number>(0);
 
+    const handleCaseSensitiveChange = useCallback((newValue: boolean) => {
+        const {updateQueryIsCaseSensitive} = useSearchStore.getState();
+        updateQueryIsCaseSensitive(newValue);
+    }, []);
+
+    const handleChange = useCallback((ev: ChangeEvent<HTMLInputElement>) => {
+        const {updateQueryString} = useSearchStore.getState();
+        updateQueryString(ev.target.value);
+    }, []);
+
     useEffect(() => {
         if (searchUiState === SEARCH_UI_STATE.QUERY_ID_PENDING) {
             if (0 !== intervalIdRef.current) {
@@ -55,16 +65,6 @@ const QueryInput = () => {
     // Clear the interval if the component unmounts.
     useEffect(() => {
         clearInterval(intervalIdRef.current);
-    }, []);
-
-    const handleCaseSensitiveChange = useCallback((newValue: boolean) => {
-        const {updateQueryIsCaseSensitive} = useSearchStore.getState();
-        updateQueryIsCaseSensitive(newValue);
-    }, []);
-
-    const handleChange = useCallback((ev: ChangeEvent<HTMLInputElement>) => {
-        const {updateQueryString} = useSearchStore.getState();
-        updateQueryString(ev.target.value);
     }, []);
 
     return (

--- a/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
@@ -34,7 +34,7 @@ const SubmitButton = () => {
         updateTimelineConfig(newTimelineConfig);
 
         handleQuerySubmit({
-            ignoreCase: queryIsCaseSensitive,
+            ignoreCase: false === queryIsCaseSensitive,
             queryString: queryString,
             timeRangeBucketSizeMillis: newTimelineConfig.bucketDuration.asMilliseconds(),
             timestampBegin: timeRange[0].valueOf(),

--- a/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
@@ -20,10 +20,9 @@ import styles from "./index.module.css";
  */
 const SubmitButton = () => {
     const searchUiState = useSearchStore((state) => state.searchUiState);
-    const timeRange = useSearchStore((state) => state.timeRange);
     const queryString = useSearchStore((state) => state.queryString);
-    const updateTimelineConfig = useSearchStore((state) => state.updateTimelineConfig);
     const queryIsCaseSensitive = useSearchStore((state) => state.queryIsCaseSensitive);
+    const timeRange = useSearchStore((state) => state.timeRange);
 
     /**
      * Submits search query.
@@ -31,6 +30,7 @@ const SubmitButton = () => {
     const handleSubmitButtonClick = useCallback(() => {
         // Update timeline to match range picker selection.
         const newTimelineConfig = computeTimelineConfig(timeRange);
+        const {updateTimelineConfig} = useSearchStore.getState();
         updateTimelineConfig(newTimelineConfig);
 
         handleQuerySubmit({
@@ -42,7 +42,6 @@ const SubmitButton = () => {
         });
     }, [queryString,
         queryIsCaseSensitive,
-        updateTimelineConfig,
         timeRange]);
 
     const isQueryStringEmpty = queryString === SEARCH_STATE_DEFAULT.queryString;

--- a/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
@@ -41,6 +41,7 @@ const SubmitButton = () => {
             timestampEnd: timeRange[1].valueOf(),
         });
     }, [queryString,
+        queryIsCaseSensitive,
         updateTimelineConfig,
         timeRange]);
 

--- a/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchControls/SearchButton/SubmitButton.tsx
@@ -19,7 +19,11 @@ import styles from "./index.module.css";
  * @return
  */
 const SubmitButton = () => {
-    const {searchUiState, timeRange, queryString, updateTimelineConfig} = useSearchStore();
+    const searchUiState = useSearchStore((state) => state.searchUiState);
+    const timeRange = useSearchStore((state) => state.timeRange);
+    const queryString = useSearchStore((state) => state.queryString);
+    const updateTimelineConfig = useSearchStore((state) => state.updateTimelineConfig);
+    const queryIsCaseSensitive = useSearchStore((state) => state.queryIsCaseSensitive);
 
     /**
      * Submits search query.
@@ -30,7 +34,7 @@ const SubmitButton = () => {
         updateTimelineConfig(newTimelineConfig);
 
         handleQuerySubmit({
-            ignoreCase: false,
+            ignoreCase: queryIsCaseSensitive,
             queryString: queryString,
             timeRangeBucketSizeMillis: newTimelineConfig.bucketDuration.asMilliseconds(),
             timestampBegin: timeRange[0].valueOf(),

--- a/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
@@ -1,4 +1,7 @@
-import {useEffect} from "react";
+import {
+    useCallback,
+    useEffect,
+} from "react";
 
 import {Card} from "antd";
 import {Dayjs} from "dayjs";
@@ -19,16 +22,10 @@ import {computeTimelineConfig} from "./utils";
  * @return
  */
 const SearchResultsTimeline = () => {
-    const queryString = useSearchStore((state) => state.queryString);
-    const updateTimeRange = useSearchStore((state) => state.updateTimeRange);
-    const updateTimeRangeOption = useSearchStore((state) => state.updateTimeRangeOption);
-    const timelineConfig = useSearchStore((state) => state.timelineConfig);
-    const searchUiState = useSearchStore((state) => state.searchUiState);
-    const updateTimelineConfig = useSearchStore((state) => state.updateTimelineConfig);
-    const updateNumSearchResultsTimeline = useSearchStore(
-        (state) => state.updateNumSearchResultsTimeline
-    );
     const queryIsCaseSensitive = useSearchStore((state) => state.queryIsCaseSensitive);
+    const queryString = useSearchStore((state) => state.queryString);
+    const searchUiState = useSearchStore((state) => state.searchUiState);
+    const timelineConfig = useSearchStore((state) => state.timelineConfig);
 
     const aggregationResults = useAggregationResults();
 
@@ -38,14 +35,20 @@ const SearchResultsTimeline = () => {
             0
         ) ?? 0;
 
+        const {
+            updateNumSearchResultsTimeline,
+        } = useSearchStore.getState();
+
         updateNumSearchResultsTimeline(numSearchResultsTimeline);
     }, [
         aggregationResults,
-        updateNumSearchResultsTimeline,
     ]);
 
-    const handleTimelineZoom = (newTimeRange: [Dayjs, Dayjs]) => {
+    const handleTimelineZoom = useCallback((newTimeRange: [Dayjs, Dayjs]) => {
         const newTimelineConfig: TimelineConfig = computeTimelineConfig(newTimeRange);
+        const {
+            updateTimeRange, updateTimeRangeOption, updateTimelineConfig,
+        } = useSearchStore.getState();
 
         // Update range picker selection to match zoomed range.
         updateTimeRange(newTimeRange);
@@ -64,7 +67,10 @@ const SearchResultsTimeline = () => {
             timestampBegin: newTimeRange[0].valueOf(),
             timestampEnd: newTimeRange[1].valueOf(),
         });
-    };
+    }, [
+        queryIsCaseSensitive,
+        queryString,
+    ]);
 
     return (
         <Card>

--- a/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
@@ -29,21 +29,6 @@ const SearchResultsTimeline = () => {
 
     const aggregationResults = useAggregationResults();
 
-    useEffect(() => {
-        const numSearchResultsTimeline = aggregationResults?.reduce(
-            (acc, curr) => acc + curr.count,
-            0
-        ) ?? 0;
-
-        const {
-            updateNumSearchResultsTimeline,
-        } = useSearchStore.getState();
-
-        updateNumSearchResultsTimeline(numSearchResultsTimeline);
-    }, [
-        aggregationResults,
-    ]);
-
     const handleTimelineZoom = useCallback((newTimeRange: [Dayjs, Dayjs]) => {
         const newTimelineConfig: TimelineConfig = computeTimelineConfig(newTimeRange);
         const {
@@ -70,6 +55,21 @@ const SearchResultsTimeline = () => {
     }, [
         queryIsCaseSensitive,
         queryString,
+    ]);
+
+    useEffect(() => {
+        const numSearchResultsTimeline = aggregationResults?.reduce(
+            (acc, curr) => acc + curr.count,
+            0
+        ) ?? 0;
+
+        const {
+            updateNumSearchResultsTimeline,
+        } = useSearchStore.getState();
+
+        updateNumSearchResultsTimeline(numSearchResultsTimeline);
+    }, [
+        aggregationResults,
     ]);
 
     return (

--- a/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
@@ -25,7 +25,9 @@ const SearchResultsTimeline = () => {
     const timelineConfig = useSearchStore((state) => state.timelineConfig);
     const searchUiState = useSearchStore((state) => state.searchUiState);
     const updateTimelineConfig = useSearchStore((state) => state.updateTimelineConfig);
-    const updateNumSearchResultsTimeline = useSearchStore((state) => state.updateNumSearchResultsTimeline);
+    const updateNumSearchResultsTimeline = useSearchStore(
+        (state) => state.updateNumSearchResultsTimeline
+    );
     const queryIsCaseSensitive = useSearchStore((state) => state.queryIsCaseSensitive);
 
     const aggregationResults = useAggregationResults();

--- a/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
@@ -58,7 +58,7 @@ const SearchResultsTimeline = () => {
         }
 
         handleQuerySubmit({
-            ignoreCase: queryIsCaseSensitive,
+            ignoreCase: false === queryIsCaseSensitive,
             queryString: queryString,
             timeRangeBucketSizeMillis: newTimelineConfig.bucketDuration.asMilliseconds(),
             timestampBegin: newTimeRange[0].valueOf(),

--- a/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchResults/SearchResultsTimeline/index.tsx
@@ -19,15 +19,14 @@ import {computeTimelineConfig} from "./utils";
  * @return
  */
 const SearchResultsTimeline = () => {
-    const {
-        queryString,
-        updateTimeRange,
-        updateTimeRangeOption,
-        timelineConfig,
-        searchUiState,
-        updateTimelineConfig,
-        updateNumSearchResultsTimeline,
-    } = useSearchStore();
+    const queryString = useSearchStore((state) => state.queryString);
+    const updateTimeRange = useSearchStore((state) => state.updateTimeRange);
+    const updateTimeRangeOption = useSearchStore((state) => state.updateTimeRangeOption);
+    const timelineConfig = useSearchStore((state) => state.timelineConfig);
+    const searchUiState = useSearchStore((state) => state.searchUiState);
+    const updateTimelineConfig = useSearchStore((state) => state.updateTimelineConfig);
+    const updateNumSearchResultsTimeline = useSearchStore((state) => state.updateNumSearchResultsTimeline);
+    const queryIsCaseSensitive = useSearchStore((state) => state.queryIsCaseSensitive);
 
     const aggregationResults = useAggregationResults();
 
@@ -57,7 +56,7 @@ const SearchResultsTimeline = () => {
         }
 
         handleQuerySubmit({
-            ignoreCase: false,
+            ignoreCase: queryIsCaseSensitive,
             queryString: queryString,
             timeRangeBucketSizeMillis: newTimelineConfig.bucketDuration.asMilliseconds(),
             timestampBegin: newTimeRange[0].valueOf(),


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Case sensitivity option was submitted as part of query, this PR adds missing option.

I also did some minor refactoring per new zustand guidelines in affected files


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested case sensitivity toggle works



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced search controls and results timeline to dynamically respect case sensitivity settings, improving search precision while maintaining the existing user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->