### PR TITLE
core-clp: Add function to preserve escaped wildcards during search (fixes #243).

### DIFF
--- a/components/core/src/clp/Grep.cpp
+++ b/components/core/src/clp/Grep.cpp
@@ -496,6 +496,28 @@ SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
 }
 }  // namespace
 
+void replace_unescaped_wildcards(
+        std::string& search_string
+) {
+    auto unescaped = [escaped = false](char c) mutable
+    {
+        bool should_replace = ('?' == c && !escaped);
+        if ('\\' == c) {
+            escaped = !escaped;
+        } else {
+            escaped = false;
+        }
+        return should_replace;
+    };
+    
+    std::replace_if(
+        search_string.begin(),
+        search_string.end(),
+        unescaped,
+        '*'
+    );
+}
+
 std::optional<Query> Grep::process_raw_query(
         Archive const& archive,
         string const& search_string,
@@ -522,12 +544,9 @@ std::optional<Query> Grep::process_raw_query(
         // Replace '?' wildcards with '*' wildcards since we currently have no support for
         // generating sub-queries with '?' wildcards. The final wildcard match on the decompressed
         // message uses the original wildcards, so correctness will be maintained.
-        std::replace(
-                search_string_for_sub_queries.begin(),
-                search_string_for_sub_queries.end(),
-                '?',
-                '*'
-        );
+        // Use replace_unescaped_wildcards() to avoid changing escaped wildcard characters.        
+        replace_unescaped_wildcards(search_string_for_sub_queries);
+
         // Clean-up in case any instances of "?*" or "*?" were changed into "**"
         search_string_for_sub_queries
                 = clean_up_wildcard_search_string(search_string_for_sub_queries);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Issue #243 describes a bug wherein queries containing the character sequence `\?` were not being matched with the appropriate search results.

`?` wildcard characters are replaced with `*` during search, but this was being done indiscriminately, i.e. `?` was being replaced with `*` regardless of whether or not it was escaped. This PR adds a helper function to `components/core/src/clp/Grep.cpp` called `replace_unescaped_wildcards()` which replaces the call to `std::replace()` that was being performed in `Grep::process_raw_query()`

`replace_unescaped_wildcards()` calls `std::replace_if()` for the string passed into it. The predicate function passed into `std::replace_if()` is a lambda function which returns `true` if the current (non-backslash) character is preceded by an even number of backslashes, i.e. that that character is not escaped. A boolean called `escaped` alternates between `false` and `true` upon encountering a `\` character.

`std::replace_if()` has the same complexity as `std::replace()`, and is single-run-through. The predicate (lambda) function does not require any caching other than the boolean `escaped`.

_NOTE: This PR does not fix the bug that affects queries that contain the character sequence `\\?`; this bug is described in issue #427 and fixed in PR #428._

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Ran queries from [query.txt](https://github.com/y-scope/clp/files/14031548/query.txt) on the logs in [log.txt](https://github.com/y-scope/clp/files/14031549/log.txt), as described in the "Reproduction steps" section of issue #243. All queries using `\?` now return the correct results.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
