### PR TITLE
fix(webui): Avoid caching virtual table ref to fix scrolling issue.

### DIFF
--- a/components/webui/client/src/components/VirtualTable/index.tsx
+++ b/components/webui/client/src/components/VirtualTable/index.tsx
@@ -23,19 +23,15 @@ const VirtualTable = <RecordType extends object = Record<string, unknown>>({
     ...tableProps
 }: VirtualTableProps<RecordType>) => {
     const containerRef = useRef<HTMLDivElement>(null);
-    const scrollNodeRef = useRef<HTMLElement>(null);
 
     const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
         if (null === containerRef.current) {
             return;
         }
 
-        const scrollNode = scrollNodeRef.current;
-        if (null === scrollNode) {
-            scrollNodeRef.current = containerRef.current.querySelector<HTMLElement>(
+        const scrollNode = containerRef.current.querySelector<HTMLElement>(
                 VIRTUAL_TABLE_HOLDER_SELECTOR
-            );
-        }
+        );
 
         if (null === scrollNode) {
             return;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

PR #972 added scroll functionality to virtual table. As part of review, we added ability to cache table ref as performance optimization. Didnt notice then that ref can reference a previous table, and not always the latest table, which breaks the scrolling functionality since it is scrolling the ref from a previous table.

This PR removes the ref.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Run a query, then tried to scroll, and scroll worked as expected. Previously, occasionally did not scroll.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
