### PR TITLE
fix(core): Drop fractional seconds from formatted timestamps used for S3 signed-URL generation (fixes #1131).

### DIFF
--- a/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
+++ b/components/core/src/clp/aws/AwsAuthenticationSigner.cpp
@@ -91,7 +91,8 @@ auto is_unreserved_characters(char c) -> bool {
 
 auto get_formatted_timestamp_string(std::chrono::system_clock::time_point const& timestamp)
         -> string {
-    return fmt::format("{:%Y%m%dT%H%M%SZ}", timestamp);
+    auto const timestamp_secs = std::chrono::time_point_cast<std::chrono::seconds>(timestamp);
+    return fmt::format("{:%Y%m%dT%H%M%SZ}", timestamp_secs);
 }
 
 auto get_formatted_date_string(std::chrono::system_clock::time_point const& timestamp) -> string {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Aws requires that the timestamp in presigned Url strictly follow the ISO8601 Long Format "yyyyMMdd'T'HHmmss'Z'"
The current implementation of timestamp [formatter](https://fmt.dev/11.1/syntax/#chrono-format-specifications) 'S' will add fractional number and generate timestamp such as `2023-03-22T03-45-46.234232 which violates the requirement of AWS.

This PR resolves the issue by adding an explicit timepoint cast to convert the timestamp into second precision.

Note: I am not sure why this was not an issue in the previous commit. Perhaps it was some undefined behavior and recently we updated either fmt verison or c++ version that revealed this issue. 
I have verified that commit 037cf108f62aee7baba88345e5fc4d38788c5c35 doesn't have this issue, so perhaps we can do a binary search to find out the first commit revealing the issue if we want to understand the root cause


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
1. Exported access_key_id and secret_access_key in my terminal (please contact me if you want to reproduce with the same set of key)
2. built clp-s
3. Ran the compression cmd `./clp-s c output --print-archive-stats --auth s3 --timestamp-key 't.$date' https://yscope-log-compression-dataset-us-west-1.s3.us-west-1.amazonaws.com/mongodb-8gb/mongod.log.2023-03-22T03-45-46`
4. Verified that
- clp-s failed without my change
- clp-s successfully compressed the log from s3 with my change.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp formatting to ensure times are displayed with second-level precision, avoiding display of sub-second values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->