### PR TITLE
fix(package): Fix potential error code in the package. 

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -957,7 +957,6 @@ def start_webui(
     ]
     necessary_mounts = [
         mounts.clp_home,
-        mounts.stream_output_dir,
     ]
     if StorageType.S3 == stream_storage.type:
         auth = stream_storage.s3_config.aws_authentication
@@ -973,6 +972,9 @@ def start_webui(
                 necessary_mounts.append(mounts.aws_config_dir)
             if aws_env_vars:
                 necessary_env_vars.extend(aws_env_vars)
+    else:
+        necessary_mounts.append(mounts.stream_output_dir)
+
     append_docker_options(container_cmd, necessary_mounts, necessary_env_vars)
     container_cmd.append(clp_config.execution_container)
 

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -366,6 +366,12 @@ class AwsAuthentication(BaseModel):
             raise ValueError(f"profile and credentials must not be set when type is '{auth_enum}.'")
         return values
 
+    def dump_to_primitive_dict(self):
+        d = self.dict()
+        if self.credentials is not None:
+            d["credentials"] = self.credentials.dict()
+        return d
+
 
 class S3Config(BaseModel):
     region_code: str
@@ -391,7 +397,9 @@ class S3IngestionConfig(BaseModel):
     aws_authentication: AwsAuthentication
 
     def dump_to_primitive_dict(self):
-        return self.dict()
+        d = self.dict()
+        d["aws_authentication"] = self.aws_authentication.dump_to_primitive_dict()
+        return d
 
 
 class FsStorage(BaseModel):

--- a/components/job-orchestration/job_orchestration/scheduler/constants.py
+++ b/components/job-orchestration/job_orchestration/scheduler/constants.py
@@ -17,10 +17,22 @@ class CompressionJobStatus(IntEnum):
     SUCCEEDED = auto()
     FAILED = auto()
 
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def to_str(self) -> str:
+        return str(self.name)
+
 
 class CompressionJobCompletionStatus(IntEnum):
     SUCCEEDED = 0
     FAILED = auto()
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def to_str(self) -> str:
+        return str(self.name)
 
 
 class CompressionTaskStatus(IntEnum):
@@ -28,6 +40,12 @@ class CompressionTaskStatus(IntEnum):
     RUNNING = auto()
     SUCCEEDED = auto()
     FAILED = auto()
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def to_str(self) -> str:
+        return str(self.name)
 
 
 # When adding new states always add them to the end of this enum


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

There are few places of code in CLP that could cause issues when running on cloud. This PR fixes all of them

This PR adds the following 3 fixes:
1. Only add stream_output_dir to the necessary_mount if stream storage type is filesystem. This prevent the webui from mounting the stream_storage_dir when storing stream on s3.
A potential error could be caused by the existing code: 1. If webui runs on another a different node from extraction worker, so the staged-stream dir wouldn't be created on webui's node. 2. On certain machine, for example ec2's arm instance. docker doesn't allow binding to a non-existing directory.

2. Add __str__ and to_str() method for scheduler enum. On ec2's arm machine, without those methods, python convert enums to int instead of string and has caused failures when updating the database.

3. Properly implement dump_to_primitive_dict for S3IngestionConfig.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
