### PR TITLE
ci: Drop support for macOS 13 & 14 to prepare to upgrade ystdlib-cpp; Lock GH runner images to latest available rather than latest stable.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -45,8 +45,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - "macos-13"
-          - "macos-14"
           - "macos-15"
         use_shared_libs:
           - true

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -42,8 +42,7 @@ concurrency:
 jobs:
   filter-relevant-changes:
     name: "filter-relevant-changes"
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     outputs:
       centos_stream_9_image_changed: "${{steps.filter.outputs.centos_stream_9_image}}"
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
@@ -100,8 +99,7 @@ jobs:
     name: "centos-stream-9-deps-image"
     if: "needs.filter-relevant-changes.outputs.centos_stream_9_image_changed == 'true'"
     needs: "filter-relevant-changes"
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -127,8 +125,7 @@ jobs:
     name: "ubuntu-jammy-deps-image"
     if: "needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'true'"
     needs: "filter-relevant-changes"
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -163,8 +160,7 @@ jobs:
         use_shared_libs: [true, false]
     name: "centos-stream-9-${{matrix.use_shared_libs == true && 'dynamic' || 'static'}}-linked-bins"
     continue-on-error: true
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -209,8 +205,7 @@ jobs:
       OS_NAME: "ubuntu-jammy"
     name: "ubuntu-jammy-${{matrix.use_shared_libs == true && 'dynamic' || 'static'}}-linked-bins"
     continue-on-error: true
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -257,8 +252,7 @@ jobs:
     # Run if the ancestor jobs were successful/skipped and building clp was successful.
     if: "!cancelled() && !failure() && needs.ubuntu-jammy-binaries.result == 'success'"
     needs: "ubuntu-jammy-binaries"
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     env:
       OS_NAME: "ubuntu-jammy"
       TMP_OUTPUT_DIR: "/tmp"
@@ -325,8 +319,7 @@ jobs:
     needs:
       - "filter-relevant-changes"
       - "ubuntu-jammy-deps-image"
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/clp-core-build.yaml
+++ b/.github/workflows/clp-core-build.yaml
@@ -42,7 +42,8 @@ concurrency:
 jobs:
   filter-relevant-changes:
     name: "filter-relevant-changes"
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     outputs:
       centos_stream_9_image_changed: "${{steps.filter.outputs.centos_stream_9_image}}"
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
@@ -99,7 +100,8 @@ jobs:
     name: "centos-stream-9-deps-image"
     if: "needs.filter-relevant-changes.outputs.centos_stream_9_image_changed == 'true'"
     needs: "filter-relevant-changes"
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -125,7 +127,8 @@ jobs:
     name: "ubuntu-jammy-deps-image"
     if: "needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'true'"
     needs: "filter-relevant-changes"
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -160,7 +163,8 @@ jobs:
         use_shared_libs: [true, false]
     name: "centos-stream-9-${{matrix.use_shared_libs == true && 'dynamic' || 'static'}}-linked-bins"
     continue-on-error: true
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -205,7 +209,8 @@ jobs:
       OS_NAME: "ubuntu-jammy"
     name: "ubuntu-jammy-${{matrix.use_shared_libs == true && 'dynamic' || 'static'}}-linked-bins"
     continue-on-error: true
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:
@@ -252,7 +257,8 @@ jobs:
     # Run if the ancestor jobs were successful/skipped and building clp was successful.
     if: "!cancelled() && !failure() && needs.ubuntu-jammy-binaries.result == 'success'"
     needs: "ubuntu-jammy-binaries"
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     env:
       OS_NAME: "ubuntu-jammy"
       TMP_OUTPUT_DIR: "/tmp"
@@ -319,7 +325,8 @@ jobs:
     needs:
       - "filter-relevant-changes"
       - "ubuntu-jammy-deps-image"
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/clp-docs.yaml
+++ b/.github/workflows/clp-docs.yaml
@@ -18,7 +18,9 @@ jobs:
     name: "build"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os:
+          - "macos-15"
+          - "ubuntu-24.04"
     runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
@@ -34,7 +36,7 @@ jobs:
         shell: "bash"
         run: "npm install -g @go-task/cli"
 
-      - if: "matrix.os == 'macos-latest'"
+      - if: "matrix.os == 'macos-15'"
         name: "Install coreutils (for md5sum)"
         run: "brew install coreutils"
 
@@ -46,7 +48,7 @@ jobs:
       - if: >-
           contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
           && ('refs/heads/main' == github.ref || startsWith(github.ref, 'refs/tags/v'))
-          && 'ubuntu-latest' == matrix.os
+          && 'ubuntu-24.04' == matrix.os
         uses: "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
         with:
           name: "docs-html"

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -24,8 +24,7 @@ concurrency:
 jobs:
   filter-relevant-changes:
     name: "filter-relevant-changes"
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     outputs:
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
     steps:
@@ -52,8 +51,7 @@ jobs:
     name: "ubuntu-jammy-execution-image"
     if: "'true' == needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed"
     needs: "filter-relevant-changes"
-    runs-on:
-      - "ubuntu-24.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/clp-execution-image-build.yaml
+++ b/.github/workflows/clp-execution-image-build.yaml
@@ -24,7 +24,8 @@ concurrency:
 jobs:
   filter-relevant-changes:
     name: "filter-relevant-changes"
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     outputs:
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
     steps:
@@ -51,7 +52,8 @@ jobs:
     name: "ubuntu-jammy-execution-image"
     if: "'true' == needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed"
     needs: "filter-relevant-changes"
-    runs-on: "ubuntu-latest"
+    runs-on:
+      - "ubuntu-24.04"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/clp-lint.yaml
+++ b/.github/workflows/clp-lint.yaml
@@ -18,7 +18,9 @@ jobs:
     name: "lint-check"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os:
+          - "macos-15"
+          - "ubuntu-24.04"
     runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
@@ -33,7 +35,7 @@ jobs:
         shell: "bash"
         run: "npm install -g @go-task/cli"
 
-      - if: "matrix.os == 'macos-latest'"
+      - if: "matrix.os == 'macos-15'"
         name: "Install coreutils (for md5sum)"
         run: "brew install coreutils"
 

--- a/.github/workflows/clp-pr-title-checks.yaml
+++ b/.github/workflows/clp-pr-title-checks.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       # For amannn/action-semantic-pull-request
       pull-requests: "read"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: "amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017"
         env:

--- a/.github/workflows/clp-s-generated-code-checks.yaml
+++ b/.github/workflows/clp-s-generated-code-checks.yaml
@@ -15,7 +15,9 @@ jobs:
     name: "antlr-code-committed"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os:
+          - "macos-15"
+          - "ubuntu-24.04"
     runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
@@ -26,7 +28,7 @@ jobs:
         shell: "bash"
         run: "npm install -g @go-task/cli"
 
-      - if: "matrix.os == 'macos-latest'"
+      - if: "matrix.os == 'macos-15'"
         name: "Install coreutils (for md5sum)"
         run: "brew install coreutils"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR drops CI support for `macos-13` and `macos-14` to enable upgrading ystdlib-cpp (#1038). #1090 outlines a problem #1038 ran into when trying to support the older macos versions. Although this PR doesn't fix the fundamental problem, it does work around it in the short term.

We also explicitly lock the Github runner images' version to the latest available rather than using `-latest`. This means we will need to manually/explicitly keep these versions updated as Github releases new images, but it avoids random breaks in CI and accidentally dropping versions when `-latest` changes .

Finally, we do some minor refactoring to change any lists from:

```yaml
list: ["entry"]
```

to:

```yaml
list:
  - "entry"
```



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
CI passing.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use explicit operating system versions, replacing generic labels with specific versions (e.g., "ubuntu-24.04" and "macos-15").
  * Removed older macOS versions from the macOS build workflow, now targeting only "macos-15".
  * Adjusted conditional steps in workflows to match the updated OS version identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->