### PR TITLE
feat: Add perf task to generate perf data.

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -16,7 +16,7 @@ vars:
   G_CORE_COMPONENT_SUBMODULES_DIR: "{{.G_CORE_COMPONENT_DIR}}/submodules"
   G_WEBUI_SRC_DIR: "{{.G_COMPONENTS_DIR}}/webui"
 
-  G_DATASET_LOCATION: "{{.ROOT_DIR}}/datasets/dataset.json"
+  G_DATASET_LOCATION: "{{.ROOT_DIR}}/datasets/dataset.log"
 
   # Build paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
@@ -243,7 +243,7 @@ tasks:
               {{if eq .BUILD_WITH_SYMBOLS "true"}}-DCMAKE_BUILD_TYPE=RelWithDebInfo{{end}}
           BUILD_DIR: "{{.G_CORE_COMPONENT_BUILD_DIR}}"
           SOURCE_DIR: "{{.G_CORE_COMPONENT_DIR}}"
-      - "rm .task/build_with_symbols_*.stamp"
+      - "rm -f .task/build_with_symbols_*.stamp"
       - "touch .task/build_with_symbols_{{.BUILD_WITH_SYMBOLS}}.stamp"
 
   core-build:
@@ -611,10 +611,11 @@ tasks:
       - "test -f {{.G_DATASET_LOCATION}}"
     cmds:
       - >-
-        curl -o output.tar.gz
+        curl --fail --location --show-error --silent
+        --output output.tar.gz
         https://zenodo.org/records/10516387/files/cockroachdb.tar.gz?download=1
-      - "tar -xvzf output.tar.gz"
-      - "rm output.tar.gz"
+      - "tar -xzf output.tar.gz"
+      - "rm -f output.tar.gz"
       - >-
         mkdir -p "$(dirname "{{.G_DATASET_LOCATION}}")"
       - "mv cockroachdb/cockroach.node1.log {{.G_DATASET_LOCATION}}"
@@ -630,8 +631,8 @@ tasks:
       - "rm -f perf.data"
       - >-
         perf record -F 99 -g -- ./build/core/clp-s c --timestamp-key "timestamp"
-        --target-encoded-size 268435456 build/clp_cockroachdb_perf_output {{.G_DATASET_LOCATION}}
-      - "chmod +777 perf.data"
+        --target-encoded-size 268435456 build/clp_cockroachdb_perf_output "{{.G_DATASET_LOCATION}}"
+      - "chmod 644 perf.data"
       - >-
         perf report -i perf.data --call-graph=graph,0.5,0,caller,function,percent --stdio --demangle
         --no-inline > perf-report.txt

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -16,6 +16,8 @@ vars:
   G_CORE_COMPONENT_SUBMODULES_DIR: "{{.G_CORE_COMPONENT_DIR}}/submodules"
   G_WEBUI_SRC_DIR: "{{.G_COMPONENTS_DIR}}/webui"
 
+  G_DATASET_LOCATION: "{{.ROOT_DIR}}/datasets/dataset.json"
+
   # Build paths
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CORE_COMPONENT_BUILD_DIR: "{{.G_BUILD_DIR}}/core"
@@ -585,6 +587,26 @@ tasks:
     dir: "components/{{.COMPONENT}}"
     cmds:
       - "rm -rf dist"
+
+  download-dataset:
+    cmds:
+      - "curl -o output.tar.gz https://zenodo.org/records/10516387/files/cockroachdb.tar.gz?download=1"
+      - "tar -xvzf output.tar.gz"
+      - "rm output.tar.gz"
+      - >-
+        mkdir -p "$(dirname "{{.G_DATASET_LOCATION}}")"
+      - "mv cockroachdb/cockroach.node1.log {{.G_DATASET_LOCATION}}"
+      - "rmdir cockroachdb"
+
+  perf:
+    deps:
+      - "package"
+      - "download-dataset"
+    cmds:
+      - 'rm -f perf.data'
+      - 'perf record -F 99 -- ./build/core/clp-s c --timestamp-key "timestamp" --target-encoded-size 268435456 build/clp_cockroachdb_perf_output {{.G_DATASET_LOCATION}}'
+      - 'chmod +777 perf.data'
+      - 'perf data convert --to-json perf.json'
 
   init:
     internal: true

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -96,6 +96,7 @@ tasks:
     vars:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK}}.md5"
       OUTPUT_DIR: "{{.G_PACKAGE_BUILD_DIR}}"
+      BUILD_WITH_SYMBOLS: "{{.BUILD_WITH_SYMBOLS | default false}}"
     sources:
       - "{{.G_BUILD_DIR}}/package-venv.md5"
       - "{{.G_BUILD_DIR}}/webui.md5"
@@ -113,7 +114,9 @@ tasks:
       - "components/package-template/src/**/*"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
-      - "core"
+      - task: "core"
+        vars:
+          BUILD_WITH_SYMBOLS: "{{.BUILD_WITH_SYMBOLS}}"
       - "clp-package-utils"
       - "clp-py-utils"
       - "init"
@@ -206,11 +209,17 @@ tasks:
             ref: ".OUTPUT_DIRS"
 
   core:
+    vars:
+      BUILD_WITH_SYMBOLS: "{{.BUILD_WITH_SYMBOLS | default false}}"
     cmds:
       - task: "core-generate"
+        vars:
+          BUILD_WITH_SYMBOLS: "{{.BUILD_WITH_SYMBOLS}}"
       - task: "core-build"
 
   core-generate:
+    vars:
+      BUILD_WITH_SYMBOLS: "{{.BUILD_WITH_SYMBOLS | default false}}"
     internal: true
     sources: &core_source_files
       - "{{.G_DEPS_CORE_CHECKSUM_FILE}}"
@@ -219,14 +228,20 @@ tasks:
       - "{{.G_CORE_COMPONENT_DIR}}/src/**/*"
       - "{{.TASKFILE}}"
       - "/etc/os-release"
+    generates:
+      # ugly workaround so that when the var changes, the task gets re-run (triggering core-build re-run)
+      - '.task/build_with_symbols_{{.BUILD_WITH_SYMBOLS}}.stamp'
     deps:
       - "clp-s-generate-parsers"
       - "deps:core"
     cmds:
       - task: "utils:cmake:generate"
         vars:
+          EXTRA_ARGS: ['{{if eq .BUILD_WITH_SYMBOLS "true"}}-DCMAKE_BUILD_TYPE=RelWithDebInfo{{end}}']
           BUILD_DIR: "{{.G_CORE_COMPONENT_BUILD_DIR}}"
           SOURCE_DIR: "{{.G_CORE_COMPONENT_DIR}}"
+      - 'rm .task/build_with_symbols_*.stamp'
+      - 'touch .task/build_with_symbols_{{.BUILD_WITH_SYMBOLS}}.stamp'
 
   core-build:
     internal: true
@@ -589,6 +604,8 @@ tasks:
       - "rm -rf dist"
 
   download-dataset:
+    status:
+      - "test -f {{.G_DATASET_LOCATION}}"
     cmds:
       - "curl -o output.tar.gz https://zenodo.org/records/10516387/files/cockroachdb.tar.gz?download=1"
       - "tar -xvzf output.tar.gz"
@@ -600,13 +617,16 @@ tasks:
 
   perf:
     deps:
-      - "package"
       - "download-dataset"
     cmds:
+      - task: "package"
+        vars:
+          BUILD_WITH_SYMBOLS: true
       - 'rm -f perf.data'
-      - 'perf record -F 99 -- ./build/core/clp-s c --timestamp-key "timestamp" --target-encoded-size 268435456 build/clp_cockroachdb_perf_output {{.G_DATASET_LOCATION}}'
+      - 'perf record -F 99 -g -- ./build/core/clp-s c --timestamp-key "timestamp" --target-encoded-size 268435456 build/clp_cockroachdb_perf_output {{.G_DATASET_LOCATION}}'
       - 'chmod +777 perf.data'
-      - 'perf data convert --to-json perf.json'
+      - 'perf report -i perf.data --call-graph=graph,0.5,0,caller,function,percent --stdio --demangle --no-inline > perf-report.txt'
+      # - 'perf data convert --to-json perf.json'
 
   init:
     internal: true

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -229,19 +229,22 @@ tasks:
       - "{{.TASKFILE}}"
       - "/etc/os-release"
     generates:
-      # ugly workaround so that when the var changes, the task gets re-run (triggering core-build re-run)
-      - '.task/build_with_symbols_{{.BUILD_WITH_SYMBOLS}}.stamp'
+      # ugly workaround so that when the var changes, the task gets re-run (triggering core-build
+      # re-run)
+      - ".task/build_with_symbols_{{.BUILD_WITH_SYMBOLS}}.stamp"
     deps:
       - "clp-s-generate-parsers"
       - "deps:core"
     cmds:
       - task: "utils:cmake:generate"
         vars:
-          EXTRA_ARGS: ['{{if eq .BUILD_WITH_SYMBOLS "true"}}-DCMAKE_BUILD_TYPE=RelWithDebInfo{{end}}']
+          EXTRA_ARGS:
+            - >-
+              {{if eq .BUILD_WITH_SYMBOLS "true"}}-DCMAKE_BUILD_TYPE=RelWithDebInfo{{end}}
           BUILD_DIR: "{{.G_CORE_COMPONENT_BUILD_DIR}}"
           SOURCE_DIR: "{{.G_CORE_COMPONENT_DIR}}"
-      - 'rm .task/build_with_symbols_*.stamp'
-      - 'touch .task/build_with_symbols_{{.BUILD_WITH_SYMBOLS}}.stamp'
+      - "rm .task/build_with_symbols_*.stamp"
+      - "touch .task/build_with_symbols_{{.BUILD_WITH_SYMBOLS}}.stamp"
 
   core-build:
     internal: true
@@ -607,7 +610,9 @@ tasks:
     status:
       - "test -f {{.G_DATASET_LOCATION}}"
     cmds:
-      - "curl -o output.tar.gz https://zenodo.org/records/10516387/files/cockroachdb.tar.gz?download=1"
+      - >-
+        curl -o output.tar.gz
+        https://zenodo.org/records/10516387/files/cockroachdb.tar.gz?download=1
       - "tar -xvzf output.tar.gz"
       - "rm output.tar.gz"
       - >-
@@ -622,11 +627,14 @@ tasks:
       - task: "package"
         vars:
           BUILD_WITH_SYMBOLS: true
-      - 'rm -f perf.data'
-      - 'perf record -F 99 -g -- ./build/core/clp-s c --timestamp-key "timestamp" --target-encoded-size 268435456 build/clp_cockroachdb_perf_output {{.G_DATASET_LOCATION}}'
-      - 'chmod +777 perf.data'
-      - 'perf report -i perf.data --call-graph=graph,0.5,0,caller,function,percent --stdio --demangle --no-inline > perf-report.txt'
-      # - 'perf data convert --to-json perf.json'
+      - "rm -f perf.data"
+      - >-
+        perf record -F 99 -g -- ./build/core/clp-s c --timestamp-key "timestamp"
+        --target-encoded-size 268435456 build/clp_cockroachdb_perf_output {{.G_DATASET_LOCATION}}
+      - "chmod +777 perf.data"
+      - >-
+        perf report -i perf.data --call-graph=graph,0.5,0,caller,function,percent --stdio --demangle
+        --no-inline > perf-report.txt
 
   init:
     internal: true

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -52,6 +52,7 @@ tasks:
   clean:
     cmds:
       - "rm -rf '{{.G_BUILD_DIR}}'"
+      - "rm -f .task/build_with_symbols_*.stamp"
       - task: "clean-python-component"
         vars:
           COMPONENT: "clp-package-utils"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This will allow `task perf` to download the cockroachdb dataset (https://zenodo.org/records/10516387) and run perf on it, outputting the perf.data file.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
`task perf` works as intended and contains symbols. Linting checks pass. `task core` and other ways of directly building the core package produce a core package that doesn't contain debug symbols.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dataset management with automated downloading and setup of a sample log file.
  * Introduced performance profiling tasks that build with debug symbols and generate detailed performance reports.
* **Chores**
  * Updated development utilities to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888469767725