### PR TITLE
refactor(clp): Prepare parsing & search code for deduplication with clp-s:

### DIFF
--- a/components/core/src/clp/DictionaryReader.hpp
+++ b/components/core/src/clp/DictionaryReader.hpp
@@ -1,7 +1,10 @@
 #ifndef CLP_DICTIONARYREADER_HPP
 #define CLP_DICTIONARYREADER_HPP
 
+#include <iterator>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
@@ -33,6 +36,9 @@ public:
         // Methods
         char const* what() const noexcept override { return "DictionaryReader operation failed"; }
     };
+
+    using dictionary_id_t = DictionaryIdType;
+    using entry_t = EntryType;
 
     // Constructors
     DictionaryReader() : m_is_open(false), m_num_segments_read_from_index(0) {
@@ -85,7 +91,7 @@ public:
      * @return a vector of matching entries, or an empty vector if no entry matches.
      */
     std::vector<EntryType const*>
-    get_entry_matching_value(std::string const& search_string, bool ignore_case) const;
+    get_entry_matching_value(std::string_view search_string, bool ignore_case) const;
     /**
      * Gets the entries that match a given wildcard string
      * @param wildcard_string
@@ -93,7 +99,7 @@ public:
      * @param entries Set in which to store found entries
      */
     void get_entries_matching_wildcard_string(
-            std::string const& wildcard_string,
+            std::string_view wildcard_string,
             bool ignore_case,
             std::unordered_set<EntryType const*>& entries
     ) const;
@@ -235,7 +241,7 @@ DictionaryReader<DictionaryIdType, EntryType>::get_value(DictionaryIdType id) co
 template <typename DictionaryIdType, typename EntryType>
 std::vector<EntryType const*>
 DictionaryReader<DictionaryIdType, EntryType>::get_entry_matching_value(
-        std::string const& search_string,
+        std::string_view search_string,
         bool ignore_case
 ) const {
     if (false == ignore_case) {
@@ -252,7 +258,11 @@ DictionaryReader<DictionaryIdType, EntryType>::get_entry_matching_value(
     }
 
     std::vector<EntryType const*> entries;
-    auto const search_string_uppercase = boost::algorithm::to_upper_copy(search_string);
+    std::string search_string_uppercase;
+    std::ignore = boost::algorithm::to_upper_copy(
+            std::back_inserter(search_string_uppercase),
+            search_string
+    );
     for (auto const& entry : m_entries) {
         if (boost::algorithm::to_upper_copy(entry.get_value()) == search_string_uppercase) {
             entries.push_back(&entry);
@@ -263,7 +273,7 @@ DictionaryReader<DictionaryIdType, EntryType>::get_entry_matching_value(
 
 template <typename DictionaryIdType, typename EntryType>
 void DictionaryReader<DictionaryIdType, EntryType>::get_entries_matching_wildcard_string(
-        std::string const& wildcard_string,
+        std::string_view wildcard_string,
         bool ignore_case,
         std::unordered_set<EntryType const*>& entries
 ) const {

--- a/components/core/src/clp/DictionaryWriter.hpp
+++ b/components/core/src/clp/DictionaryWriter.hpp
@@ -2,7 +2,8 @@
 #define CLP_DICTIONARYWRITER_HPP
 
 #include <string>
-#include <unordered_map>
+
+#include <absl/container/flat_hash_map.h>
 
 #include "ArrayBackedPosIntSet.hpp"
 #include "Defs.h"
@@ -33,6 +34,9 @@ public:
         // Methods
         char const* what() const noexcept override { return "DictionaryWriter operation failed"; }
     };
+
+    using dictionary_id_t = DictionaryIdType;
+    using entry_t = EntryType;
 
     // Constructors
     DictionaryWriter() : m_is_open(false) {}
@@ -83,7 +87,7 @@ public:
 
 protected:
     // Types
-    using value_to_id_t = std::unordered_map<std::string, DictionaryIdType>;
+    using value_to_id_t = absl::flat_hash_map<std::string, DictionaryIdType>;
 
     // Variables
     bool m_is_open;

--- a/components/core/src/clp/EncodedVariableInterpreter.hpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.hpp
@@ -2,14 +2,18 @@
 #define CLP_ENCODEDVARIABLEINTERPRETER_HPP
 
 #include <string>
+#include <string_view>
+#include <unordered_set>
 #include <vector>
 
+#include "DictionaryConcepts.hpp"
+#include "ffi/ir_stream/decoding_methods.hpp"
 #include "ir/LogEvent.hpp"
 #include "ir/types.hpp"
 #include "Query.hpp"
+#include "spdlog_with_specializations.hpp"
 #include "TraceableException.hpp"
-#include "VariableDictionaryReader.hpp"
-#include "VariableDictionaryWriter.hpp"
+#include "type_utils.hpp"
 
 namespace clp {
 /**
@@ -47,6 +51,39 @@ public:
     // Methods
     static encoded_variable_t encode_var_dict_id(variable_dictionary_id_t id);
     static variable_dictionary_id_t decode_var_dict_id(encoded_variable_t encoded_var);
+
+    /**
+     * Adds a dictionary variable placeholder to the given logtype
+     * @param logtype
+     */
+    static void add_dict_var(std::string& logtype) {
+        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Dictionary);
+    }
+
+    /**
+     * Adds an integer variable placeholder to the given logtype
+     * @param logtype
+     */
+    static void add_int_var(std::string& logtype) {
+        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Integer);
+    }
+
+    /**
+     * Adds a float variable placeholder to the given logtype
+     * @param logtype
+     */
+    static void add_float_var(std::string& logtype) {
+        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Float);
+    }
+
+    /**
+     * Adds an escape character to the given logtype
+     * @param logtype
+     */
+    static void add_escape(std::string& logtype) {
+        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Escape);
+    }
+
     /**
      * Converts the given string into a representable integer variable if possible
      * @param value
@@ -54,7 +91,7 @@ public:
      * @return true if was successfully converted, false otherwise
      */
     static bool convert_string_to_representable_integer_var(
-            std::string const& value,
+            std::string_view value,
             encoded_variable_t& encoded_var
     );
     /**
@@ -64,7 +101,7 @@ public:
      * @return true if was successfully converted, false otherwise
      */
     static bool convert_string_to_representable_float_var(
-            std::string const& value,
+            std::string_view value,
             encoded_variable_t& encoded_var
     );
     /**
@@ -77,16 +114,21 @@ public:
     /**
      * Parses all variables from a message (while constructing the logtype) and encodes them (adding
      * them to the variable dictionary if necessary)
+     * @tparam VariableDictionaryWriterType
+     * @tparam LogTypeDictionaryEntryType
      * @param message
      * @param logtype_dict_entry
      * @param var_dict
      * @param encoded_vars
      * @param var_ids
      */
+    template <
+            VariableDictionaryWriterReq VariableDictionaryWriterType,
+            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType>
     static void encode_and_add_to_dictionary(
-            std::string const& message,
-            LogTypeDictionaryEntry& logtype_dict_entry,
-            VariableDictionaryWriter& var_dict,
+            std::string_view message,
+            LogTypeDictionaryEntryType& logtype_dict_entry,
+            VariableDictionaryWriterType& var_dict,
             std::vector<encoded_variable_t>& encoded_vars,
             std::vector<variable_dictionary_id_t>& var_ids
     );
@@ -95,7 +137,9 @@ public:
      * Encodes the given IR log event, constructing a logtype dictionary entry, and adding any
      * dictionary variables to the dictionary. NOTE: Four-byte encoded variables will be converted
      * to eight-byte encoded variables.
-     * @tparam encoded_variable_t The type of the encoded variables in the log event
+     * @tparam EncodedVariableType The type of the encoded variables in the log event.
+     * @tparam LogTypeDictionaryEntryType
+     * @tparam VariableDictionaryWriterType
      * @param log_event
      * @param logtype_dict_entry
      * @param var_dict
@@ -104,11 +148,14 @@ public:
      * @param raw_num_bytes Returns an estimate of the number of bytes that this log event would
      * occupy if it was not encoded in CLP's IR
      */
-    template <typename encoded_variable_t>
+    template <
+            typename EncodedVariableType,
+            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+            VariableDictionaryWriterReq VariableDictionaryWriterType>
     static void encode_and_add_to_dictionary(
-            ir::LogEvent<encoded_variable_t> const& log_event,
-            LogTypeDictionaryEntry& logtype_dict_entry,
-            VariableDictionaryWriter& var_dict,
+            ir::LogEvent<EncodedVariableType> const& log_event,
+            LogTypeDictionaryEntryType& logtype_dict_entry,
+            VariableDictionaryWriterType& var_dict,
             std::vector<ir::eight_byte_encoded_variable_t>& encoded_vars,
             std::vector<variable_dictionary_id_t>& var_ids,
             size_t& raw_num_bytes
@@ -116,22 +163,30 @@ public:
 
     /**
      * Decodes all variables and decompresses them into a message
+     * @tparam LogTypeDictionaryEntryType
+     * @tparam VariableDictionaryReaderType
+     * @tparam EncodedVariableVectorType A vector of `clp::encoded_variable_t`.
      * @param logtype_dict_entry
      * @param var_dict
      * @param encoded_vars
      * @param decompressed_msg
      * @return true if successful, false otherwise
      */
+    template <
+            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+            VariableDictionaryReaderReq VariableDictionaryReaderType,
+            typename EncodedVariableVectorType>  // TODO: Make a concept.
     static bool decode_variables_into_message(
-            LogTypeDictionaryEntry const& logtype_dict_entry,
-            VariableDictionaryReader const& var_dict,
-            std::vector<encoded_variable_t> const& encoded_vars,
+            LogTypeDictionaryEntryType const& logtype_dict_entry,
+            VariableDictionaryReaderType const& var_dict,
+            EncodedVariableVectorType const& encoded_vars,
             std::string& decompressed_msg
     );
 
     /**
      * Encodes a string-form variable, and if it is dictionary variable, searches for its ID in the
-     * given variable dictionary
+     * given variable dictionary.
+     * @tparam VariableDictionaryReaderType
      * @param var_str
      * @param var_dict
      * @param ignore_case
@@ -141,25 +196,32 @@ public:
      * dictionary
      * @return false otherwise
      */
+    template <VariableDictionaryReaderReq VariableDictionaryReaderType>
     static bool encode_and_search_dictionary(
-            std::string const& var_str,
-            VariableDictionaryReader const& var_dict,
+            std::string_view var_str,
+            VariableDictionaryReaderType const& var_dict,
             bool ignore_case,
             std::string& logtype,
             SubQuery& sub_query
     );
     /**
      * Search for the given string-form variable in the variable dictionary, encode any matches, and
-     * add them to the given sub-query
+     * add them to the given sub-query.
+     * @tparam VariableDictionaryReaderType
+     * @tparam VariableDictionaryEntryType
      * @param var_wildcard_str
      * @param var_dict
      * @param ignore_case
      * @param sub_query
      * @return true if any match found, false otherwise
      */
+    template <
+            VariableDictionaryReaderReq VariableDictionaryReaderType,
+            VariableDictionaryEntryReq VariableDictionaryEntryType
+            = VariableDictionaryReaderType::entry_t>
     static bool wildcard_search_dictionary_and_get_encoded_matches(
-            std::string const& var_wildcard_str,
-            VariableDictionaryReader const& var_dict,
+            std::string_view var_wildcard_str,
+            VariableDictionaryReaderType const& var_dict,
             bool ignore_case,
             SubQuery& sub_query
     );
@@ -167,7 +229,9 @@ public:
 private:
     /**
      * Encodes the given string as a dictionary or non-dictionary variable and adds a corresponding
-     * placeholder to the logtype
+     * placeholder to the logtype.
+     * @tparam LogTypeDictionaryEntryType
+     * @tparam VariableDictionaryWriterType
      * @param var
      * @param logtype_dict_entry
      * @param var_dict
@@ -175,29 +239,327 @@ private:
      * variable)
      * @return The encoded variable
      */
+    template <
+            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+            VariableDictionaryWriterReq VariableDictionaryWriterType>
     static encoded_variable_t encode_var(
-            std::string const& var,
-            LogTypeDictionaryEntry& logtype_dict_entry,
-            VariableDictionaryWriter& var_dict,
+            std::string_view var,
+            LogTypeDictionaryEntryType& logtype_dict_entry,
+            VariableDictionaryWriterType& var_dict,
             std::vector<variable_dictionary_id_t>& var_ids
     );
 
     /**
      * Adds the given string to the variable dictionary and adds a corresponding placeholder to
-     * logtype
+     * logtype.
+     * @tparam LogTypeDictionaryEntryType
+     * @tparam VariableDictionaryWriterType
      * @param var
      * @param logtype_dict_entry
      * @param var_dict
      * @param var_ids A container to add the dictionary ID to
      * @return The dictionary ID
      */
+    template <
+            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+            VariableDictionaryWriterReq VariableDictionaryWriterType>
     static variable_dictionary_id_t add_dict_var(
-            std::string const& var,
-            LogTypeDictionaryEntry& logtype_dict_entry,
-            VariableDictionaryWriter& var_dict,
+            std::string_view var,
+            LogTypeDictionaryEntryType& logtype_dict_entry,
+            VariableDictionaryWriterType& var_dict,
             std::vector<variable_dictionary_id_t>& var_ids
     );
 };
+
+template <
+        VariableDictionaryWriterReq VariableDictionaryWriterType,
+        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType>
+void EncodedVariableInterpreter::encode_and_add_to_dictionary(
+        std::string_view message,
+        LogTypeDictionaryEntryType& logtype_dict_entry,
+        VariableDictionaryWriterType& var_dict,
+        std::vector<encoded_variable_t>& encoded_vars,
+        std::vector<variable_dictionary_id_t>& var_ids
+) {
+    // Extract all variables and add to dictionary while building logtype
+    size_t var_begin_pos = 0;
+    size_t var_end_pos = 0;
+    std::string_view var_str;
+    logtype_dict_entry.clear();
+    // To avoid reallocating the logtype as we append to it, reserve enough space to hold the entire
+    // message
+    logtype_dict_entry.reserve_constant_length(message.length());
+    while (logtype_dict_entry.parse_next_var(message, var_begin_pos, var_end_pos, var_str)) {
+        auto encoded_var = encode_var(var_str, logtype_dict_entry, var_dict, var_ids);
+        encoded_vars.push_back(encoded_var);
+    }
+}
+
+template <
+        typename EncodedVariableType,
+        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+        VariableDictionaryWriterReq VariableDictionaryWriterType>
+void EncodedVariableInterpreter::encode_and_add_to_dictionary(
+        ir::LogEvent<EncodedVariableType> const& log_event,
+        LogTypeDictionaryEntryType& logtype_dict_entry,
+        VariableDictionaryWriterType& var_dict,
+        std::vector<ir::eight_byte_encoded_variable_t>& encoded_vars,
+        std::vector<variable_dictionary_id_t>& var_ids,
+        size_t& raw_num_bytes
+) {
+    logtype_dict_entry.clear();
+    auto const& log_message = log_event.get_message();
+    logtype_dict_entry.reserve_constant_length(log_message.get_logtype().length());
+
+    raw_num_bytes = 0;
+
+    auto constant_handler = [&](std::string const& value, size_t begin_pos, size_t length) {
+        raw_num_bytes += length;
+        logtype_dict_entry.add_constant(value, begin_pos, length);
+    };
+
+    auto encoded_int_handler = [&](EncodedVariableType encoded_var) {
+        raw_num_bytes += ffi::decode_integer_var(encoded_var).length();
+        logtype_dict_entry.add_int_var();
+
+        ir::eight_byte_encoded_variable_t eight_byte_encoded_var{};
+        if constexpr (std::is_same_v<EncodedVariableType, ir::eight_byte_encoded_variable_t>) {
+            eight_byte_encoded_var = encoded_var;
+        } else {  // std::is_same_v<EncodedVariableType, ir::four_byte_encoded_variable_t>
+            eight_byte_encoded_var = ffi::encode_four_byte_integer_as_eight_byte(encoded_var);
+        }
+        encoded_vars.push_back(eight_byte_encoded_var);
+    };
+
+    auto encoded_float_handler = [&](EncodedVariableType encoded_var) {
+        raw_num_bytes += ffi::decode_float_var(encoded_var).length();
+        logtype_dict_entry.add_float_var();
+
+        ir::eight_byte_encoded_variable_t eight_byte_encoded_var{};
+        if constexpr (std::is_same_v<EncodedVariableType, ir::eight_byte_encoded_variable_t>) {
+            eight_byte_encoded_var = encoded_var;
+        } else {  // std::is_same_v<EncodedVariableType, ir::four_byte_encoded_variable_t>
+            eight_byte_encoded_var = ffi::encode_four_byte_float_as_eight_byte(encoded_var);
+        }
+        encoded_vars.push_back(eight_byte_encoded_var);
+    };
+
+    auto dict_var_handler = [&](std::string const& dict_var) {
+        raw_num_bytes += dict_var.length();
+
+        ir::eight_byte_encoded_variable_t encoded_var{};
+        if constexpr (std::is_same_v<EncodedVariableType, ir::eight_byte_encoded_variable_t>) {
+            encoded_var = encode_var_dict_id(
+                    add_dict_var(dict_var, logtype_dict_entry, var_dict, var_ids)
+            );
+        } else {  // std::is_same_v<EncodedVariableType, ir::four_byte_encoded_variable_t>
+            encoded_var = encode_var(dict_var, logtype_dict_entry, var_dict, var_ids);
+        }
+        encoded_vars.push_back(encoded_var);
+    };
+
+    ffi::ir_stream::generic_decode_message<false>(
+            log_message.get_logtype(),
+            log_message.get_encoded_vars(),
+            log_message.get_dict_vars(),
+            constant_handler,
+            encoded_int_handler,
+            encoded_float_handler,
+            dict_var_handler
+    );
+}
+
+template <
+        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+        VariableDictionaryReaderReq VariableDictionaryReaderType,
+        typename EncodedVariableVectorType>
+bool EncodedVariableInterpreter::decode_variables_into_message(
+        LogTypeDictionaryEntryType const& logtype_dict_entry,
+        VariableDictionaryReaderType const& var_dict,
+        EncodedVariableVectorType const& encoded_vars,
+        std::string& decompressed_msg
+) {
+    // Ensure the number of variables in the logtype matches the number of encoded variables given
+    auto const& logtype_value = logtype_dict_entry.get_value();
+    size_t const num_vars = logtype_dict_entry.get_num_variables();
+    if (num_vars != encoded_vars.size()) {
+        SPDLOG_ERROR(
+                "EncodedVariableInterpreter: Logtype '{}' contains {} variables, but {} were given "
+                "for decoding.",
+                logtype_value.c_str(),
+                num_vars,
+                encoded_vars.size()
+        );
+        return false;
+    }
+
+    ir::VariablePlaceholder var_placeholder;
+    size_t constant_begin_pos = 0;
+    std::string float_str;
+    variable_dictionary_id_t var_dict_id;
+    size_t const num_placeholders_in_logtype = logtype_dict_entry.get_num_placeholders();
+    for (size_t placeholder_ix = 0, var_ix = 0; placeholder_ix < num_placeholders_in_logtype;
+         ++placeholder_ix)
+    {
+        size_t placeholder_position
+                = logtype_dict_entry.get_placeholder_info(placeholder_ix, var_placeholder);
+
+        // Add the constant that's between the last placeholder and this one
+        decompressed_msg.append(
+                logtype_value,
+                constant_begin_pos,
+                placeholder_position - constant_begin_pos
+        );
+        switch (var_placeholder) {
+            case ir::VariablePlaceholder::Integer:
+                decompressed_msg += std::to_string(encoded_vars[var_ix++]);
+                break;
+            case ir::VariablePlaceholder::Float:
+                convert_encoded_float_to_string(encoded_vars[var_ix++], float_str);
+                decompressed_msg += float_str;
+                break;
+            case ir::VariablePlaceholder::Dictionary:
+                var_dict_id = decode_var_dict_id(encoded_vars[var_ix++]);
+                decompressed_msg += var_dict.get_value(var_dict_id);
+                break;
+            case ir::VariablePlaceholder::Escape:
+                break;
+            default:
+                SPDLOG_ERROR(
+                        "EncodedVariableInterpreter: Logtype '{}' contains unexpected variable "
+                        "placeholder 0x{:x}",
+                        logtype_value,
+                        enum_to_underlying_type(var_placeholder)
+                );
+                return false;
+        }
+        // Move past the variable placeholder
+        constant_begin_pos = placeholder_position + 1;
+    }
+    // Append remainder of logtype, if any
+    if (constant_begin_pos < logtype_value.length()) {
+        decompressed_msg.append(logtype_value, constant_begin_pos, std::string::npos);
+    }
+
+    return true;
+}
+
+template <VariableDictionaryReaderReq VariableDictionaryReaderType>
+bool EncodedVariableInterpreter::encode_and_search_dictionary(
+        std::string_view var_str,
+        VariableDictionaryReaderType const& var_dict,
+        bool ignore_case,
+        std::string& logtype,
+        SubQuery& sub_query
+) {
+    size_t length = var_str.length();
+    if (0 == length) {
+        throw OperationFailed(ErrorCode_BadParam, __FILENAME__, __LINE__);
+    }
+
+    encoded_variable_t encoded_var;
+    if (convert_string_to_representable_integer_var(var_str, encoded_var)) {
+        add_int_var(logtype);
+        sub_query.add_non_dict_var(encoded_var);
+    } else if (convert_string_to_representable_float_var(var_str, encoded_var)) {
+        add_float_var(logtype);
+        sub_query.add_non_dict_var(encoded_var);
+    } else {
+        auto const entries = var_dict.get_entry_matching_value(var_str, ignore_case);
+        if (entries.empty()) {
+            // Not in dictionary
+            return false;
+        }
+
+        add_dict_var(logtype);
+
+        if (entries.size() == 1) {
+            auto const* entry = entries.at(0);
+            sub_query.add_dict_var(encode_var_dict_id(entry->get_id()), entry->get_id());
+            return true;
+        }
+
+        std::unordered_set<encoded_variable_t> encoded_vars;
+        std::unordered_set<variable_dictionary_id_t> var_dict_ids;
+        encoded_vars.reserve(entries.size());
+        for (auto const* entry : entries) {
+            encoded_vars.emplace(encode_var_dict_id(entry->get_id()));
+            var_dict_ids.emplace(entry->get_id());
+        }
+        sub_query.add_imprecise_dict_var(encoded_vars, var_dict_ids);
+    }
+
+    return true;
+}
+
+template <
+        VariableDictionaryReaderReq VariableDictionaryReaderType,
+        VariableDictionaryEntryReq VariableDictionaryEntryType>
+bool EncodedVariableInterpreter::wildcard_search_dictionary_and_get_encoded_matches(
+        std::string_view var_wildcard_str,
+        VariableDictionaryReaderType const& var_dict,
+        bool ignore_case,
+        SubQuery& sub_query
+) {
+    // Find matches
+    std::unordered_set<VariableDictionaryEntryType const*> var_dict_entries;
+    var_dict.get_entries_matching_wildcard_string(var_wildcard_str, ignore_case, var_dict_entries);
+    if (var_dict_entries.empty()) {
+        // Not in dictionary
+        return false;
+    }
+
+    // Encode matches
+    std::unordered_set<encoded_variable_t> encoded_vars;
+    std::unordered_set<variable_dictionary_id_t> var_dict_ids;
+    for (auto entry : var_dict_entries) {
+        encoded_vars.emplace(encode_var_dict_id(entry->get_id()));
+        var_dict_ids.emplace(entry->get_id());
+    }
+
+    sub_query.add_imprecise_dict_var(encoded_vars, var_dict_ids);
+
+    return true;
+}
+
+template <
+        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+        VariableDictionaryWriterReq VariableDictionaryWriterType>
+encoded_variable_t EncodedVariableInterpreter::encode_var(
+        std::string_view var,
+        LogTypeDictionaryEntryType& logtype_dict_entry,
+        VariableDictionaryWriterType& var_dict,
+        std::vector<variable_dictionary_id_t>& var_ids
+) {
+    encoded_variable_t encoded_var{0};
+    if (convert_string_to_representable_integer_var(var, encoded_var)) {
+        logtype_dict_entry.add_int_var();
+    } else if (convert_string_to_representable_float_var(var, encoded_var)) {
+        logtype_dict_entry.add_float_var();
+    } else {
+        // Variable string looks like a dictionary variable, so encode it as so
+        encoded_var = encode_var_dict_id(add_dict_var(var, logtype_dict_entry, var_dict, var_ids));
+    }
+    return encoded_var;
+}
+
+template <
+        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
+        VariableDictionaryWriterReq VariableDictionaryWriterType>
+variable_dictionary_id_t EncodedVariableInterpreter::add_dict_var(
+        std::string_view var,
+        LogTypeDictionaryEntryType& logtype_dict_entry,
+        VariableDictionaryWriterType& var_dict,
+        std::vector<variable_dictionary_id_t>& var_ids
+) {
+    variable_dictionary_id_t id{cVariableDictionaryIdMax};
+    var_dict.add_entry(var, id);
+    var_ids.push_back(id);
+
+    logtype_dict_entry.add_dictionary_var();
+
+    return id;
+}
 }  // namespace clp
 
 #endif  // CLP_ENCODEDVARIABLEINTERPRETER_HPP

--- a/components/core/src/clp/EncodedVariableInterpreter.hpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.hpp
@@ -56,7 +56,7 @@ public:
      * @param logtype
      */
     static void add_dict_var(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Dictionary);
+        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Dictionary));
     }
 
     /**
@@ -64,7 +64,7 @@ public:
      * @param logtype
      */
     static void add_int_var(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Integer);
+        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Integer));
     }
 
     /**
@@ -72,7 +72,7 @@ public:
      * @param logtype
      */
     static void add_float_var(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Float);
+        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Float));
     }
 
     /**
@@ -80,7 +80,7 @@ public:
      * @param logtype
      */
     static void add_escape(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Escape);
+        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Escape));
     }
 
     /**
@@ -162,7 +162,7 @@ public:
      * Decodes all variables and decompresses them into a message
      * @tparam LogTypeDictionaryEntryType
      * @tparam VariableDictionaryReaderType
-     * @tparam EncodedVariableVectorType A vector of `clp::encoded_variable_t`.
+     * @tparam EncodedVariableContainerType A random access list of `clp::encoded_variable_t`.
      * @param logtype_dict_entry
      * @param var_dict
      * @param encoded_vars
@@ -172,11 +172,11 @@ public:
     template <
             typename LogTypeDictionaryEntryType,
             typename VariableDictionaryReaderType,
-            typename EncodedVariableVectorType>
+            typename EncodedVariableContainerType>
     static bool decode_variables_into_message(
             LogTypeDictionaryEntryType const& logtype_dict_entry,
             VariableDictionaryReaderType const& var_dict,
-            EncodedVariableVectorType const& encoded_vars,
+            EncodedVariableContainerType const& encoded_vars,
             std::string& decompressed_msg
     );
 
@@ -365,11 +365,11 @@ void EncodedVariableInterpreter::encode_and_add_to_dictionary(
 template <
         typename LogTypeDictionaryEntryType,
         typename VariableDictionaryReaderType,
-        typename EncodedVariableVectorType>
+        typename EncodedVariableContainerType>
 bool EncodedVariableInterpreter::decode_variables_into_message(
         LogTypeDictionaryEntryType const& logtype_dict_entry,
         VariableDictionaryReaderType const& var_dict,
-        EncodedVariableVectorType const& encoded_vars,
+        EncodedVariableContainerType const& encoded_vars,
         std::string& decompressed_msg
 ) {
     // Ensure the number of variables in the logtype matches the number of encoded variables given

--- a/components/core/src/clp/EncodedVariableInterpreter.hpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.hpp
@@ -56,7 +56,7 @@ public:
      * @param logtype
      */
     static void add_dict_var(std::string& logtype) {
-        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Dictionary));
+        logtype.push_back(enum_to_underlying_type(ir::VariablePlaceholder::Dictionary));
     }
 
     /**
@@ -64,7 +64,7 @@ public:
      * @param logtype
      */
     static void add_int_var(std::string& logtype) {
-        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Integer));
+        logtype.push_back(enum_to_underlying_type(ir::VariablePlaceholder::Integer));
     }
 
     /**
@@ -72,7 +72,7 @@ public:
      * @param logtype
      */
     static void add_float_var(std::string& logtype) {
-        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Float));
+        logtype.push_back(enum_to_underlying_type(ir::VariablePlaceholder::Float));
     }
 
     /**
@@ -80,7 +80,7 @@ public:
      * @param logtype
      */
     static void add_escape(std::string& logtype) {
-        logtype.emplace_back(enum_to_underlying_type(ir::VariablePlaceholder::Escape));
+        logtype.push_back(enum_to_underlying_type(ir::VariablePlaceholder::Escape));
     }
 
     /**

--- a/components/core/src/clp/EncodedVariableInterpreter.hpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.hpp
@@ -6,7 +6,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "DictionaryConcepts.hpp"
 #include "ffi/ir_stream/decoding_methods.hpp"
 #include "ir/LogEvent.hpp"
 #include "ir/types.hpp"
@@ -123,8 +122,8 @@ public:
      * @param var_ids
      */
     template <
-            VariableDictionaryWriterReq VariableDictionaryWriterType,
-            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType>
+            typename VariableDictionaryWriterType,
+            typename LogTypeDictionaryEntryType>
     static void encode_and_add_to_dictionary(
             std::string_view message,
             LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -150,8 +149,8 @@ public:
      */
     template <
             typename EncodedVariableType,
-            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-            VariableDictionaryWriterReq VariableDictionaryWriterType>
+            typename LogTypeDictionaryEntryType,
+            typename VariableDictionaryWriterType>
     static void encode_and_add_to_dictionary(
             ir::LogEvent<EncodedVariableType> const& log_event,
             LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -173,9 +172,9 @@ public:
      * @return true if successful, false otherwise
      */
     template <
-            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-            VariableDictionaryReaderReq VariableDictionaryReaderType,
-            typename EncodedVariableVectorType>  // TODO: Make a concept.
+            typename LogTypeDictionaryEntryType,
+            typename VariableDictionaryReaderType,
+            typename EncodedVariableVectorType>
     static bool decode_variables_into_message(
             LogTypeDictionaryEntryType const& logtype_dict_entry,
             VariableDictionaryReaderType const& var_dict,
@@ -196,7 +195,7 @@ public:
      * dictionary
      * @return false otherwise
      */
-    template <VariableDictionaryReaderReq VariableDictionaryReaderType>
+    template <typename VariableDictionaryReaderType>
     static bool encode_and_search_dictionary(
             std::string_view var_str,
             VariableDictionaryReaderType const& var_dict,
@@ -216,8 +215,8 @@ public:
      * @return true if any match found, false otherwise
      */
     template <
-            VariableDictionaryReaderReq VariableDictionaryReaderType,
-            VariableDictionaryEntryReq VariableDictionaryEntryType
+            typename VariableDictionaryReaderType,
+            typename VariableDictionaryEntryType
             = VariableDictionaryReaderType::entry_t>
     static bool wildcard_search_dictionary_and_get_encoded_matches(
             std::string_view var_wildcard_str,
@@ -240,8 +239,8 @@ private:
      * @return The encoded variable
      */
     template <
-            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-            VariableDictionaryWriterReq VariableDictionaryWriterType>
+            typename LogTypeDictionaryEntryType,
+            typename VariableDictionaryWriterType>
     static encoded_variable_t encode_var(
             std::string_view var,
             LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -261,8 +260,8 @@ private:
      * @return The dictionary ID
      */
     template <
-            LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-            VariableDictionaryWriterReq VariableDictionaryWriterType>
+            typename LogTypeDictionaryEntryType,
+            typename VariableDictionaryWriterType>
     static variable_dictionary_id_t add_dict_var(
             std::string_view var,
             LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -272,8 +271,8 @@ private:
 };
 
 template <
-        VariableDictionaryWriterReq VariableDictionaryWriterType,
-        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType>
+        typename VariableDictionaryWriterType,
+        typename LogTypeDictionaryEntryType>
 void EncodedVariableInterpreter::encode_and_add_to_dictionary(
         std::string_view message,
         LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -297,8 +296,8 @@ void EncodedVariableInterpreter::encode_and_add_to_dictionary(
 
 template <
         typename EncodedVariableType,
-        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-        VariableDictionaryWriterReq VariableDictionaryWriterType>
+        typename LogTypeDictionaryEntryType,
+        typename VariableDictionaryWriterType>
 void EncodedVariableInterpreter::encode_and_add_to_dictionary(
         ir::LogEvent<EncodedVariableType> const& log_event,
         LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -370,8 +369,8 @@ void EncodedVariableInterpreter::encode_and_add_to_dictionary(
 }
 
 template <
-        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-        VariableDictionaryReaderReq VariableDictionaryReaderType,
+        typename LogTypeDictionaryEntryType,
+        typename VariableDictionaryReaderType,
         typename EncodedVariableVectorType>
 bool EncodedVariableInterpreter::decode_variables_into_message(
         LogTypeDictionaryEntryType const& logtype_dict_entry,
@@ -444,7 +443,7 @@ bool EncodedVariableInterpreter::decode_variables_into_message(
     return true;
 }
 
-template <VariableDictionaryReaderReq VariableDictionaryReaderType>
+template <typename VariableDictionaryReaderType>
 bool EncodedVariableInterpreter::encode_and_search_dictionary(
         std::string_view var_str,
         VariableDictionaryReaderType const& var_dict,
@@ -493,8 +492,8 @@ bool EncodedVariableInterpreter::encode_and_search_dictionary(
 }
 
 template <
-        VariableDictionaryReaderReq VariableDictionaryReaderType,
-        VariableDictionaryEntryReq VariableDictionaryEntryType>
+        typename VariableDictionaryReaderType,
+        typename VariableDictionaryEntryType>
 bool EncodedVariableInterpreter::wildcard_search_dictionary_and_get_encoded_matches(
         std::string_view var_wildcard_str,
         VariableDictionaryReaderType const& var_dict,
@@ -523,8 +522,8 @@ bool EncodedVariableInterpreter::wildcard_search_dictionary_and_get_encoded_matc
 }
 
 template <
-        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-        VariableDictionaryWriterReq VariableDictionaryWriterType>
+        typename LogTypeDictionaryEntryType,
+        typename VariableDictionaryWriterType>
 encoded_variable_t EncodedVariableInterpreter::encode_var(
         std::string_view var,
         LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -544,8 +543,8 @@ encoded_variable_t EncodedVariableInterpreter::encode_var(
 }
 
 template <
-        LogTypeDictionaryEntryReq LogTypeDictionaryEntryType,
-        VariableDictionaryWriterReq VariableDictionaryWriterType>
+        typename LogTypeDictionaryEntryType,
+        typename VariableDictionaryWriterType>
 variable_dictionary_id_t EncodedVariableInterpreter::add_dict_var(
         std::string_view var,
         LogTypeDictionaryEntryType& logtype_dict_entry,

--- a/components/core/src/clp/EncodedVariableInterpreter.hpp
+++ b/components/core/src/clp/EncodedVariableInterpreter.hpp
@@ -113,15 +113,15 @@ public:
     /**
      * Parses all variables from a message (while constructing the logtype) and encodes them (adding
      * them to the variable dictionary if necessary)
-     * @tparam VariableDictionaryWriterType
      * @tparam LogTypeDictionaryEntryType
+     * @tparam VariableDictionaryWriterType
      * @param message
      * @param logtype_dict_entry
      * @param var_dict
      * @param encoded_vars
      * @param var_ids
      */
-    template <typename VariableDictionaryWriterType, typename LogTypeDictionaryEntryType>
+    template <typename LogTypeDictionaryEntryType, typename VariableDictionaryWriterType>
     static void encode_and_add_to_dictionary(
             std::string_view message,
             LogTypeDictionaryEntryType& logtype_dict_entry,
@@ -196,7 +196,7 @@ public:
      */
     template <
             typename VariableDictionaryReaderType,
-            typename VariableDictionaryEntryType = VariableDictionaryReaderType::entry_t>
+            typename VariableDictionaryEntryType = typename VariableDictionaryReaderType::entry_t>
     static bool encode_and_search_dictionary(
             std::string_view var_str,
             VariableDictionaryReaderType const& var_dict,
@@ -217,7 +217,7 @@ public:
      */
     template <
             typename VariableDictionaryReaderType,
-            typename VariableDictionaryEntryType = VariableDictionaryReaderType::entry_t>
+            typename VariableDictionaryEntryType = typename VariableDictionaryReaderType::entry_t>
     static bool wildcard_search_dictionary_and_get_encoded_matches(
             std::string_view var_wildcard_str,
             VariableDictionaryReaderType const& var_dict,
@@ -266,7 +266,7 @@ private:
     );
 };
 
-template <typename VariableDictionaryWriterType, typename LogTypeDictionaryEntryType>
+template <typename LogTypeDictionaryEntryType, typename VariableDictionaryWriterType>
 void EncodedVariableInterpreter::encode_and_add_to_dictionary(
         std::string_view message,
         LogTypeDictionaryEntryType& logtype_dict_entry,

--- a/components/core/src/clp/Grep.cpp
+++ b/components/core/src/clp/Grep.cpp
@@ -343,11 +343,11 @@ bool process_var_token(
         }
 
         if (query_token.is_float_var()) {
-            LogTypeDictionaryEntry::add_float_var(logtype);
+            EncodedVariableInterpreter::add_float_var(logtype);
         } else if (query_token.is_int_var()) {
-            LogTypeDictionaryEntry::add_int_var(logtype);
+            EncodedVariableInterpreter::add_int_var(logtype);
         } else {
-            LogTypeDictionaryEntry::add_dict_var(logtype);
+            EncodedVariableInterpreter::add_dict_var(logtype);
 
             if (query_token.cannot_convert_to_non_dict_var()) {
                 // Must be a dictionary variable, so search variable dictionary
@@ -451,7 +451,7 @@ SubQueryMatchabilityResult generate_logtypes_and_vars_for_subquery(
                 logtype += '*';
             } else {
                 logtype += '*';
-                LogTypeDictionaryEntry::add_dict_var(logtype);
+                EncodedVariableInterpreter::add_dict_var(logtype);
                 logtype += '*';
             }
         } else {

--- a/components/core/src/clp/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/clp/LogTypeDictionaryEntry.hpp
@@ -1,6 +1,8 @@
 #ifndef CLP_LOGTYPEDICTIONARYENTRY_HPP
 #define CLP_LOGTYPEDICTIONARYENTRY_HPP
 
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "Defs.h"
@@ -11,7 +13,6 @@
 #include "streaming_compression/zstd/Compressor.hpp"
 #include "streaming_compression/zstd/Decompressor.hpp"
 #include "TraceableException.hpp"
-#include "type_utils.hpp"
 
 namespace clp {
 /**
@@ -42,38 +43,6 @@ public:
     LogTypeDictionaryEntry& operator=(LogTypeDictionaryEntry const&) = default;
 
     // Methods
-    /**
-     * Adds a dictionary variable placeholder to the given logtype
-     * @param logtype
-     */
-    static void add_dict_var(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Dictionary);
-    }
-
-    /**
-     * Adds an integer variable placeholder to the given logtype
-     * @param logtype
-     */
-    static void add_int_var(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Integer);
-    }
-
-    /**
-     * Adds a float variable placeholder to the given logtype
-     * @param logtype
-     */
-    static void add_float_var(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Float);
-    }
-
-    /**
-     * Adds an escape character to the given logtype
-     * @param logtype
-     */
-    static void add_escape(std::string& logtype) {
-        logtype += enum_to_underlying_type(ir::VariablePlaceholder::Escape);
-    }
-
     /**
      * @return The number of variable placeholders (including escaped ones) in the logtype.
      */
@@ -106,8 +75,7 @@ public:
      * @param begin_pos Start of the constant in value_containing_constant
      * @param length
      */
-    void
-    add_constant(std::string const& value_containing_constant, size_t begin_pos, size_t length);
+    void add_constant(std::string_view value_containing_constant, size_t begin_pos, size_t length);
     /**
      * Adds an int variable placeholder
      */
@@ -137,10 +105,10 @@ public:
      * @return true if another variable was found, false otherwise
      */
     bool parse_next_var(
-            std::string const& msg,
+            std::string_view msg,
             size_t& var_begin_pos,
             size_t& var_end_pos,
-            std::string& var
+            std::string_view& var
     );
 
     /**

--- a/components/core/src/clp/LogTypeDictionaryEntry.hpp
+++ b/components/core/src/clp/LogTypeDictionaryEntry.hpp
@@ -1,7 +1,6 @@
 #ifndef CLP_LOGTYPEDICTIONARYENTRY_HPP
 #define CLP_LOGTYPEDICTIONARYENTRY_HPP
 
-#include <string>
 #include <string_view>
 #include <vector>
 

--- a/components/core/src/clp/VariableDictionaryWriter.cpp
+++ b/components/core/src/clp/VariableDictionaryWriter.cpp
@@ -1,10 +1,14 @@
 #include "VariableDictionaryWriter.hpp"
 
+#include <string>
+#include <string_view>
+
+#include "Defs.h"
 #include "dictionary_utils.hpp"
 #include "spdlog_with_specializations.hpp"
 
 namespace clp {
-bool VariableDictionaryWriter::add_entry(std::string const& value, variable_dictionary_id_t& id) {
+bool VariableDictionaryWriter::add_entry(std::string_view value, variable_dictionary_id_t& id) {
     bool new_entry = false;
 
     auto const ix = m_value_to_id.find(value);
@@ -23,7 +27,7 @@ bool VariableDictionaryWriter::add_entry(std::string const& value, variable_dict
         ++m_next_id;
 
         // Insert the ID obtained from the database into the dictionary
-        auto entry = VariableDictionaryEntry(value, id);
+        auto entry = VariableDictionaryEntry(std::string{value}, id);
         m_value_to_id[value] = id;
 
         new_entry = true;

--- a/components/core/src/clp/VariableDictionaryWriter.hpp
+++ b/components/core/src/clp/VariableDictionaryWriter.hpp
@@ -1,6 +1,8 @@
 #ifndef CLP_VARIABLEDICTIONARYWRITER_HPP
 #define CLP_VARIABLEDICTIONARYWRITER_HPP
 
+#include <string_view>
+
 #include "Defs.h"
 #include "DictionaryWriter.hpp"
 #include "VariableDictionaryEntry.hpp"
@@ -30,7 +32,7 @@ public:
      * @param value
      * @param id ID of the variable matching the given entry
      */
-    bool add_entry(std::string const& value, variable_dictionary_id_t& id);
+    bool add_entry(std::string_view value, variable_dictionary_id_t& id);
 };
 }  // namespace clp
 

--- a/components/core/src/clp/clg/CMakeLists.txt
+++ b/components/core/src/clp/clg/CMakeLists.txt
@@ -132,6 +132,7 @@ if(CLP_BUILD_EXECUTABLES)
         )
         target_link_libraries(clg
                 PRIVATE
+                absl::flat_hash_map
                 Boost::filesystem Boost::program_options
                 date::date
                 fmt::fmt

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -160,6 +160,7 @@ if(CLP_BUILD_EXECUTABLES)
         )
         target_link_libraries(clo
                 PRIVATE
+                absl::flat_hash_map
                 Boost::filesystem Boost::program_options
                 date::date
                 fmt::fmt

--- a/components/core/src/clp/clp/CMakeLists.txt
+++ b/components/core/src/clp/clp/CMakeLists.txt
@@ -174,6 +174,7 @@ if(CLP_BUILD_EXECUTABLES)
         )
         target_link_libraries(clp
                 PRIVATE
+                absl::flat_hash_map
                 Boost::filesystem Boost::program_options
                 date::date
                 fmt::fmt

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -4,7 +4,10 @@
 
 #include "../src/clp/EncodedVariableInterpreter.hpp"
 #include "../src/clp/ir/types.hpp"
+#include "../src/clp/LogTypeDictionaryEntry.hpp"
 #include "../src/clp/streaming_archive/Constants.hpp"
+#include "../src/clp/VariableDictionaryReader.hpp"
+#include "../src/clp/VariableDictionaryWriter.hpp"
 
 using clp::cVariableDictionaryIdMax;
 using clp::encoded_variable_t;

--- a/components/core/tests/test-EncodedVariableInterpreter.cpp
+++ b/components/core/tests/test-EncodedVariableInterpreter.cpp
@@ -412,10 +412,9 @@ TEST_CASE("EncodedVariableInterpreter", "[EncodedVariableInterpreter]") {
         var_dict_reader.open(std::string{cVarDictPath}, std::string{cVarSegmentIndexPath});
         var_dict_reader.read_new_entries();
 
-        REQUIRE(var_dict_reader.get_entry_matching_value(std::string{var_strs.at(0)}, true).size()
+        REQUIRE(var_dict_reader.get_entry_matching_value(var_strs.at(0), true).size()
                 == var_strs.size());
-        REQUIRE(var_dict_reader.get_entry_matching_value(std::string{var_strs.at(0)}, false).size()
-                == 1);
+        REQUIRE(var_dict_reader.get_entry_matching_value(var_strs.at(0), false).size() == 1);
 
         var_dict_reader.close();
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR is the first of several that is attempting to bring the core CLP parsing and search code to a state where it can be shared by both clp and clp-s. The full end to end integration can be seen [here](https://github.com/gibber9809/clp/tree/clp-core-refactor-prototype).

This initial PR does two things:
1. It changes `EncodedVariableInterpreter` to use templates instead of dictionary and dictionary entry implementations specific to CLP

This will end up allowing both clp and clp-s to share the same core logic while using their own respective dictionary implementations. These templates will be enhanced in a follow-up PR to use concepts in order to ensure dictionaries passed to these methods follow a certain interface.

2. We change several methods in `EncodedVariableInterpreter` and the various dictionary classes to accept `std::string_view` instead of `std::string const&`.

This allows us to avoid some string copies (more once combined with a follow-up PR that modifies `Grep`). It also makes the `EncodedVariableInterpreter` interface agree more with the ffi parsing interfaces.

As part of changing the dictionary writers to accept `std::string_view` we also switch their internal hashmap representation to `absl::flat_hash_map<std::string,...>`. The performance of flat hash map is a bit better than `std::unordered_map`, but the main advantage here is that absl has defined their hash functions such that `std::string_view` can be hashed in the same way as `std::string` to do lookups in a hashmap keyed by `std::string` (which allows us to avoid a string copy on the fast path), whereas with `std::unordered_map` we would have to provide our own hash function to accomplish the same thing which is error prone and forces us to use a more verbose template for `std::unordered_map`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Ensured that all unit tests pass
* Verified that after the entire sequence of planned PRs performance looks good


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved efficiency and flexibility of variable encoding, decoding, and dictionary operations by introducing templated and generic implementations.
  * Enhanced error diagnostics during variable decoding and log message reconstruction.

* **Refactor**
  * Updated interfaces to use `std::string_view` for more efficient string handling.
  * Centralized variable placeholder methods into a single utility, simplifying and modernizing the API.
  * Replaced internal map types with more efficient alternatives for better performance.
  * Simplified variable encoding implementation by removing redundant methods and consolidating logic.
  * Updated query processing to use centralized variable handling methods for consistency.

* **Chores**
  * Updated build configuration to include necessary dependencies for improved performance and compatibility.
  * Added required header includes in test files for better code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->