### PR TITLE
docs: Update required Task version (fixes #1159).

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ this project:
     the size of repo as we add and update images.
 * [Node.js] >= 16 to be able to [view the output](#viewing-the-output)
 * Python 3.10 or later
-* [Task] >= 3.38.0 and < 3.43.0
+* [Task] >= 3.40.0 and < 3.43.0
   * We constrain the version due to unresolved [issues][clp-issue-872].
 
 ## Build Commands

--- a/docs/src/dev-guide/building-package.md
+++ b/docs/src/dev-guide/building-package.md
@@ -13,7 +13,7 @@ prebuilt version instead, check out the [releases](https://github.com/y-scope/cl
 * Python 3.9 or newer
 * python3-dev
 * python3-venv (for the version of Python installed)
-* [Task] >= 3.38.0 and < 3.43.0
+* [Task] >= 3.40.0 and < 3.43.0
   * We constrain the version due to unresolved [issues][clp-issue-872].
 
 ## Setup

--- a/docs/src/dev-guide/components-core/index.md
+++ b/docs/src/dev-guide/components-core/index.md
@@ -9,7 +9,7 @@ CLP core is the low-level component that performs compression, decompression, an
 * A recent compiler that fully supports C++20 features such as
   * std::span
   * std::source_location
-* [Task] >= 3.38.0 and < 3.43.0
+* [Task] >= 3.40.0 and < 3.43.0
   * We constrain the version due to unresolved [issues][clp-issue-872].
 
 To build, we require some source dependencies, packages from package managers, and libraries built


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Commit 581bd46198a97a89b174849851cc3f1f2100e466 updated the yscope-dev-utils to a version which requires Task >= 3.40.0 for linting. However, the docs were not updated to reflect this change. Since yscope-dev-utils is a dependency in most use cases, we set the minimum required version across the project rather than just for linting.



This PR updates the document so that the required version of Task is correct.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Confirmed that task 3.40.0 can run `task lint:fix-py` without error.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to require Task tool version 3.40.0 or higher (previously 3.38.0), with the upper limit remaining below 3.43.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->