### PR TITLE
fix(webui): Remove MongoDB type in presto utilities fixing build error. 

### DIFF
--- a/components/webui/server/src/routes/api/presto-search/utils.ts
+++ b/components/webui/server/src/routes/api/presto-search/utils.ts
@@ -38,7 +38,7 @@ const insertPrestoRowsToMongo = (
     columns: {name: string}[],
     searchJobId: string,
     mongoDb: Db
-): Promise<InsertManyResult<Document>> => {
+): Promise<InsertManyResult> => {
     const collection = mongoDb.collection(searchJobId);
     const resultDocs = data.map((row) => prestoRowToObject(row, columns));
     return collection.insertMany(resultDocs);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

PR #1150 referenced a non imported type leading to build error. Not sure why did not cause error in testing/validation.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Package builds and runs without error.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type definitions to improve consistency. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->