### PR TITLE
fix(webui): Improve clarity of ingestion job status labels.

### DIFF
--- a/components/webui/client/src/pages/IngestPage/Jobs/typings.tsx
+++ b/components/webui/client/src/pages/IngestPage/Jobs/typings.tsx
@@ -89,11 +89,9 @@ const jobColumns: NonNullable<TableProps<JobData>["columns"]> = [
     },
 ];
 
-export type {
-    JobData,
-};
+export type {JobData};
 
 export {
     CompressionJobStatus,
-    jobColumns
+    jobColumns,
 };

--- a/components/webui/client/src/pages/IngestPage/Jobs/utils.ts
+++ b/components/webui/client/src/pages/IngestPage/Jobs/utils.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 
 import {
     CompressionJobStatus,
-    type JobData,
+    JobData,
 } from "../Jobs/typings";
 import {QueryJobsItem} from "./sql";
 import {formatSizeInBytes} from "./units";


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Change the `status` field type in `JobsData` to `CompressionJobStatus` and render the status to badges in `render` function.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

`running` and `succeeded` status looks correct.


---
@junhaoliao validated the labels looked correct and intuitive

<img width="2136" height="1996" alt="image" src="https://github.com/user-attachments/assets/4168ffb4-0082-47a2-8cc6-079c13ff1dd8" />

---


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Compression job statuses now use clear, explicit labels and colours in the job table.
  * Improved consistency and readability of job status display for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->