### PR TITLE
build: Update log-surgeon to commit a82ad13.

### DIFF
--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -237,8 +237,8 @@ tasks:
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
             - "-Dlog_surgeon_BUILD_TESTING=OFF"
           LIB_NAME: "log_surgeon"
-          TARBALL_SHA256: "d91a7469db437162d518eb0f9175268084b478b5003163d0f6233abbbce9b0f8"
-          TARBALL_URL: "https://github.com/y-scope/log-surgeon/archive/dfd5c79.tar.gz"
+          TARBALL_SHA256: "6053f7e26ff21aef0c4cf409502d3abb0cfcf76d8f76786c3bb1bcc03e8f5df2"
+          TARBALL_URL: "https://github.com/y-scope/log-surgeon/archive/a82ad13.tar.gz"
 
   lz4:
     internal: true


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Update the version log surgeon, primarily to include https://github.com/y-scope/log-surgeon/pull/148.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

CI passing.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the log-surgeon dependency used by the formatting tool installation, aligning to a newer release with refreshed download reference and checksum.
  - CI and local setup will automatically retrieve the updated package; no manual steps required.
  - No functional or UI changes; existing commands and workflows continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->