### PR TITLE
fix(package): Move archive manager constants to avoid host MariaDB dependency (fixes #1185).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/archive_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/archive_manager.py
@@ -26,15 +26,13 @@ from clp_package_utils.general import (
 )
 
 # Command/Argument Constants
-from clp_package_utils.scripts.native.archive_manager import (
-    BEGIN_TS_ARG,
-    DEL_BY_FILTER_SUBCOMMAND,
-    DEL_BY_IDS_SUBCOMMAND,
-    DEL_COMMAND,
-    DRY_RUN_ARG,
-    END_TS_ARG,
-    FIND_COMMAND,
-)
+FIND_COMMAND: typing.Final[str] = "find"
+DEL_COMMAND: typing.Final[str] = "del"
+DEL_BY_IDS_SUBCOMMAND: typing.Final[str] = "by-ids"
+DEL_BY_FILTER_SUBCOMMAND: typing.Final[str] = "by-filter"
+BEGIN_TS_ARG: typing.Final[str] = "--begin-ts"
+END_TS_ARG: typing.Final[str] = "--end-ts"
+DRY_RUN_ARG: typing.Final[str] = "--dry-run"
 
 logger: logging.Logger = logging.getLogger(__file__)
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
@@ -21,16 +21,16 @@ from clp_package_utils.general import (
     get_clp_home,
     load_config_file,
 )
+from clp_package_utils.scripts.archive_manager import (
+    BEGIN_TS_ARG,
+    DEL_BY_FILTER_SUBCOMMAND,
+    DEL_BY_IDS_SUBCOMMAND,
+    DEL_COMMAND,
+    DRY_RUN_ARG,
+    END_TS_ARG,
+    FIND_COMMAND,
+)
 from clp_package_utils.scripts.native.utils import validate_dataset_exists
-
-# Command/Argument Constants
-FIND_COMMAND: str = "find"
-DEL_COMMAND: str = "del"
-DEL_BY_IDS_SUBCOMMAND: str = "by-ids"
-DEL_BY_FILTER_SUBCOMMAND: str = "by-filter"
-BEGIN_TS_ARG: str = "--begin-ts"
-END_TS_ARG: str = "--end-ts"
-DRY_RUN_ARG: str = "--dry-run"
 
 logger: logging.Logger = logging.getLogger(__file__)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The current non-native archive_manager.py imports constants from native/archive_manager.sh. As a side effect, it also imports dependencies that may not be available on the host machine.

This PR reorders the import such that the constants are defined in non-native script and imported by native script. In this way, the dependency issue can be avoided.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Manually run the package on `debian-bullseye-w-docker` container and confirmed that archive-manager.sh doesn't error with any dependency issue.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Centralized command/subcommand/flag definitions for archive management to a single module for consistency across implementations.
- Chores
  - Introduced explicit type annotations for those constants to improve clarity and tooling support.
- Impact
  - No user-facing changes; CLI behavior and workflows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->