### PR TITLE
fix(package): Update `native/decompress.py` to use CLI args and env vars for DB config (fixes #1199); Prevent IR extraction with clp-s storage engine and only use dataset argument for JSON extraction (fixes #1200).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/decompress.py
@@ -185,7 +185,7 @@ def handle_extract_stream_cmd(
         logger.error(f"JSON extraction is not supported for storage engine `{storage_engine}`.")
         return -1
 
-    dataset = parsed_args.dataset
+    dataset = getattr(parsed_args, "dataset", None)
     if StorageEngine.CLP_S == storage_engine:
         dataset = CLP_DEFAULT_DATASET_NAME if dataset is None else dataset
         try:

--- a/components/clp-package-utils/clp_package_utils/scripts/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/decompress.py
@@ -208,12 +208,6 @@ def handle_extract_stream_cmd(
     # fmt: on
 
     if EXTRACT_IR_CMD == job_command:
-        if hasattr(parsed_args, "dataset"):
-            logger.error(
-                f"Dataset selection is not supported for storage engine: {storage_engine}."
-            )
-            return -1
-
         extract_cmd.append(str(parsed_args.msg_ix))
         if parsed_args.orig_file_id:
             extract_cmd.append("--orig-file-id")

--- a/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import logging
+import os
 import pathlib
 import subprocess
 import sys
@@ -8,7 +9,6 @@ import uuid
 from contextlib import closing
 from typing import Optional
 
-import yaml
 from clp_py_utils.clp_config import (
     CLPConfig,
     Database,
@@ -229,18 +229,24 @@ def handle_extract_file_cmd(
     logs_dir = clp_config.logs_directory
     archives_dir = clp_config.archive_output.get_directory()
 
-    # Generate database config file for clp
-    db_config_file_path = logs_dir / f".decompress-db-config-{uuid.uuid4()}.yml"
-    with open(db_config_file_path, "w") as f:
-        yaml.safe_dump(clp_config.database.get_clp_connection_params_and_type(True), f)
-
+    # Configure CLP metadata DB connection params.
+    clp_db_connection_params = clp_config.database.get_clp_connection_params_and_type(True)
     # fmt: off
     extract_cmd = [
         str(clp_home / "bin" / "clp"),
         "x", str(archives_dir), str(extraction_dir),
-        "--db-config-file", str(db_config_file_path),
+        "--db-type", "mysql",
+        "--db-host", clp_db_connection_params["host"],
+        "--db-port", str(clp_db_connection_params["port"]),
+        "--db-name", clp_db_connection_params["name"],
+        "--db-table-prefix", clp_db_connection_params["table_prefix"],
     ]
     # fmt: on
+    extract_env = {
+        **os.environ,
+        "CLP_DB_USER": clp_db_connection_params["username"],
+        "CLP_DB_PASS": clp_db_connection_params["password"],
+    }
 
     files_to_extract_list_path = None
     if list_path is not None:
@@ -256,7 +262,7 @@ def handle_extract_file_cmd(
         extract_cmd.append("-f")
         extract_cmd.append(str(files_to_extract_list_path))
 
-    proc = subprocess.Popen(extract_cmd)
+    proc = subprocess.Popen(extract_cmd, env=extract_env)
     return_code = proc.wait()
     if 0 != return_code:
         logger.error(f"File extraction failed, return_code={return_code}")
@@ -265,7 +271,6 @@ def handle_extract_file_cmd(
     # Remove generated files
     if files_to_extract_list_path is not None:
         files_to_extract_list_path.unlink()
-    db_config_file_path.unlink()
 
     return 0
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
@@ -235,7 +235,7 @@ def handle_extract_file_cmd(
     extract_cmd = [
         str(clp_home / "bin" / "clp"),
         "x", str(archives_dir), str(extraction_dir),
-        "--db-type", "mysql",
+        "--db-type", clp_db_connection_params["type"],
         "--db-host", clp_db_connection_params["host"],
         "--db-port", str(clp_db_connection_params["port"]),
         "--db-name", clp_db_connection_params["name"],


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR addresses two issues:

1. Fixes #1199: The `native/decompress.py` script was still using the deprecated `--db-config-file` argument instead of command-line database parameters. This caused runtime errors since the core CLP components no longer accept the `--db-config-file` argument after the refactoring in #1148. This PR updated `native/decompress.py` to pass database connection parameters as command-line arguments and environment variables instead of using a temporary YAML config file.

2. Fixes #1200: The IR extraction parser was missing the `--dataset` argument, causing an `AttributeError` when trying to access `parsed_args.dataset` in the `handle_extract_stream_cmd` function (i.e., `sbin/decompress.sh i`). The fix uses `getattr` with a fallback to `None` when the dataset attribute is not available.

3. Check if engine type before submitting an IR extraction job. If type is clp-s, error out and do not submit.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Built the CLP package with `task package`

## For CLP-Text

- `cd build/clp-package/sbin`
- `./compress.sh ~/samples/hive-24hr`
- `./decompress.sh x`
- `./decompress.sh i --orig-file-id <id> 0`
- (-ve): `./decompress.sh j a8722927-820e-4d04-9b0e-bfb739fb91c9` -> `2025-08-14T15:17:20.637 ERROR [decompress] JSON extraction is not supported for storage engine `clp`.` 

## For CLP-JSON

- Changed clp-config.yml to start the package as CLP-JSON
  ```yaml
  package:
    storage_engine: "clp-s"
    query_engine: "clp-s"
  ```
- `./compress.sh ~/samples/postgresql/ --timestamp-key=timestamp`
- (-ve): `./decompress.sh x` -> `2025-08-14T15:21:51.715 ERROR [decompress] File extraction is not supported for archive storage type `fs` with storage engine `clp-s`.`
- (-ve): `./decompress.sh i --orig-file-id <id> 0` -> `2025-08-14T15:24:21.453 ERROR [decompress] IR extraction is not supported for storage engine `clp-s`.`
- `./decompress.sh j <id>`


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure DB connection via CLI flags rather than a temporary config file.
  * Pass DB credentials to subprocesses through environment variables (CLP_DB_USER, CLP_DB_PASS).

* **Bug Fixes**
  * Enforce storage-engine compatibility: IR extraction limited to the CLP engine with clear errors for invalid combos.
  * JSON extraction now defaults and validates the dataset before running; dataset argument is restricted for IR extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->