### PR TITLE
fix(job-orchestration): Forget Celery task result to prevent resource leak and deadlock (fixes #1059).

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -383,6 +383,7 @@ def poll_running_jobs(db_conn, db_cursor):
         jobs_to_delete.append(job_id)
 
     for job_id in jobs_to_delete:
+        scheduled_jobs[job_id].async_task_result.forget()
         del scheduled_jobs[job_id]
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

See the RCA at https://github.com/y-scope/clp/issues/1059#issuecomment-3192480667

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

See the RCA at https://github.com/y-scope/clp/issues/1059#issuecomment-3192480667

Also, to cover the case where we create new jobs in `handle_finished_search_job`, i also tried compressing 10 copies of hive-24hr logs. Performing queries in the WebUI let the backend scheduled multiple Celery jobs, and no stuck was observed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Fixed lingering background-task handles after job completion, transitions, or errors to prevent stale job artefacts.
  - Ensured jobs are removed cleanly from active scheduling when finished or cancelled.
- Performance
  - Reduced memory and backend load by discarding task results once they’re no longer needed.
- Chores
  - Improved runtime cleanup across job orchestration paths for greater stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->