### PR TITLE
feat(clp-s): Add support for duplicate columns in projections.

### DIFF
--- a/components/core/src/clp_s/search/Projection.cpp
+++ b/components/core/src/clp_s/search/Projection.cpp
@@ -13,12 +13,13 @@ void Projection::add_column(std::shared_ptr<ast::ColumnDescriptor> column) {
     if (ProjectionMode::ReturnAllColumns == m_projection_mode) {
         throw OperationFailed(ErrorCodeUnsupported, __FILE__, __LINE__);
     }
-    if (m_selected_columns.end()
-        != std::find_if(
-                m_selected_columns.begin(),
-                m_selected_columns.end(),
-                [column](auto const& rhs) -> bool { return *column == *rhs; }
-        ))
+    if (false == m_allow_duplicate_columns
+        && m_selected_columns.end()
+                   != std::find_if(
+                           m_selected_columns.begin(),
+                           m_selected_columns.end(),
+                           [column](auto const& rhs) -> bool { return *column == *rhs; }
+                   ))
     {
         // no duplicate columns in projection
         throw OperationFailed(ErrorCodeBadParam, __FILE__, __LINE__);

--- a/components/core/src/clp_s/search/Projection.cpp
+++ b/components/core/src/clp_s/search/Projection.cpp
@@ -18,7 +18,7 @@ void Projection::add_column(std::shared_ptr<ast::ColumnDescriptor> column) {
                    != std::find_if(
                            m_selected_columns.begin(),
                            m_selected_columns.end(),
-                           [column](auto const& rhs) -> bool { return *column == *rhs; }
+                           [&column](auto const& rhs) -> bool { return *column == *rhs; }
                    ))
     {
         // no duplicate columns in projection

--- a/components/core/src/clp_s/search/Projection.hpp
+++ b/components/core/src/clp_s/search/Projection.hpp
@@ -30,6 +30,13 @@ public:
                 : TraceableException(error_code, filename, line_number) {}
     };
 
+    /**
+     * Constructs a Projection object with the specified mode and column handling behavior.
+     *
+     * @param mode Projection mode that determines how expressions are projected.
+     * @param allow_duplicate_columns Whether duplicate column descriptiors are permitted in the
+     * projection.
+     */
     explicit Projection(ProjectionMode mode, bool allow_duplicate_columns = false)
             : m_projection_mode{mode},
               m_allow_duplicate_columns{allow_duplicate_columns} {}
@@ -88,7 +95,7 @@ private:
     absl::flat_hash_set<int32_t> m_matching_nodes;
     std::vector<std::vector<int32_t>> m_ordered_matching_nodes;
     ProjectionMode m_projection_mode{ProjectionMode::ReturnAllColumns};
-    bool m_allow_duplicate_columns;
+    bool m_allow_duplicate_columns{false};
 };
 }  // namespace clp_s::search
 

--- a/components/core/src/clp_s/search/Projection.hpp
+++ b/components/core/src/clp_s/search/Projection.hpp
@@ -34,7 +34,7 @@ public:
      * Constructs a Projection object with the specified mode and column handling behavior.
      *
      * @param mode Projection mode that determines how expressions are projected.
-     * @param allow_duplicate_columns Whether duplicate column descriptiors are permitted in the
+     * @param allow_duplicate_columns Whether duplicate column descriptors are permitted in the
      * projection.
      */
     explicit Projection(ProjectionMode mode, bool allow_duplicate_columns = false)

--- a/components/core/src/clp_s/search/Projection.hpp
+++ b/components/core/src/clp_s/search/Projection.hpp
@@ -30,7 +30,9 @@ public:
                 : TraceableException(error_code, filename, line_number) {}
     };
 
-    explicit Projection(ProjectionMode mode) : m_projection_mode{mode} {}
+    explicit Projection(ProjectionMode mode, bool allow_duplicate_columns = false)
+            : m_projection_mode{mode},
+              m_allow_duplicate_columns{allow_duplicate_columns} {}
 
     /**
      * Adds a column to the set of columns that should be included in the projected results
@@ -86,6 +88,7 @@ private:
     absl::flat_hash_set<int32_t> m_matching_nodes;
     std::vector<std::vector<int32_t>> m_ordered_matching_nodes;
     ProjectionMode m_projection_mode{ProjectionMode::ReturnAllColumns};
+    bool m_allow_duplicate_columns;
 };
 }  // namespace clp_s::search
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This change adds support for duplicate columns in Projection.

When using CLP as a library, results may not always be serialized into a JSON string. In these cases, enforcing uniqueness is unnecessary and, in some scenarios, duplicate columns are expected.

For example, in the Velox–CLP connector, accessing the same nested field through both a UDF and a row type may produce two projection fields. Even if one of them is unused, we still need to allow duplicates.

Since the default value remains false, this change does not affect existing CLP behavior.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an option (off by default) to allow duplicate columns in projection results, enabling repeated fields to be preserved when desired.

- Bug Fixes
  - Prevents errors in workflows that intentionally produce repeated columns; such workflows now succeed when the option is enabled.

- Notes
  - Default behaviour unchanged for users who do not enable the duplicate-columns option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->