### PR TITLE
feat(webui): Add cache control for static files.

### DIFF
--- a/components/webui/server/src/routes/static.ts
+++ b/components/webui/server/src/routes/static.ts
@@ -1,11 +1,44 @@
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 
-import {fastifyStatic} from "@fastify/static";
+import fastifyStatic from "@fastify/static";
 import {FastifyPluginAsync} from "fastify";
 
 import settings from "../../settings.json" with {type: "json"};
 
+
+const CACHE_CONTROL_HEADER_KEY = "Cache-Control";
+const CACHE_CONTROL_HEADER_VALUE_NO_CACHE = "public, max-age=0";
+
+// Cache all other static files for 1 year without revalidation.
+const CACHE_CONTROL_HEADER_VALUE_LONG_TERM_CACHE = "public, max-age=31536000, immutable";
+
+
+/**
+ * Configures `Cache-Control` header for static files to reduce network traffic.
+ *
+ * @param res
+ * @param reqPath
+ * @param extraNoCachePaths
+ */
+const setCacheHeaders = (
+    res: Parameters<NonNullable<fastifyStatic.FastifyStaticOptions["setHeaders"]>>[0],
+    reqPath: string,
+    extraNoCachePaths: string[] = []
+): void => {
+    const noCachePaths = [
+        "/index.html",
+        ...extraNoCachePaths,
+    ];
+
+    if (noCachePaths.some((noCachePath) => reqPath.endsWith(noCachePath))) {
+        res.setHeader(CACHE_CONTROL_HEADER_KEY, CACHE_CONTROL_HEADER_VALUE_NO_CACHE);
+
+        return;
+    }
+
+    res.setHeader(CACHE_CONTROL_HEADER_KEY, CACHE_CONTROL_HEADER_VALUE_LONG_TERM_CACHE);
+};
 
 /**
  * Creates static files serving routes.
@@ -40,21 +73,32 @@ const routes: FastifyPluginAsync = async (fastify) => {
         logViewerDir = path.resolve(rootDirname, logViewerDir);
     }
     await fastify.register(fastifyStatic, {
+        decorateReply: false,
         prefix: "/log-viewer",
         root: logViewerDir,
-        decorateReply: false,
+
+        // Prevent fastify-static from adding its own cache headers and provide our own.
+        cacheControl: false,
+        setHeaders: (res, reqPath) => {
+            setCacheHeaders(res, reqPath);
+        },
     });
 
     let clientDir = settings.ClientDir;
     if (false === path.isAbsolute(clientDir)) {
         clientDir = path.resolve(rootDirname, settings.ClientDir);
     }
-
     await fastify.register(fastifyStatic, {
+        decorateReply: true,
         prefix: "/",
         root: clientDir,
-        decorateReply: true,
         wildcard: false,
+
+        // Prevent fastify-static from adding its own cache headers and provide our own.
+        cacheControl: false,
+        setHeaders: (res, reqPath) => {
+            setCacheHeaders(res, reqPath, ["/settings.json"]);
+        },
     });
 
     // Serve index.html for all unmatched routes in the React Single Page Application (SPA).


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Add Cache-Control headers for static files to reduce network traffic
  - Configure no-cache for specific files (e.g., index.html, settings.json)
  - Set long-term caching for all other static files
  - Improve caching strategy for both log viewer and client directories

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Below test was done without the changes in #1234 

## Stress test

1. Built and started the package
    ```
    task package
    cd build/clp-package/sbin
    ./start-clp.sh
    ```
2. Visited http://localhost:4000 in Microsoft Edge Version 139.0.3405.102 (Official build) (64-bit)
3. Clear browser cache for the site:
    1. `F12` to open Developer Console in the browser.
    2. Right-clicked on the "Refresh" button on the left of the browser address bar
    3. Clicked on "Empty cache and hard refresh"
4. Idled for 1 minute.
5. Kept refreshing the http://localhost:4000/ingest page at a rate of roughly twice a second. After roughly 30 seconds, observed "Rate limit exceeded, retry in 30 seconds".

## Inspect headers

Idled for 1 minute so that the rate limit recovered from the above stress test.

### The Web UI SPA

1. Opened Developer Console in Microsoft Edge Version 139.0.3405.102 (Official build) (64-bit). Switched to the "Network" tab in the Developer Console.
2. Visited http://localhost:4000/ingest 
3. Observed most requests were loaded from the cache:
   <img width="1558" height="654" alt="image" src="https://github.com/user-attachments/assets/dae6eed5-2e26-4ca6-bd35-338e94c12fe4" />
4. ... except requests for "ingest", "settings.json", "sql" (ignored "content-fontface-intercept.js" because that's caused by a Chrome extension i installed). Inspected the requests and observed "Cache-Control: public, max-age=0" was set for those.
5. Visited http://localhost:4000/ (a different path from http://localhost:4000/ingest though index.html is also served) and repeated Step 4 to ensure the no cache header was set.

### The log viewer SPA

1. Compressed sample logs: `clp-package/sbin/compress.sh ~/sample/hive-24hr`
2. Visited http://localhost:4000/search and performed a search with query string "1". Observed results were shown.
3. Clicked on any "Open file" link in any search result. The log viewer showed up.
4. Clicked the Refresh button on the left of the browser address bar to refresh the page.
5. Opened Developer Console. Switched to the "Network" tab in the Developer Console.
6. Observed most requests were loaded from the cache:
   <img width="1578" height="692" alt="image" src="https://github.com/user-attachments/assets/dfbc9bc1-55be-416e-bc05-64b3448c3183" />
7. ... except requests for "index.html?filePath=/streams/...", "dc4314df-6284-4555-824a-548de0932ebe_0_641.clp.zst" (ignored "content-fontface-intercept.js" because that's caused by a Chrome extension i installed). Inspected the requests and observed "Cache-Control: public, max-age=0" was set for those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Enhanced cache-control for static assets: long-term caching for files like JS/CSS/images, with index.html and settings.json always served fresh.
  * Faster repeat page loads while ensuring users receive up-to-date app shell and configuration.

* Bug Fixes
  * Prevents stale content after deployments, reducing issues with outdated pages or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888468774326