### PR TITLE
feat(webui): Set number results using server metadata to display total result count for presto queries. 

### DIFF
--- a/components/webui/client/src/pages/SearchPage/SearchQueryStatus/Results.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchQueryStatus/Results.tsx
@@ -19,16 +19,19 @@ type TextTypes = GetProps<typeof Text>["type"];
  * @return
  */
 const Results = () => {
+    const numSearchResultsMetadata = useSearchStore((state) => state.numSearchResultsMetadata);
     const numSearchResultsTimeline = useSearchStore((state) => state.numSearchResultsTimeline);
     const numSearchResultsTable = useSearchStore((state) => state.numSearchResultsTable);
     const searchUiState = useSearchStore((state) => state.searchUiState);
 
-    // Number of results is the maximum of the number of results in the timeline and table. The
-    // timeline may have more results since the table results are capped. Having two sources may
-    // provide more timely updates to the user.
+    // Number of results is the maximum from timeline, table, and server metadata sources.
+    // Multiple sources provide more timely updates. Source behavior differs by query engine:
+    // - clp/clp-s: table and server metadata counts are capped
+    // - presto: table count is capped, no timeline available
     const numResults = useMemo(
-        () => Math.max(numSearchResultsTimeline, numSearchResultsTable),
+        () => Math.max(numSearchResultsMetadata, numSearchResultsTimeline, numSearchResultsTable),
         [
+            numSearchResultsMetadata,
             numSearchResultsTimeline,
             numSearchResultsTable,
         ]

--- a/components/webui/client/src/pages/SearchPage/SearchQueryStatus/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchQueryStatus/index.tsx
@@ -24,7 +24,7 @@ const SearchQueryStatus = () => {
             {(searchUiState === SEARCH_UI_STATE.QUERYING ||
                 searchUiState === SEARCH_UI_STATE.DONE) && (
                 <Text type={"secondary"}>
-                    Search job #
+                    Search job id:
                     {searchJobId}
                     {" "}
                     found

--- a/components/webui/client/src/pages/SearchPage/SearchState/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/SearchState/index.tsx
@@ -18,6 +18,7 @@ import {SEARCH_UI_STATE} from "./typings";
 const SEARCH_STATE_DEFAULT = Object.freeze({
     aggregationJobId: null,
     cachedDataset: null,
+    numSearchResultsMetadata: 0,
     numSearchResultsTable: 0,
     numSearchResultsTimeline: 0,
     queryIsCaseSensitive: false,
@@ -42,6 +43,11 @@ interface SearchState {
      * log viewer links.
      */
     cachedDataset: Nullable<string>;
+
+    /**
+     * The number of search results from metadata (total results when search is complete).
+     */
+    numSearchResultsMetadata: number;
 
     /**
      * The number of search table results.
@@ -97,6 +103,7 @@ interface SearchState {
 
     updateAggregationJobId: (id: string | null) => void;
     updateCachedDataset: (dataset: string) => void;
+    updateNumSearchResultsMetadata: (num: number) => void;
     updateNumSearchResultsTable: (num: number) => void;
     updateNumSearchResultsTimeline: (num: number) => void;
     updateQueryIsCaseSensitive: (newValue: boolean) => void;
@@ -116,6 +123,9 @@ const useSearchStore = create<SearchState>((set) => ({
     },
     updateCachedDataset: (dataset) => {
         set({cachedDataset: dataset});
+    },
+    updateNumSearchResultsMetadata: (num) => {
+        set({numSearchResultsMetadata: num});
     },
     updateNumSearchResultsTable: (num) => {
         set({numSearchResultsTable: num});

--- a/components/webui/client/src/pages/SearchPage/SearchState/useUpdateStateWithMetadata.ts
+++ b/components/webui/client/src/pages/SearchPage/SearchState/useUpdateStateWithMetadata.ts
@@ -10,18 +10,24 @@ import useSearchStore from "./index";
 import {SEARCH_UI_STATE} from "./typings";
 import {useResultsMetadata} from "./useResultsMetadata";
 
-
 /**
- * Custom hook to update the UI state to `DONE` when the results metadata signal indicates
- * that the query is complete, or `FAILED` if the query fails. If there is an error, it will
- * also display a notification with the error message.
+ * Custom hook to update the client state based on results metadata from the server.
+ * - Sets the UI state to `DONE` when the results metadata signal indicates that the query is
+ * complete, or `FAILED` if the query fails.
+ * - If there is an error, it will display a notification with the error message.
+ * - Updates the number of search results from the metadata.
  */
-const useUiUpdateOnDoneSignal = () => {
-    const {updateSearchUiState} = useSearchStore();
+const useUpdateStateWithMetadata = () => {
+    const {updateSearchUiState, updateNumSearchResultsMetadata} = useSearchStore();
     const resultsMetadata = useResultsMetadata();
+
     useEffect(() => {
         if (null === resultsMetadata) {
             return;
+        }
+
+        if ("undefined" !== typeof resultsMetadata.numTotalResults) {
+            updateNumSearchResultsMetadata(resultsMetadata.numTotalResults);
         }
 
         switch (resultsMetadata.lastSignal) {
@@ -47,7 +53,8 @@ const useUiUpdateOnDoneSignal = () => {
     }, [
         resultsMetadata,
         updateSearchUiState,
+        updateNumSearchResultsMetadata,
     ]);
 };
 
-export {useUiUpdateOnDoneSignal};
+export {useUpdateStateWithMetadata};

--- a/components/webui/client/src/pages/SearchPage/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/index.tsx
@@ -8,7 +8,7 @@ import SearchControls from "./SearchControls";
 import SearchQueryStatus from "./SearchQueryStatus";
 import SearchResultsTable from "./SearchResults/SearchResultsTable";
 import SearchResultsTimeline from "./SearchResults/SearchResultsTimeline";
-import {useUiUpdateOnDoneSignal} from "./SearchState/useUpdateStateWithMetadata";
+import {useUpdateStateWithMetadata} from "./SearchState/useUpdateStateWithMetadata";
 
 
 /**
@@ -17,7 +17,7 @@ import {useUiUpdateOnDoneSignal} from "./SearchState/useUpdateStateWithMetadata"
  * @return
  */
 const SearchPage = () => {
-    useUiUpdateOnDoneSignal();
+    useUpdateStateWithMetadata();
 
     return (
         <>


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Previous result count only considered the number of results in the table for presto queries. This PR allows the UI to also include the result count from server metadata. After this PR, the result count is no longer limited to 1k results, and will show the true amount of results from presto in query status header. The table is still limited to 1k results.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Ran long query and verified results >1000 in header


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
