### PR TITLE
fix(package): Properly pass credentials to dataset_manager container.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/dataset_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/dataset_manager.py
@@ -7,6 +7,8 @@ from typing import Final, List
 
 from clp_py_utils.clp_config import (
     ARCHIVE_MANAGER_ACTION_NAME,
+    CLP_DB_PASS_ENV_VAR_NAME,
+    CLP_DB_USER_ENV_VAR_NAME,
     StorageEngine,
     StorageType,
 )
@@ -141,8 +143,12 @@ def main(argv: List[str]) -> int:
     if aws_mount:
         necessary_mounts.append(mounts.aws_config_dir)
 
+    extra_env_vars = {
+        CLP_DB_USER_ENV_VAR_NAME: clp_config.database.username,
+        CLP_DB_PASS_ENV_VAR_NAME: clp_config.database.password,
+    }
     container_start_cmd = generate_container_start_cmd(
-        container_name, necessary_mounts, clp_config.execution_container
+        container_name, necessary_mounts, clp_config.execution_container, extra_env_vars
     )
 
     if len(aws_env_vars) != 0:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
@@ -222,6 +222,7 @@ def main(argv: List[str]) -> int:
     try:
         clp_config = load_config_file(config_file_path, default_config_file_path, clp_home)
         clp_config.validate_logs_dir()
+        clp_config.database.load_credentials_from_env()
     except:
         logger.exception("Failed to load config.")
         return -1


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The PR 1152 standardized how we pass credentials to the containers, but missed to update dataset_manager.py and it's native scripts.

This PR adds the missing changes to these two scripts.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Manually ran the script and make sure it prints out 
```2025-08-19T21:41:09.391 INFO [dataset_manager] Found 0 datasets.```, showing that it is able to read the database credentials.

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
