### PR TITLE
fix(ci): Add the missing parser generation step in `clp-s-generated-code-checks` workflow.

### DIFF
--- a/.github/workflows/clp-s-generated-code-checks.yaml
+++ b/.github/workflows/clp-s-generated-code-checks.yaml
@@ -32,6 +32,10 @@ jobs:
         name: "Install coreutils (for md5sum)"
         run: "brew install coreutils"
 
+      - name: "Generate parsers"
+        shell: "bash"
+        run: "task clp-s-generate-parsers"
+
       - name: "Check if the generated parsers are the latest"
         shell: "bash"
         run:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

In the current workflow, `clp-s-generated-code-checks` doesn't actually generate any parsers. This PR fixes it by adding the parser generation step properly.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
