### PR TITLE
docs: Add missing `ts` flags to `archive-manager.sh del by-filter` example command.

### DIFF
--- a/docs/src/user-guide/reference-admin-tools.md
+++ b/docs/src/user-guide/reference-admin-tools.md
@@ -76,8 +76,8 @@ named `default`.
 
     ```bash
     sbin/admin-tools/archive-manager.sh del by-filter \
-      <begin-epoch-time-millis> \
-      <end-epoch-time-millis>
+      --begin-ts <begin-epoch-time-millis> \
+      --end-ts <end-epoch-time-millis>
     ```
 
     * Replace `<begin-epoch-time-millis>` with the timestamp of the time range's beginning (in


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The `archive-manager.sh del by-filter` example command in `reference-admin-tools.md` was missing the `--begin-ts` and `--end-ts` flags. Without them, the command doesn't work.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Built and served the docs.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
