### PR TITLE
chore: Bump version to 0.5.1-dev for next development cycle.

### DIFF
--- a/components/clp-package-utils/pyproject.toml
+++ b/components/clp-package-utils/pyproject.toml
@@ -3,7 +3,7 @@ requires-python = ">= 3.9"
 
 [tool.poetry]
 name = "clp-package-utils"
-version = "0.4.0-dev"
+version = "0.5.1-dev"
 description = "Utilities for the CLP package."
 authors = ["YScope Inc. <dev@yscope.com>"]
 readme = "README.md"

--- a/components/clp-py-utils/pyproject.toml
+++ b/components/clp-py-utils/pyproject.toml
@@ -3,7 +3,7 @@ requires-python = ">= 3.9"
 
 [tool.poetry]
 name = "clp-py-utils"
-version = "0.4.0-dev"
+version = "0.5.1-dev"
 description = "Utilities for other Python packages in CLP."
 authors = ["YScope Inc. <dev@yscope.com>"]
 readme = "README.md"

--- a/components/core/src/clp/version.hpp
+++ b/components/core/src/clp/version.hpp
@@ -2,7 +2,7 @@
 #define CLP_VERSION_HPP
 
 namespace clp {
-constexpr char cVersion[] = "0.4.0-dev";
+constexpr char cVersion[] = "0.5.1-dev";
 }  // namespace clp
 
 #endif  // CLP_VERSION_HPP

--- a/components/core/src/glt/version.hpp
+++ b/components/core/src/glt/version.hpp
@@ -2,7 +2,7 @@
 #define GLT_VERSION_HPP
 
 namespace glt {
-constexpr char cVersion[] = "0.4.0-dev";
+constexpr char cVersion[] = "0.5.1-dev";
 }  // namespace glt
 
 #endif  // GLT_VERSION_HPP

--- a/components/job-orchestration/pyproject.toml
+++ b/components/job-orchestration/pyproject.toml
@@ -3,7 +3,7 @@ requires-python = ">= 3.9"
 
 [tool.poetry]
 name = "job-orchestration"
-version = "0.4.0-dev"
+version = "0.5.1-dev"
 description = "Scheduler and worker cluster for CLP's distributed architecture."
 authors = ["YScope Inc. <dev@yscope.com>"]
 readme = "README.md"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -29,7 +29,7 @@ vars:
   G_UTILS_TASKFILE: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
   # Versions
-  G_PACKAGE_VERSION: "0.4.0-dev"
+  G_PACKAGE_VERSION: "0.5.1-dev"
 
   # Build parameters
   # NOTE: Defaulting to an empty string is safe since CMake ignores an empty string.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As we've now released v0.5.0, we need to bump the development version (mostly for clarity when developing). Note that previous dev version bumps were actually wrong to simply append "-dev" to the released version; this is because "<version>-dev" is actually meant to be pre-release version of "<version>". That's why we now pick the next version after the released version instead.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* The package can be built successfully.
* CI succeeded.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
