### PR TITLE
feat(webui): Remove timeline for presto queries. 

### DIFF
--- a/components/webui/client/src/pages/SearchPage/index.tsx
+++ b/components/webui/client/src/pages/SearchPage/index.tsx
@@ -27,7 +27,7 @@ const SearchPage = () => {
                     <SearchControls/>
                     <SearchQueryStatus/>
                 </div>
-                <SearchResultsTimeline/>
+                {SETTINGS_QUERY_ENGINE !== CLP_QUERY_ENGINES.PRESTO && <SearchResultsTimeline/>}
                 <SearchResultsTable/>
             </div>
         </>


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Removes the timeline since not yet supported for presto. Timeline support will be added in phase II of presto webui. 

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Timeline does not render



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
