### PR TITLE
fix(taskfile): Correct Python-component venv checksum filename reference to avoid unnecessary venv rebuilds (fixes #1252).

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -540,7 +540,7 @@ tasks:
     requires:
       vars: ["COMPONENT"]
     sources:
-      - "{{.G_BUILD_DIR}}/{{.COMPONENT}}_venv.md5"
+      - "{{.G_BUILD_DIR}}/{{.COMPONENT}}-venv.md5"
       - "{{.PACKAGE}}/**/*"
       - "{{.ROOT_DIR}}/requirements.txt"
       - "{{.TASKFILE}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

see #1252. this PR fixes the misalignment of the venv checksum name.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Ran `task clp-py-utils` twice and observed the tasks don't get re-run the second time.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized naming convention for per-component virtual environment checksum files, switching from underscore to dash separators.
  - Improves consistency across tooling and reduces the chance of cache misses during builds.
  - No functional changes to runtime behaviour or interfaces.
  - Existing environments will regenerate automatically if required; no action needed from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->