### PR TITLE
chore: Expose Presto coordinator container port 8080 to host 8889 (resolves #1264).

### DIFF
--- a/tools/deployment/presto-clp/docker-compose.yaml
+++ b/tools/deployment/presto-clp/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   presto-coordinator:
-    image: "ghcr.io/y-scope/presto/coordinator:dev"
+    image: "ghcr.io/anlowee/presto/coordinator:dev"
     entrypoint: ["/bin/bash", "-c", "/scripts/generate-configs.sh && /opt/entrypoint.sh"]
     env_file:
       - ".env"
@@ -12,6 +12,8 @@ services:
       - "coordinator-config:/opt/presto-server/etc"
     networks:
       - "presto"
+    ports:
+      - "8889:8080"
     healthcheck:
       test:
         - "CMD"
@@ -22,7 +24,7 @@ services:
       retries: 30
 
   presto-worker:
-    image: "ghcr.io/y-scope/presto/prestissimo-worker:dev"
+    image: "ghcr.io/anlowee/presto/prestissimo-worker:dev"
     depends_on:
       presto-coordinator:
         condition: "service_healthy"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR resolves #1264 .

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.
Tried `ssh -L8889:localhost:8889 user@host` to access the UI locally.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
