### PR TITLE
refactor(clp-s): Delete unused `clp_s::StringUtils` methods; Remove unused includes of `Utils.hpp`.

### DIFF
--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -15,7 +15,6 @@
 #include "SchemaReader.hpp"
 #include "search/Projection.hpp"
 #include "TimestampDictionaryReader.hpp"
-#include "Utils.hpp"
 
 namespace clp_s {
 class ArchiveReader {

--- a/components/core/src/clp_s/DictionaryEntry.cpp
+++ b/components/core/src/clp_s/DictionaryEntry.cpp
@@ -12,7 +12,6 @@
 #include "../clp/ir/parsing.hpp"
 #include "../clp/ir/types.hpp"
 #include "../clp/type_utils.hpp"
-#include "Utils.hpp"
 
 using clp::EncodedVariableInterpreter;
 using clp::enum_to_underlying_type;

--- a/components/core/src/clp_s/DictionaryReader.hpp
+++ b/components/core/src/clp_s/DictionaryReader.hpp
@@ -14,7 +14,6 @@
 
 #include "ArchiveReaderAdaptor.hpp"
 #include "DictionaryEntry.hpp"
-#include "Utils.hpp"
 
 namespace clp_s {
 template <typename DictionaryIdType, typename EntryType>

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -28,7 +28,6 @@
 #include "SchemaTree.hpp"
 #include "SchemaWriter.hpp"
 #include "TimestampDictionaryWriter.hpp"
-#include "Utils.hpp"
 #include "ZstdCompressor.hpp"
 
 using namespace simdjson;

--- a/components/core/src/clp_s/Schema.hpp
+++ b/components/core/src/clp_s/Schema.hpp
@@ -8,7 +8,6 @@
 
 #include "SchemaTree.hpp"
 #include "TraceableException.hpp"
-#include "Utils.hpp"
 
 namespace clp_s {
 /**

--- a/components/core/src/clp_s/TimestampDictionaryWriter.cpp
+++ b/components/core/src/clp_s/TimestampDictionaryWriter.cpp
@@ -4,8 +4,6 @@
 #include <sstream>
 #include <string_view>
 
-#include "Utils.hpp"
-
 namespace clp_s {
 void TimestampDictionaryWriter::write_timestamp_entries(
         std::map<std::string, TimestampEntry> const& ranges,

--- a/components/core/src/clp_s/Utils.cpp
+++ b/components/core/src/clp_s/Utils.cpp
@@ -163,56 +163,6 @@ bool UriUtils::get_last_uri_component(std::string_view const uri, std::string& n
     return true;
 }
 
-bool StringUtils::get_bounds_of_next_var(string const& msg, size_t& begin_pos, size_t& end_pos) {
-    auto const msg_length = msg.length();
-    if (end_pos >= msg_length) {
-        return false;
-    }
-
-    while (true) {
-        begin_pos = end_pos;
-        // Find next non-delimiter
-        for (; begin_pos < msg_length; ++begin_pos) {
-            if (false == is_delim(msg[begin_pos])) {
-                break;
-            }
-        }
-        if (msg_length == begin_pos) {
-            // Early exit for performance
-            return false;
-        }
-
-        bool contains_decimal_digit = false;
-        bool contains_alphabet = false;
-
-        // Find next delimiter
-        end_pos = begin_pos;
-        for (; end_pos < msg_length; ++end_pos) {
-            char c = msg[end_pos];
-            if (clp::string_utils::is_decimal_digit(c)) {
-                contains_decimal_digit = true;
-            } else if (clp::string_utils::is_alphabet(c)) {
-                contains_alphabet = true;
-            } else if (is_delim(c)) {
-                break;
-            }
-        }
-
-        // Treat token as variable if:
-        // - it contains a decimal digit, or
-        // - it's directly preceded by an equals sign and contains an alphabet, or
-        // - it could be a multi-digit hex value
-        if (contains_decimal_digit
-            || (begin_pos > 0 && '=' == msg[begin_pos - 1] && contains_alphabet)
-            || could_be_multi_digit_hex_value(msg, begin_pos, end_pos))
-        {
-            break;
-        }
-    }
-
-    return (msg_length != begin_pos);
-}
-
 void StringUtils::escape_json_string(std::string& destination, std::string_view const source) {
     // Escaping is implemented using this `append_unescaped_slice` approach to offer a fast path
     // when strings are mostly or entirely valid escaped JSON. Benchmarking shows that this offers

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -66,54 +66,6 @@ public:
 class StringUtils {
 public:
     /**
-     * Checks if character is a hexadecimal (base-16) digit
-     * @param c
-     * @return true if c is a hexadecimal digit, false otherwise
-     */
-    static inline bool is_delim(char c) {
-        return !(
-                '+' == c || ('-' <= c && c <= '9') || ('A' <= c && c <= 'Z') || '\\' == c
-                || '_' == c || ('a' <= c && c <= 'z')
-        );
-    }
-
-    /**
-     * Checks if the string could be a hexadecimal value
-     * @param str
-     * @param begin_pos
-     * @param end_pos
-     * @return true if str could be a hexadecimal value, false otherwise
-     */
-    static inline bool
-    could_be_multi_digit_hex_value(std::string const& str, size_t begin_pos, size_t end_pos) {
-        if (end_pos - begin_pos < 2) {
-            return false;
-        }
-
-        for (size_t i = begin_pos; i < end_pos; ++i) {
-            auto c = str[i];
-            if (false
-                == (('a' <= c && c <= 'f') || ('A' <= c && c <= 'F') || ('0' <= c && c <= '9')))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Returns bounds of next variable in given string
-     * A variable is a token (word between two delimiters) that contains numbers or is directly
-     * preceded by an equals sign
-     * @param msg
-     * @param begin_pos Begin position of last variable, changes to begin position of next variable
-     * @param end_pos End position of last variable, changes to end position of next variable
-     * @return true if a variable was found, false otherwise
-     */
-    static bool get_bounds_of_next_var(std::string const& msg, size_t& begin_pos, size_t& end_pos);
-
-    /**
      * Escapes a string according to JSON string escaping rules and appends the escaped string to
      * a buffer. The input string can be either ascii or UTF-8.
      *

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -38,7 +38,6 @@
 #include "search/Projection.hpp"
 #include "search/SchemaMatch.hpp"
 #include "TimestampPattern.hpp"
-#include "Utils.hpp"
 
 using namespace clp_s::search;
 using clp_s::cArchiveFormatDevelopmentVersionFlag;
@@ -47,7 +46,6 @@ using clp_s::cEpochTimeMin;
 using clp_s::CommandLineArguments;
 using clp_s::KvIrSearchError;
 using clp_s::KvIrSearchErrorEnum;
-using clp_s::StringUtils;
 
 namespace {
 /**

--- a/components/core/src/clp_s/search/QueryRunner.cpp
+++ b/components/core/src/clp_s/search/QueryRunner.cpp
@@ -11,6 +11,7 @@
 #include "../../clp/Query.hpp"
 #include "../../clp/type_utils.hpp"
 #include "../SchemaTree.hpp"
+#include "../Utils.hpp"
 #include "ast/AndExpr.hpp"
 #include "ast/ColumnDescriptor.hpp"
 #include "ast/Expression.hpp"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR follows up on #1163 and #1103 by deleting the remainder of the `StringUtils` methods that have equivalent implementations in clp; it is now safe to remove the rest of these copied methods since we now use the core clp parsing and search code directly in clp-s. We also clean up unused references to clp-s' `Utils.hpp` header (most of these remaining references were previously used in order to include the now-deleted methods).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that unit tests still pass.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
