### PR TITLE
feat(log-surgeon)!: Add support for a single capture group in a schema rule to have parity with the heuristic parser.

### DIFF
--- a/components/core/tests/test-ParserWithUserSchema.cpp
+++ b/components/core/tests/test-ParserWithUserSchema.cpp
@@ -179,3 +179,26 @@ TEST_CASE("Test lexer", "[Search]") {
         token = opt_token.value();
     }
 }
+
+TEST_CASE("Test schema with single capture group", "[load_lexer]") {
+    std::string const schema_path{"../tests/test_schema_files/single_capture_group.txt"};
+    ByteLexer lexer;
+    load_lexer_from_file(schema_path, lexer);
+
+    auto const rule_id{lexer.m_symbol_id.at("capture")};
+    auto const capture_ids{lexer.get_capture_ids_from_rule_id(rule_id)};
+    REQUIRE(capture_ids.has_value());
+    REQUIRE(1 == capture_ids.value().size());
+    REQUIRE("group" == lexer.m_id_symbol.at(capture_ids->at(0)));
+}
+
+TEST_CASE("Test error for schema rule with multiple capture groups", "[load_lexer]") {
+    std::string const schema_path{"../tests/test_schema_files/multiple_capture_groups.txt"};
+    ByteLexer lexer;
+    REQUIRE_THROWS_WITH(
+            load_lexer_from_file(schema_path, lexer),
+            schema_path
+                    + ":1: error: the schema rule 'multicapture' has a regex pattern containing > "
+                      "1 capture group.\n"
+    );
+}

--- a/components/core/tests/test_schema_files/multiple_capture_groups.txt
+++ b/components/core/tests/test_schema_files/multiple_capture_groups.txt
@@ -1,0 +1,1 @@
+multicapture:text(?<group0>var0)text(?<group1>var1)text

--- a/components/core/tests/test_schema_files/single_capture_group.txt
+++ b/components/core/tests/test_schema_files/single_capture_group.txt
@@ -1,0 +1,1 @@
+capture:text(?<group>var)text


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Previously, when using log surgeon for parsing the full match of a schema rule's regex pattern would be stored as a variable in CLP. This created differences from the heuristic parser's behaviour for certain cases.

For example, the heuristic's "equals" rule can be represented with the regex pattern `.*=(?<var>.*[a-zA-Z0-9].*)`. The heuristic parser will only store the `var` capture group as a variable (storing the prefix `.*=` as static text). When using log surgeon without capture groups this behaviour was not possible as we would store the full match (including the prefix `.*=`) as a variable.

This PR allows schema rules to contain up to 1 capture group. If a capture group is present only the capture's match will be stored as a variable and anything surrounding it will be stored as static text. In the case where the capture is repeated (e.g. `text(?<var>variable)+text)`) all repetitions will be stored together as a single variable.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Added unit tests for schema creation with single or multiple captures.
*TODO* Generated archives and matched their contents.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
