### PR TITLE
ci(lint): Lock clang-format to v20.1.x until we can upgrade our code to meet v21's formatting standards.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,6 @@
 black>=24.4.2
-clang-format>=20.1
+# Lock to 20.1.x until we can upgrade our settings to work with 21.x.
+clang-format~=20.1
 # Lock to v19.x until we can upgrade our code to fix new v20 issues.
 clang-tidy~=19.1
 ruff>=0.4.4


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR locks clang-format to 20.1.x releases in order to avoid ci failures related to the new 21.x release (e.g. [here](https://github.com/y-scope/clp/actions/runs/17300429539/job/49109853242?pr=1270)). We can unlock our clang-format version again once we've addressed the issues we're encountering with the 21.x release.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that ci now passes


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated lint tooling constraints: switched clang-format to the compatible 20.1.x series with a temporary lock noted until a future 21.x upgrade. Other lint tool versions remain unchanged (black, clang-tidy, ruff, yamllint).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->