### PR TITLE
fix(clp-s):  Handle pure wildcards and unexpected literal types correctly in `EvaluateTimestampIndex` (fixes #1096).

### DIFF
--- a/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
+++ b/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
@@ -120,15 +120,9 @@ EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& ex
             }
             Integral64 integral = integral_literal->get();
             if (std::holds_alternative<int64_t>(integral)) {
-                ret = range_it->second->evaluate_filter(
-                        filter->get_operation(),
-                        std::get<int64_t>(integral)
-                );
+                ret = range_it->second->evaluate_filter(filter_op, std::get<int64_t>(integral));
             } else {
-                ret = range_it->second->evaluate_filter(
-                        filter->get_operation(),
-                        std::get<double>(integral)
-                );
+                ret = range_it->second->evaluate_filter(filter_op, std::get<double>(integral));
             }
 
             if (ret == EvaluatedValue::True) {

--- a/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
+++ b/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
@@ -65,6 +65,11 @@ EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& ex
              range_it != m_timestamp_dict->tokenized_column_to_range_end();
              range_it++)
         {
+            // Don't attempt to evaluate the timestamp index against columns with wildcard tokens.
+            if (column->has_unresolved_tokens()) {
+                continue;
+            }
+
             std::vector<std::string> const& tokens = range_it->first;
             auto const& descriptors = column->get_descriptor_list();
             if (tokens.size() != descriptors.size()) {
@@ -72,8 +77,8 @@ EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& ex
             }
 
             bool matched = true;
-            for (size_t i = 0; i < descriptors.size(); ++i) {
-                if (tokens[i] != descriptors[i].get_token() || descriptors[i].wildcard()) {
+            for (size_t i{0ULL}; i < descriptors.size(); ++i) {
+                if (tokens[i] != descriptors[i].get_token()) {
                     matched = false;
                     break;
                 }

--- a/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
+++ b/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
@@ -66,7 +66,7 @@ EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& ex
              range_it++)
         {
             // Don't attempt to evaluate the timestamp index against columns with wildcard tokens.
-            if (column->has_unresolved_tokens()) {
+            if (column->is_unresolved_descriptor()) {
                 continue;
             }
 

--- a/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
+++ b/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
@@ -87,32 +87,13 @@ EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& ex
                 continue;
             }
 
-            // Leave handling EXISTS/NEXISTS to schema matching.
-            auto const filter_op{filter->get_operation()};
-            if (FilterOperation::EXISTS == filter_op || FilterOperation::NEXISTS == filter_op) {
-                return EvaluatedValue::Unknown;
-            }
-
             auto const literal{filter->get_operand()};
-            // Defend against future FilterOperation types that don't take a literal.
             if (nullptr == literal) {
                 return EvaluatedValue::Unknown;
             }
 
-            // Handle the case where the literal is a pure wildcard.
-            if (literal->as_any(filter_op)) {
-                switch (filter_op) {
-                    case FilterOperation::EQ:
-                        return filter->is_inverted() ? EvaluatedValue::False : EvaluatedValue::True;
-                    case FilterOperation::NEQ:
-                        return filter->is_inverted() ? EvaluatedValue::True : EvaluatedValue::False;
-                    default:
-                        // Not reachable.
-                        return EvaluatedValue::Unknown;
-                }
-            }
-
             EvaluatedValue ret{EvaluatedValue::Unknown};
+            auto const filter_op{filter->get_operation()};
             int64_t int_literal{};
             double float_literal{};
             if (literal->as_int(int_literal, filter_op)) {

--- a/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
+++ b/components/core/src/clp_s/search/EvaluateTimestampIndex.cpp
@@ -3,6 +3,7 @@
 #include "ast/AndExpr.hpp"
 #include "ast/Expression.hpp"
 #include "ast/FilterExpr.hpp"
+#include "ast/FilterOperation.hpp"
 #include "ast/Integral.hpp"
 #include "ast/Literal.hpp"
 #include "ast/OrExpr.hpp"
@@ -10,6 +11,7 @@
 using clp_s::search::ast::AndExpr;
 using clp_s::search::ast::Expression;
 using clp_s::search::ast::FilterExpr;
+using clp_s::search::ast::FilterOperation;
 using clp_s::search::ast::Integral;
 using clp_s::search::ast::Integral64;
 using clp_s::search::ast::literal_type_bitmask_t;
@@ -82,19 +84,50 @@ EvaluatedValue EvaluateTimestampIndex::run(std::shared_ptr<Expression> const& ex
                 continue;
             }
 
-            EvaluatedValue ret;
-            // this is safe after type narrowing because all DateType literals are either
-            // Integral or a derived class of Integral
-            Integral64 literal = std::static_pointer_cast<Integral>(filter->get_operand())->get();
-            if (std::holds_alternative<int64_t>(literal)) {
+            // Leave handling EXISTS/NEXISTS to schema matching.
+            auto const filter_op{filter->get_operation()};
+            if (FilterOperation::EXISTS == filter_op || FilterOperation::NEXISTS == filter_op) {
+                return EvaluatedValue::Unknown;
+            }
+
+            auto const literal{filter->get_operand()};
+            // Defend against future FilterOperation types that don't take a literal.
+            if (nullptr == literal) {
+                return EvaluatedValue::Unknown;
+            }
+
+            // Handle the case where the literal is a pure wildcard.
+            if (literal->as_any(filter_op)) {
+                switch (filter_op) {
+                    case FilterOperation::EQ:
+                        return filter->is_inverted() ? EvaluatedValue::False : EvaluatedValue::True;
+                    case FilterOperation::NEQ:
+                        return filter->is_inverted() ? EvaluatedValue::True : EvaluatedValue::False;
+                    default:
+                        // Not reachable.
+                        return EvaluatedValue::Unknown;
+                }
+            }
+
+            EvaluatedValue ret{EvaluatedValue::Unknown};
+            // This should be safe after type narrowing and checking that the literal exists and is
+            // not a pure wildcard because all DateType literals are either Integral or a derived
+            // class of Integral. Still, we check whether the literal is an Integral in case this
+            // assumption breaks for future versions of the AST.
+            auto integral_literal{std::dynamic_pointer_cast<Integral>(literal)};
+            if (nullptr == integral_literal) {
+                return EvaluatedValue::Unknown;
+            }
+            Integral64 integral = integral_literal->get();
+            if (std::holds_alternative<int64_t>(integral)) {
                 ret = range_it->second->evaluate_filter(
                         filter->get_operation(),
-                        std::get<int64_t>(literal)
+                        std::get<int64_t>(integral)
                 );
             } else {
                 ret = range_it->second->evaluate_filter(
                         filter->get_operation(),
-                        std::get<double>(literal)
+                        std::get<double>(integral)
                 );
             }
 

--- a/components/core/tests/clp_s_test_utils.cpp
+++ b/components/core/tests/clp_s_test_utils.cpp
@@ -42,7 +42,7 @@ auto compress_archive(
     parser_option.single_file_archive = single_file_archive;
     parser_option.input_file_type = file_type;
     if (timestamp_key.has_value()) {
-        parser_option.timestamp_key = timestamp_key.value();
+        parser_option.timestamp_key = std::move(timestamp_key.value());
     }
 
     clp_s::JsonParser parser{parser_option};

--- a/components/core/tests/clp_s_test_utils.cpp
+++ b/components/core/tests/clp_s_test_utils.cpp
@@ -1,6 +1,7 @@
 #include "clp_s_test_utils.hpp"
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -13,6 +14,7 @@
 auto compress_archive(
         std::string const& file_path,
         std::string const& archive_directory,
+        std::optional<std::string> timestamp_key,
         bool single_file_archive,
         bool structurize_arrays,
         clp_s::FileType file_type
@@ -39,6 +41,9 @@ auto compress_archive(
     parser_option.structurize_arrays = structurize_arrays;
     parser_option.single_file_archive = single_file_archive;
     parser_option.input_file_type = file_type;
+    if (timestamp_key.has_value()) {
+        parser_option.timestamp_key = timestamp_key.value();
+    }
 
     clp_s::JsonParser parser{parser_option};
     std::vector<clp_s::ArchiveStats> archive_stats;

--- a/components/core/tests/clp_s_test_utils.hpp
+++ b/components/core/tests/clp_s_test_utils.hpp
@@ -1,6 +1,7 @@
 #ifndef CLP_S_TEST_UTILS_HPP
 #define CLP_S_TEST_UTILS_HPP
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -22,6 +23,7 @@
 [[nodiscard]] auto compress_archive(
         std::string const& file_path,
         std::string const& archive_directory,
+        std::optional<std::string> timestamp_key,
         bool single_file_archive,
         bool structurize_arrays,
         clp_s::FileType file_type

--- a/components/core/tests/test-clp_s-delta-encode-log-order.cpp
+++ b/components/core/tests/test-clp_s-delta-encode-log-order.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -68,6 +69,7 @@ TEST_CASE("clp-s-delta-encode-log-order", "[clp-s][delta-encode-log-order]") {
     REQUIRE_NOTHROW(compress_archive(
             get_test_input_local_path(),
             std::string{cTestDeltaEncodeOrderArchiveDirectory},
+            std::nullopt,
             true,
             false,
             clp_s::FileType::Json

--- a/components/core/tests/test-clp_s-end_to_end.cpp
+++ b/components/core/tests/test-clp_s-end_to_end.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -108,6 +109,7 @@ TEST_CASE("clp-s-compress-extract-no-floats", "[clp-s][end-to-end]") {
             std::ignore = compress_archive(
                     get_test_input_local_path(),
                     std::string{cTestEndToEndArchiveDirectory},
+                    std::nullopt,
                     single_file_archive,
                     structurize_arrays,
                     clp_s::FileType::Json

--- a/components/core/tests/test-clp_s-range_index.cpp
+++ b/components/core/tests/test-clp_s-range_index.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -224,6 +225,7 @@ TEST_CASE("clp-s-range-index", "[clp-s][range-index]") {
             archive_stats = compress_archive(
                     input_file,
                     std::string{cTestRangeIndexArchiveDirectory},
+                    std::nullopt,
                     single_file_archive,
                     false,
                     input_file_type

--- a/components/core/tests/test-clp_s-search.cpp
+++ b/components/core/tests/test-clp_s-search.cpp
@@ -225,7 +225,7 @@ TEST_CASE("clp-s-search", "[clp-s][search]") {
              {1}},
             {R"aa(ambiguous_varstring: "a*e")aa", {10, 11, 12}},
             {R"aa(ambiguous_varstring: "a\*e")aa", {12}},
-            {R"aa(idx: * AND NOT idx: null and idx: 0)aa", {0}}
+            {R"aa(idx: * AND NOT idx: null AND idx: 0)aa", {0}}
     };
     auto structurize_arrays = GENERATE(true, false);
     auto single_file_archive = GENERATE(true, false);
@@ -236,7 +236,7 @@ TEST_CASE("clp-s-search", "[clp-s][search]") {
             std::ignore = compress_archive(
                     get_test_input_local_path(),
                     std::string{cTestSearchArchiveDirectory},
-                    "idx",
+                    std::string{cTestIdxKey},
                     single_file_archive,
                     structurize_arrays,
                     clp_s::FileType::Json

--- a/components/core/tests/test-clp_s-search.cpp
+++ b/components/core/tests/test-clp_s-search.cpp
@@ -2,6 +2,7 @@
 #include <exception>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -223,7 +224,8 @@ TEST_CASE("clp-s-search", "[clp-s][search]") {
              R"aa(idx: 0 OR idx: 1)aa",
              {1}},
             {R"aa(ambiguous_varstring: "a*e")aa", {10, 11, 12}},
-            {R"aa(ambiguous_varstring: "a\*e")aa", {12}}
+            {R"aa(ambiguous_varstring: "a\*e")aa", {12}},
+            {R"aa(idx: * AND NOT idx: null and idx: 0)aa", {0}}
     };
     auto structurize_arrays = GENERATE(true, false);
     auto single_file_archive = GENERATE(true, false);
@@ -234,6 +236,7 @@ TEST_CASE("clp-s-search", "[clp-s][search]") {
             std::ignore = compress_archive(
                     get_test_input_local_path(),
                     std::string{cTestSearchArchiveDirectory},
+                    "idx",
                     single_file_archive,
                     structurize_arrays,
                     clp_s::FileType::Json


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fixes several crashes in `EvaluateTimestampIndex` that were caused by the assumptions that:
1. Filters reaching the evaluation code would always have a literal
2. That literal would always be of integral type
which on the surface appear valid, because the pass is designed to run after type narrowing, meaning that the column must actually be able to match integral types.

These assumptions are untrue in the following scenarios:
1. The literal is a pure wildcard and can actually match any type (the literal is a `StringLiteral` in this case)
2. The literal is null and has been used in a clause such as `NOT ts: null`
3. The filter has no literal because it is an `EXISTS` or `NEXISTS` filter

The code has been updated to:
1. Not attempt to evaluate timestamp filters when the operation is `EXISTS`/`NEXISTS`
2. Not attempt to evaluate timestamp filters when there is no literal
3. Handle evaluation when the literal is a pure wildcard
4. Verify that the literal is actually an integral in the expected case

We also add a test case that exercises the behaviour that caused a crash prior to this PR.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Manually validated that cases from #1096 no longer crash
* Added passing test case that exercises crashing behaviour from #1096 


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved timestamp-based search evaluation with wildcard-aware matching and refined EXISTS/NEXISTS behaviour.
  - Test utilities accept an optional timestamp key (can be omitted) to customise archive compression inputs.

- **Bug Fixes**
  - Safer handling of missing/invalid filter operands; indeterminate cases now return Unknown.
  - More robust numeric evaluation and correct inversion of filter results.

- **Tests**
  - Updated tests to pass the new optional parameter and added cases for escaped/wildcard queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->