### PR TITLE
fix(webui): Defer query done status until all result data is delivered instead of relying on Presto's finished state.

### DIFF
--- a/components/webui/client/src/pages/SearchPage/SearchState/useUpdateStateWithMetadata.ts
+++ b/components/webui/client/src/pages/SearchPage/SearchState/useUpdateStateWithMetadata.ts
@@ -38,7 +38,7 @@ const useUpdateStateWithMetadata = () => {
 
         switch (resultsMetadata.lastSignal) {
             case SEARCH_SIGNAL.RESP_DONE:
-            case PRESTO_SEARCH_SIGNAL.FINISHED:
+            case PRESTO_SEARCH_SIGNAL.DONE:
                 updateSearchUiState(SEARCH_UI_STATE.DONE);
                 break;
             case PRESTO_SEARCH_SIGNAL.FAILED:

--- a/components/webui/common/index.ts
+++ b/components/webui/common/index.ts
@@ -103,6 +103,9 @@ enum PRESTO_SEARCH_SIGNAL {
     FINISHED = "FINISHED",
     CANCELED = "CANCELED",
     FAILED = "FAILED",
+    // Used internally by the UI to mark when all data has been received, since Presto may report
+    // `FINISHED` before the result stream is fully delivered. `DONE` state is never set by Presto.
+    DONE = "DONE"
 }
 
 /**

--- a/components/webui/server/src/routes/api/presto-search/index.ts
+++ b/components/webui/server/src/routes/api/presto-search/index.ts
@@ -182,6 +182,20 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
                         },
                         success: () => {
                             request.log.info("Presto search succeeded");
+                            if (false === isResolved) {
+                                request.log.error(
+                                    "Presto query finished received before searchJobId was resolved; "
+                                );
+                                return;
+                            } else {
+                                searchResultsMetadataCollection.updateOne(
+                                    {_id: searchJobId},
+                                    {$set: {lastSignal: PRESTO_SEARCH_SIGNAL.DONE}}
+                                ).catch((err: unknown) => {
+                                    request.log.error(err, "Failed to update Presto metadata");
+                                });
+                            }
+
                         },
                         timeout: null,
                     });


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

I noticed that sometimes the state is updated to `FINISHED`, and the results are shown in green (DONE state), but some more results can still stream in. Not sure if always happens or just due to slow/overloaded machine i'm using. Nonetheless, effectively it appears the issue is that Presto completes the query and updates the state, but the UI has yet to dump all the results in Mongo. 

This PR fixes the issue by setting the done state only after all the data is recieved. 



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
