### PR TITLE
feat(kv-ir): Add support for getting the number of log events read from the deserializer.

### DIFF
--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -158,6 +158,13 @@ public:
      */
     [[nodiscard]] auto get_metadata() const -> nlohmann::json const& { return m_metadata; }
 
+    /**
+     * @return The number of deserialized log events so far.
+     */
+    [[nodiscard]] auto get_num_log_events_deserialized() const -> size_t {
+        return m_next_log_event_idx;
+    }
+
 private:
     // Factory function
     /**

--- a/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
+++ b/components/core/src/clp/ffi/ir_stream/Deserializer.hpp
@@ -159,7 +159,8 @@ public:
     [[nodiscard]] auto get_metadata() const -> nlohmann::json const& { return m_metadata; }
 
     /**
-     * @return The number of deserialized log events so far.
+     * @return The number of log events (log event IR units) that have been deserialized from the
+     * current stream.
      */
     [[nodiscard]] auto get_num_log_events_deserialized() const -> size_t {
         return m_next_log_event_idx;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR added a getter for `Deserializer` to get the number of deserialized log events so far. This will be used by Velox CLP-connector to get the scanned log events for batch control (which is consistent to reading archives, which can get the total number of log events in an archive).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a public API to retrieve the current count of deserialized log events at runtime.
  * Exposes this metric via the public interface for easier access by clients and integrations.
  * Improves observability for tooling and dashboards to display deserialization progress and status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->