### PR TITLE
feat(clp-package): Warn the user if they do not use the `--timestamp-key` flag when compressing with the `clp-s` storage engine

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -205,7 +205,8 @@ def main(argv):
 
         if parsed_args.timestamp_key is None:
             logger.warning(
-                "If your logs have a timestamp field, you should use the --timestamp-key flag."
+                "`--timestamp-key` not specified. Events will not have assigned timestamps and can "
+                "only be searched from the command line without a timestamp filter."
             )
     elif dataset is not None:
         logger.error(f"Dataset selection is not supported for storage engine: {storage_engine}.")


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

When using the `clp-s` storage engine, users are currently not warned if they do not use the `--timestamp-key` flag in the compression command. This PR introduces a warning that notifies the user if they do not specify the `--timestamp-key` flag. This will create a better experience for users whose logs have a timestamp key and who have forgotten to specify it. The warning is phrased in such a way that users whose logs do _not_ have a timestamp key (or users who have otherwise _intentionally_ omitted the `--timestamp-key`) will not be deterred from using the `clp-s` storage engine to compress their logs.

The warning reads as follows:

```text
`--timestamp-key` not specified. Events will not have assigned timestamps and can only be searched from the command line without a timestamp filter.
```

The behaviour of compression scripts is otherwise unchanged, i.e., compression jobs will still proceed regardless of whether the user uses the `--timestamp-key` flag.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Compressed without using the `--timestamp-key` flag; received the warning correctly.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Displays a runtime warning during compression after dataset validation when no timestamp key is provided, advising use of the --timestamp-key flag.
  - No change to behaviour or outputs; the timestamp flag is included in the compression command only when explicitly supplied by the user.
  - Does not alter public interfaces or return values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->