### PR TITLE
Improve schema-based search accuracy using `log_surgeon::Query`.

### DIFF
--- a/components/core/src/clp/GrepCore.cpp
+++ b/components/core/src/clp/GrepCore.cpp
@@ -146,7 +146,7 @@ bool GrepCore::get_bounds_of_next_potential_var(
 }
 
 auto GrepCore::get_wildcard_encodable_positions(QueryInterpretation const& interpretation)
--> vector<size_t> {
+        -> vector<size_t> {
     vector<size_t> wildcard_encodable_positions;
     for (size_t i{0}; i < interpretation.get_logtype().size(); ++i) {
         auto const& token{interpretation.get_logtype()[i]};

--- a/components/core/src/clp/GrepCore.cpp
+++ b/components/core/src/clp/GrepCore.cpp
@@ -1,35 +1,30 @@
 #include "GrepCore.hpp"
 
 #include <cstddef>
-#include <set>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <vector>
 
 #include <log_surgeon/Constants.hpp>
 #include <string_utils/string_utils.hpp>
 
 #include "ir/parsing.hpp"
-#include "LogSurgeonReader.hpp"
-#include "QueryToken.hpp"
 #include "StringReader.hpp"
 
 using clp::ir::is_delim;
 using clp::string_utils::is_alphabet;
 using clp::string_utils::is_wildcard;
+using log_surgeon::SymbolId::TokenFloat;
+using log_surgeon::SymbolId::TokenInt;
+using log_surgeon::wildcard_query_parser::QueryInterpretation;
+using log_surgeon::wildcard_query_parser::StaticQueryToken;
+using log_surgeon::wildcard_query_parser::VariableQueryToken;
 using std::string;
+using std::unordered_map;
+using std::vector;
 
 namespace clp {
-namespace {
-/**
- * Wraps the tokens returned from the log_surgeon lexer, and stores the variable ids of the tokens
- * in a search query in a set. This allows for optimized search performance.
- */
-class SearchToken : public log_surgeon::Token {
-public:
-    std::set<int> m_type_ids_set;
-};
-}  // namespace
-
 bool GrepCore::get_bounds_of_next_potential_var(
         string const& value,
         size_t& begin_pos,
@@ -150,124 +145,90 @@ bool GrepCore::get_bounds_of_next_potential_var(
     return (value_length != begin_pos);
 }
 
-bool GrepCore::get_bounds_of_next_potential_var(
-        string const& value,
-        size_t& begin_pos,
-        size_t& end_pos,
-        bool& is_var,
-        log_surgeon::lexers::ByteLexer& lexer
-) {
-    size_t const value_length = value.length();
-    if (end_pos >= value_length) {
-        return false;
-    }
-
-    is_var = false;
-    bool contains_wildcard = false;
-    while (false == is_var && false == contains_wildcard && begin_pos < value_length) {
-        // Start search at end of last token
-        begin_pos = end_pos;
-
-        // Find variable begin or wildcard
-        bool is_escaped = false;
-        for (; begin_pos < value_length; ++begin_pos) {
-            char c = value[begin_pos];
-
-            if (is_escaped) {
-                is_escaped = false;
-
-                if (false == lexer.is_delimiter(c)) {
-                    // Found escaped non-delimiter, so reverse the index to retain the escape
-                    // character
-                    --begin_pos;
-                    break;
-                }
-            } else if ('\\' == c) {
-                // Escape character
-                is_escaped = true;
-            } else {
-                if (is_wildcard(c)) {
-                    contains_wildcard = true;
-                    break;
-                }
-                if (false == lexer.is_delimiter(c)) {
-                    break;
-                }
-            }
-        }
-
-        // Find next delimiter
-        is_escaped = false;
-        end_pos = begin_pos;
-        for (; end_pos < value_length; ++end_pos) {
-            char c = value[end_pos];
-
-            if (is_escaped) {
-                is_escaped = false;
-
-                if (lexer.is_delimiter(c)) {
-                    // Found escaped delimiter, so reverse the index to retain the escape character
-                    --end_pos;
-                    break;
-                }
-            } else if ('\\' == c) {
-                // Escape character
-                is_escaped = true;
-            } else {
-                if (is_wildcard(c)) {
-                    contains_wildcard = true;
-                } else if (lexer.is_delimiter(c)) {
-                    // Found delimiter that's not also a wildcard
-                    break;
-                }
-            }
-        }
-
-        if (end_pos > begin_pos) {
-            bool has_prefix_wildcard = ('*' == value[begin_pos]) || ('?' == value[begin_pos]);
-            bool has_suffix_wildcard = ('*' == value[end_pos - 1]) || ('?' == value[end_pos - 1]);
-            bool has_wildcard_in_middle = false;
-            for (size_t i = begin_pos + 1; i < end_pos - 1; ++i) {
-                if (('*' == value[i] || '?' == value[i]) && value[i - 1] != '\\') {
-                    has_wildcard_in_middle = true;
-                    break;
-                }
-            }
-            SearchToken search_token;
-            if (has_wildcard_in_middle || has_prefix_wildcard) {
-                // DO NOTHING
-            } else {
-                StringReader string_reader;
-                LogSurgeonReader reader_wrapper(string_reader);
-                log_surgeon::ParserInputBuffer parser_input_buffer;
-                if (has_suffix_wildcard) {  // text*
-                    // TODO: creating a string reader, setting it equal to a string, to read it into
-                    // the ParserInputBuffer, seems like a convoluted way to set a string equal to a
-                    // string, should be improved when adding a SearchParser to log_surgeon
-                    string_reader.open(value.substr(begin_pos, end_pos - begin_pos - 1));
-                    parser_input_buffer.read_if_safe(reader_wrapper);
-                    lexer.reset();
-                    lexer.scan_with_wildcard(parser_input_buffer, value[end_pos - 1], search_token);
-                } else {  // no wildcards
-                    string_reader.open(value.substr(begin_pos, end_pos - begin_pos));
-                    parser_input_buffer.read_if_safe(reader_wrapper);
-                    lexer.reset();
-                    auto [err, token] = lexer.scan(parser_input_buffer);
-                    if (log_surgeon::ErrorCode::Success != err) {
-                        return false;
-                    }
-                    search_token = SearchToken{token.value()};
-                    search_token.m_type_ids_set.insert(search_token.m_type_ids_ptr->at(0));
-                }
-                auto const& type = search_token.m_type_ids_ptr->at(0);
-                if (type != static_cast<int>(log_surgeon::SymbolId::TokenUncaughtString)
-                    && type != static_cast<int>(log_surgeon::SymbolId::TokenEnd))
-                {
-                    is_var = true;
-                }
+auto GrepCore::get_wildcard_encodable_positions(QueryInterpretation const& interpretation)
+-> vector<size_t> {
+    vector<size_t> wildcard_encodable_positions;
+    for (size_t i{0}; i < interpretation.get_logtype().size(); ++i) {
+        auto const& token{interpretation.get_logtype()[i]};
+        if (std::holds_alternative<VariableQueryToken>(token)) {
+            auto const& variable_token{std::get<VariableQueryToken>(token)};
+            auto const var_type{variable_token.get_variable_type()};
+            bool const is_int{static_cast<uint32_t>(TokenInt) == var_type};
+            bool const is_float{static_cast<uint32_t>(TokenFloat) == var_type};
+            if (variable_token.get_contains_wildcard() && (is_int || is_float)) {
+                wildcard_encodable_positions.push_back(i);
             }
         }
     }
-    return (value_length != begin_pos);
+    return wildcard_encodable_positions;
+}
+
+auto GrepCore::generate_logtype_string(
+        QueryInterpretation const& interpretation,
+        unordered_map<size_t, bool> const& wildcard_mask_map
+) -> std::string {
+    std::string logtype_string;
+
+    // Reserve size for `logtype_string`.
+    size_t logtype_string_size{0};
+    for (auto const& token : interpretation.get_logtype()) {
+        if (std::holds_alternative<StaticQueryToken>(token)) {
+            auto const& static_token{std::get<StaticQueryToken>(token)};
+            logtype_string_size += static_token.get_query_substring().size();
+        } else {
+            logtype_string_size++;
+        }
+    }
+    logtype_string.reserve(logtype_string_size);
+
+    // Generete `logtype_string`.
+    for (size_t i{0}; i < interpretation.get_logtype().size(); ++i) {
+        auto const& token{interpretation.get_logtype()[i]};
+        if (std::holds_alternative<StaticQueryToken>(token)) {
+            logtype_string += std::get<StaticQueryToken>(token).get_query_substring();
+            continue;
+        }
+
+        auto const& var_token{std::get<VariableQueryToken>(token)};
+        auto const& raw_string{var_token.get_query_substring()};
+        auto const var_type{var_token.get_variable_type()};
+
+        bool const is_int{static_cast<uint32_t>(TokenInt) == var_type};
+        bool const is_float{static_cast<uint32_t>(TokenFloat) == var_type};
+
+        if (wildcard_mask_map.contains(i)) {
+            bool const use_encoded{wildcard_mask_map.at(i)};
+            if (use_encoded) {
+                if (is_int) {
+                    EncodedVariableInterpreter::add_int_var(logtype_string);
+                } else {
+                    EncodedVariableInterpreter::add_float_var(logtype_string);
+                }
+            } else {
+                EncodedVariableInterpreter::add_dict_var(logtype_string);
+            }
+            continue;
+        }
+
+        encoded_variable_t encoded_var{0};
+        if (is_int
+            && EncodedVariableInterpreter::convert_string_to_representable_integer_var(
+                    raw_string,
+                    encoded_var
+            ))
+        {
+            EncodedVariableInterpreter::add_int_var(logtype_string);
+        } else if (is_float
+                   && EncodedVariableInterpreter::convert_string_to_representable_float_var(
+                           raw_string,
+                           encoded_var
+                   ))
+        {
+            EncodedVariableInterpreter::add_float_var(logtype_string);
+        } else {
+            EncodedVariableInterpreter::add_dict_var(logtype_string);
+        }
+    }
+    return logtype_string;
 }
 }  // namespace clp

--- a/components/core/src/clp/GrepCore.hpp
+++ b/components/core/src/clp/GrepCore.hpp
@@ -136,8 +136,8 @@ private:
      *    - 0: treat as a dictionary variable (\d)
      *    - 1: treat as an encoded variable (\i for integers, \f for floats)
      *
-     *    If there are k encodable wildcard variables, then 2^k logtype strings are possible. Each bit
-     *    in the mask corresponds to one variable.
+     *    If there are k encodable wildcard variables, then 2^k logtype strings are possible. Each
+     *    bit in the mask corresponds to one variable.
      *
      *    Example:
      *      Search query: "a *1 *2 b",
@@ -564,7 +564,8 @@ void GrepCore::generate_schema_sub_queries(
             for (size_t i{0}; i < interpretation.get_logtype().size(); ++i) {
                 auto const& token{interpretation.get_logtype()[i]};
                 if (std::holds_alternative<log_surgeon::wildcard_query_parser::VariableQueryToken>(
-                        token))
+                            token
+                    ))
                 {
                     bool is_wildcard_mask_encoded{false};
                     if (wildcard_mask_map.contains(i)) {
@@ -654,7 +655,7 @@ auto GrepCore::process_schema_var_token(
     std::unordered_set<encoded_variable_t> encoded_vars;
     std::unordered_set<variable_dictionary_id_t> var_dict_ids;
     encoded_vars.reserve(entries.size());
-    for (auto const* entry: entries) {
+    for (auto const* entry : entries) {
         encoded_vars.emplace(EncodedVariableInterpreter::encode_var_dict_id(entry->get_id()));
         var_dict_ids.emplace(entry->get_id());
     }

--- a/components/core/src/clp/ffi/ir_stream/search/test/test_QueryHandlerImpl.cpp
+++ b/components/core/src/clp/ffi/ir_stream/search/test/test_QueryHandlerImpl.cpp
@@ -12,6 +12,7 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <ystdlib/error_handling/Result.hpp>
 
 #include "../../../../../clp_s/archive_constants.hpp"

--- a/components/core/src/clp/ffi/ir_stream/search/test/utils.cpp
+++ b/components/core/src/clp/ffi/ir_stream/search/test/utils.cpp
@@ -12,6 +12,7 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <ystdlib/error_handling/Result.hpp>
 
 #include "../../../../../clp_s/search/ast/Literal.hpp"

--- a/components/core/tests/test-GrepCore.cpp
+++ b/components/core/tests/test-GrepCore.cpp
@@ -1,89 +1,66 @@
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
-#include <log_surgeon/Lexer.hpp>
-#include <log_surgeon/SchemaParser.hpp>
 
 #include "../src/clp/GrepCore.hpp"
-#include "../src/clp/Utils.hpp"
 
 using clp::GrepCore;
-using clp::load_lexer_from_file;
-using log_surgeon::DelimiterStringAST;
-using log_surgeon::lexers::ByteLexer;
-using log_surgeon::ParserAST;
-using log_surgeon::SchemaAST;
-using log_surgeon::SchemaParser;
-using log_surgeon::SchemaVarAST;
 using std::string;
 
 TEST_CASE("get_bounds_of_next_potential_var", "[get_bounds_of_next_potential_var]") {
-    ByteLexer lexer;
-    load_lexer_from_file("../tests/test_schema_files/search_schema.txt", lexer);
-
     string str;
-    size_t begin_pos;
-    size_t end_pos;
-    bool is_var;
+    size_t begin_pos{};
+    size_t end_pos{};
+    bool is_var{};
 
     // m_end_pos past the end of the string
     str = "";
     begin_pos = string::npos;
     end_pos = string::npos;
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == false);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == false);
 
     // Empty string
     str = "";
     begin_pos = 0;
     end_pos = 0;
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == false);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == false);
 
     // No tokens
     str = "=";
     begin_pos = 0;
     end_pos = 0;
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == false);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == false);
 
     // No wildcards
     str = " MAC address 95: ad ff 95 24 0d ff =-abc- ";
     begin_pos = 0;
     end_pos = 0;
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE("95" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE("ad" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE("ff" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE("95" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE("24" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE("0d" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE("ff" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
@@ -91,8 +68,7 @@ TEST_CASE("get_bounds_of_next_potential_var", "[get_bounds_of_next_potential_var
     REQUIRE("-abc-" == str.substr(begin_pos, end_pos - begin_pos));
     REQUIRE(true == is_var);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == false);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == false);
     REQUIRE(str.length() == begin_pos);
 
     // With wildcards
@@ -100,33 +76,25 @@ TEST_CASE("get_bounds_of_next_potential_var", "[get_bounds_of_next_potential_var
     begin_pos = 0;
     end_pos = 0;
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
-    REQUIRE(str.substr(begin_pos, end_pos - begin_pos) == "1\\*x");
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
+    REQUIRE(str.substr(begin_pos, end_pos - begin_pos) == "1");
     REQUIRE(is_var == true);
-    // REQUIRE(is_var == true);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE(str.substr(begin_pos, end_pos - begin_pos) == "abc*123");
-    REQUIRE(is_var == false);
-    // REQUIRE(is_var == true);
+    REQUIRE(is_var == true);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE(str.substr(begin_pos, end_pos - begin_pos) == "1.2");
     REQUIRE(is_var == true);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
-    REQUIRE(str.substr(begin_pos, end_pos - begin_pos) == "+394/-");
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
+    REQUIRE(str.substr(begin_pos, end_pos - begin_pos) == "+394");
     REQUIRE(is_var == true);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == true);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == true);
     REQUIRE(str.substr(begin_pos, end_pos - begin_pos) == "-*abc-");
     REQUIRE(is_var == false);
 
-    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var, lexer)
-            == false);
+    REQUIRE(GrepCore::get_bounds_of_next_potential_var(str, begin_pos, end_pos, is_var) == false);
 }

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -250,8 +250,8 @@ tasks:
             - "-DFMT_DOC=OFF"
             - "-DFMT_TEST=OFF"
           LIB_NAME: "{{.G_FMT_LIB_NAME}}"
-          TARBALL_SHA256: "1250e4cc58bf06ee631567523f48848dc4596133e163f02615c97f78bab6c811"
-          TARBALL_URL: "https://github.com/fmtlib/fmt/archive/refs/tags/10.2.1.tar.gz"
+          TARBALL_SHA256: "bc23066d87ab3168f27cef3e97d545fa63314f5c79df5ea444d41d56f962c6af"
+          TARBALL_URL: "https://github.com/fmtlib/fmt/archive/refs/tags/11.2.0.tar.gz"
 
   liblzma:
     internal: true
@@ -317,8 +317,8 @@ tasks:
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
             - "-Dlog_surgeon_BUILD_TESTING=OFF"
           LIB_NAME: "log_surgeon"
-          TARBALL_SHA256: "6053f7e26ff21aef0c4cf409502d3abb0cfcf76d8f76786c3bb1bcc03e8f5df2"
-          TARBALL_URL: "https://github.com/y-scope/log-surgeon/archive/a82ad13.tar.gz"
+          TARBALL_SHA256: "69a99e0804a52c6b6397c5e7eabecc9bb4915d0145632c66fc63ad13678ff56a"
+          TARBALL_URL: "https://github.com/y-scope/log-surgeon/archive/a722d07.tar.gz"
 
   lz4:
     internal: true
@@ -440,11 +440,11 @@ tasks:
             - "-DSPDLOG_BUILD_EXAMPLE_HO=OFF"
             - "-DSPDLOG_FMT_EXTERNAL=ON"
           LIB_NAME: "spdlog"
-          TARBALL_SHA256: "1586508029a7d0670dfcb2d97575dcdc242d3868a259742b69f100801ab4e16b"
+          TARBALL_SHA256: "15a04e69c222eb6c01094b5c7ff8a249b36bb22788d72519646fb85feb267e67"
 
           # NOTE: Since spdlog depends on fmt, we need to choose a version of spdlog that's
           # compatible with the version of fmt we use.
-          TARBALL_URL: "https://github.com/gabime/spdlog/archive/refs/tags/v1.14.1.tar.gz"
+          TARBALL_URL: "https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.tar.gz"
 
   sqlite3:
     internal: true


### PR DESCRIPTION
# Description
This PR updates schema-based search in CLP to leverage the new `log_surgeon::Query` class to improve accuracy on schema compressed archives. This class improves accuracy by performing DFA intersections between a user's query and the variables in the schema. When generating subqueries using this class the following must be done:
- Check if each `QueryInterpretation`  matches the logtype and variable dictionaries.
- Transform the `QueryInterpretation` into a set of `SubQuery`s if  it matches the dictionaries.

To compare against the dictionaries, CLP must consider the various combinations of encodable variable types a single QueryInterpretation can have. For example:
  - Search query: "a *1 *2 b",
  - QueryInterpretation (one of many): "a <int>(*1) <float>(*2) b"
  - Possible logtypes (for the above interpretation):
    - mask 00 -> "a \d \d b"
    - mask 01 ->"a \d \f b"
    - mask 10 ->"a \i \d b"
    - mask 11 ->"a \i \f b"

Key changes:
- `process_raw_query`:  updated to use the `log_surgeon::Query` class for DFA-based matching.
- Added methods to support sub query generation:
  - `generate_schema_sub_queries`: iterate over all encodable combinations of interpretations and add a sub query if it matches the dictionaries.
  - `generate_logtype_string`: generates a logtype string for a given interpretation and encodable variable mask
  - `get_wildcard_encodable_positions`: converts mask for encodable variables to array positions.
  - `process_schema_var_token`: adds variable to the sub query.
- Removes unused code: `get_bounds_of_next_potential_var` overload (schema case) and `SearchToken`.

# Validation performed
- Adding unit-tests