### PR TITLE
fix(docs): Remove outdated note that queries containing values with spaces are treated as substring searches.

### DIFF
--- a/docs/src/user-docs/reference-json-search-syntax.md
+++ b/docs/src/user-docs/reference-json-search-syntax.md
@@ -34,7 +34,8 @@ To search for a key or value with multiple words, you must quote the key/value w
 ```
 
 :::{note}
-Queries will be interpreted as _exact_ searches unless they include
+Keys and values in queries will be interpreted as searches for _exact_ matches unless they include
+[wildcards](#wildcards-in-values).
 [wildcards](#wildcards-in-values).
 :::
 

--- a/docs/src/user-docs/reference-json-search-syntax.md
+++ b/docs/src/user-docs/reference-json-search-syntax.md
@@ -36,7 +36,6 @@ To search for a key or value with multiple words, you must quote the key/value w
 :::{note}
 Keys and values in queries will be interpreted as searches for _exact_ matches unless they include
 [wildcards](#wildcards-in-values).
-[wildcards](#wildcards-in-values).
 :::
 
 :::{note}

--- a/docs/src/user-docs/reference-json-search-syntax.md
+++ b/docs/src/user-docs/reference-json-search-syntax.md
@@ -33,10 +33,9 @@ To search for a key or value with multiple words, you must quote the key/value w
 "multi-word key": "multi-word value"
 ```
 
-:::{caution}
-Currently, a query that contains spaces is interpreted as a substring search, i.e., it will match
-log events that contain the value as a *substring*. In a future version of CLP, these queries will
-be interpreted as _exact_ searches unless they include [wildcards](#wildcards-in-values).
+:::{note}
+Queries will be interpreted as _exact_ searches unless they include
+[wildcards](#wildcards-in-values).
 :::
 
 :::{note}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fixes an outdated note in the `clp-json` search syntax reference which claimed that query predicates with spaces are treated as substring searches. This hasn't been true for a long time and the current behaviour is that users need to explicitly specify all wildcards. The `::caution` block has been replaced by a `::note` which correctly describes the current behaviour.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that updated section of docs renders correctly


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Clarified JSON search syntax: queries are now explicitly documented as exact matches unless wildcards are used.
  - Replaced a caution with a clearer note, removing references to future behaviour and focusing on current rules.
  - Improved guidance on how spaces and wildcards affect searches, reducing ambiguity when crafting queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->