### PR TITLE
fix(clp-package): Use short-form `docker stop` timeout option to support older Docker versions (fixes #1322).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -39,7 +39,7 @@ def stop_running_container(
 ):
     if is_container_running(container_name):
         logger.info(f"Stopping {container_name}...")
-        cmd = ["docker", "stop", "--timeout", str(timeout), container_name]
+        cmd = ["docker", "stop", "-t", str(timeout), container_name]
         subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
 
         logger.info(f"Removing {container_name}...")


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says.

Docker renamed the `--time` option to `--timeout` in [v28](https://docs.docker.com/engine/release-notes/28/#removed) which was only released in February. It seems unrealistic that most of our users would've upgraded to v28, so switching to the shortform option `-t` will allow greater compatibility.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
sbin/start-clp.sh
sbin/stop-clp.sh
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated container stop behaviour to use the short-form timeout flag for improved compatibility across environments. The configured timeout value and overall behaviour remain unchanged.
  - No changes to user-facing commands or interfaces.  
  - Improves consistency without affecting existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->