### PR TITLE
fix(taskfile): Make `deps:core` and `deps:spider-dep` write into different top-level CMake configuration files (fixes #1330).

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -123,7 +123,7 @@ if(PROJECT_IS_TOP_LEVEL)
     # NOTE: We mark the file optional since it's not required if the user happens to have the
     # dependencies installed already.
     set(CLP_CORE_DEPS_DIR "${CMAKE_SOURCE_DIR}/../../build/deps/cpp")
-    include("${CLP_CORE_DEPS_DIR}/cmake-settings/all.cmake"
+    include("${CLP_CORE_DEPS_DIR}/cmake-settings/core-all.cmake"
             OPTIONAL
             RESULT_VARIABLE CLP_DEPS_SETTINGS_FILE_PATH
     )

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -123,7 +123,7 @@ if(PROJECT_IS_TOP_LEVEL)
     # NOTE: We mark the file optional since it's not required if the user happens to have the
     # dependencies installed already.
     set(CLP_CORE_DEPS_DIR "${CMAKE_SOURCE_DIR}/../../build/deps/cpp")
-    include("${CLP_CORE_DEPS_DIR}/cmake-settings/core-all.cmake"
+    include("${CLP_CORE_DEPS_DIR}/cmake-settings/all-core.cmake"
             OPTIONAL
             RESULT_VARIABLE CLP_DEPS_SETTINGS_FILE_PATH
     )

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -46,7 +46,7 @@ tasks:
       - task: "yscope-dev-utils:cmake:install-deps-and-generate-settings"
         vars:
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}"
-          CMAKE_SETTINGS_FILE: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/core-all.cmake"
+          CMAKE_SETTINGS_FILE: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/all-core.cmake"
           DEP_TASK: "core-all-parallel"
       - task: "utils:combine-cpp-checksum-files"
 
@@ -106,7 +106,7 @@ tasks:
           WORK_DIR: "{{.G_SPIDER_BUILD_DIR}}"
           CMAKE_JOBS: "{{.G_CPP_MAX_PARALLELISM_PER_BUILD_TASK}}"
           CMAKE_GEN_ARGS:
-            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/spider-all.cmake"
+            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/all-spider.cmake"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
             - "-DSPIDER_BUILD_TESTING=OFF"
@@ -122,7 +122,7 @@ tasks:
       - task: "yscope-dev-utils:cmake:install-deps-and-generate-settings"
         vars:
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}"
-          CMAKE_SETTINGS_FILE: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/spider-all.cmake"
+          CMAKE_SETTINGS_FILE: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/all-spider.cmake"
           DEP_TASK: "spider-all-parallel"
       - task: "utils:combine-cpp-checksum-files"
 

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -46,6 +46,7 @@ tasks:
       - task: "yscope-dev-utils:cmake:install-deps-and-generate-settings"
         vars:
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}"
+          CMAKE_SETTINGS_FILE: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/core-all.cmake"
           DEP_TASK: "core-all-parallel"
       - task: "utils:combine-cpp-checksum-files"
 
@@ -105,7 +106,7 @@ tasks:
           WORK_DIR: "{{.G_SPIDER_BUILD_DIR}}"
           CMAKE_JOBS: "{{.G_CPP_MAX_PARALLELISM_PER_BUILD_TASK}}"
           CMAKE_GEN_ARGS:
-            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/all.cmake"
+            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/spider-all.cmake"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
             - "-DSPIDER_BUILD_TESTING=OFF"
@@ -121,6 +122,7 @@ tasks:
       - task: "yscope-dev-utils:cmake:install-deps-and-generate-settings"
         vars:
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}"
+          CMAKE_SETTINGS_FILE: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/spider-all.cmake"
           DEP_TASK: "spider-all-parallel"
       - task: "utils:combine-cpp-checksum-files"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
## Problem
Both `deps:core` and `deps:spider-dep` write to `build/deps/cpp/cmake-setting/all.cmake`. When running in parallel, the content of `all.cmake` is corrupted, and both `core` and `deps:spider` fail to load the corrupted cmake file.

## Solution
This PR solves the problem by splitting the cmake setting file into two. `deps:core` writes to `core-all.cmake` and `deps:spider-dep` writes to `spider-all.cmake`, avoiding concurrent writes to same file. `core` and `deps:spider` now consume different cmake setting files.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Running `task` no longer triggers errors.
* [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized build configuration by switching to component-specific CMake settings for core and Spider.
  - Ensured the chosen settings file is propagated through dependency generation and installation steps to improve reproducibility.
  - Aligned dependency installation and task execution to use consistent presets, reducing configuration drift across environments.
  - No user-facing functionality changes; improves reliability and predictability of builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->