### PR TITLE
fix(integration-tests): Refactor `integration_test_config` so that CLP core binaries test does not depend on a complete package (fixes #1281).

### DIFF
--- a/integration-tests/tests/fixtures/integration_test_config.py
+++ b/integration-tests/tests/fixtures/integration_test_config.py
@@ -13,17 +13,25 @@ from tests.utils.utils import get_env_var
 
 
 @pytest.fixture(scope="session")
-def integration_test_config() -> IntegrationTestConfig:
-    """Fixture that provides an IntegrationTestConfig shared across tests."""
-    core_config = CoreConfig(
+def core_config() -> CoreConfig:
+    """Fixture that provides a CoreConfig shared across tests."""
+    return CoreConfig(
         clp_core_bins_dir=Path(get_env_var("CLP_CORE_BINS_DIR")).expanduser().resolve()
     )
-    package_config = PackageConfig(
+
+
+@pytest.fixture(scope="session")
+def package_config() -> PackageConfig:
+    """Fixture that provides a PackageConfig shared across tests."""
+    return PackageConfig(
         clp_package_dir=Path(get_env_var("CLP_PACKAGE_DIR")).expanduser().resolve()
     )
-    test_root_dir = Path(get_env_var("CLP_BUILD_DIR")).expanduser().resolve() / "integration-tests"
+
+
+@pytest.fixture(scope="session")
+def integration_test_config() -> IntegrationTestConfig:
+    """Fixture that provides an IntegrationTestConfig shared across tests."""
     return IntegrationTestConfig(
-        core_config=core_config,
-        package_config=package_config,
-        test_root_dir=test_root_dir,
+        test_root_dir=Path(get_env_var("CLP_BUILD_DIR")).expanduser().resolve()
+        / "integration-tests",
     )

--- a/integration-tests/tests/test_identity_transformation.py
+++ b/integration-tests/tests/test_identity_transformation.py
@@ -8,6 +8,7 @@ import pytest
 from tests.utils.asserting_utils import run_and_assert
 from tests.utils.config import (
     CompressionTestConfig,
+    CoreConfig,
     IntegrationTestConfig,
     IntegrationTestLogs,
 )
@@ -37,6 +38,7 @@ json_datasets = pytest.mark.parametrize(
 @text_datasets
 def test_clp_identity_transform(
     request: pytest.FixtureRequest,
+    core_config: CoreConfig,
     integration_test_config: IntegrationTestConfig,
     test_logs_fixture: str,
 ) -> None:
@@ -45,6 +47,7 @@ def test_clp_identity_transform(
     lossless.
 
     :param request:
+    :param core_config:
     :param integration_test_config:
     :param test_logs_fixture:
     """
@@ -56,7 +59,7 @@ def test_clp_identity_transform(
     )
     test_paths.clear_test_outputs()
 
-    bin_path = str(integration_test_config.core_config.clp_binary_path)
+    bin_path = str(core_config.clp_binary_path)
     src_path = str(test_paths.logs_source_dir)
     compression_path = str(test_paths.compression_dir)
     decompression_path = str(test_paths.decompression_dir)
@@ -89,6 +92,7 @@ def test_clp_identity_transform(
 @json_datasets
 def test_clp_s_identity_transform(
     request: pytest.FixtureRequest,
+    core_config: CoreConfig,
     integration_test_config: IntegrationTestConfig,
     test_logs_fixture: str,
 ) -> None:
@@ -97,6 +101,7 @@ def test_clp_s_identity_transform(
     lossless.
 
     :param request:
+    :param core_config:
     :param integration_test_config:
     :param test_logs_fixture:
     """
@@ -108,7 +113,7 @@ def test_clp_s_identity_transform(
         logs_source_dir=integration_test_logs.extraction_dir,
         integration_test_config=integration_test_config,
     )
-    _clp_s_compress_and_decompress(integration_test_config, test_paths)
+    _clp_s_compress_and_decompress(core_config, test_paths)
 
     # Recompress the decompressed output that's consolidated into a single json file, and decompress
     # it again to verify consistency. The compression input of the second iteration points to the
@@ -121,7 +126,7 @@ def test_clp_s_identity_transform(
         logs_source_dir=test_paths.decompression_dir,
         integration_test_config=integration_test_config,
     )
-    _clp_s_compress_and_decompress(integration_test_config, consolidated_json_test_paths)
+    _clp_s_compress_and_decompress(core_config, consolidated_json_test_paths)
 
     _consolidated_json_file_name = "original"
     input_path = consolidated_json_test_paths.logs_source_dir / _consolidated_json_file_name
@@ -135,10 +140,11 @@ def test_clp_s_identity_transform(
 
 
 def _clp_s_compress_and_decompress(
-    integration_test_config: IntegrationTestConfig, test_paths: CompressionTestConfig
+    core_config: CoreConfig,
+    test_paths: CompressionTestConfig,
 ) -> None:
     test_paths.clear_test_outputs()
-    bin_path = str(integration_test_config.core_config.clp_s_binary_path)
+    bin_path = str(core_config.clp_s_binary_path)
     src_path = str(test_paths.logs_source_dir)
     compression_path = str(test_paths.compression_dir)
     decompression_path = str(test_paths.decompression_dir)

--- a/integration-tests/tests/utils/config.py
+++ b/integration-tests/tests/utils/config.py
@@ -74,10 +74,6 @@ class PackageConfig:
 class IntegrationTestConfig:
     """The general configuration for integration tests."""
 
-    #:
-    core_config: CoreConfig
-    #:
-    package_config: PackageConfig
     #: Root directory for integration tests output.
     test_root_dir: Path
     logs_download_dir_init: InitVar[Path | None] = None

--- a/taskfiles/tests/integration.yaml
+++ b/taskfiles/tests/integration.yaml
@@ -17,8 +17,7 @@ tasks:
 
   core:
     deps:
-      # TODO: https://github.com/y-scope/clp/issues/1281
-      - task: "::package"
+      - task: "::core"
     dir: "{{.G_INTEGRATION_TESTS_DIR}}"
     env:
       CLP_BUILD_DIR: "{{.G_BUILD_DIR}}"


### PR DESCRIPTION
…independent from each other

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
