### PR TITLE
feat(clp-package): Write version string to `VERSION` in the package.

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -167,6 +167,7 @@ tasks:
       - |-
         cd "{{.OUTPUT_DIR}}/var/www/webui"
         PATH="{{.G_NODEJS_22_BIN_DIR}}":$PATH npm ci --omit=dev
+      - "echo '{{.G_PACKAGE_VERSION}}' > '{{.OUTPUT_DIR}}/VERSION'"
       # This command must be last
       - task: "utils:checksum:compute"
         vars:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR writes the version string to `build/clp-package/VERSION`, which can be useful in future incident investigations.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Ran `task` and verified the version string specified at https://github.com/y-scope/clp/blob/761ec124dbf94a99b39a570c364329e89b1b854b/taskfile.yaml#L36
   was correctly written to `build/clp-package/VERSION`.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Build artifacts now include a VERSION file that clearly records the package version, improving traceability and verification for downloads.
- Chores
  - Packaging process updated to write the version into the output before checksums are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->