### PR TITLE
chore: Add support for installing the Rust toolchains in all development environments.

### DIFF
--- a/components/core/tools/scripts/lib_install/centos-stream-9/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/centos-stream-9/install-prebuilt-packages.sh
@@ -24,6 +24,10 @@ if ! command -v pipx >/dev/null 2>&1; then
     python3 -m pip install pipx
 fi
 
-# Install remaining packages through pipx
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# Install Rust toolchain
+"${script_dir}/../rust-toolchain/setup.sh"
+
+# Install remaining packages through pipx
 "${script_dir}/../pipx-packages/install-all.sh"

--- a/components/core/tools/scripts/lib_install/macos/install-all.sh
+++ b/components/core/tools/scripts/lib_install/macos/install-all.sh
@@ -25,6 +25,10 @@ if ! command -v pkg-config >/dev/null 2>&1; then
     brew install pkg-config
 fi
 
-# Install remaining packages through pipx
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# Install Rust toolchain
+"${script_dir}/../rust-toolchain/setup.sh"
+
+# Install remaining packages through pipx
 "${script_dir}/../pipx-packages/install-all.sh"

--- a/components/core/tools/scripts/lib_install/manylinux_2_28/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/manylinux_2_28/install-prebuilt-packages.sh
@@ -14,6 +14,10 @@ dnf install -y \
     zlib-devel \
     zlib-static
 
-# Install remaining packages through pipx
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# Install Rust toolchain
+"${script_dir}/../rust-toolchain/setup.sh"
+
+# Install remaining packages through pipx
 "${script_dir}/../pipx-packages/install-all.sh"

--- a/components/core/tools/scripts/lib_install/musllinux_1_2/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/musllinux_1_2/install-prebuilt-packages.sh
@@ -15,6 +15,10 @@ apk update && apk add --no-cache \
     zlib-dev \
     zlib-static
 
-# Install remaining packages through pipx
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# Install Rust toolchain
+"${script_dir}/../rust-toolchain/setup.sh"
+
+# Install remaining packages through pipx
 "${script_dir}/../pipx-packages/install-all.sh"

--- a/components/core/tools/scripts/lib_install/rust-toolchain/setup.sh
+++ b/components/core/tools/scripts/lib_install/rust-toolchain/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
+# This command downloads and installs the Rust toolchain using the latest stable version. If rustup
+# is already installed, it updates the Rust toolchain to the latest stable version.
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Source the cargo environment to make rustup and cargo available in the current shell session.
+. "$HOME/.cargo/env"
+
+# This command installs or updates the Rust nightly toolchain to the latest version. If the nightly
+# toolchain is already present, it will be updated.
+rustup toolchain install nightly
+
+# Add rustfmt and clippy components to the nightly toolchain.
+rustup component add rustfmt --toolchain nightly
+rustup component add clippy --toolchain nightly

--- a/components/core/tools/scripts/lib_install/rust-toolchain/setup.sh
+++ b/components/core/tools/scripts/lib_install/rust-toolchain/setup.sh
@@ -13,10 +13,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # Source the cargo environment to make rustup and cargo available in the current shell session.
 . "$HOME/.cargo/env"
 
-# This command installs or updates the Rust nightly toolchain to the latest version. If the nightly
-# toolchain is already present, it will be updated.
-rustup toolchain install nightly
-
-# Add rustfmt and clippy components to the nightly toolchain.
-rustup component add rustfmt --toolchain nightly
-rustup component add clippy --toolchain nightly
+# This command installs or updates the Rust nightly toolchain to the latest version with clippy and
+# rustfmt components.
+# NOTE: The `--allow-downgrade` flag allows rustup to select a previous version of that toolchain if
+# the newest one does not support all the requested components.
+rustup toolchain install nightly --allow-downgrade \
+    --component clippy \
+    --component rustfmt

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-prebuilt-packages.sh
@@ -28,6 +28,10 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     software-properties-common \
     unzip
 
-# Install remaining packages through pipx
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# Install Rust toolchain
+"${script_dir}/../rust-toolchain/setup.sh"
+
+# Install remaining packages through pipx
 "${script_dir}/../pipx-packages/install-all.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR introduces a helper script to install the Rust toolchain in all development environments. Essentially, this script will:
- Download and install the latest stable version Rust toolchain.
- Download and install the latest nightly version Rust toolchain for rustfmt and clippy.

If the toolchains are already installed, this script also helps to upgrade them to the latest available stable/nightly version.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows passed.
* [x] Log in to the built Ubuntu image to check the toolchain can be used.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic Rust toolchain setup added to environment installation across macOS, Ubuntu, CentOS Stream 9, manylinux and musllinux.
  - Installs rustup, nightly toolchain, rustfmt and clippy to improve Rust readiness.
  - Rust setup now runs before pipx package installation for more reliable installs.

- Chores
  - Standardized installation ordering and minor comment/consistency updates across scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->