### PR TITLE
refactor(clp-package): Use direct imports from `typing` instead of module references (fixes #1346).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -6,7 +6,6 @@ import re
 import secrets
 import socket
 import subprocess
-import typing
 import uuid
 from enum import auto
 from typing import Dict, List, Optional, Tuple
@@ -87,16 +86,16 @@ class DockerMount:
 
 class CLPDockerMounts:
     def __init__(self, clp_home: pathlib.Path, docker_clp_home: pathlib.Path):
-        self.input_logs_dir: typing.Optional[DockerMount] = None
-        self.clp_home: typing.Optional[DockerMount] = DockerMount(
+        self.input_logs_dir: Optional[DockerMount] = None
+        self.clp_home: Optional[DockerMount] = DockerMount(
             DockerMountType.BIND, clp_home, docker_clp_home
         )
-        self.data_dir: typing.Optional[DockerMount] = None
-        self.logs_dir: typing.Optional[DockerMount] = None
-        self.archives_output_dir: typing.Optional[DockerMount] = None
-        self.stream_output_dir: typing.Optional[DockerMount] = None
-        self.aws_config_dir: typing.Optional[DockerMount] = None
-        self.generated_config_file: typing.Optional[DockerMount] = None
+        self.data_dir: Optional[DockerMount] = None
+        self.logs_dir: Optional[DockerMount] = None
+        self.archives_output_dir: Optional[DockerMount] = None
+        self.stream_output_dir: Optional[DockerMount] = None
+        self.aws_config_dir: Optional[DockerMount] = None
+        self.generated_config_file: Optional[DockerMount] = None
 
 
 def _validate_data_directory(data_dir: pathlib.Path, component_name: str) -> None:

--- a/components/clp-py-utils/clp_py_utils/compression.py
+++ b/components/clp-py-utils/clp_py_utils/compression.py
@@ -1,5 +1,5 @@
 import pathlib
-import typing
+from typing import List
 
 import Levenshtein
 
@@ -60,7 +60,7 @@ def file_paths_in_same_group(a: pathlib.Path, b: pathlib.Path):
     return Levenshtein.ratio(str(a.name), str(b.name)) >= FILE_GROUPING_MIN_LEVENSHTEIN_RATIO
 
 
-def group_files_by_similar_filenames(files: typing.List[FileMetadata]):
+def group_files_by_similar_filenames(files: List[FileMetadata]):
     groups = []
 
     if len(files) == 0:

--- a/components/job-orchestration/job_orchestration/scheduler/compress/partition.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/partition.py
@@ -1,6 +1,6 @@
 import copy
 import pathlib
-import typing
+from typing import Any, Dict, List, Optional
 
 import brotli
 import msgpack
@@ -21,14 +21,14 @@ class PathsToCompressBuffer:
         clp_io_config: ClpIoConfig,
         clp_metadata_db_connection_config: dict,
     ):
-        self.__files: typing.List[FileMetadata] = []
-        self.__tasks: typing.List[typing.Dict[str, typing.Any]] = []
-        self.__partition_info: typing.List[typing.Dict[str, typing.Any]] = []
+        self.__files: List[FileMetadata] = []
+        self.__tasks: List[Dict[str, Any]] = []
+        self.__partition_info: List[Dict[str, Any]] = []
         self.__maintain_file_ordering: bool = maintain_file_ordering
         if empty_directories_allowed:
-            self.__empty_directories: typing.Optional[typing.List[str]] = []
+            self.__empty_directories: Optional[List[str]] = []
         else:
-            self.__empty_directories: typing.Optional[typing.List[str]] = None
+            self.__empty_directories: Optional[List[str]] = None
         self.__total_file_size: int = 0
         self.__target_archive_size: int = clp_io_config.output.target_archive_size
         self.__file_size_to_trigger_compression: int = clp_io_config.output.target_archive_size * 2

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing
 from enum import auto
+from typing import List, Literal, Optional, Tuple, Union
 
 from clp_py_utils.clp_config import S3Config
 from pydantic import BaseModel, field_validator
@@ -14,28 +14,28 @@ class InputType(LowercaseStrEnum):
 
 
 class PathsToCompress(BaseModel):
-    file_paths: typing.List[str]
-    group_ids: typing.List[int]
-    st_sizes: typing.List[int]
-    empty_directories: typing.Optional[typing.List[str]] = None
+    file_paths: List[str]
+    group_ids: List[int]
+    st_sizes: List[int]
+    empty_directories: Optional[List[str]] = None
 
 
 class FsInputConfig(BaseModel):
-    type: typing.Literal[InputType.FS.value] = InputType.FS.value
-    dataset: typing.Optional[str] = None
-    paths_to_compress: typing.List[str]
+    type: Literal[InputType.FS.value] = InputType.FS.value
+    dataset: Optional[str] = None
+    paths_to_compress: List[str]
     path_prefix_to_remove: str = None
-    timestamp_key: typing.Optional[str] = None
+    timestamp_key: Optional[str] = None
 
 
 class S3InputConfig(S3Config):
-    type: typing.Literal[InputType.S3.value] = InputType.S3.value
-    dataset: typing.Optional[str] = None
-    timestamp_key: typing.Optional[str] = None
+    type: Literal[InputType.S3.value] = InputType.S3.value
+    dataset: Optional[str] = None
+    timestamp_key: Optional[str] = None
 
 
 class OutputConfig(BaseModel):
-    tags: typing.Optional[typing.List[str]] = None
+    tags: Optional[List[str]] = None
     target_archive_size: int
     target_dictionaries_size: int
     target_segment_size: int
@@ -44,45 +44,45 @@ class OutputConfig(BaseModel):
 
 
 class ClpIoConfig(BaseModel):
-    input: typing.Union[FsInputConfig, S3InputConfig]
+    input: Union[FsInputConfig, S3InputConfig]
     output: OutputConfig
 
 
 class AggregationConfig(BaseModel):
-    job_id: typing.Optional[int] = None
-    reducer_host: typing.Optional[str] = None
-    reducer_port: typing.Optional[int] = None
-    do_count_aggregation: typing.Optional[bool] = None
-    count_by_time_bucket_size: typing.Optional[int] = None  # Milliseconds
+    job_id: Optional[int] = None
+    reducer_host: Optional[str] = None
+    reducer_port: Optional[int] = None
+    do_count_aggregation: Optional[bool] = None
+    count_by_time_bucket_size: Optional[int] = None  # Milliseconds
 
 
 class QueryJobConfig(BaseModel):
-    dataset: typing.Optional[str] = None
+    dataset: Optional[str] = None
 
 
 class ExtractIrJobConfig(QueryJobConfig):
     orig_file_id: str
     msg_ix: int
-    file_split_id: typing.Optional[str] = None
-    target_uncompressed_size: typing.Optional[int] = None
+    file_split_id: Optional[str] = None
+    target_uncompressed_size: Optional[int] = None
 
 
 class ExtractJsonJobConfig(QueryJobConfig):
     archive_id: str
-    target_chunk_size: typing.Optional[int] = None
+    target_chunk_size: Optional[int] = None
 
 
 class SearchJobConfig(QueryJobConfig):
     query_string: str
     max_num_results: int
-    tags: typing.Optional[typing.List[str]] = None
-    begin_timestamp: typing.Optional[int] = None
-    end_timestamp: typing.Optional[int] = None
+    tags: Optional[List[str]] = None
+    begin_timestamp: Optional[int] = None
+    end_timestamp: Optional[int] = None
     ignore_case: bool = False
-    path_filter: typing.Optional[str] = None
+    path_filter: Optional[str] = None
     # Tuple of (host, port)
-    network_address: typing.Optional[typing.Tuple[str, int]] = None
-    aggregation_config: typing.Optional[AggregationConfig] = None
+    network_address: Optional[Tuple[str, int]] = None
+    aggregation_config: Optional[AggregationConfig] = None
 
     @field_validator("network_address")
     @classmethod


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR removes all `typing` modules imports and replaces them with direct imports.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. `task` to build the package.
2. `cd build/clp-package && ./sbin/start-clp.sh` and observed the package was started without any error reported in the console.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
