### PR TITLE
feat(clp-package): Select execution container from image id or version file.

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -52,7 +52,7 @@ vars:
 
 tasks:
   default:
-    deps: ["package"]
+    deps: ["docker-images:package"]
 
   clean:
     cmds:

--- a/taskfiles/docker-images.yaml
+++ b/taskfiles/docker-images.yaml
@@ -12,3 +12,4 @@ tasks:
       - ":package"
     cmds:
       - "./build.sh"
+      - "rsync -a '{{.G_BUILD_DIR}}/clp-package-image.id' '{{.G_PACKAGE_BUILD_DIR}}'"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds the mechanism to the package init scripts to select the clp-package image built inside the project directory.

As a result, the ["clp-execution-base-ubuntu-jammy"](https://github.com/y-scope/clp/tree/main/tools/docker-images/clp-execution-base-ubuntu-jammy) image will no longer be in use, and its build script and related GH workflow can be removed.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
