### PR TITLE
fix(job-orchestration): Correct `QueryTaskResult.task_id type` from `str` to `int` (fixes #1363).

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/scheduler_data.py
+++ b/components/job-orchestration/job_orchestration/scheduler/scheduler_data.py
@@ -99,6 +99,6 @@ class SearchJob(QueryJob):
 
 class QueryTaskResult(BaseModel):
     status: QueryTaskStatus
-    task_id: str
+    task_id: int
     duration: float
     error_log_path: Optional[str] = None


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says. By correcting the type, type validations no longer fail during extraction job execution.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. (CLP-Text) Compressed logs then performed a search in the webui. Clicked on links in the search results, which redirected the log viewer with the original log context restored as expected.
2. (CLP-JSON) Repeat Step 1 with clp-s and JSON logs.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
