### PR TITLE
refactor(scheduler): Rename `field` -> `value` in Pydantic `@field_validator` methods (fixes #1362).

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -86,8 +86,8 @@ class SearchJobConfig(QueryJobConfig):
 
     @field_validator("network_address")
     @classmethod
-    def validate_network_address(cls, field):
-        if field is not None and (field[1] < 1 or field[1] > 65535):
+    def validate_network_address(cls, value):
+        if value is not None and (value[1] < 1 or value[1] > 65535):
             raise ValueError("Port must be in the range [1, 65535]")
 
-        return field
+        return value

--- a/components/job-orchestration/job_orchestration/scheduler/scheduler_data.py
+++ b/components/job-orchestration/job_orchestration/scheduler/scheduler_data.py
@@ -33,11 +33,11 @@ class CompressionTaskResult(BaseModel):
 
     @field_validator("status")
     @classmethod
-    def valid_status(cls, field):
+    def valid_status(cls, value):
         supported_status = [CompressionTaskStatus.SUCCEEDED, CompressionTaskStatus.FAILED]
-        if field not in supported_status:
+        if value not in supported_status:
             raise ValueError(f'must be one of the following {"|".join(supported_status)}')
-        return field
+        return value
 
 
 class InternalJobState(Enum):


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title suggests, the change is non-functional and is purely stylistic

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. (CLP-Text) Compressed logs then performed a search in the webui. Clicked on links in the search results, which redirected the log viewer with the original log context restored as expected.
2. (CLP-JSON) Repeat Step 1 with clp-s and JSON logs.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
