### PR TITLE
fix(query-scheduler): Gracefully terminate reducer connections that do not attempt a connection handshake (fixes #1386).

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/query/reducer_handler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/reducer_handler.py
@@ -215,6 +215,12 @@ async def handle_reducer_connection(
                 msg = ReducerHandlerMessage(ReducerHandlerMessageType.SUCCESS)
                 await msg_queues.put_to_listeners(msg)
                 break
+    except asyncio.IncompleteReadError as err:
+        if len(err.partial) == 0:
+            # Connection was opened but no data was sent; treat as benign noise.
+            logger.debug("Reducer connection closed without sending handshake bytes.")
+            return
+        raise
     finally:
         writer.close()
         await writer.wait_closed()

--- a/components/job-orchestration/job_orchestration/scheduler/query/reducer_handler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/reducer_handler.py
@@ -78,15 +78,23 @@ async def _handle_unexpected_msg_from_listener(
     await msg_queues.put_to_listeners(msg)
 
 
-async def _recv_msg_from_reducer(reader: asyncio.StreamReader) -> bytes:
+async def _recv_msg_from_reducer(reader: asyncio.StreamReader) -> Optional[bytes]:
     """
     Receives and deserializes a message from the connected reducer
     :param reader: StreamReader connected to a reducer
-    :return: The received message
+    :return: The received message, or None if the connection was closed without sending any data.
+    :raise: asyncio.IncompleteReadError if the connection is closed mid-message.
     """
-    msg_size_bytes = await reader.readexactly(8)
-    msg_size = int.from_bytes(msg_size_bytes, byteorder="little")
-    return await reader.readexactly(msg_size)
+    try:
+        msg_size_bytes = await reader.readexactly(8)
+        msg_size = int.from_bytes(msg_size_bytes, byteorder="little")
+        return await reader.readexactly(msg_size)
+    except asyncio.IncompleteReadError as e:
+        if len(e.partial) == 0:
+            # Connection was opened but no data was sent; treat as benign noise.
+            logger.debug("Reducer connection closed without sending handshake bytes.")
+            return None
+        raise
 
 
 async def _send_msg_to_reducer(msg: bytes, writer: asyncio.StreamWriter):
@@ -107,14 +115,9 @@ async def handle_reducer_connection(
     reducer_connection_queue: asyncio.Queue,
 ):
     try:
-        try:
-            message_bytes = await _recv_msg_from_reducer(reader)
-        except asyncio.IncompleteReadError as err:
-            if len(err.partial) == 0:
-                # Connection was opened but no data was sent; treat as benign noise.
-                logger.debug("Reducer connection closed without sending handshake bytes.")
-                return
-            raise
+        message_bytes = await _recv_msg_from_reducer(reader)
+        if message_bytes is None:
+            return
         reducer_addr_info = msgpack.unpackb(message_bytes)
 
         msg_queues = ReducerHandlerMessageQueues()


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds graceful handling for empty reducer connections to the query scheduler, by ignoring such benign noises.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Built and started the package.
2. Ran `docker ps` to find out the instance id of the query-scheduler.
3. Ran `docker exec <query-scheduler-id> bash -c '< /dev/tcp/localhost/7000'` and observed the command exited successfully.
4. Ran `docker logs <query-scheduler-id>` and observed no exception logs were printed as before.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Treat reducer connections that close without sending data as benign to avoid spurious errors or crashes.
  - Short-circuit connection handling when no message is received and log these cases at debug level to reduce noisy error logs.
  - Updated docstrings to clarify return behavior and error handling for closed connections.

- **Reliability**
  - Improved resilience of connection handling for smoother job orchestration under intermittent network conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->