### PR TITLE
fix(clp-package): Use component-specific log directories for compression-scheduler and query-scheduler (fixes #1483).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -288,6 +288,9 @@ class BaseController(ABC):
         component_name = COMPRESSION_SCHEDULER_COMPONENT_NAME
         logger.info(f"Setting up environment for {component_name}...")
 
+        logs_dir = self._clp_config.logs_directory / component_name
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
         env_vars = EnvVarsDict()
 
         # Logging config
@@ -307,6 +310,9 @@ class BaseController(ABC):
         """
         component_name = QUERY_SCHEDULER_COMPONENT_NAME
         logger.info(f"Setting up environment for {component_name}...")
+
+        logs_dir = self._clp_config.logs_directory / component_name
+        logs_dir.mkdir(parents=True, exist_ok=True)
 
         env_vars = EnvVarsDict()
 

--- a/tools/deployment/package/docker-compose.base.yaml
+++ b/tools/deployment/package/docker-compose.base.yaml
@@ -222,7 +222,7 @@ services:
       CLP_DB_PASS: "${CLP_DB_PASS:?Please set a value.}"
       CLP_DB_USER: "${CLP_DB_USER:?Please set a value.}"
       CLP_LOGGING_LEVEL: "${CLP_COMPRESSION_SCHEDULER_LOGGING_LEVEL:-INFO}"
-      CLP_LOGS_DIR: "/var/log"
+      CLP_LOGS_DIR: "/var/log/compression_scheduler"
       PYTHONPATH: "/opt/clp/lib/python3/site-packages"
       RESULT_BACKEND: "redis://default:${CLP_REDIS_PASS:?Please set a value.}@redis:6379\
         /${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"

--- a/tools/deployment/package/docker-compose.yaml
+++ b/tools/deployment/package/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       CLP_DB_PASS: "${CLP_DB_PASS:?Please set a value.}"
       CLP_DB_USER: "${CLP_DB_USER:?Please set a value.}"
       CLP_LOGGING_LEVEL: "${CLP_QUERY_SCHEDULER_LOGGING_LEVEL:-INFO}"
-      CLP_LOGS_DIR: "/var/log"
+      CLP_LOGS_DIR: "/var/log/query_scheduler"
       PYTHONPATH: "/opt/clp/lib/python3/site-packages"
       RESULT_BACKEND: "redis://default:${CLP_REDIS_PASS:?Please set a value.}@redis:6379\
         /${CLP_REDIS_BACKEND_DB_QUERY:-0}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR changes the logs directory bases back to component-specific directories before the changes to /var/log were incorrectly introduced in #1178 :
* `compression-scheduler`: `./var/log` -> `./var/log/compression_scheduler`
* `query-scheduler`: `./var/log` -> `./var/log/query_scheduler`

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
task

cd build/clp-package
./sbin/start-clp.sh

ls -l $(find var/log/ | grep scheduler)
```
->
```
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ ls -l $(find var/log/ | grep scheduler)
-rw-r--r-- 1 junhao junhao   84 Oct 23 13:55 var/log/compression_scheduler/compression_scheduler.log
-rw-r--r-- 1 junhao junhao  170 Oct 23 13:55 var/log/query_scheduler/query_scheduler.log

var/log/compression_scheduler:
total 4
-rw-r--r-- 1 junhao junhao 84 Oct 23 13:55 compression_scheduler.log

var/log/query_scheduler:
total 4
-rw-r--r-- 1 junhao junhao 170 Oct 23 13:55 query_scheduler.log
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Scheduler components now use separate, dedicated log directories for improved organization.
  * Log directories are automatically created during scheduler initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->