### PR TITLE
fix(clp-mcp-server): Fix the missing link field in the log search result.

### DIFF
--- a/components/clp-mcp-server/clp_mcp_server/server/utils.py
+++ b/components/clp-mcp-server/clp_mcp_server/server/utils.py
@@ -83,8 +83,9 @@ def format_query_results(query_results: list[dict[str, Any]]) -> list[str]:
     kv-pairs:
     - "timestamp": An integer representing the epoch timestamp in milliseconds.
     - "message": A string representing the log message.
+    - "link": A string representing the log viewer link to display the message.
 
-    The message will be formatted as `timestamp: <date string>, message: <message>`:
+    The message will be formatted as `timestamp: <date string>, message: <message>, link: <link>`
 
     :param query_results: A list of dictionaries representing kv-pair log events.
     :return: A list of strings representing formatted log events.
@@ -105,7 +106,12 @@ def format_query_results(query_results: list[dict[str, Any]]) -> list[str]:
             logger.warning("Empty message attached to a log event: %s.", obj)
             continue
 
-        formatted_log_events.append(f"timestamp: {timestamp_str}, message: {message}")
+        link = obj.get("link", "")
+        if not link:
+            logger.warning("Missing link attached to a log event: %s.", obj)
+            continue
+
+        formatted_log_events.append(f"timestamp: {timestamp_str}, message: {message}, link: {link}")
 
     return formatted_log_events
 

--- a/components/clp-mcp-server/tests/server/test_utils.py
+++ b/components/clp-mcp-server/tests/server/test_utils.py
@@ -83,6 +83,8 @@ class TestUtils:
             "orig_file_path": "/var/log/app.log",
             "archive_id": "abc123",
             "log_event_ix": 99,
+            "link": ("http://localhost:4000/streamFile?dataset=default&"
+                     "type=json&streamId=abc123&logEventIdx=99"),
         },
         {
             "_id": "test001",
@@ -135,7 +137,9 @@ class TestUtils:
         (
             'timestamp: N/A, message: '
             '{"pid":null,"tid":null,'
-            '"message":"Log at epoch none"}\n'
+            '"message":"Log at epoch none"}\n, '
+            'link: http://localhost:4000/streamFile?dataset=default&'
+            'type=json&streamId=abc123&logEventIdx=99'
         ),
     ]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes the missing `link` field in the search result returned by the `search_kql_query` tool. The field is used by LLM to create hyperlinks when displaying the log messages. The current implementation fails to include it when formatting the query result.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Manually tested.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Formatted log/query results now include a required clickable link for each entry; entries without a link are omitted from formatted output.

* **Tests**
  * Test suite updated to verify formatted log entries include the link and that entries missing a link are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->