### PR TITLE
feat(deployment): Add `--setup-only` flag to `start-clp.sh` to set up the package without starting components (resolves #1475).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -87,16 +87,16 @@ class BaseController(ABC):
         self._conf_dir = self._clp_home / "etc"
 
     @abstractmethod
-    def start(self) -> None:
-        """
-        Starts the components.
-        """
-
-    @abstractmethod
     def set_up_env(self) -> None:
         """
         Sets up all components to run by preparing environment variables, directories, and
         configuration files.
+        """
+
+    @abstractmethod
+    def start(self) -> None:
+        """
+        Starts the components.
         """
 
     @abstractmethod

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -37,6 +37,11 @@ def main(argv):
         action="store_true",
         help="Enable debug logging.",
     )
+    args_parser.add_argument(
+        "--setup-only",
+        action="store_true",
+        help="Validate configuration and prepare directories without starting services.",
+    )
 
     parsed_args = args_parser.parse_args(argv[1:])
 
@@ -79,6 +84,12 @@ def main(argv):
     try:
         instance_id = get_or_create_instance_id(clp_config)
         controller = DockerComposeController(clp_config, instance_id)
+        if parsed_args.setup_only:
+            controller.set_up_env()
+            logger.info(
+                "Completed setup. Services are not started because --setup-only was provided."
+            )
+            return 0
         controller.start()
     except Exception as ex:
         if type(ex) == ValueError:

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -84,8 +84,8 @@ def main(argv):
     try:
         instance_id = get_or_create_instance_id(clp_config)
         controller = DockerComposeController(clp_config, instance_id)
+        controller.set_up_env()
         if parsed_args.setup_only:
-            controller.set_up_env()
             logger.info(
                 "Completed setup. Services are not started because --setup-only was provided."
             )

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -87,7 +87,7 @@ def main(argv):
         controller.set_up_env()
         if parsed_args.setup_only:
             logger.info(
-                "Completed setup. Services are not started because --setup-only was provided."
+                "Completed setup. Services not started because `--setup-only` was specified."
             )
             return 0
         controller.start()

--- a/docs/src/user-docs/quick-start/clp-json.md
+++ b/docs/src/user-docs/quick-start/clp-json.md
@@ -17,6 +17,11 @@ To start CLP, run:
 sbin/start-clp.sh
 ```
 
+:::{tip}
+To validate configuration and prepare directories without launching services, add the
+`--setup-only` flag (e.g., `sbin/start-clp.sh --setup-only`).
+:::
+
 :::{note}
 If CLP fails to start (e.g., due to a port conflict), try adjusting the settings in
 `etc/clp-config.yml` and then run the start command again.

--- a/docs/src/user-docs/quick-start/clp-text.md
+++ b/docs/src/user-docs/quick-start/clp-text.md
@@ -19,6 +19,11 @@ To start CLP, run:
 sbin/start-clp.sh
 ```
 
+:::{tip}
+To validate configuration and prepare directories without launching services, add the
+`--setup-only` flag (e.g., `sbin/start-clp.sh --setup-only`).
+:::
+
 :::{note}
 If CLP fails to start (e.g., due to a port conflict), try adjusting the settings in
 `etc/clp-config.yml` and then run the start command again.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
cd <project-root>
task

cd build/clp-package
./sbin/start-clp.sh --help
# ...
#   --setup-only          Validate configuration and prepare directories without starting services.

./sbin/start-clp.sh --setup-only
docker compose up --wait

./sbin/compress.sh ~/samples/hive-24h
```
Then performed a search of string "1" in the webui http://localhost:4000 and observed results displayed in the UI.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --setup-only flag to the start script to validate configuration and prepare directories without launching services; displays a completion message when done.

* **Documentation**
  * Updated quick-start guides to document the --setup-only pre-launch setup and validation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->