### PR TITLE
fix(deployment): Use container user's home directory as the base for the AWS config path (fixes #1524).

### DIFF
--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -48,8 +48,8 @@ COMPRESSION_JOBS_TABLE_NAME = "compression_jobs"
 COMPRESSION_TASKS_TABLE_NAME = "compression_tasks"
 
 # Paths
-CONTAINER_AWS_CONFIG_DIRECTORY = pathlib.Path("/") / ".aws"
 CONTAINER_CLP_HOME = pathlib.Path("/") / "opt" / "clp"
+CONTAINER_AWS_CONFIG_DIRECTORY = CONTAINER_CLP_HOME / ".aws"
 CONTAINER_INPUT_LOGS_ROOT_DIR = pathlib.Path("/") / "mnt" / "logs"
 CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH = pathlib.Path("etc") / "clp-config.yml"
 CLP_DEFAULT_CREDENTIALS_FILE_PATH = pathlib.Path("etc") / "credentials.yml"

--- a/tools/deployment/package/docker-compose.base.yaml
+++ b/tools/deployment/package/docker-compose.base.yaml
@@ -229,7 +229,7 @@ services:
     volumes:
       - *volume_clp_config_readonly
       - *volume_clp_logs
-      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/.aws:ro"
+      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_LOGS_INPUT_DIR_HOST:-empty}:${CLP_LOGS_INPUT_DIR_CONTAINER:-/mnt/logs}"
     depends_on:
       db-table-creator:
@@ -263,7 +263,7 @@ services:
       - *volume_clp_config_readonly
       - *volume_clp_logs
       - "${CLP_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/archives"
-      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/.aws:ro"
+      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_LOGS_INPUT_DIR_HOST:-empty}:${CLP_LOGS_INPUT_DIR_CONTAINER:-/mnt/logs}"
       - "${CLP_STAGED_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/staged-archives"
       - type: "bind"
@@ -300,7 +300,7 @@ services:
         published: "${CLP_WEBUI_PORT:-4000}"
         target: 4000
     volumes:
-      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/.aws:ro"
+      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_STREAM_OUTPUT_DIR_HOST:-empty}:/var/data/streams"
       - type: "bind"
         source: "./var/www/webui/client/settings.json"
@@ -346,7 +346,7 @@ services:
       - *volume_clp_config_readonly
       - *volume_clp_logs
       - "${CLP_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/archives"
-      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/.aws:ro"
+      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_STREAM_OUTPUT_DIR_HOST:-empty}:/var/data/streams"
     depends_on:
       db-table-creator:

--- a/tools/deployment/package/docker-compose.yaml
+++ b/tools/deployment/package/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
       - *volume_clp_config_readonly
       - *volume_clp_logs
       - "${CLP_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/archives"
-      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/.aws:ro"
+      - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_STAGED_STREAM_OUTPUT_DIR_HOST:-empty}:/var/data/staged-streams"
       - "${CLP_STREAM_OUTPUT_DIR_HOST:-empty}:/var/data/streams"
     command: [


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes where AWS credentials are mounted and looked up inside our containers after #1413 changes the in-container `$HOME` from `/` to `/opt/clp`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
task
cd build/clp-package

# configure s3 archives & stream output storages as s3 with `profile` auth type: https://docs.yscope.com/clp/main/user-docs/guides-using-object-storage/clp-config.html

./sbin/start-clp.sh
./sbin/compress-from-s3.sh --timestamp-key=timestamp s3-object https://<redacted>/postgresql.jsonl
# observed compression was successful

# launched the webui, performed a search with string `1`, observed results returned
# clicked on the result's link which brought up the log viewer displaying the log context
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS configuration directory path in deployment configurations. AWS credentials are now resolved from the application home directory instead of the system root across all containerized services. Users deploying this version should verify AWS configuration file placement is updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->