### PR TITLE
fix(clp-package): Ensure at least one worker in default calculations (fixes #1509).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -792,7 +792,7 @@ class DockerComposeController(BaseController):
         :return: Number of worker processes to run.
         """
         # This will change when we move from single to multi-container workers. See y-scope/clp#1424
-        return multiprocessing.cpu_count() // 2
+        return max(1, multiprocessing.cpu_count() // 2)
 
     def _get_docker_file_name(self) -> str:
         """


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Fixed the `_get_num_workers()` method in controller.py to ensure at least 1 worker is returned, even on single-CPU systems. The error in the equation has long existed and was moved from start_clp.py in #1178 .


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

In WSL Ubuntu
```
task
```
Then changed the `processors` setting to `1`: https://learn.microsoft.com/en-us/windows/wsl/wsl-config#main-wsl-settings ; restarted wsl

```
cd <project-root>
cd build/clp-package
./sbin/start-clp.sh
./sbin/compress.sh ~/samples/hive-24hr
# observed the compression completed successfully

# performed a search with string "1" in the webui and observed results were returned and the timeline was correctly displayed
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
