### PR TITLE
fix: Standardize error handling in shell scripts with errexit, nounset, and pipefail (fixes #1556).

### DIFF
--- a/components/core/tools/docker-images/clp-core-ubuntu-jammy/build.sh
+++ b/components/core/tools/docker-images/clp-core-ubuntu-jammy/build.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# Exit on any error
-set -e
-
-# Error on undefined variable
-set -u
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cUsage="Usage: ${BASH_SOURCE[0]} <clp-core-build-dir>"
 if [ "$#" -lt 1 ]; then

--- a/components/core/tools/docker-images/clp-env-base-centos-stream-9/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos-stream-9/build.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# Exit on any error
-set -e
-
-# Error on undefined variable
-set -u
+set -o errexit
+set -o nounset
+set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 component_root="${script_dir}/../../../"

--- a/components/core/tools/docker-images/clp-env-base-manylinux_2_28-aarch64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-manylinux_2_28-aarch64/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/components/core/tools/docker-images/clp-env-base-manylinux_2_28-x86_64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-manylinux_2_28-x86_64/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86_64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86_64/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 component_root=${script_dir}/../../../
 

--- a/components/core/tools/scripts/lib_install/centos-stream-9/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/centos-stream-9/install-packages-from-source.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# Exit on any error
-set -e
-
-# Error on undefined variable
-set -u
+set -o errexit
+set -o nounset
+set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 lib_install_scripts_dir="${script_dir}/.."

--- a/components/core/tools/scripts/lib_install/install-curl.sh
+++ b/components/core/tools/scripts/lib_install/install-curl.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Exit on error
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cUsage="Usage: ${BASH_SOURCE[0]} <version>"
 if [ "$#" -lt 1 ] ; then

--- a/components/core/tools/scripts/lib_install/libarchive.sh
+++ b/components/core/tools/scripts/lib_install/libarchive.sh
@@ -5,8 +5,9 @@
 # - curl
 # NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
 
-# Exit on any error
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then

--- a/components/core/tools/scripts/lib_install/liblzma.sh
+++ b/components/core/tools/scripts/lib_install/liblzma.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# Exit on any error
-set -e
-
-# Error on undefined variable
-set -u
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # Dependencies:
 # - curl

--- a/components/core/tools/scripts/lib_install/liblzma.sh
+++ b/components/core/tools/scripts/lib_install/liblzma.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
 # Dependencies:
 # - curl
 # - make
 # - gcc
 # NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 for cmd in curl make gcc; do
     if ! $cmd --version >/dev/null 2>&1; then

--- a/components/core/tools/scripts/lib_install/lz4.sh
+++ b/components/core/tools/scripts/lib_install/lz4.sh
@@ -6,8 +6,9 @@
 # - gcc
 # NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
 
-# Exit on any error
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then

--- a/components/core/tools/scripts/lib_install/manylinux_2_28/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/manylinux_2_28/install-packages-from-source.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/components/core/tools/scripts/lib_install/mariadb-connector-c.sh
+++ b/components/core/tools/scripts/lib_install/mariadb-connector-c.sh
@@ -5,8 +5,9 @@
 # - rsync
 # NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
 
-# Exit on any error
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then

--- a/components/core/tools/scripts/lib_install/musllinux_1_2/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/musllinux_1_2/install-packages-from-source.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
+++ b/components/core/tools/scripts/lib_install/ubuntu-jammy/install-packages-from-source.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# Exit on any error
-set -e
-
-# Error on undefined variable
-set -u
+set -o errexit
+set -o nounset
+set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 lib_install_scripts_dir=$script_dir/..

--- a/components/core/tools/scripts/lib_install/zstandard.sh
+++ b/components/core/tools/scripts/lib_install/zstandard.sh
@@ -6,8 +6,9 @@
 # - g++
 # NOTE: Dependencies should be installed outside the script to allow the script to be largely distro-agnostic
 
-# Exit on any error
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cUsage="Usage: ${BASH_SOURCE[0]} <version>[ <.deb output directory>]"
 if [ "$#" -lt 1 ] ; then

--- a/components/core/tools/scripts/utils/run-in-container.sh
+++ b/components/core/tools/scripts/utils/run-in-container.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Exit on any error
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 component_root="$script_dir/../../../"

--- a/components/package-template/src/sbin/.common-env.sh
+++ b/components/package-template/src/sbin/.common-env.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 package_root=$(readlink -f "$script_dir/..")
 

--- a/components/package-template/src/sbin/admin-tools/archive-manager.sh
+++ b/components/package-template/src/sbin/admin-tools/archive-manager.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/../.common-env.sh"
 

--- a/components/package-template/src/sbin/admin-tools/dataset-manager.sh
+++ b/components/package-template/src/sbin/admin-tools/dataset-manager.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/../.common-env.sh"
 

--- a/components/package-template/src/sbin/compress-from-s3.sh
+++ b/components/package-template/src/sbin/compress-from-s3.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/.common-env.sh"
 

--- a/components/package-template/src/sbin/compress.sh
+++ b/components/package-template/src/sbin/compress.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/.common-env.sh"
 

--- a/components/package-template/src/sbin/decompress.sh
+++ b/components/package-template/src/sbin/decompress.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/.common-env.sh"
 

--- a/components/package-template/src/sbin/search.sh
+++ b/components/package-template/src/sbin/search.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/.common-env.sh"
 

--- a/components/package-template/src/sbin/start-clp.sh
+++ b/components/package-template/src/sbin/start-clp.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/.common-env.sh"
 

--- a/components/package-template/src/sbin/stop-clp.sh
+++ b/components/package-template/src/sbin/stop-clp.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 common_env_path="$script_dir/.common-env.sh"
 

--- a/tools/deployment/presto-clp/coordinator/scripts/generate-configs.sh
+++ b/tools/deployment/presto-clp/coordinator/scripts/generate-configs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 readonly PRESTO_CONFIG_DIR="/opt/presto-server/etc"

--- a/tools/deployment/presto-clp/scripts/set-up-config.sh
+++ b/tools/deployment/presto-clp/scripts/set-up-config.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)

--- a/tools/deployment/presto-clp/worker/scripts/generate-configs.sh
+++ b/tools/deployment/presto-clp/worker/scripts/generate-configs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 # Emits a log event to stderr with an auto-generated ISO timestamp as well as the given level

--- a/tools/docker-images/clp-package/build.sh
+++ b/tools/docker-images/clp-package/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 remove_temp_file_and_prev_image() {

--- a/tools/docker-images/clp-package/setup-scripts/install-prebuilt-packages.sh
+++ b/tools/docker-images/clp-package/setup-scripts/install-prebuilt-packages.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 set -o pipefail
 
 apt-get update

--- a/tools/scripts/deps-download/init.sh
+++ b/tools/scripts/deps-download/init.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# Exit on any error
-set -e
-
-# Error on undefined variable
-set -u
+set -o errexit
+set -o nounset
+set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 project_root_dir="$script_dir/../../../"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Add the long form

```
set -o errexit
set -o nounset
set -o pipefail
```

to all shell scripts in the repo.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Ran `start_clp.sh` on a host without Docker installed and observed the script exited immediately after an error was reported
2. Did a global search and confirmed all shell scripts in the repo have included those shell options:
	* <img width="1098" height="510" alt="image" src="https://github.com/user-attachments/assets/db6395aa-51eb-429b-a597-4d28193b466f" />
	* <img width="1094" height="444" alt="image" src="https://github.com/user-attachments/assets/ab9aec56-2a40-4a9b-9cc4-2dd16456b2f8" />


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling consistency across build and deployment scripts by enabling strict shell options that enforce immediate exit on command failures, treat unset variables as errors, and properly propagate pipeline failures.
  * Improved dependency validation in installation scripts to ensure required tools are present before execution, providing explicit error messages when dependencies are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->