### PR TITLE
fix(clp-package): Disable Docker interactive mode when running `sbin` scripts non-interactively (fixes #1566).

### DIFF
--- a/components/package-template/src/sbin/.common-env.sh
+++ b/components/package-template/src/sbin/.common-env.sh
@@ -68,3 +68,8 @@ if [[ -z "${CLP_DOCKER_SOCK_PATH:-}" ]]; then
         export CLP_DOCKER_SOCK_PATH="$socket"
     fi
 fi
+
+CLP_COMPOSE_RUN_EXTRA_FLAGS=()
+if [[ $- != *i* ]]; then
+    CLP_COMPOSE_RUN_EXTRA_FLAGS+=(--interactive=false)
+fi

--- a/components/package-template/src/sbin/admin-tools/archive-manager.sh
+++ b/components/package-template/src/sbin/admin-tools/archive-manager.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/../.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.archive_manager \
     "$@"

--- a/components/package-template/src/sbin/admin-tools/dataset-manager.sh
+++ b/components/package-template/src/sbin/admin-tools/dataset-manager.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/../.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.dataset_manager \
     "$@"

--- a/components/package-template/src/sbin/compress-from-s3.sh
+++ b/components/package-template/src/sbin/compress-from-s3.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.compress_from_s3 \
     "$@"

--- a/components/package-template/src/sbin/compress.sh
+++ b/components/package-template/src/sbin/compress.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.compress \
     "$@"

--- a/components/package-template/src/sbin/decompress.sh
+++ b/components/package-template/src/sbin/decompress.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.decompress \
     "$@"

--- a/components/package-template/src/sbin/search.sh
+++ b/components/package-template/src/sbin/search.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.search \
     "$@"

--- a/components/package-template/src/sbin/start-clp.sh
+++ b/components/package-template/src/sbin/start-clp.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.start_clp \
     "$@"

--- a/components/package-template/src/sbin/stop-clp.sh
+++ b/components/package-template/src/sbin/stop-clp.sh
@@ -10,7 +10,8 @@ common_env_path="$script_dir/.common-env.sh"
 # shellcheck source=.common-env.sh
 source "$common_env_path"
 
-docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" run --rm clp-runtime \
+docker compose -f "$CLP_HOME/docker-compose.runtime.yaml" \
+    run --rm "${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}" clp-runtime \
     python3 \
     -m clp_package_utils.scripts.stop_clp \
     "$@"

--- a/tools/deployment/package/docker-compose.runtime.yaml
+++ b/tools/deployment/package/docker-compose.runtime.yaml
@@ -5,8 +5,6 @@ services:
     logging:
       driver: "local"
     network_mode: "host"
-    stdin_open: true
-    tty: true
     user: "${CLP_FIRST_PARTY_SERVICE_UID_GID:-1000:999}"
     environment:
       # NOTE: We forward "$HOME" into the container so that if the user specified "~" anywhere in


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Problem
When `sbin` scripts were run in the background (e.g., `./sbin/compress.sh ~/samples/hive-24hr &`), the Docker container's output (stdout/stderr) was not being forwarded to the terminal. The job would run successfully, but users couldn't see any progress, logs, or errors.

This happened because:
1. `docker compose run` has `stdin_open: true` and `tty: true` enabled by default [no matter what value is set](https://github.com/docker/compose/blob/c37ede62dbb6485c4d5e297db9134631e9b2095e/cmd/compose/run.go#L88-L89) (undocumented) in `docker-compose.runtime.yaml`, not to mention we should have set `stdin_open: false`.
2. When running with `&`, the shell is non-interactive and stdin is detached
3. Docker Compose's interactive mode would prevent proper output forwarding in this scenario

## Solution
- Removed `stdin_open: true` and `tty: true` from `docker-compose.runtime.yaml` (they default to false)
- Added `CLP_COMPOSE_RUN_EXTRA_FLAGS` array in `.common-env.sh` that detects non-interactive shells using `[[ $- != *i* ]]`
- When the shell is non-interactive, adds `--interactive=false` flag to all `docker compose run` commands
- Updated all `sbin` scripts to use `"${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}"` in their compose commands

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ ./sbin/start-clp.sh 
2025-11-06T23:35:44.843 INFO [controller] Setting up environment for database...
2025-11-06T23:35:44.846 INFO [controller] Setting up environment for queue...
2025-11-06T23:35:44.846 INFO [controller] Setting up environment for redis...
2025-11-06T23:35:44.847 INFO [controller] Setting up environment for results_cache...
2025-11-06T23:35:44.848 INFO [controller] Setting up environment for compression_scheduler...
2025-11-06T23:35:44.848 INFO [controller] Setting up environment for query_scheduler...
2025-11-06T23:35:44.848 INFO [controller] Setting up environment for compression_worker...
2025-11-06T23:35:44.848 INFO [controller] Setting up environment for query_worker...
2025-11-06T23:35:44.848 INFO [controller] Setting up environment for reducer...
2025-11-06T23:35:44.849 INFO [controller] Setting up environment for webui...
2025-11-06T23:35:44.850 INFO [controller] The MCP Server is not configured, skipping mcp_server creation...
2025-11-06T23:35:44.850 INFO [controller] Setting up environment for garbage_collector...
2025-11-06T23:35:44.959 INFO [controller] Starting CLP using Docker Compose (full deployment)...
[+] Running 14/14
 ✔ Network clp-package-b7df_default                            Created          0.2s 
 ✔ Container clp-package-b7df-results-cache-1                  Healthy         17.8s 
 ✔ Container clp-package-b7df-redis-1                          Healthy         17.8s 
 ✔ Container clp-package-b7df-query-worker-1                   Healthy         17.8s 
 ✔ Container clp-package-b7df-database-1                       Healthy         17.8s 
 ✔ Container clp-package-b7df-compression-worker-1             Healthy         17.8s 
 ✔ Container clp-package-b7df-queue-1                          Healthy         17.8s 
 ✔ Container clp-package-b7df-db-table-creator-1               Exited          17.5s 
 ✔ Container clp-package-b7df-results-cache-indices-creator-1  Exited          17.3s 
 ✔ Container clp-package-b7df-compression-scheduler-1          Healthy         17.2s 
 ✔ Container clp-package-b7df-query-scheduler-1                Healthy         17.2s 
 ✔ Container clp-package-b7df-webui-1                          Healthy         17.1s 
 ✔ Container clp-package-b7df-garbage-collector-1              Healthy         17.1s 
 ✔ Container clp-package-b7df-reducer-1                        Healthy         17.0s 
2025-11-06T23:36:03.196 INFO [controller] Started CLP.
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ ./sbin/compress.sh ~/samples/hive-24hr/
2025-11-06T23:36:13.959 INFO [compress] Compression job 1 submitted.
2025-11-06T23:36:18.970 INFO [compress] Compressed 1.99GB into 44.92MB (45.33x). Speed: 694.51MB/s.
2025-11-06T23:36:19.472 INFO [compress] Compression finished.
2025-11-06T23:36:19.472 INFO [compress] Compressed 1.99GB into 44.92MB (45.33x). Speed: 644.37MB/s.
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ ./sbin/compress.sh ~/samples/hive-24hr/ &
[1] 701023
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ ./sbin/compress.sh ~/samples/hive-24hr/ &
[2] 701644
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ ./sbin/compress.sh ~/samples/hive-24hr/ &
[3] 701949
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ 2025-11-06T23:36:26.244 INFO [compress] Compression job 2 submitted.
2025-11-06T23:36:26.562 INFO [compress] Compression job 3 submitted.
2025-11-06T23:36:27.261 INFO [compress] Compression job 4 submitted.
2025-11-06T23:36:30.756 INFO [compress] Compressed 192.56MB into 5.06MB (38.09x). Speed: 87.69MB/s.
2025-11-06T23:36:31.257 INFO [compress] Compressed 704.70MB into 18.01MB (39.13x). Speed: 261.30MB/s.
2025-11-06T23:36:31.759 INFO [compress] Compressed 1.99GB into 44.92MB (45.33x). Speed: 636.67MB/s.
2025-11-06T23:36:35.084 INFO [compress] Compressed 192.56MB into 5.06MB (38.09x). Speed: 77.09MB/s.
2025-11-06T23:36:35.586 INFO [compress] Compressed 1.99GB into 44.92MB (45.33x). Speed: 678.83MB/s.
2025-11-06T23:36:36.272 INFO [compress] Compression finished.
2025-11-06T23:36:36.272 INFO [compress] Compressed 1.99GB into 44.92MB (45.33x). Speed: 272.19MB/s.
2025-11-06T23:36:36.588 INFO [compress] Compression finished.
2025-11-06T23:36:36.588 INFO [compress] Compressed 1.99GB into 44.92MB (45.33x). Speed: 513.73MB/s.
2025-11-06T23:36:37.787 INFO [compress] Compressed 192.56MB into 5.06MB (38.09x). Speed: 83.63MB/s.
2025-11-06T23:36:38.289 INFO [compress] Compressed 960.75MB into 24.42MB (39.34x). Speed: 342.64MB/s.
2025-11-06T23:36:38.790 INFO [compress] Compression finished.
2025-11-06T23:36:38.790 INFO [compress] Compressed 1.99GB into 44.92MB (45.33x). Speed: 701.06MB/s.

[1]   Done                    ./sbin/compress.sh ~/samples/hive-24hr/
[2]-  Done                    ./sbin/compress.sh ~/samples/hive-24hr/
[3]+  Done                    ./sbin/compress.sh ~/samples/hive-24hr/
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ ./sbin/stop-clp.sh &
[1] 704202
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ 2025-11-06T23:37:12.977 INFO [controller] Stopping all CLP containers using Docker Compose...
[+] Running 14/14
 ✔ Container clp-package-b7df-compression-scheduler-1          Removed          2.4s 
 ✔ Container clp-package-b7df-reducer-1                        Removed         11.5s 
 ✔ Container clp-package-b7df-garbage-collector-1              Removed         11.4s 
 ✔ Container clp-package-b7df-compression-worker-1             Removed          4.2s 
 ✔ Container clp-package-b7df-webui-1                          Removed          1.9s 
 ✔ Container clp-package-b7df-query-worker-1                   Removed          3.7s 
 ✔ Container clp-package-b7df-query-scheduler-1                Removed         11.1s 
 ✔ Container clp-package-b7df-results-cache-indices-creator-1  Removed          0.2s 
 ✔ Container clp-package-b7df-results-cache-1                  Removed          1.8s 
 ✔ Container clp-package-b7df-db-table-creator-1               Removed          0.2s 
 ✔ Container clp-package-b7df-queue-1                          Removed          2.7s 
 ✔ Container clp-package-b7df-redis-1                          Removed          1.5s 
 ✔ Container clp-package-b7df-database-1                       Removed          1.8s 
 ✔ Network clp-package-b7df_default                            Removed          2.3s 
2025-11-06T23:37:40.658 INFO [controller] Stopped CLP.

[1]+  Done                    ./sbin/stop-clp.sh
junhao@GIGABYTE:~/workspace/2-clp/build/clp-package$ 
```

Observed that:
1. ANSI colors were correctly shown in `start-clp.sh` and `stop-clp.sh`, no matter when running with or without `&`.
2. When the `compress.sh` was run with `&`, stdin was detached and therefore i could quickly run another `compress.sh` command. The outputs of those commands were printed to the console. 

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for passing extra Docker Compose runtime flags to CLI commands for enhanced execution flexibility.

* **Changes**
  * Removed interactive TTY allocation from the runtime service to better support non-interactive execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->