### PR TITLE
fix(clp-package): Remove `v` prefix from the package container image's version tag (fixes #1576).

### DIFF
--- a/components/package-template/src/sbin/.common-env.sh
+++ b/components/package-template/src/sbin/.common-env.sh
@@ -21,7 +21,7 @@ if [[ -f "$image_id_file" ]]; then
     export CLP_PACKAGE_CONTAINER_IMAGE_REF="$image_id"
 elif [[ -f "$version_file" ]]; then
     version="$(tr -d '[:space:]' <"$version_file")"
-    export CLP_PACKAGE_CONTAINER_IMAGE_REF="ghcr.io/y-scope/clp/clp-package:v$version"
+    export CLP_PACKAGE_CONTAINER_IMAGE_REF="ghcr.io/y-scope/clp/clp-package:$version"
 else
     echo >&2 "Error: Neither '${image_id_file}' nor '${version_file}' exist."
     return 1


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Set `G_PACKAGE_VERSION` to `0.6.0` in `taskfile.yaml`
* `task`
* `cd build/clp`
* `rm clp-package-image.id`
* `sbin/start-clp.sh`

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated container image version tag format to remove the "v" prefix, aligning with standard versioning conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->