### PR TITLE
chore: Bump version to 0.6.1-dev for next development cycle.

### DIFF
--- a/components/clp-mcp-server/pyproject.toml
+++ b/components/clp-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clp-mcp-server"
-version = "0.5.2-dev"
+version = "0.6.1-dev"
 description = "MCP server for CLP"
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/clp-mcp-server/uv.lock
+++ b/components/clp-mcp-server/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "clp-mcp-server"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiomysql" },

--- a/components/clp-package-utils/pyproject.toml
+++ b/components/clp-package-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clp-package-utils"
-version = "0.5.2-dev"
+version = "0.6.1-dev"
 description = "Utilities for the CLP package."
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/clp-package-utils/uv.lock
+++ b/components/clp-package-utils/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "clp-package-utils"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },

--- a/components/clp-py-utils/pyproject.toml
+++ b/components/clp-py-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clp-py-utils"
-version = "0.5.2-dev"
+version = "0.6.1-dev"
 description = "Utilities for other Python packages in CLP."
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/clp-py-utils/uv.lock
+++ b/components/clp-py-utils/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "clp-py-utils"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/components/core/src/clp/version.hpp
+++ b/components/core/src/clp/version.hpp
@@ -2,7 +2,7 @@
 #define CLP_VERSION_HPP
 
 namespace clp {
-constexpr char cVersion[] = "0.5.2-dev";
+constexpr char cVersion[] = "0.6.1-dev";
 }  // namespace clp
 
 #endif  // CLP_VERSION_HPP

--- a/components/core/src/glt/version.hpp
+++ b/components/core/src/glt/version.hpp
@@ -2,7 +2,7 @@
 #define GLT_VERSION_HPP
 
 namespace glt {
-constexpr char cVersion[] = "0.5.2-dev";
+constexpr char cVersion[] = "0.6.1-dev";
 }  // namespace glt
 
 #endif  // GLT_VERSION_HPP

--- a/components/job-orchestration/pyproject.toml
+++ b/components/job-orchestration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "job-orchestration"
-version = "0.5.2-dev"
+version = "0.6.1-dev"
 description = "Scheduler and worker cluster for CLP's distributed architecture."
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/job-orchestration/uv.lock
+++ b/components/job-orchestration/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "job-orchestration"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },

--- a/integration-tests/uv.lock
+++ b/integration-tests/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "clp-mcp-server"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { directory = "../components/clp-mcp-server" }
 dependencies = [
     { name = "aiomysql" },
@@ -502,7 +502,7 @@ dev = [
 
 [[package]]
 name = "clp-package-utils"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { directory = "../components/clp-package-utils" }
 dependencies = [
     { name = "brotli" },
@@ -525,7 +525,7 @@ requires-dist = [
 
 [[package]]
 name = "clp-py-utils"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { directory = "../components/clp-py-utils" }
 dependencies = [
     { name = "boto3" },
@@ -957,7 +957,7 @@ wheels = [
 
 [[package]]
 name = "job-orchestration"
-version = "0.5.2.dev0"
+version = "0.6.1.dev0"
 source = { directory = "../components/job-orchestration" }
 dependencies = [
     { name = "brotli" },

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -35,7 +35,7 @@ vars:
   G_UTILS_TASKFILE: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
   # Versions
-  G_PACKAGE_VERSION: "0.5.2-dev"
+  G_PACKAGE_VERSION: "0.6.1-dev"
 
   # Build parameters
   # NOTE: Defaulting to an empty string is safe since CMake ignores an empty string.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This update increments all internal package and component versions from `0.5.2-dev` to `0.6.1-dev` across the repository. 
 
The affected modules include:

* `clp-mcp-server`
* `clp-package-utils`
* `clp-py-utils`
* `job-orchestration`
* Core libraries (`clp` and `glt`)
* Integration test dependency references (NOTE: the `integration-test` module's own version string was not updated because that is an independent project)
* Global `taskfile.yaml` version variable (`G_PACKAGE_VERSION`)


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. `task` to build the project and observed the build was successful.
2. Verified that all files updated in #1324 have also been updated in this PR.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version from 0.5.2-dev to 0.6.1-dev across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->