### PR TITLE
style(clp-package): Rename Python classes to properly follow PascalCase naming conventions.

### DIFF
--- a/components/clp-mcp-server/clp_mcp_server/clp_mcp_server.py
+++ b/components/clp-mcp-server/clp_mcp_server/clp_mcp_server.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 import click
-from clp_py_utils.clp_config import CLPConfig, MCP_SERVER_COMPONENT_NAME
+from clp_py_utils.clp_config import ClpConfig, MCP_SERVER_COMPONENT_NAME
 from clp_py_utils.clp_logging import get_logger, get_logging_formatter, set_logging_level
 from clp_py_utils.core import read_yaml_config_file
 from pydantic import ValidationError
@@ -72,7 +72,7 @@ def main(host: str, port: int, config_path: Path) -> int:
         exit_code = 1
 
     try:
-        clp_config = CLPConfig.model_validate(read_yaml_config_file(config_path))
+        clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
     except ValidationError:
         logger.exception("Configuration validation failed.")
         exit_code = 1

--- a/components/clp-mcp-server/clp_mcp_server/server/server.py
+++ b/components/clp-mcp-server/clp_mcp_server/server/server.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from clp_py_utils.clp_config import CLPConfig
+from clp_py_utils.clp_config import ClpConfig
 from fastmcp import Context, FastMCP
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -14,7 +14,7 @@ from .session_manager import SessionManager
 from .utils import format_query_results, parse_timestamp_range, sort_by_timestamp
 
 
-def create_mcp_server(clp_config: CLPConfig) -> FastMCP:
+def create_mcp_server(clp_config: ClpConfig) -> FastMCP:
     """
     Creates and defines API tool calls for the CLP MCP server.
 

--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -12,7 +12,7 @@ from typing import Any, Optional
 
 from clp_py_utils.clp_config import (
     AwsAuthType,
-    CLPConfig,
+    ClpConfig,
     COMPRESSION_JOBS_TABLE_NAME,
     COMPRESSION_SCHEDULER_COMPONENT_NAME,
     COMPRESSION_WORKER_COMPONENT_NAME,
@@ -82,7 +82,7 @@ class BaseController(ABC):
     variables, directories, and configuration files for each component.
     """
 
-    def __init__(self, clp_config: CLPConfig) -> None:
+    def __init__(self, clp_config: ClpConfig) -> None:
         self._clp_config = clp_config
         self._clp_home = get_clp_home()
         self._conf_dir = self._clp_home / "etc"
@@ -425,7 +425,7 @@ class BaseController(ABC):
 
         return env_vars
 
-    def _set_up_env_for_webui(self, container_clp_config: CLPConfig) -> EnvVarsDict:
+    def _set_up_env_for_webui(self, container_clp_config: ClpConfig) -> EnvVarsDict:
         """
         Sets up environment variables and settings for the Web UI component.
 
@@ -665,7 +665,7 @@ class DockerComposeController(BaseController):
     Controller for orchestrating CLP components using Docker Compose.
     """
 
-    def __init__(self, clp_config: CLPConfig, instance_id: str) -> None:
+    def __init__(self, clp_config: ClpConfig, instance_id: str) -> None:
         self._project_name = f"clp-package-{instance_id}"
         super().__init__(clp_config)
 
@@ -831,7 +831,7 @@ class DockerComposeController(BaseController):
         return "docker-compose.yaml"
 
 
-def get_or_create_instance_id(clp_config: CLPConfig) -> str:
+def get_or_create_instance_id(clp_config: ClpConfig) -> str:
     """
     Gets or creates a unique instance ID for this CLP instance.
 

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -15,7 +15,7 @@ import yaml
 from clp_py_utils.clp_config import (
     CLP_DEFAULT_CREDENTIALS_FILE_PATH,
     CLP_SHARED_CONFIG_FILENAME,
-    CLPConfig,
+    ClpConfig,
     CONTAINER_AWS_CONFIG_DIRECTORY,
     CONTAINER_CLP_HOME,
     CONTAINER_INPUT_LOGS_ROOT_DIR,
@@ -231,8 +231,8 @@ def is_path_already_mounted(
 
 
 def generate_container_config(
-    clp_config: CLPConfig, clp_home: pathlib.Path
-) -> Tuple[CLPConfig, CLPDockerMounts]:
+    clp_config: ClpConfig, clp_home: pathlib.Path
+) -> Tuple[ClpConfig, CLPDockerMounts]:
     """
     Copies the given config and sets up mounts mapping the relevant host paths into the container
 
@@ -314,7 +314,7 @@ def generate_container_config(
     return container_clp_config, docker_mounts
 
 
-def generate_docker_compose_container_config(clp_config: CLPConfig) -> CLPConfig:
+def generate_docker_compose_container_config(clp_config: ClpConfig) -> ClpConfig:
     """
     Copies the given config and transforms mount paths and hosts for Docker Compose.
 
@@ -327,7 +327,7 @@ def generate_docker_compose_container_config(clp_config: CLPConfig) -> CLPConfig
     return container_clp_config
 
 
-def generate_worker_config(clp_config: CLPConfig) -> WorkerConfig:
+def generate_worker_config(clp_config: ClpConfig) -> WorkerConfig:
     worker_config = WorkerConfig()
     worker_config.package = clp_config.package.model_copy(deep=True)
     worker_config.archive_output = clp_config.archive_output.model_copy(deep=True)
@@ -344,7 +344,7 @@ def get_container_config_filename(container_name: str) -> str:
 
 
 def dump_container_config(
-    container_clp_config: CLPConfig, clp_config: CLPConfig, config_filename: str
+    container_clp_config: ClpConfig, clp_config: ClpConfig, config_filename: str
 ):
     """
     Writes the given container config to the logs directory, so that it's accessible in the
@@ -364,7 +364,7 @@ def dump_container_config(
     return config_file_path_on_container, config_file_path_on_host
 
 
-def dump_shared_container_config(container_clp_config: CLPConfig, clp_config: CLPConfig):
+def dump_shared_container_config(container_clp_config: ClpConfig, clp_config: ClpConfig):
     """
     Dumps the given container config to `CLP_SHARED_CONFIG_FILENAME` in the logs directory, so that
     it's accessible in the container.
@@ -432,14 +432,14 @@ def load_config_file(
     if config_file_path.exists():
         raw_clp_config = read_yaml_config_file(config_file_path)
         if raw_clp_config is None:
-            clp_config = CLPConfig()
+            clp_config = ClpConfig()
         else:
-            clp_config = CLPConfig.model_validate(raw_clp_config)
+            clp_config = ClpConfig.model_validate(raw_clp_config)
     else:
         if config_file_path != default_config_file_path:
             raise ValueError(f"Config file '{config_file_path}' does not exist.")
 
-        clp_config = CLPConfig()
+        clp_config = ClpConfig()
 
     clp_config.make_config_paths_absolute(clp_home)
     clp_config.load_container_image_ref()
@@ -463,7 +463,7 @@ def generate_credentials_file(credentials_file_path: pathlib.Path):
 
 
 def validate_credentials_file_path(
-    clp_config: CLPConfig, clp_home: pathlib.Path, generate_default_file: bool
+    clp_config: ClpConfig, clp_home: pathlib.Path, generate_default_file: bool
 ):
     credentials_file_path = clp_config.credentials_file_path
     resolved_credentials_file_path = resolve_host_path_in_container(credentials_file_path)
@@ -481,28 +481,28 @@ def validate_credentials_file_path(
 
 
 def validate_and_load_db_credentials_file(
-    clp_config: CLPConfig, clp_home: pathlib.Path, generate_default_file: bool
+    clp_config: ClpConfig, clp_home: pathlib.Path, generate_default_file: bool
 ):
     validate_credentials_file_path(clp_config, clp_home, generate_default_file)
     clp_config.database.load_credentials_from_file(clp_config.credentials_file_path)
 
 
 def validate_and_load_queue_credentials_file(
-    clp_config: CLPConfig, clp_home: pathlib.Path, generate_default_file: bool
+    clp_config: ClpConfig, clp_home: pathlib.Path, generate_default_file: bool
 ):
     validate_credentials_file_path(clp_config, clp_home, generate_default_file)
     clp_config.queue.load_credentials_from_file(clp_config.credentials_file_path)
 
 
 def validate_and_load_redis_credentials_file(
-    clp_config: CLPConfig, clp_home: pathlib.Path, generate_default_file: bool
+    clp_config: ClpConfig, clp_home: pathlib.Path, generate_default_file: bool
 ):
     validate_credentials_file_path(clp_config, clp_home, generate_default_file)
     clp_config.redis.load_credentials_from_file(clp_config.credentials_file_path)
 
 
 def validate_db_config(
-    clp_config: CLPConfig,
+    clp_config: ClpConfig,
     component_config: pathlib.Path,
     data_dir: pathlib.Path,
     logs_dir: pathlib.Path,
@@ -516,14 +516,14 @@ def validate_db_config(
     validate_port(f"{DB_COMPONENT_NAME}.port", clp_config.database.host, clp_config.database.port)
 
 
-def validate_queue_config(clp_config: CLPConfig, logs_dir: pathlib.Path):
+def validate_queue_config(clp_config: ClpConfig, logs_dir: pathlib.Path):
     _validate_log_directory(logs_dir, QUEUE_COMPONENT_NAME)
 
     validate_port(f"{QUEUE_COMPONENT_NAME}.port", clp_config.queue.host, clp_config.queue.port)
 
 
 def validate_redis_config(
-    clp_config: CLPConfig,
+    clp_config: ClpConfig,
     component_config: pathlib.Path,
     data_dir: pathlib.Path,
     logs_dir: pathlib.Path,
@@ -539,7 +539,7 @@ def validate_redis_config(
     validate_port(f"{REDIS_COMPONENT_NAME}.port", clp_config.redis.host, clp_config.redis.port)
 
 
-def validate_reducer_config(clp_config: CLPConfig, logs_dir: pathlib.Path, num_workers: int):
+def validate_reducer_config(clp_config: ClpConfig, logs_dir: pathlib.Path, num_workers: int):
     _validate_log_directory(logs_dir, REDUCER_COMPONENT_NAME)
 
     for i in range(0, num_workers):
@@ -551,7 +551,7 @@ def validate_reducer_config(clp_config: CLPConfig, logs_dir: pathlib.Path, num_w
 
 
 def validate_results_cache_config(
-    clp_config: CLPConfig,
+    clp_config: ClpConfig,
     component_config: pathlib.Path,
     data_dir: pathlib.Path,
     logs_dir: pathlib.Path,
@@ -571,7 +571,7 @@ def validate_results_cache_config(
     )
 
 
-def validate_output_storage_config(clp_config: CLPConfig) -> None:
+def validate_output_storage_config(clp_config: ClpConfig) -> None:
     clp_config.validate_archive_output_config(True)
     clp_config.validate_stream_output_config(True)
 
@@ -580,7 +580,7 @@ def validate_output_storage_config(clp_config: CLPConfig) -> None:
 
 
 def validate_webui_config(
-    clp_config: CLPConfig,
+    clp_config: ClpConfig,
     client_settings_json_path: pathlib.Path,
     server_settings_json_path: pathlib.Path,
 ):
@@ -592,7 +592,7 @@ def validate_webui_config(
     validate_port(f"{WEBUI_COMPONENT_NAME}.port", clp_config.webui.host, clp_config.webui.port)
 
 
-def validate_mcp_server_config(clp_config: CLPConfig, logs_dir: pathlib.Path):
+def validate_mcp_server_config(clp_config: ClpConfig, logs_dir: pathlib.Path):
     _validate_log_directory(logs_dir, MCP_SERVER_COMPONENT_NAME)
 
     validate_port(
@@ -663,7 +663,7 @@ def validate_dataset_name(clp_table_prefix: str, dataset_name: str) -> None:
         )
 
 
-def validate_retention_config(clp_config: CLPConfig) -> None:
+def validate_retention_config(clp_config: ClpConfig) -> None:
     clp_query_engine = clp_config.package.query_engine
     if is_retention_period_configured(clp_config) and clp_query_engine == QueryEngine.PRESTO:
         raise ValueError(
@@ -671,7 +671,7 @@ def validate_retention_config(clp_config: CLPConfig) -> None:
         )
 
 
-def is_retention_period_configured(clp_config: CLPConfig) -> bool:
+def is_retention_period_configured(clp_config: ClpConfig) -> bool:
     if clp_config.archive_output.retention_period is not None:
         return True
 
@@ -699,7 +699,7 @@ def get_common_env_vars_list(
 
 
 def get_credential_env_vars_list(
-    container_clp_config: CLPConfig,
+    container_clp_config: ClpConfig,
     include_db_credentials=False,
     include_queue_credentials=False,
     include_redis_credentials=False,
@@ -728,7 +728,7 @@ def get_credential_env_vars_list(
     return env_vars
 
 
-def get_celery_connection_env_vars_list(container_clp_config: CLPConfig) -> List[str]:
+def get_celery_connection_env_vars_list(container_clp_config: ClpConfig) -> List[str]:
     """
     :param container_clp_config:
     :return: A list of Celery connection environment variables for Docker containers, in the format

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -129,7 +129,7 @@ class DockerMount:
         return mount_str
 
 
-class CLPDockerMounts:
+class ClpDockerMounts:
     def __init__(self, clp_home: pathlib.Path, docker_clp_home: pathlib.Path):
         self.input_logs_dir: Optional[DockerMount] = None
         self.clp_home: Optional[DockerMount] = DockerMount(
@@ -232,7 +232,7 @@ def is_path_already_mounted(
 
 def generate_container_config(
     clp_config: ClpConfig, clp_home: pathlib.Path
-) -> Tuple[ClpConfig, CLPDockerMounts]:
+) -> Tuple[ClpConfig, ClpDockerMounts]:
     """
     Copies the given config and sets up mounts mapping the relevant host paths into the container
 
@@ -242,7 +242,7 @@ def generate_container_config(
     """
     container_clp_config = clp_config.model_copy(deep=True)
 
-    docker_mounts = CLPDockerMounts(clp_home, CONTAINER_CLP_HOME)
+    docker_mounts = ClpDockerMounts(clp_home, CONTAINER_CLP_HOME)
 
     if StorageType.FS == clp_config.logs_input.type:
         input_logs_dir = resolve_host_path(clp_config.logs_input.directory)

--- a/components/clp-package-utils/clp_package_utils/scripts/archive_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/archive_manager.py
@@ -17,7 +17,7 @@ from clp_py_utils.clp_config import (
 from clp_py_utils.core import resolve_host_path_in_container
 
 from clp_package_utils.general import (
-    CLPConfig,
+    ClpConfig,
     DockerMount,
     dump_container_config,
     generate_container_config,
@@ -171,7 +171,7 @@ def main(argv: List[str]) -> int:
     # Validate and load config file
     try:
         config_file_path: Path = Path(parsed_args.config)
-        clp_config: CLPConfig = load_config_file(
+        clp_config: ClpConfig = load_config_file(
             resolve_host_path_in_container(config_file_path),
             resolve_host_path_in_container(default_config_file_path),
             clp_home,

--- a/components/clp-package-utils/clp_package_utils/scripts/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/decompress.py
@@ -12,7 +12,7 @@ from clp_py_utils.clp_config import (
     CLP_DB_USER_ENV_VAR_NAME,
     CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH,
     CLP_DEFAULT_DATASET_NAME,
-    CLPConfig,
+    ClpConfig,
     StorageEngine,
     StorageType,
 )
@@ -44,7 +44,7 @@ def validate_and_load_config(
     clp_home: pathlib.Path,
     config_file_path: pathlib.Path,
     default_config_file_path: pathlib.Path,
-) -> Optional[CLPConfig]:
+) -> Optional[ClpConfig]:
     """
     Validates and loads the config file.
     :param clp_home:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
@@ -15,7 +15,7 @@ from clp_py_utils.clp_metadata_db_utils import (
 from clp_py_utils.sql_adapter import SQL_Adapter
 
 from clp_package_utils.general import (
-    CLPConfig,
+    ClpConfig,
     get_clp_home,
     load_config_file,
 )
@@ -189,7 +189,7 @@ def main(argv: List[str]) -> int:
     # Validate and load config file
     config_file_path: Path = Path(parsed_args.config)
     try:
-        clp_config: CLPConfig = load_config_file(
+        clp_config: ClpConfig = load_config_file(
             config_file_path, default_config_file_path, clp_home
         )
         clp_config.validate_logs_dir()

--- a/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
@@ -12,7 +12,7 @@ from clp_py_utils.clp_metadata_db_utils import (
     delete_archives_from_metadata_db,
     get_archives_table_name,
 )
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from clp_package_utils.general import (
     ClpConfig,
@@ -271,7 +271,7 @@ def _find_archives(
     dataset_specific_message = f" of dataset `{dataset}`" if dataset is not None else ""
     logger.info(f"Starting to find archives{dataset_specific_message} from the database.")
     try:
-        sql_adapter: SQL_Adapter = SQL_Adapter(database_config)
+        sql_adapter: SqlAdapter = SqlAdapter(database_config)
         clp_db_connection_params: dict[str, Any] = (
             database_config.get_clp_connection_params_and_type(True)
         )
@@ -336,7 +336,7 @@ def _delete_archives(
     archive_ids: List[str]
     dataset_specific_message = f" of dataset `{dataset}`" if dataset is not None else ""
     logger.info(f"Starting to delete archives{dataset_specific_message} from the database.")
-    sql_adapter: SQL_Adapter = SQL_Adapter(database_config)
+    sql_adapter: SqlAdapter = SqlAdapter(database_config)
     clp_db_connection_params: dict[str, Any] = database_config.get_clp_connection_params_and_type(
         True
     )

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -13,7 +13,7 @@ import msgpack
 from clp_py_utils.clp_config import (
     AwsAuthentication,
     CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH,
-    CLPConfig,
+    ClpConfig,
     COMPRESSION_JOBS_TABLE_NAME,
     StorageType,
 )
@@ -143,7 +143,7 @@ def handle_job(sql_adapter: SQL_Adapter, clp_io_config: ClpIoConfig, no_progress
 
 
 def _generate_clp_io_config(
-    clp_config: CLPConfig,
+    clp_config: ClpConfig,
     logs_to_compress: list[str],
     parsed_args: argparse.Namespace,
 ) -> Union[S3InputConfig, FsInputConfig]:
@@ -280,7 +280,7 @@ def _parse_and_validate_s3_object_urls(
     return region_code, bucket_name, key_prefix, key_list
 
 
-def _get_aws_authentication_from_config(clp_config: CLPConfig) -> AwsAuthentication:
+def _get_aws_authentication_from_config(clp_config: ClpConfig) -> AwsAuthentication:
     """
     Gets AWS authentication configuration.
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -19,7 +19,7 @@ from clp_py_utils.clp_config import (
 )
 from clp_py_utils.pretty_size import pretty_size
 from clp_py_utils.s3_utils import parse_s3_url
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 from job_orchestration.scheduler.constants import (
     CompressionJobCompletionStatus,
     CompressionJobStatus,
@@ -115,7 +115,7 @@ def handle_job_update(db, db_cursor, job_id, no_progress_reporting):
         time.sleep(0.5)
 
 
-def handle_job(sql_adapter: SQL_Adapter, clp_io_config: ClpIoConfig, no_progress_reporting: bool):
+def handle_job(sql_adapter: SqlAdapter, clp_io_config: ClpIoConfig, no_progress_reporting: bool):
     with closing(sql_adapter.create_connection(True)) as db, closing(
         db.cursor(dictionary=True)
     ) as db_cursor:
@@ -382,7 +382,7 @@ def main(argv):
             clp_output_config.tags = tag_list
     clp_io_config = ClpIoConfig(input=clp_input_config, output=clp_output_config)
 
-    mysql_adapter = SQL_Adapter(clp_config.database)
+    mysql_adapter = SqlAdapter(clp_config.database)
     return handle_job(
         sql_adapter=mysql_adapter,
         clp_io_config=clp_io_config,

--- a/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
@@ -21,7 +21,7 @@ from clp_py_utils.s3_utils import s3_delete_by_key_prefix
 from clp_py_utils.sql_adapter import SQL_Adapter
 
 from clp_package_utils.general import (
-    CLPConfig,
+    ClpConfig,
     get_clp_home,
     load_config_file,
 )
@@ -62,7 +62,7 @@ def _handle_list_datasets(datasets: Dict[str, str]) -> int:
 
 
 def _handle_del_datasets(
-    clp_config: CLPConfig,
+    clp_config: ClpConfig,
     parsed_args: argparse.Namespace,
     existing_datasets_info: Dict[str, str],
 ):
@@ -89,7 +89,7 @@ def _handle_del_datasets(
     return 0
 
 
-def _delete_dataset(clp_config: CLPConfig, dataset: str, dataset_archive_storage_dir: str) -> bool:
+def _delete_dataset(clp_config: ClpConfig, dataset: str, dataset_archive_storage_dir: str) -> bool:
     try:
         _try_deleting_archives(clp_config.archive_output, dataset_archive_storage_dir)
         logger.info(f"Deleted archives of dataset `{dataset}`.")

--- a/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
@@ -18,7 +18,7 @@ from clp_py_utils.clp_metadata_db_utils import (
     get_datasets_table_name,
 )
 from clp_py_utils.s3_utils import s3_delete_by_key_prefix
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from clp_package_utils.general import (
     ClpConfig,
@@ -41,7 +41,7 @@ def _get_dataset_info(
     :return: A map of name -> archive_storage_directory for each dataset that exists.
     """
 
-    sql_adapter = SQL_Adapter(db_config)
+    sql_adapter = SqlAdapter(db_config)
     with closing(sql_adapter.create_connection(True)) as db_conn, closing(
         db_conn.cursor(dictionary=True)
     ) as db_cursor:
@@ -150,7 +150,7 @@ def _try_deleting_archives_from_s3(s3_config: S3Config, archive_storage_key_pref
 
 
 def _delete_dataset_from_database(database_config: Database, dataset: str) -> None:
-    sql_adapter = SQL_Adapter(database_config)
+    sql_adapter = SqlAdapter(database_config)
 
     with closing(sql_adapter.create_connection(True)) as db_conn, closing(
         db_conn.cursor(dictionary=True)

--- a/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
@@ -13,7 +13,7 @@ from clp_py_utils.clp_config import (
     CLP_DB_PASS_ENV_VAR_NAME,
     CLP_DB_USER_ENV_VAR_NAME,
     CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH,
-    CLPConfig,
+    ClpConfig,
     Database,
 )
 from clp_py_utils.clp_metadata_db_utils import get_files_table_name
@@ -179,7 +179,7 @@ def validate_and_load_config_file(
     clp_home: pathlib.Path,
     config_file_path: pathlib.Path,
     default_config_file_path: pathlib.Path,
-) -> Optional[CLPConfig]:
+) -> Optional[ClpConfig]:
     """
     Validates and loads the config file.
     :param clp_home:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
@@ -17,7 +17,7 @@ from clp_py_utils.clp_config import (
     Database,
 )
 from clp_py_utils.clp_metadata_db_utils import get_files_table_name
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 from job_orchestration.scheduler.constants import QueryJobStatus, QueryJobType
 from job_orchestration.scheduler.job_config import (
     ExtractIrJobConfig,
@@ -50,7 +50,7 @@ def get_orig_file_id(db_config: Database, path: str) -> Optional[str]:
     NOTE: Multiple original files may have the same path in which case this method returns the ID of
     only one of them.
     """
-    sql_adapter = SQL_Adapter(db_config)
+    sql_adapter = SqlAdapter(db_config)
     clp_db_connection_params = db_config.get_clp_connection_params_and_type(True)
     table_prefix = clp_db_connection_params["table_prefix"]
     with closing(sql_adapter.create_connection(True)) as db_conn, closing(
@@ -89,7 +89,7 @@ def submit_and_monitor_extraction_job_in_db(
     :param job_config:
     :return: 0 on success, -1 otherwise.
     """
-    sql_adapter = SQL_Adapter(db_config)
+    sql_adapter = SqlAdapter(db_config)
     job_id = submit_query_job(sql_adapter, job_config, job_type)
     job_status = wait_for_query_job(sql_adapter, job_id)
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -16,7 +16,7 @@ from clp_py_utils.clp_config import (
     Database,
     ResultsCache,
 )
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 from job_orchestration.scheduler.constants import QueryJobStatus, QueryJobType
 from job_orchestration.scheduler.job_config import AggregationConfig, SearchJobConfig
 
@@ -71,7 +71,7 @@ def create_and_monitor_job_in_db(
         if len(tag_list) > 0:
             search_config.tags = tag_list
 
-    sql_adapter = SQL_Adapter(db_config)
+    sql_adapter = SqlAdapter(db_config)
     job_id = submit_query_job(sql_adapter, search_config, QueryJobType.SEARCH_OR_AGGREGATION)
     job_status = wait_for_query_job(sql_adapter, job_id)
 

--- a/components/clp-package-utils/clp_package_utils/scripts/native/utils.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/utils.py
@@ -9,7 +9,7 @@ from clp_py_utils.clp_config import (
     QUERY_JOBS_TABLE_NAME,
 )
 from clp_py_utils.clp_metadata_db_utils import fetch_existing_datasets
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 from job_orchestration.scheduler.constants import QueryJobStatus, QueryJobType
 from job_orchestration.scheduler.scheduler_data import QueryJobConfig
 
@@ -50,7 +50,7 @@ async def run_function_in_process(function, *args, initializer=None, init_args=N
 
 
 def submit_query_job(
-    sql_adapter: SQL_Adapter, job_config: QueryJobConfig, job_type: QueryJobType
+    sql_adapter: SqlAdapter, job_config: QueryJobConfig, job_type: QueryJobType
 ) -> int:
     """
     Submits a query job.
@@ -79,7 +79,7 @@ def validate_dataset_exists(db_config: Database, dataset: str) -> None:
     :param dataset:
     :raise: ValueError if the dataset doesn't exist.
     """
-    sql_adapter = SQL_Adapter(db_config)
+    sql_adapter = SqlAdapter(db_config)
     clp_db_connection_params = db_config.get_clp_connection_params_and_type(True)
     table_prefix = clp_db_connection_params["table_prefix"]
     with closing(sql_adapter.create_connection(True)) as db_conn, closing(
@@ -89,7 +89,7 @@ def validate_dataset_exists(db_config: Database, dataset: str) -> None:
             raise ValueError(f"Dataset `{dataset}` doesn't exist.")
 
 
-def wait_for_query_job(sql_adapter: SQL_Adapter, job_id: int) -> QueryJobStatus:
+def wait_for_query_job(sql_adapter: SqlAdapter, job_id: int) -> QueryJobStatus:
     """
     Waits for the query job with the given ID to complete.
     :param sql_adapter:

--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -610,7 +610,7 @@ def _get_env_var(name: str) -> str:
     return value
 
 
-class CLPConfig(BaseModel):
+class ClpConfig(BaseModel):
     container_image_ref: Optional[NonEmptyStr] = None
 
     logs_input: Union[FsIngestionConfig, S3IngestionConfig] = FsIngestionConfig()
@@ -856,7 +856,7 @@ class CLPConfig(BaseModel):
 class WorkerConfig(BaseModel):
     package: Package = Package()
     archive_output: ArchiveOutput = ArchiveOutput()
-    tmp_directory: SerializablePath = CLPConfig().tmp_directory
+    tmp_directory: SerializablePath = ClpConfig().tmp_directory
 
     # Only needed by query workers.
     stream_output: StreamOutput = StreamOutput()

--- a/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import closing
 
 from pydantic import ValidationError
-from sql_adapter import SQL_Adapter
+from sql_adapter import SqlAdapter
 
 from clp_py_utils.clp_config import (
     ClpConfig,
@@ -55,7 +55,7 @@ def main(argv):
         return -1
 
     try:
-        sql_adapter = SQL_Adapter(clp_config.database)
+        sql_adapter = SqlAdapter(clp_config.database)
         clp_db_connection_params = clp_config.database.get_clp_connection_params_and_type(True)
         table_prefix = clp_db_connection_params["table_prefix"]
         with closing(sql_adapter.create_connection(True)) as metadata_db, closing(

--- a/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-clp-metadata-db.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from sql_adapter import SQL_Adapter
 
 from clp_py_utils.clp_config import (
-    CLPConfig,
+    ClpConfig,
     StorageEngine,
 )
 from clp_py_utils.clp_metadata_db_utils import (
@@ -45,7 +45,7 @@ def main(argv):
     # Load configuration
     config_path = pathlib.Path(parsed_args.config)
     try:
-        clp_config = CLPConfig.model_validate(read_yaml_config_file(config_path))
+        clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
         clp_config.database.load_credentials_from_env()
     except (ValidationError, ValueError) as err:
         logger.error(err)

--- a/components/clp-py-utils/clp_py_utils/initialize-orchestration-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-orchestration-db.py
@@ -12,7 +12,7 @@ from job_orchestration.scheduler.constants import (
     QueryTaskStatus,
 )
 from pydantic import ValidationError
-from sql_adapter import SQL_Adapter
+from sql_adapter import SqlAdapter
 
 from clp_py_utils.clp_config import (
     ClpConfig,
@@ -54,7 +54,7 @@ def main(argv):
         return -1
 
     try:
-        sql_adapter = SQL_Adapter(clp_config.database)
+        sql_adapter = SqlAdapter(clp_config.database)
         with closing(sql_adapter.create_connection(True)) as scheduling_db, closing(
             scheduling_db.cursor(dictionary=True)
         ) as scheduling_db_cursor:

--- a/components/clp-py-utils/clp_py_utils/initialize-orchestration-db.py
+++ b/components/clp-py-utils/clp_py_utils/initialize-orchestration-db.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from sql_adapter import SQL_Adapter
 
 from clp_py_utils.clp_config import (
-    CLPConfig,
+    ClpConfig,
     COMPRESSION_JOBS_TABLE_NAME,
     COMPRESSION_TASKS_TABLE_NAME,
     QUERY_JOBS_TABLE_NAME,
@@ -44,7 +44,7 @@ def main(argv):
     # Load configuration
     config_path = pathlib.Path(parsed_args.config)
     try:
-        clp_config = CLPConfig.model_validate(read_yaml_config_file(config_path))
+        clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
         clp_config.database.load_credentials_from_env()
     except (ValidationError, ValueError) as err:
         logger.error(err)

--- a/components/clp-py-utils/clp_py_utils/s3_utils.py
+++ b/components/clp-py-utils/clp_py_utils/s3_utils.py
@@ -12,7 +12,7 @@ from clp_py_utils.clp_config import (
     ARCHIVE_MANAGER_ACTION_NAME,
     AwsAuthentication,
     AwsAuthType,
-    CLPConfig,
+    ClpConfig,
     COMPRESSION_SCHEDULER_COMPONENT_NAME,
     COMPRESSION_WORKER_COMPONENT_NAME,
     FsStorage,
@@ -100,7 +100,7 @@ def get_credential_env_vars(auth: AwsAuthentication) -> Dict[str, str]:
 
 
 def generate_container_auth_options(
-    clp_config: CLPConfig, container_type: str
+    clp_config: ClpConfig, container_type: str
 ) -> Tuple[bool, List[str]]:
     """
     Generates Docker container authentication options for AWS S3 access based on the given type.

--- a/components/clp-py-utils/clp_py_utils/s3_utils.py
+++ b/components/clp-py-utils/clp_py_utils/s3_utils.py
@@ -106,7 +106,7 @@ def generate_container_auth_options(
     Generates Docker container authentication options for AWS S3 access based on the given type.
     Handles authentication methods that require extra configuration (profile, env_vars).
 
-    :param clp_config: CLPConfig containing storage configurations.
+    :param clp_config: ClpConfig containing storage configurations.
     :param container_type: Type of the calling container.
     :return: Tuple of (whether aws config mount is needed, credential env_vars to set).
     :raises: ValueError if environment variables are not set correctly.

--- a/components/clp-py-utils/clp_py_utils/sql_adapter.py
+++ b/components/clp-py-utils/clp_py_utils/sql_adapter.py
@@ -57,7 +57,7 @@ class ConnectionPoolWrapper:
         return True
 
 
-class SQL_Adapter:
+class SqlAdapter:
     def __init__(self, database_config: Database):
         self.database_config = database_config
 

--- a/components/clp-rust-utils/src/clp_config/package/config.rs
+++ b/components/clp-rust-utils/src/clp_config/package/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-/// Mirror of `clp_py_utils.clp_config.CLPConfig`.
+/// Mirror of `clp_py_utils.clp_config.ClpConfig`.
 ///
 /// # NOTE
 ///

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -29,7 +29,7 @@ from clp_py_utils.s3_utils import (
     get_credential_env_vars,
     s3_put,
 )
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from job_orchestration.scheduler.constants import CompressionTaskStatus
 from job_orchestration.scheduler.job_config import (
@@ -349,7 +349,7 @@ def run_clp(
     task_id: int,
     tag_ids: list[int],
     paths_to_compress: PathsToCompress,
-    sql_adapter: SQL_Adapter,
+    sql_adapter: SqlAdapter,
     clp_metadata_db_connection_config,
     logger,
 ):
@@ -364,7 +364,7 @@ def run_clp(
     :param task_id:
     :param tag_ids:
     :param paths_to_compress: PathToCompress
-    :param sql_adapter: SQL_Adapter
+    :param sql_adapter: SqlAdapter
     :param clp_metadata_db_connection_config
     :param logger
     :return: tuple -- (whether compression was successful, output messages)
@@ -626,7 +626,7 @@ def compression_entry_point(
     clp_io_config = ClpIoConfig.model_validate_json(clp_io_config_json)
     paths_to_compress = PathsToCompress.model_validate_json(paths_to_compress_json)
 
-    sql_adapter = SQL_Adapter(Database.model_validate(clp_metadata_db_connection_config))
+    sql_adapter = SqlAdapter(Database.model_validate(clp_metadata_db_connection_config))
 
     start_time = datetime.datetime.now()
     logger.info(f"[job_id={job_id} task_id={task_id}] COMPRESSION STARTED.")

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -19,7 +19,7 @@ from clp_py_utils.s3_utils import (
     get_credential_env_vars,
     s3_put,
 )
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from job_orchestration.executor.query.celery import app
 from job_orchestration.executor.query.utils import (
@@ -200,7 +200,7 @@ def extract_stream(
 
     start_time = datetime.datetime.now()
     task_status: QueryTaskStatus
-    sql_adapter = SQL_Adapter(Database.model_validate(clp_metadata_db_conn_params))
+    sql_adapter = SqlAdapter(Database.model_validate(clp_metadata_db_conn_params))
 
     # Load configuration
     clp_config_path = Path(os.getenv("CLP_CONFIG_PATH"))

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -13,7 +13,7 @@ from clp_py_utils.clp_config import (
 )
 from clp_py_utils.clp_logging import set_logging_level
 from clp_py_utils.s3_utils import generate_s3_virtual_hosted_style_url, get_credential_env_vars
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from job_orchestration.executor.query.celery import app
 from job_orchestration.executor.query.utils import (
@@ -185,7 +185,7 @@ def search(
     logger.info(f"Started {task_name} task for job {job_id}")
 
     start_time = datetime.datetime.now()
-    sql_adapter = SQL_Adapter(Database.model_validate(clp_metadata_db_conn_params))
+    sql_adapter = SqlAdapter(Database.model_validate(clp_metadata_db_conn_params))
 
     # Load configuration
     clp_config_path = Path(os.getenv("CLP_CONFIG_PATH"))

--- a/components/job-orchestration/job_orchestration/executor/query/utils.py
+++ b/components/job-orchestration/job_orchestration/executor/query/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from clp_py_utils.clp_config import QUERY_TASKS_TABLE_NAME
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from job_orchestration.scheduler.scheduler_data import QueryTaskResult, QueryTaskStatus
 
@@ -21,7 +21,7 @@ def get_task_log_file_path(clp_logs_dir: Path, job_id: str, task_id: int) -> Pat
 
 
 def report_task_failure(
-    sql_adapter: SQL_Adapter,
+    sql_adapter: SqlAdapter,
     task_id: int,
     start_time: datetime.datetime,
 ):
@@ -40,7 +40,7 @@ def report_task_failure(
 
 
 def run_query_task(
-    sql_adapter: SQL_Adapter,
+    sql_adapter: SqlAdapter,
     logger: Logger,
     clp_logs_dir: Path,
     task_command: List[str],
@@ -117,7 +117,7 @@ def run_query_task(
 
 
 def update_query_task_metadata(
-    sql_adapter: SQL_Adapter,
+    sql_adapter: SqlAdapter,
     task_id: int,
     kv_pairs: Dict[str, Any],
 ):

--- a/components/job-orchestration/job_orchestration/garbage_collector/archive_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/archive_garbage_collector.py
@@ -17,7 +17,7 @@ from clp_py_utils.clp_metadata_db_utils import (
     fetch_existing_datasets,
     get_archives_table_name,
 )
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 from job_orchestration.garbage_collector.constants import (
     ARCHIVE_GARBAGE_COLLECTOR_NAME,
     MIN_TO_SECONDS,
@@ -156,7 +156,7 @@ def _collect_and_sweep_expired_archives(
 
     clp_connection_param = database_config.get_clp_connection_params_and_type()
     table_prefix = clp_connection_param["table_prefix"]
-    sql_adapter = SQL_Adapter(database_config)
+    sql_adapter = SqlAdapter(database_config)
     with closing(sql_adapter.create_connection(True)) as db_conn, closing(
         db_conn.cursor(dictionary=True)
     ) as db_cursor:

--- a/components/job-orchestration/job_orchestration/garbage_collector/archive_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/archive_garbage_collector.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from clp_py_utils.clp_config import (
     ArchiveOutput,
-    CLPConfig,
+    ClpConfig,
     Database,
     QUERY_JOBS_TABLE_NAME,
     StorageEngine,
@@ -192,7 +192,7 @@ def _collect_and_sweep_expired_archives(
 
 
 async def archive_garbage_collector(
-    clp_config: CLPConfig, log_directory: pathlib.Path, logging_level: str
+    clp_config: ClpConfig, log_directory: pathlib.Path, logging_level: str
 ) -> None:
     configure_logger(logger, logging_level, log_directory, ARCHIVE_GARBAGE_COLLECTOR_NAME)
 

--- a/components/job-orchestration/job_orchestration/garbage_collector/garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/garbage_collector.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
 from clp_py_utils.clp_config import (
-    CLPConfig,
+    ClpConfig,
     GARBAGE_COLLECTOR_COMPONENT_NAME,
 )
 from clp_py_utils.clp_logging import get_logger
@@ -42,7 +42,7 @@ async def main(argv: List[str]) -> int:
     # Load configuration
     config_path = Path(parsed_args.config)
     try:
-        clp_config = CLPConfig.model_validate(read_yaml_config_file(config_path))
+        clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
         clp_config.database.load_credentials_from_env()
     except (ValidationError, ValueError) as err:
         logger.error(err)

--- a/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
@@ -5,7 +5,7 @@ from typing import Final, List
 import pymongo
 import pymongo.database
 from bson import ObjectId
-from clp_py_utils.clp_config import CLPConfig, ResultsCache
+from clp_py_utils.clp_config import ClpConfig, ResultsCache
 from clp_py_utils.clp_logging import get_logger
 from job_orchestration.garbage_collector.constants import (
     MIN_TO_SECONDS,
@@ -70,7 +70,7 @@ def _collect_and_sweep_expired_search_results(
 
 
 async def search_result_garbage_collector(
-    clp_config: CLPConfig, log_directory: pathlib.Path, logging_level: str
+    clp_config: ClpConfig, log_directory: pathlib.Path, logging_level: str
 ) -> None:
     configure_logger(logger, logging_level, log_directory, SEARCH_RESULT_GARBAGE_COLLECTOR_NAME)
 

--- a/components/job-orchestration/job_orchestration/reducer/reducer.py
+++ b/components/job-orchestration/job_orchestration/reducer/reducer.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from clp_py_utils.clp_config import CLPConfig
+from clp_py_utils.clp_config import ClpConfig
 from clp_py_utils.clp_logging import get_logger, get_logging_formatter, set_logging_level
 from clp_py_utils.core import read_yaml_config_file
 from pydantic import ValidationError
@@ -43,7 +43,7 @@ def main(argv: List[str]) -> int:
     # Load configuration
     config_path = Path(parsed_args.config)
     try:
-        clp_config = CLPConfig.model_validate(read_yaml_config_file(config_path))
+        clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
     except ValidationError as err:
         logger.error(err)
         return 1

--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -13,7 +13,7 @@ import brotli
 import msgpack
 from clp_package_utils.general import CONTAINER_INPUT_LOGS_ROOT_DIR
 from clp_py_utils.clp_config import (
-    CLPConfig,
+    ClpConfig,
     COMPRESSION_JOBS_TABLE_NAME,
     COMPRESSION_SCHEDULER_COMPONENT_NAME,
     COMPRESSION_TASKS_TABLE_NAME,
@@ -222,7 +222,7 @@ def _write_user_failure_log(
 
 
 def search_and_schedule_new_tasks(
-    clp_config: CLPConfig,
+    clp_config: ClpConfig,
     db_conn,
     db_cursor,
     clp_metadata_db_connection_config: Dict[str, Any],
@@ -507,7 +507,7 @@ def main(argv):
     # Load configuration
     config_path = Path(args.config)
     try:
-        clp_config = CLPConfig.model_validate(read_yaml_config_file(config_path))
+        clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
         clp_config.database.load_credentials_from_env()
     except (ValidationError, ValueError) as err:
         logger.error(err)

--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -28,7 +28,7 @@ from clp_py_utils.clp_metadata_db_utils import (
 from clp_py_utils.compression import validate_path_and_get_info
 from clp_py_utils.core import read_yaml_config_file
 from clp_py_utils.s3_utils import s3_get_object_metadata
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 from pydantic import ValidationError
 
 from job_orchestration.scheduler.compress.partition import PathsToCompressBuffer
@@ -518,7 +518,7 @@ def main(argv):
         return -1
 
     logger.info(f"Starting {COMPRESSION_SCHEDULER_COMPONENT_NAME}")
-    sql_adapter = SQL_Adapter(clp_config.database)
+    sql_adapter = SqlAdapter(clp_config.database)
 
     task_manager = CeleryTaskManager()
 

--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -31,7 +31,7 @@ import celery
 import msgpack
 import pymongo
 from clp_py_utils.clp_config import (
-    CLPConfig,
+    ClpConfig,
     QUERY_JOBS_TABLE_NAME,
     QUERY_SCHEDULER_COMPONENT_NAME,
     QUERY_TASKS_TABLE_NAME,
@@ -1160,7 +1160,7 @@ async def main(argv: List[str]) -> int:
     # Load configuration
     config_path = pathlib.Path(parsed_args.config)
     try:
-        clp_config = CLPConfig.model_validate(read_yaml_config_file(config_path))
+        clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
         clp_config.database.load_credentials_from_env()
     except (ValidationError, ValueError) as err:
         logger.error(err)

--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -46,7 +46,7 @@ from clp_py_utils.clp_metadata_db_utils import (
 )
 from clp_py_utils.core import read_yaml_config_file
 from clp_py_utils.decorators import exception_default_value
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 from pydantic import ValidationError
 
 from job_orchestration.executor.query.extract_stream_task import extract_stream
@@ -1171,7 +1171,7 @@ async def main(argv: List[str]) -> int:
 
     reducer_connection_queue = asyncio.Queue(32)
 
-    sql_adapter = SQL_Adapter(clp_config.database)
+    sql_adapter = SqlAdapter(clp_config.database)
 
     try:
         killed_jobs = kill_hanging_jobs(sql_adapter, SchedulerType.QUERY)

--- a/components/job-orchestration/job_orchestration/scheduler/utils.py
+++ b/components/job-orchestration/job_orchestration/scheduler/utils.py
@@ -9,7 +9,7 @@ from clp_py_utils.clp_config import (
     QUERY_JOBS_TABLE_NAME,
     QUERY_TASKS_TABLE_NAME,
 )
-from clp_py_utils.sql_adapter import SQL_Adapter
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from job_orchestration.scheduler.constants import (
     CompressionJobStatus,
@@ -20,7 +20,7 @@ from job_orchestration.scheduler.constants import (
 )
 
 
-def kill_hanging_jobs(sql_adapter: SQL_Adapter, scheduler_type: str) -> Optional[List[int]]:
+def kill_hanging_jobs(sql_adapter: SqlAdapter, scheduler_type: str) -> Optional[List[int]]:
     if SchedulerType.COMPRESSION == scheduler_type:
         jobs_table_name = COMPRESSION_JOBS_TABLE_NAME
         job_status_running = CompressionJobStatus.RUNNING


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->


Standardizes class naming across the codebase:

- Rename `CLPConfig` -> `ClpConfig`.
- Rename `SQL_Adapter` -> `SqlAdapter`.
- Rename `CLPDockerMounts` -> `ClpDockerMounts` 

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
`task`
# observed the build was successful

cd build/clp-package
./sbin/start-clp.sh
# observed the package was started without seeing any error message

./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.log
# observed the compression was successful

# performed a search in the webui with string "1" and observed results were returned
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardised public type names: CLPConfig → ClpConfig and SQL_Adapter → SqlAdapter across the codebase.
  * Updated public APIs and type annotations to use the new names for configuration and database adapter types.
  * Adjusted related defaults and documentation references to match renamed types; no functional behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->