### PR TITLE
fix(webui): Update default `storage_engine` and `query_engine` to `clp-s` (fixes #1588).

### DIFF
--- a/components/webui/client/public/settings.json
+++ b/components/webui/client/public/settings.json
@@ -1,6 +1,6 @@
 {
-    "ClpStorageEngine": "clp",
-    "ClpQueryEngine": "clp",
+    "ClpStorageEngine": "clp-s",
+    "ClpQueryEngine": "clp-s",
     "MongoDbSearchResultsMetadataCollectionName": "results-metadata",
     "SqlDbClpArchivesTableName": "clp_archives",
     "SqlDbClpDatasetsTableName": "clp_datasets",

--- a/components/webui/server/settings.json
+++ b/components/webui/server/settings.json
@@ -18,7 +18,7 @@
     "StreamFilesS3PathPrefix": null,
     "StreamFilesS3Profile": null,
 
-    "ClpQueryEngine": "clp",
+    "ClpQueryEngine": "clp-s",
     "PrestoHost": "localhost",
     "PrestoPort": 8889
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This change updates both WebUI client and server configuration files to use the new CLP engine default `clp-s` instead of the previous `clp`.  
Specifically:
- Updated `ClpStorageEngine` and `ClpQueryEngine` in `components/webui/client/public/settings.json`.
- Updated `ClpQueryEngine` in `components/webui/server/settings.json`.

This change aligns the Web UI configuration with the changes done in #1572 .

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Ran `npm run dev` in `components/webui`
2. Launched the webui in a browser. Navigated to the Search tab and observed the "dataset" popup was shown, which is a clp-s specific feature:
   <img width="1434" height="498" alt="image" src="https://github.com/user-attachments/assets/5a629963-b023-4c5c-9842-2fb473aab955" />



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated query and storage engine configuration to use the latest version.
  * Added new database configuration options for improved system flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->