### PR TITLE
ci: Drop macOS 14 from GH workflows since it's over 2 years old.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -45,7 +45,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - "macos-14"
           - "macos-15"
         use_shared_libs:
           - true


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

On 2025-Sep-26, macOS 14 (Sonoma) turned 2. We generally only support macOS versions up to 2 years in the past, so it's now safe to drop macOS 14 from our workflows. This will also alleviate some of the contention for macOS GH-hosted runners.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Validated that workflows no longer use macOS 14.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal build configuration for macOS compatibility.

*Note: No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->