### PR TITLE
ci: Add missing monitored paths to the `clp-rust-checks` GH workflow.

### DIFF
--- a/.github/workflows/clp-rust-checks.yaml
+++ b/.github/workflows/clp-rust-checks.yaml
@@ -7,10 +7,12 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - ".github/workflows/clp-rust-checks.yaml"
+      - "components/api-server/**"
       - "components/clp-rust-utils/**"
       - "components/log-ingestor/**"
       - "taskfile.yaml"
       - "taskfiles/**"
+      - "tools/scripts/localstack/**"
   push:
     paths: *monitored_paths
   schedule:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The current `clp-rust-checks` workflow misses the following path filter:

* `tools/scripts/localstack/**`: Used for Rust tests.
* `components/api-server`: A missing Rust component.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to monitor additional code paths for changes, enabling automated checks to run when specific components are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->