### PR TITLE
feat(clp-package): Add healthcheck to api-server service in Docker Compose (fixes #1608).

### DIFF
--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -513,3 +513,11 @@ services:
       "--port", "3001",
       "--config", "/etc/clp-config.yml"
     ]
+    healthcheck:
+      <<: *healthcheck_defaults
+      test: [
+        "CMD",
+        "curl",
+        "-f",
+        "http://api_server:3001/health"
+      ]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This enables proper monitoring of api-server service health status during Docker Compose orchestration.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
task
cd build/clp-package
./sbin/start-clp.sh

# observed the package was started successfully

the API server also reported health:
 ✔ Container clp-package-43cd-api-server-1                     Healthy                                                                                                                        13.9s 
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced API server health monitoring by implementing automated health checks to detect service availability and improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->