### PR TITLE
refactor(deployment): Use `replicas` to control and standardize MCP server enablement in Docker Compose (resolves #1620).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -599,6 +599,11 @@ class BaseController(ABC):
 
         env_vars = EnvVarsDict()
 
+        # Service enablement
+        env_vars |= {
+            "CLP_MCP_SERVER_ENABLED": "1",
+        }
+
         # Connection config
         env_vars |= {
             "CLP_MCP_HOST": _get_ip_from_hostname(self._clp_config.mcp_server.host),
@@ -797,8 +802,6 @@ class DockerComposeController(BaseController):
 
         cmd = ["docker", "compose", "--project-name", self._project_name]
         cmd += ["--file", self._get_docker_file_name()]
-        if self._clp_config.mcp_server is not None:
-            cmd += ["--profile", "mcp"]
         cmd += ["up", "--detach", "--wait"]
         subprocess.run(
             cmd,

--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -452,7 +452,9 @@ services:
   mcp-server:
     <<: *service_defaults
     hostname: "mcp_server"
-    profiles: ["mcp"]
+    deploy:
+      # Value must be either 0 or 1. Set to 0 to disable the MCP server.
+      replicas: "${CLP_MCP_SERVER_ENABLED:-0}"
     environment:
       CLP_LOGGING_LEVEL: "${CLP_MCP_LOGGING_LEVEL:-INFO}"
       CLP_LOGS_DIR: "/var/log/mcp_server"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR follows #1620 , to modify the CLP package utilities to enable the MCP server via an environment variable (`CLP_MCP_SERVER_ENABLED`). The Docker Compose script was updated to control the MCP server deployment using the same variable. The changes remove conditional profile usage in `controller.py` and allow toggling the server by setting the environment variable to `0` or `1`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. The MCP server is not started when it's not configured in `etc/clp-package.yaml`
	```
	cd build/clp-package
	./sbin/start-clp.sh
	# observed: 
	# 2025-11-19T22:19:47.142 INFO [controller] The MCP Server is not configured, skipping mcp_server creation...
	# also, from the docker compose start logs, the MCP server was not started 
	./sbin/stop-clp.sh
	```
2. The MCP server is started and accessible when it's configured in `etc/clp-package.yaml`
   1. Edited `etc/clp-package.yaml`:
		```yaml
		mcp_server:
		   host: "localhost"
		   port: 8000
		```
   2. Started the Package and observed the MCP server is started and accessible
		```
		./sbin/start-clp.sh
		# observed: 
		# 2025-11-19T22:18:51.085 INFO [controller] Setting up environment for mcp_server...
		# also, from the docker compose start logs, the MCP server was started 
		#  ✔ Container clp-package-d1f8-mcp-server-1                     Health
        
        curl http://localhost:8000/health
        # OK
		```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configuration to be controlled via the CLP_MCP_SERVER_ENABLED environment variable, replacing the previous profile-based approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->