### PR TITLE
fix(clp-package): Change the API server's build path in Dockerfile to `rust-targets`.

### DIFF
--- a/tools/docker-images/clp-package/Dockerfile
+++ b/tools/docker-images/clp-package/Dockerfile
@@ -41,5 +41,5 @@ COPY --link --chown=${UID} ./build/spider/spider-build/src/spider/spider_schedul
 COPY --link --chown=${UID} ./build/spider/spider-build/src/spider/spider_worker bin/
 COPY --link --chown=${UID} ./build/nodejs-22/bin/node bin/node-22
 COPY --link --chown=${UID} ./build/python-libs/ lib/python3/site-packages/
-COPY --link --chown=${UID} ./build/rust/release/api_server bin/
+COPY --link --chown=${UID} ./build/rust-targets/release/api_server bin/
 COPY --link --chown=${UID} ./build/webui/ var/www/webui/


### PR DESCRIPTION

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

the package doesn't build after the latest change in taskfile. This is because the build dir in Dockerfile is hardcoded and wasn't updated.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

the package builds now


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker image build configuration to source the API server binary from a new build output directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->