### PR TITLE
fix(clp-package): Restore missing env var `CLP_QUEUE_LOGS_DIR_HOST` in the queue service's bundling setup method (fixes #1693).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -220,6 +220,11 @@ class BaseController(ABC):
 
         env_vars = EnvVarsDict()
 
+        # Paths
+        env_vars |= {
+            "CLP_QUEUE_LOGS_DIR_HOST": str(logs_dir),
+        }
+
         return env_vars
 
     def _set_up_env_for_queue(self) -> EnvVarsDict:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

During the refactoring in PR #1648, the `CLP_QUEUE_LOGS_DIR_HOST` environment variable was accidentally removed from the `_set_up_env_for_queue` method in `components/clp-package-utils/clp_package_utils/controller.py`. This PR brings it back

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
```
task

cd build/clp-package
./sbin/start-clp.sh
# observe the whole package, including the queue was started successfully
# inspect `.env` and found `CLP_QUEUE_LOGS_DIR_HOST` was set

./sbin/stop-clp.sh
rm -f .env
./sbin/start-clp.sh --setup-only
# again inspect `.env` and found `CLP_QUEUE_LOGS_DIR_HOST` was set
```


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
