### PR TITLE
fix(webui): Add absolute path validation to compression paths input (fixes #1702).

### DIFF
--- a/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
+++ b/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
@@ -1,8 +1,38 @@
+import {Value} from "@sinclair/typebox/value";
+import {AbsolutePathSchema} from "@webui/common/schemas/compression";
+import {Nullable} from "@webui/common/utility-types";
 import {
     Form,
     Input,
 } from "antd";
 
+
+/**
+ * Validates that all non-empty lines in the input are absolute paths using AbsolutePathSchema.
+ *
+ * @param value The multiline string input containing paths.
+ * @return An error message if validation fails, or null if validation passes.
+ */
+const validateAbsolutePaths = (value: string): Nullable<string> => {
+    const lines = value.split("\n");
+    let pathCount = 0;
+    for (const [index, line] of lines.entries()) {
+        const trimmedLine = line.trim();
+        if (0 === trimmedLine.length) {
+            continue;
+        }
+        if (false === Value.Check(AbsolutePathSchema, trimmedLine)) {
+            return `Line ${index + 1}: Path must be absolute (start with "/").`;
+        }
+        pathCount++;
+    }
+
+    if (0 === pathCount) {
+        return "Please enter at least one path.";
+    }
+
+    return null;
+};
 
 /**
  * Renders a form item for inputting file paths for compression job submission.
@@ -13,11 +43,22 @@ const PathsInputFormItem = () => (
     <Form.Item
         label={"Paths"}
         name={"paths"}
-        rules={[{required: true, message: "Please enter at least one path"}]}
+        rules={[
+            {
+                // The `validator` function expects a `Promise` to be returned.
+                // eslint-disable-next-line @typescript-eslint/require-await
+                validator: async (_, value?: string) => {
+                    const error = validateAbsolutePaths(value ?? "");
+                    if (null !== error) {
+                        throw new Error(error);
+                    }
+                },
+            },
+        ]}
     >
         <Input.TextArea
             autoSize={{minRows: 4, maxRows: 10}}
-            placeholder={"Enter paths to compress, one per line"}/>
+            placeholder={"Enter absolute paths to compress, one per line"}/>
     </Form.Item>
 );
 

--- a/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
+++ b/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
@@ -24,8 +24,8 @@ const PathsInputFormItem = () => (
             {
                 // The `validator` function expects a `Promise` to be returned.
                 // eslint-disable-next-line @typescript-eslint/require-await
-                validator: async (_, value?: string) => {
-                    const error = validateAbsolutePaths(value ?? "");
+                validator: async (_, value: string) => {
+                    const error = validateAbsolutePaths(value);
                     if (null !== error) {
                         throw new Error(error);
                     }

--- a/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
+++ b/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
@@ -15,7 +15,6 @@ import {
  */
 const validateAbsolutePaths = (value: string): Nullable<string> => {
     const lines = value.split("\n");
-    let pathCount = 0;
     for (const [index, line] of lines.entries()) {
         const trimmedLine = line.trim();
         if (0 === trimmedLine.length) {
@@ -24,11 +23,6 @@ const validateAbsolutePaths = (value: string): Nullable<string> => {
         if (false === Value.Check(AbsolutePathSchema, trimmedLine)) {
             return `Line ${index + 1}: Path must be absolute (start with "/").`;
         }
-        pathCount++;
-    }
-
-    if (0 === pathCount) {
-        return "Please enter at least one path.";
     }
 
     return null;
@@ -44,6 +38,11 @@ const PathsInputFormItem = () => (
         label={"Paths"}
         name={"paths"}
         rules={[
+            {
+                message: "Please enter at least one path.",
+                required: true,
+                whitespace: true,
+            },
             {
                 // The `validator` function expects a `Promise` to be returned.
                 // eslint-disable-next-line @typescript-eslint/require-await

--- a/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
+++ b/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
@@ -1,32 +1,10 @@
-import {Value} from "@sinclair/typebox/value";
-import {AbsolutePathSchema} from "@webui/common/schemas/compression";
-import {Nullable} from "@webui/common/utility-types";
 import {
     Form,
     Input,
 } from "antd";
 
+import {validateAbsolutePaths} from "./validation";
 
-/**
- * Validates that all non-empty lines in the input are absolute paths using AbsolutePathSchema.
- *
- * @param value The multiline string input containing paths.
- * @return An error message if validation fails, or null if validation passes.
- */
-const validateAbsolutePaths = (value: string): Nullable<string> => {
-    const lines = value.split("\n");
-    for (const [index, line] of lines.entries()) {
-        const trimmedLine = line.trim();
-        if (0 === trimmedLine.length) {
-            continue;
-        }
-        if (false === Value.Check(AbsolutePathSchema, trimmedLine)) {
-            return `Line ${index + 1}: Path must be absolute (start with "/").`;
-        }
-    }
-
-    return null;
-};
 
 /**
  * Renders a form item for inputting file paths for compression job submission.

--- a/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
+++ b/components/webui/client/src/pages/IngestPage/Compress/PathsInputFormItem.tsx
@@ -58,7 +58,7 @@ const PathsInputFormItem = () => (
     >
         <Input.TextArea
             autoSize={{minRows: 4, maxRows: 10}}
-            placeholder={"Enter absolute paths to compress, one per line"}/>
+            placeholder={"Enter absolute paths on the server host, one per line"}/>
     </Form.Item>
 );
 

--- a/components/webui/client/src/pages/IngestPage/Compress/validation.ts
+++ b/components/webui/client/src/pages/IngestPage/Compress/validation.ts
@@ -1,9 +1,33 @@
 import {ValueErrorType} from "@sinclair/typebox/errors";
 import {Value} from "@sinclair/typebox/value";
 import {
+    AbsolutePathSchema,
     DATASET_NAME_MAX_LEN,
     DatasetNameSchema,
 } from "@webui/common/schemas/compression";
+import {Nullable} from "@webui/common/utility-types";
+
+
+/**
+ * Validates that all non-empty lines in the input are absolute paths using AbsolutePathSchema.
+ *
+ * @param value The multiline string input containing paths.
+ * @return An error message if validation fails, or null if validation passes.
+ */
+const validateAbsolutePaths = (value: string): Nullable<string> => {
+    const lines = value.split("\n");
+    for (const [index, line] of lines.entries()) {
+        const trimmedLine = line.trim();
+        if (0 === trimmedLine.length) {
+            continue;
+        }
+        if (false === Value.Check(AbsolutePathSchema, trimmedLine)) {
+            return `Line ${index + 1}: Path must be absolute (start with "/").`;
+        }
+    }
+
+    return null;
+};
 
 
 /**
@@ -42,4 +66,7 @@ const validateDatasetName = (datasetName: string): string | null => {
 };
 
 
-export {validateDatasetName};
+export {
+    validateAbsolutePaths,
+    validateDatasetName,
+};

--- a/components/webui/common/src/schemas/compression.ts
+++ b/components/webui/common/src/schemas/compression.ts
@@ -5,10 +5,20 @@ import {
 
 
 /**
+ * Schema for an absolute file system path.
+ * - Must not be empty.
+ * - Must start with "/": the path must be an absolute path.
+ */
+const AbsolutePathSchema = Type.String({
+    minLength: 1,
+    pattern: "^/",
+});
+
+/**
  * Schema for request to create a new compression job.
  */
 const CompressionJobCreationSchema = Type.Object({
-    paths: Type.Array(Type.String()),
+    paths: Type.Array(AbsolutePathSchema, {minItems: 1}),
     dataset: Type.Optional(Type.String()),
     timestampKey: Type.Optional(Type.String()),
 });
@@ -25,6 +35,7 @@ const CompressionJobSchema = Type.Object({
 type CompressionJob = Static<typeof CompressionJobSchema>;
 
 export {
+    AbsolutePathSchema,
     CompressionJobCreationSchema,
     CompressionJobSchema,
 };

--- a/components/webui/common/src/schemas/compression.ts
+++ b/components/webui/common/src/schemas/compression.ts
@@ -6,7 +6,7 @@ import {
 import {
     CLP_DEFAULT_TABLE_PREFIX,
     SqlTableSuffix,
-} from "../config";
+} from "../config.js";
 
 
 /**


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This change introduces validation for absolute file system paths in compression job
submission workflows.

Changes include:

* Adding `AbsolutePathSchema` to constrain values to non-empty strings beginning with `/`.
* Updating `CompressionJobCreationSchema` so `paths` is now an array of `AbsolutePathSchema` with
  `minItems: 1`.
* Adding `validateAbsolutePaths` to the ingest page to validate each line of multiline input.
* Replacing the old required-rule check with a custom validator that provides line-specific error
  messages.
* Updating the placeholder text to clarify that only absolute paths are valid.

These updates ensure that only valid absolute paths can be submitted, preventing backend errors and
improving user feedback.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Manually tested frontend validation in the ingestion UI:
   * Entered valid absolute paths:
     * `/var/log/syslog`
     * `/home/samples`
     * Empty lines mixed with valid paths
   * Verified that form submission succeeded with no validation errors.
2. Tested invalid values:
   * Relative paths (`logs/syslog`)
   * Paths with tildes (`~/samples`)
   * Lines containing only whitespace
   * Verified error messages referenced correct line number and blocked submission.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-line validation for path inputs: ignores blank lines and shows a clear, line-specific error for the first non-absolute path.

* **New Features**
  * Forms now require at least one absolute path (one per line) and include an updated placeholder guiding users to enter absolute paths on the server host.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->