### PR TITLE
build(rust): Remove unnecessary executable permission from Rust toolchain env file (fixes #1717).

### DIFF
--- a/taskfiles/toolchains.yaml
+++ b/taskfiles/toolchains.yaml
@@ -98,7 +98,6 @@ tasks:
         export RUSTUP_HOME="{{.G_RUSTUP_HOME}}"
         . "{{.G_CARGO_HOME}}/env"
         EOF
-        chmod +x "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
 
       # Disable Rustup's auto self update at the end to avoid unexpected checksum mismatches.
       - |-


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says, the `chmod` command to add `x` bits after generating the file, is removed.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All workflow pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified Rust toolchain environment script setup by removing the need for execute permission; the script continues to be created and sourced with no functional change, reducing setup friction for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->