### PR TITLE
refactor(deployment): Mount Redis config to `/etc` instead of `/usr/local/etc` in CLP package Docker Compose (resolves #1738).

### DIFF
--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -150,7 +150,7 @@ services:
     volumes:
       - type: "bind"
         source: "${CLP_REDIS_CONF_FILE_HOST:-./etc/redis/redis.conf}"
-        target: "/usr/local/etc/redis/redis.conf"
+        target: "/etc/redis/redis.conf"
         read_only: true
       - type: "bind"
         source: "${CLP_REDIS_DATA_DIR_HOST:-./var/data/redis}"
@@ -160,7 +160,7 @@ services:
         target: "/var/log/redis"
     command: [
       "redis-server",
-      "/usr/local/etc/redis/redis.conf",
+      "/etc/redis/redis.conf",
       "--requirepass", "${CLP_REDIS_PASS:?Please set a value.}"
     ]
     healthcheck:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
task

cd build/clp-package
./sbin/start-clp.sh
# observed the package was started successfully
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis service configuration in the deployment infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->