### PR TITLE
feat(deployment): Add support for root database credentials in Helm templates.

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.2-dev.2"
+version: "0.1.2-dev.3"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.7.1-dev"

--- a/tools/deployment/package-helm/templates/database-secret.yaml
+++ b/tools/deployment/package-helm/templates/database-secret.yaml
@@ -9,3 +9,5 @@ type: "Opaque"
 stringData:
   username: {{ .Values.credentials.database.username | quote }}
   password: {{ .Values.credentials.database.password | quote }}
+  root_username: {{ .Values.credentials.database.root_username | quote }}
+  root_password: {{ .Values.credentials.database.root_password | quote }}

--- a/tools/deployment/package-helm/templates/database-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/database-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "clp.fullname" . }}-database
-                  key: "password"
+                  key: "root_password"
           ports:
             - name: "database"
               containerPort: 3306

--- a/tools/deployment/package-helm/templates/db-table-creator-job.yaml
+++ b/tools/deployment/package-helm/templates/db-table-creator-job.yaml
@@ -44,6 +44,16 @@ spec:
                 secretKeyRef:
                   name: {{ include "clp.fullname" . }}-database
                   key: "password"
+            - name: "CLP_DB_ROOT_USER"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clp.fullname" . }}-database
+                  key: "root_username"
+            - name: "CLP_DB_ROOT_PASS"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clp.fullname" . }}-database
+                  key: "root_password"
             - name: "PYTHONPATH"
               value: "/opt/clp/lib/python3/site-packages"
           volumeMounts:

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -52,6 +52,8 @@ credentials:
   database:
     username: "clp-user"
     password: "pass"
+    root_username: "root"
+    root_password: "root-pass"
 
   queue:
     username: "clp-user"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

> [!NOTE]  
This PR is part of the ongoing work for #1309. More PRs will be submitted until the Helm chart is complete and fully functional.

This PR updates the CLP Helm chart to include support for root database credentials. The changes include:

* Database secret: Added `root_username` and `root_password` fields to database-secret.yaml.
* Database StatefulSet: Updated the environment variable in the container to use `root_password` for relevant operations.
* DB table creator job: Added `CLP_DB_ROOT_USER` and `CLP_DB_ROOT_PASS` environment variables for root-level access during table creation.
* Default values: Added root credentials to `values.yaml` with default values `"root"` / `"root-pass"`.

These changes allow the chart to support operations requiring root-level database access, matching the Docker Compose orchestration.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
```
junhao@ASUS-X870E:~/workspace/2-clp$ cd tools/deployment/package-helm/
junhao@ASUS-X870E:~/workspace/2-clp/tools/deployment/package-helm$ ./test.sh 
Deleting cluster "clp-test" ...
Deleted nodes: ["clp-test-control-plane"]
Creating cluster "clp-test" ...
 ✓ Ensuring node image (kindest/node:v1.34.0) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-clp-test"
You can now use your cluster with:

kubectl cluster-info --context kind-clp-test

Thanks for using kind! 😊
Error: uninstall: Release not loaded: test: release: not found
I1210 08:27:35.838412  174262 warnings.go:110] "Warning: spec.SessionAffinity is ignored for headless services"
I1210 08:27:35.839204  174262 warnings.go:110] "Warning: spec.SessionAffinity is ignored for headless services"
NAME: test
LAST DEPLOYED: Wed Dec 10 08:27:35 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None

# wait for 40s

# observed no failure in the pods
junhao@ASUS-X870E:~/workspace/2-clp/tools/deployment/package-helm$ kubectl get pods
NAME                                           READY   STATUS      RESTARTS   AGE
test-clp-database-0                            1/1     Running     0          40s
test-clp-db-table-creator-dw5k4                0/1     Completed   0          40s
test-clp-queue-0                               1/1     Running     0          40s
test-clp-redis-0                               1/1     Running     0          40s
test-clp-results-cache-0                       1/1     Running     0          40s
test-clp-results-cache-indices-creator-w96gp   0/1     Completed   0          40s

junhao@ASUS-X870E:~/workspace/2-clp/tools/deployment/package-helm$ kubectl exec -it test-clp-database-0 -- mysql -u clp-user -p"pass" -e "SELECT 1;"
+---+
| 1 |
+---+
| 1 |
+---+
junhao@ASUS-X870E:~/workspace/2-clp/tools/deployment/package-helm$ kubectl exec -it test-clp-database-0 -- mysql -u root -p"pass" -e "SELECT 1;"
ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)
command terminated with exit code 1
junhao@ASUS-X870E:~/workspace/2-clp/tools/deployment/package-helm$ kubectl exec -it test-clp-database-0 -- mysql -u root -p"root-pass" -e "SELECT 1;"
+---+
| 1 |
+---+
| 1 |
+---+
```


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment version to 0.1.2-dev.3.
  * Enhanced database credential management in deployment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->