### PR TITLE
refactor(clp-package-utils): Simplify `load_config_file` function and update its usage across scripts.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -13,6 +13,7 @@ from enum import auto
 import yaml
 from clp_py_utils.clp_config import (
     CLP_DEFAULT_CREDENTIALS_FILE_PATH,
+    CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH,
     CLP_SHARED_CONFIG_FILENAME,
     ClpConfig,
     CONTAINER_AWS_CONFIG_DIRECTORY,
@@ -424,19 +425,27 @@ def validate_config_key_existence(config, key):
     return value
 
 
-def load_config_file(
-    config_file_path: pathlib.Path, default_config_file_path: pathlib.Path, clp_home: pathlib.Path
-):
+def load_config_file(config_file_path: pathlib.Path) -> ClpConfig:
+    """
+    Loads and validates a CLP configuration file.
+
+    :param config_file_path:
+    :return: The loaded and validated ClpConfig object.
+    :raise ValueError: If the specified config file does not exist.
+    """
+    clp_home = get_clp_home()
+    default_config_file_path = clp_home / CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH
+
     if config_file_path.exists():
         raw_clp_config = read_yaml_config_file(config_file_path)
         if raw_clp_config is None:
             clp_config = ClpConfig()
         else:
             clp_config = ClpConfig.model_validate(raw_clp_config)
+    elif config_file_path != default_config_file_path:
+        err_msg = f"Config file '{config_file_path}' does not exist."
+        raise ValueError(err_msg)
     else:
-        if config_file_path != default_config_file_path:
-            raise ValueError(f"Config file '{config_file_path}' does not exist.")
-
         clp_config = ClpConfig()
 
     clp_config.make_config_paths_absolute(clp_home)

--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -431,7 +431,8 @@ def load_config_file(config_file_path: pathlib.Path) -> ClpConfig:
 
     :param config_file_path:
     :return: The loaded and validated ClpConfig object.
-    :raise ValueError: If the specified config file does not exist.
+    :raise ValueError: If the specified config file does not exist, and the requested path is not
+    the path to the default config file.
     """
     clp_home = get_clp_home()
     default_config_file_path = clp_home / CLP_DEFAULT_CONFIG_FILE_RELATIVE_PATH

--- a/components/clp-package-utils/clp_package_utils/scripts/archive_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/archive_manager.py
@@ -172,11 +172,7 @@ def main(argv: list[str]) -> int:
     # Validate and load config file
     try:
         config_file_path: Path = Path(parsed_args.config)
-        clp_config: ClpConfig = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config: ClpConfig = load_config_file(resolve_host_path_in_container(config_file_path))
         clp_config.validate_logs_dir(True)
 
         # Validate and load necessary credentials

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -178,11 +178,7 @@ def main(argv):
     # Validate and load config file
     try:
         config_file_path = pathlib.Path(parsed_args.config)
-        clp_config = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config = load_config_file(resolve_host_path_in_container(config_file_path))
         clp_config.validate_logs_dir(True)
 
         # Validate and load necessary credentials

--- a/components/clp-package-utils/clp_package_utils/scripts/compress_from_s3.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress_from_s3.py
@@ -225,11 +225,7 @@ def main(argv):
 
     try:
         config_file_path = pathlib.Path(parsed_args.config)
-        clp_config = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config = load_config_file(resolve_host_path_in_container(config_file_path))
         clp_config.validate_logs_dir(True)
 
         validate_and_load_db_credentials_file(clp_config, clp_home, False)

--- a/components/clp-package-utils/clp_package_utils/scripts/dataset_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/dataset_manager.py
@@ -96,11 +96,7 @@ def main(argv: list[str]) -> int:
     # Validate and load config file
     try:
         config_file_path = Path(parsed_args.config)
-        clp_config = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config = load_config_file(resolve_host_path_in_container(config_file_path))
         clp_config.validate_logs_dir(True)
 
         # Validate and load necessary credentials

--- a/components/clp-package-utils/clp_package_utils/scripts/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/decompress.py
@@ -52,11 +52,7 @@ def validate_and_load_config(
     :return: The config object on success, None otherwise.
     """
     try:
-        clp_config = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config = load_config_file(resolve_host_path_in_container(config_file_path))
         clp_config.validate_logs_dir(True)
 
         # Validate and load necessary credentials

--- a/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/archive_manager.py
@@ -189,9 +189,7 @@ def main(argv: list[str]) -> int:
     # Validate and load config file
     config_file_path: Path = Path(parsed_args.config)
     try:
-        clp_config: ClpConfig = load_config_file(
-            config_file_path, default_config_file_path, clp_home
-        )
+        clp_config: ClpConfig = load_config_file(config_file_path)
         clp_config.validate_logs_dir()
         clp_config.database.load_credentials_from_env()
     except:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -356,7 +356,7 @@ def main(argv):
     # Validate and load config file
     try:
         config_file_path = pathlib.Path(parsed_args.config)
-        clp_config = load_config_file(config_file_path, default_config_file_path, clp_home)
+        clp_config = load_config_file(config_file_path)
         clp_config.validate_logs_input_config()
         clp_config.validate_logs_dir()
         clp_config.database.load_credentials_from_env()

--- a/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/dataset_manager.py
@@ -217,7 +217,7 @@ def main(argv: list[str]) -> int:
     # Validate and load config file
     config_file_path = Path(parsed_args.config)
     try:
-        clp_config = load_config_file(config_file_path, default_config_file_path, clp_home)
+        clp_config = load_config_file(config_file_path)
         clp_config.validate_logs_dir()
         clp_config.database.load_credentials_from_env()
     except:

--- a/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/decompress.py
@@ -189,7 +189,7 @@ def validate_and_load_config_file(
     :return: clp_config on success, None otherwise.
     """
     try:
-        clp_config = load_config_file(config_file_path, default_config_file_path, clp_home)
+        clp_config = load_config_file(config_file_path)
         clp_config.validate_archive_output_config()
         clp_config.validate_logs_dir()
         clp_config.database.load_credentials_from_env()

--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -298,7 +298,7 @@ def main(argv):
     # Validate and load config file
     try:
         config_file_path = pathlib.Path(parsed_args.config)
-        clp_config = load_config_file(config_file_path, default_config_file_path, clp_home)
+        clp_config = load_config_file(config_file_path)
         clp_config.validate_logs_dir()
         clp_config.database.load_credentials_from_env()
     except:

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -93,11 +93,7 @@ def main(argv):
     # Validate and load config file
     try:
         config_file_path = pathlib.Path(parsed_args.config)
-        clp_config = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config = load_config_file(resolve_host_path_in_container(config_file_path))
         clp_config.validate_logs_dir(True)
 
         # Validate and load necessary credentials

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -53,11 +53,7 @@ def main(argv):
     try:
         # Validate and load config file.
         config_file_path = pathlib.Path(parsed_args.config)
-        clp_config = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config = load_config_file(resolve_host_path_in_container(config_file_path))
 
         validate_and_load_db_credentials_file(clp_config, clp_home, True)
         if clp_config.queue is not None:

--- a/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/stop_clp.py
@@ -31,11 +31,7 @@ def main(argv):
 
     try:
         config_file_path = pathlib.Path(parsed_args.config)
-        clp_config = load_config_file(
-            resolve_host_path_in_container(config_file_path),
-            resolve_host_path_in_container(default_config_file_path),
-            clp_home,
-        )
+        clp_config = load_config_file(resolve_host_path_in_container(config_file_path))
     except:
         logger.exception("Failed to load config.")
         return -1


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR simplifies the `load_config_file()` function signature to reduce boilerplate across the codebase.

## Changes

### 1. Refactored load_config_file() function

**Before:**
```python
def load_config_file(
    config_file_path: pathlib.Path,
    default_config_file_path: pathlib.Path,
    clp_home: pathlib.Path,
) -> ClpConfig:
```

**After:**
```python
def load_config_file(config_file_path: pathlib.Path) -> ClpConfig:
```

The function now computes `clp_home` and `default_config_file_path` internally, eliminating the need for all callers to pass these values.

### 2. Updated all callers

Updated scripts that call `load_config_file()` to use the simplified signature.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

```bash
task # to rebuild the project
cd build/clp-package

# Tested package started and stopped as expected
./sbin/start-clp.sh
# Output: 2025-12-09T11:57:42.587 INFO [controller] Started CLP.
./sbin/stop-clp.sh
# Output: 2025-12-09T11:58:12.083 INFO [controller] Stopped CLP.

# Tested `--setup-only` flag
./sbin/start-clp.sh --setup-only
# Output: 2025-12-09T11:58:17.379 INFO [start_clp] Completed setup. Services not started because `--setup-only` was specified.

# Tested non-existent `--config` path - correctly raises error
./sbin/start-clp.sh --config non-existent
# Output: ValueError: Config file 'non-existent' does not exist.

# Tested default config works even when file doesn't exist
mv ./etc/clp-config.yaml ./etc/clp-config.yaml.bak
./sbin/start-clp.sh --setup-only
# Output: 2025-12-09T11:58:43.467 INFO [start_clp] Completed setup. Services not started because `--setup-only` was specified.
mv ./etc/clp-config.yaml.bak ./etc/clp-config.yaml

# Tested click help output formatting
./sbin/start-clp.sh --help
# Output shows well-formatted help with option descriptions

./sbin/stop-clp.sh --help
# Output shows well-formatted help with option descriptions

# Tested custom config path specification with template files
mv ./etc/clp-config.yaml ./etc/clp-config.yaml.bak
./sbin/start-clp.sh --config etc/clp-config.template.json.yaml --setup-only
# Output: 2025-12-09T12:02:42.265 INFO [start_clp] Completed setup. Services not started because `--setup-only` was specified.
./sbin/start-clp.sh --config etc/clp-config.template.text.yaml --setup-only
# Output: 2025-12-09T12:02:47.789 INFO [start_clp] Completed setup. Services not started because `--setup-only` was specified.
mv ./etc/clp-config.yaml.bak ./etc/clp-config.yaml

# Tested full compression and search workflow
./sbin/start-clp.sh
# Output: Started CLP.

# Note: This requires having a sample file at ~/samples/postgresql.jsonl
# For testing, you can use any JSON log file or create a simple test file
./sbin/compress.sh ~/samples/postgresql.jsonl
# Output: Compression successful with compression ratio displayed

# Tested search functionality
./sbin/search.sh '*'
# Output: Search results displayed

./sbin/stop-clp.sh
# Output: Stopped CLP.
```
<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration loading across package utilities: callers now pass only the config file path while default config resolution and application home handling are performed internally. Call sites across tools and scripts were simplified to the new interface. Post-load steps and validations (path normalization, container refs, logs/credentials/mount checks) remain intact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->