### PR TITLE
refactor(clp-package): Fix to address Virtual-hosted–style requests.

### DIFF
--- a/components/clp-rust-utils/src/job_config/ingestion.rs
+++ b/components/clp-rust-utils/src/job_config/ingestion.rs
@@ -14,6 +14,9 @@ pub mod s3 {
         /// The S3 key prefix to ingest from.
         pub key_prefix: NonEmptyString,
 
+        // Endpoint url of s3 object store
+        pub endpoint_url: Option<String>,
+
         /// The dataset to ingest into. Defaults to `None` (which uses the default dataset).
         #[serde(default)]
         pub dataset: Option<NonEmptyString>,

--- a/components/clp-rust-utils/src/s3/client.rs
+++ b/components/clp-rust-utils/src/s3/client.rs
@@ -34,7 +34,17 @@ pub async fn create_new_client(
         .region(region)
         .credentials_provider(credential)
         .force_path_style(true);
-    config_builder.set_endpoint_url(endpoint.map(std::borrow::ToOwned::to_owned));
+    if let Some(ep) = endpoint {
+        let normalised_endpoint = normalize_endpoint(ep);
+        config_builder = config_builder.endpoint_url(normalised_endpoint);
+    }
     let config = config_builder.build();
     Client::from_conf(config)
+}
+
+fn normalize_endpoint(endpoint: &str) -> String {
+    match endpoint {
+        e if e.starts_with("http://") || e.starts_with("https://") => e.into(),
+        e => format!("https://{e}"),
+    }
 }

--- a/components/log-ingestor/src/aws_client_manager.rs
+++ b/components/log-ingestor/src/aws_client_manager.rs
@@ -74,9 +74,9 @@ impl S3ClientWrapper {
         Self { client }
     }
 
-    pub async fn create(region: &str, access_key_id: &str, secret_access_key: &str) -> Self {
+    pub async fn create(region: &str, access_key_id: &str, secret_access_key: &str, endpoint_url: Option<&str>) -> Self {
         let s3_client =
-            clp_rust_utils::s3::create_new_client(region, access_key_id, secret_access_key, None)
+            clp_rust_utils::s3::create_new_client(region, access_key_id, secret_access_key, endpoint_url)
                 .await;
         Self::from(s3_client)
     }

--- a/components/log-ingestor/src/ingestion_job_manager.rs
+++ b/components/log-ingestor/src/ingestion_job_manager.rs
@@ -108,6 +108,7 @@ impl IngestionJobManagerState {
             config.base.region.as_str(),
             self.inner.aws_credentials.access_key_id.as_str(),
             self.inner.aws_credentials.secret_access_key.as_str(),
+            config.base.endpoint_url.as_deref(),
         )
         .await;
         self.create_s3_ingestion_job(config.base.clone(), move |job_id, sender| {

--- a/components/log-ingestor/tests/test_ingestion_job.rs
+++ b/components/log-ingestor/tests/test_ingestion_job.rs
@@ -180,6 +180,7 @@ async fn test_sqs_listener() -> Result<()> {
             dataset: None,
             timestamp_key: None,
             unstructured: false,
+            endpoint_url: Some(aws_config.endpoint.clone()),
             tags: None,
         },
     };
@@ -197,7 +198,7 @@ async fn test_sqs_listener() -> Result<()> {
         aws_config.region.as_str(),
         aws_config.access_key_id.as_str(),
         aws_config.secret_access_key.as_str(),
-        Some(aws_config.endpoint.as_str()),
+        Some(aws_config.endpoint).as_deref(),
     )
     .await;
 
@@ -255,6 +256,7 @@ async fn test_s3_scanner() -> Result<()> {
             dataset: None,
             timestamp_key: None,
             unstructured: false,
+            endpoint_url: Some(aws_config.endpoint),
             tags: None,
         },
         scanning_interval_sec: 1,


### PR DESCRIPTION
Summary:
<!-- markdownlint-disable MD012 -->

<!--
refactor(core): Fix to address Virtual-hosted–style requests. 
Existing code does not address the log ingestion for Virtual-hosted–style requests. This changes includes fixes for handling regex and support endpoint-url as param to enable Virtual-hosted–style requests.
-->

# Description
This PR includes fixes for following:
  1. clp_config.py to add place holder for endpoint.
  2. s3_utils.py to handle regex
	- generate_s3_virtual_hosted_style_url to handle Virtual-hosted–style. - parse_s3_url to handle regex to support host:port and http(s)
  3. ingestion.rs to have place holder for endpoint.
  4. client.rs to create s3 client based on endpoint and normalise endpoint-url.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Tested virtual style urls with various url styles
- http://clp.s3.us-east-1.domain.com:8080/logs_test/logs_10_01.log 
- https://amzn-s3-demo-bucket1.s3.us-west-2.amazonaws.com/puppy.png
`{ "region": "us-east-1", "bucket_name": "logs-pub", "key_prefix": "logs/", "dataset": "default", "timestamp_key": "ts", "unstructured": false, "scanning_interval_sec": 1800, "start_after": "2025-01-01T00:00:00Z", "endpoint_url": "http://minio:9000.com" }`
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 client supports optional custom endpoint URLs for S3-compatible and third-party storage; endpoints are auto-normalized to ensure proper URI scheme.
* **Tests**
  * Integration and unit tests updated to cover passing and handling of custom endpoint URLs across ingestion and client creation flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->