### PR TITLE
fix(helm): Replace `database.name` with `database.names.clp` (fixes #1811).

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.2-dev.7"
+version: "0.1.2-dev.8"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.7.1-dev"

--- a/tools/deployment/package-helm/templates/configmap.yaml
+++ b/tools/deployment/package-helm/templates/configmap.yaml
@@ -30,7 +30,8 @@ data:
       auto_commit: false
       compress: true
       host: {{ include "clp.fullname" . }}-database
-      name: {{ .Values.clpConfig.database.name | quote }}
+      names:
+        clp: {{ .Values.clpConfig.database.names.clp | quote }}
       port: 3306
       ssl_cert: null
       type: {{ .Values.clpConfig.database.type | quote }}
@@ -128,7 +129,7 @@ data:
     {
       "SqlDbHost": "{{ include "clp.fullname" . }}-database",
       "SqlDbPort": 3306,
-      "SqlDbName": {{ .Values.clpConfig.database.name | quote }},
+      "SqlDbName": {{ .Values.clpConfig.database.names.clp | quote }},
       "SqlDbQueryJobsTableName": "query_jobs",
       "SqlDbCompressionJobsTableName": "compression_jobs",
       "MongoDbHost": "{{ include "clp.fullname" . }}-results-cache",

--- a/tools/deployment/package-helm/templates/database-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/database-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: "Always"
           env:
             - name: "MYSQL_DATABASE"
-              value: {{ .Values.clpConfig.database.name | quote }}
+              value: {{ .Values.clpConfig.database.names.clp | quote }}
             - name: "MYSQL_USER"
               valueFrom:
                 secretKeyRef:

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -37,7 +37,8 @@ clpConfig:
   database:
     type: "mariadb"  # "mariadb" or "mysql"
     port: 30306
-    name: "clp-db"
+    names:
+      clp: "clp-db"
 
   compression_scheduler:
     jobs_poll_delay: 0.1  # seconds


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

> [!NOTE]
> This PR is part of the ongoing work for #1309. More PRs will be submitted until the Helm chart is complete and fully functional.

This change aligns with the CLP package configuration structure where database names are organized under a `names` object, matching the structure used in `clp-config.yaml`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
cd tools/deployment/package-helm
./test.sh

# observed "All jobs completed and services are ready."
```


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped deployment chart version to 0.1.2-dev.8.
  * Updated database configuration structure in deployment templates to use a nested naming convention, improving configuration clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->