### PR TITLE
feat(helm): Add readiness and liveness probes to query-scheduler (resolves #1813).

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.2-dev.7"
+version: "0.1.2-dev.10"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.7.1-dev"

--- a/tools/deployment/package-helm/templates/query-scheduler-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-scheduler-deployment.yaml
@@ -70,6 +70,13 @@ spec:
           ports:
             - name: "query-scheduler"
               containerPort: 7000
+          readinessProbe:
+            {{- include "clp.readinessProbeTimings" . | nindent 12 }}
+            tcpSocket: &query-scheduler-health-check
+              port: 7000
+          livenessProbe:
+            {{- include "clp.livenessProbeTimings" . | nindent 12 }}
+            tcpSocket: *query-scheduler-health-check
           volumeMounts:
             - name: "config"
               mountPath: "/etc/clp-config.yaml"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

> [!NOTE]
> This PR is part of the ongoing work for #1309. More PRs will be submitted until the Helm chart is complete and fully functional.

Add readiness and liveness probes to the query-scheduler deployment to improve reliability and enable Kubernetes to properly manage the pod lifecycle. This aligns the Helm deployment with the healthcheck settings already defined in the docker-compose configuration.

The probes use:
- `tcpSocket` check on port 7000 (the query-scheduler internal port)
- Standard probe timings from `clp.readinessProbeTimings` and `clp.livenessProbeTimings` helpers
- YAML anchors for DRY configuration (consistent with webui-deployment.yaml pattern)

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

```
cd tools/deployment/package-helm
./test.sh

# observed "All jobs completed and services are ready."
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
