### PR TITLE
feat(helm): Add garbage collector deployment with retention period configuration.

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.2-dev.9"
+version: "0.1.2-dev.11"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.7.1-dev"

--- a/tools/deployment/package-helm/templates/configmap.yaml
+++ b/tools/deployment/package-helm/templates/configmap.yaml
@@ -26,6 +26,11 @@ data:
     compression_worker:
       logging_level: {{ .Values.clpConfig.compression_worker.logging_level | quote }}
     data_directory: "/var/data"
+    garbage_collector:
+      logging_level: {{ .Values.clpConfig.garbage_collector.logging_level | quote }}
+      sweep_interval:
+        archive: {{ .Values.clpConfig.garbage_collector.sweep_interval.archive | int }}
+        search_result: {{ .Values.clpConfig.garbage_collector.sweep_interval.search_result | int }}
     database:
       auto_commit: false
       compress: true
@@ -67,6 +72,7 @@ data:
       db_name: {{ .Values.clpConfig.results_cache.db_name | quote }}
       host: {{ include "clp.fullname" . }}-results-cache
       port: 27017
+      retention_period: {{ .Values.clpConfig.results_cache.retention_period }}
       stream_collection_name: {{ .Values.clpConfig.results_cache.stream_collection_name | quote }}
     stream_output:
       storage:

--- a/tools/deployment/package-helm/templates/configmap.yaml
+++ b/tools/deployment/package-helm/templates/configmap.yaml
@@ -11,7 +11,11 @@ data:
       storage:
         directory: "/var/data/archives"
         type: "fs"
+      {{- if .Values.clpConfig.archive_output.retention_period }}
       retention_period: {{ .Values.clpConfig.archive_output.retention_period | int }}
+      {{- else }}
+      retention_period: null
+      {{- end }}
       target_archive_size: {{ .Values.clpConfig.archive_output.target_archive_size | int }}
       target_dictionaries_size: {{ .Values.clpConfig.archive_output.target_dictionaries_size
         | int }}
@@ -74,7 +78,11 @@ data:
       db_name: {{ .Values.clpConfig.results_cache.db_name | quote }}
       host: {{ include "clp.fullname" . }}-results-cache
       port: 27017
+      {{- if .Values.clpConfig.results_cache.retention_period }}
       retention_period: {{ .Values.clpConfig.results_cache.retention_period | int }}
+      {{- else }}
+      retention_period: null
+      {{- end }}
       stream_collection_name: {{ .Values.clpConfig.results_cache.stream_collection_name | quote }}
     stream_output:
       storage:

--- a/tools/deployment/package-helm/templates/configmap.yaml
+++ b/tools/deployment/package-helm/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
       storage:
         directory: "/var/data/archives"
         type: "fs"
+      retention_period: {{ .Values.clpConfig.archive_output.retention_period | int }}
       target_archive_size: {{ .Values.clpConfig.archive_output.target_archive_size | int }}
       target_dictionaries_size: {{ .Values.clpConfig.archive_output.target_dictionaries_size
         | int }}
@@ -73,7 +74,7 @@ data:
       db_name: {{ .Values.clpConfig.results_cache.db_name | quote }}
       host: {{ include "clp.fullname" . }}-results-cache
       port: 27017
-      retention_period: {{ .Values.clpConfig.results_cache.retention_period }}
+      retention_period: {{ .Values.clpConfig.results_cache.retention_period | int }}
       stream_collection_name: {{ .Values.clpConfig.results_cache.stream_collection_name | quote }}
     stream_output:
       storage:

--- a/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
+++ b/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
@@ -1,0 +1,105 @@
+{{- if or .Values.clpConfig.archive_output.retention_period .Values.clpConfig.results_cache.retention_period }}
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: {{ include "clp.fullname" . }}-garbage-collector
+  labels:
+    {{- include "clp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "garbage-collector"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "clp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "garbage-collector"
+  template:
+    metadata:
+      labels:
+        {{- include "clp.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "garbage-collector"
+    spec:
+      serviceAccountName: {{ include "clp.fullname" . }}-job-watcher
+      terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsUser: {{ .Values.securityContext.firstParty.uid }}
+        runAsGroup: {{ .Values.securityContext.firstParty.gid }}
+        fsGroup: {{ .Values.securityContext.firstParty.gid }}
+      initContainers:
+        - {{- include "clp.waitFor" (dict
+            "root" .
+            "type" "job"
+            "name" "db-table-creator"
+          ) | nindent 10 }}
+        - {{- include "clp.waitFor" (dict
+            "root" .
+            "type" "job"
+            "name" "results-cache-indices-creator"
+          ) | nindent 10 }}
+      containers:
+        - name: "garbage-collector"
+          image: "{{ include "clp.image.ref" . }}"
+          imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
+          env:
+            - name: "CLP_DB_PASS"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clp.fullname" . }}-database
+                  key: "password"
+            - name: "CLP_DB_USER"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clp.fullname" . }}-database
+                  key: "username"
+            - name: "CLP_HOME"
+              value: "/opt/clp"
+            - name: "CLP_LOGGING_LEVEL"
+              value: {{ .Values.clpConfig.garbage_collector.logging_level | quote }}
+            - name: "CLP_LOGS_DIR"
+              value: "/var/log/garbage_collector"
+            - name: "PYTHONPATH"
+              value: "/opt/clp/lib/python3/site-packages"
+          volumeMounts:
+            - name: "config"
+              mountPath: "/etc/clp-config.yaml"
+              subPath: "clp-config.yaml"
+              readOnly: true
+            - name: {{ include "clp.volumeName" (dict
+                "component_category" "garbage-collector"
+                "name" "logs"
+              ) | quote }}
+              mountPath: "/var/log/garbage_collector"
+            - name: {{ include "clp.volumeName" (dict
+                "component_category" "shared-data"
+                "name" "archives"
+              ) | quote }}
+              mountPath: "/var/data/archives"
+            - name: {{ include "clp.volumeName" (dict
+                "component_category" "shared-data"
+                "name" "streams"
+              ) | quote }}
+              mountPath: "/var/data/streams"
+          command: [
+            "python3", "-u",
+            "-m", "job_orchestration.garbage_collector.garbage_collector",
+            "--config", "/etc/clp-config.yaml"
+          ]
+      volumes:
+        - {{- include "clp.pvcVolume" (dict
+            "root" .
+            "component_category" "garbage-collector"
+            "name" "logs"
+          ) | nindent 10 }}
+        - {{- include "clp.pvcVolume" (dict
+            "root" .
+            "component_category" "shared-data"
+            "name" "archives"
+          ) | nindent 10 }}
+        - {{- include "clp.pvcVolume" (dict
+            "root" .
+            "component_category" "shared-data"
+            "name" "streams"
+          ) | nindent 10 }}
+        - name: "config"
+          configMap:
+            name: {{ include "clp.fullname" . }}-config
+{{- end }}

--- a/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
+++ b/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
@@ -63,6 +63,8 @@ spec:
               mountPath: "/etc/clp-config.yaml"
               subPath: "clp-config.yaml"
               readOnly: true
+            - name: "tmp"
+              mountPath: "/var/log"
             - name: {{ include "clp.volumeName" (dict
                 "component_category" "garbage-collector"
                 "name" "logs"
@@ -102,4 +104,6 @@ spec:
         - name: "config"
           configMap:
             name: {{ include "clp.fullname" . }}-config
+        - name: "tmp"
+          emptyDir: {}
 {{- end }}

--- a/tools/deployment/package-helm/templates/garbage-collector-logs-pv.yaml
+++ b/tools/deployment/package-helm/templates/garbage-collector-logs-pv.yaml
@@ -1,0 +1,11 @@
+{{- if or .Values.clpConfig.archive_output.retention_period .Values.clpConfig.results_cache.retention_period }}
+{{- include "clp.createLocalPv" (dict
+  "root" .
+  "component_category" "garbage-collector"
+  "name" "logs"
+  "nodeRole" "control-plane"
+  "capacity" "5Gi"
+  "accessModes" (list "ReadWriteOnce")
+  "hostPath" (printf "%s/garbage_collector" .Values.clpConfig.logs_directory)
+) }}
+{{- end }}

--- a/tools/deployment/package-helm/templates/garbage-collector-logs-pvc.yaml
+++ b/tools/deployment/package-helm/templates/garbage-collector-logs-pvc.yaml
@@ -1,0 +1,9 @@
+{{- if or .Values.clpConfig.archive_output.retention_period .Values.clpConfig.results_cache.retention_period }}
+{{- include "clp.createPvc" (dict
+  "root" .
+  "component_category" "garbage-collector"
+  "name" "logs"
+  "capacity" "5Gi"
+  "accessModes" (list "ReadWriteOnce")
+) }}
+{{- end }}

--- a/tools/deployment/package-helm/test.sh
+++ b/tools/deployment/package-helm/test.sh
@@ -67,6 +67,12 @@ wget -O - https://zenodo.org/records/10516402/files/postgresql.tar.gz?download=1
   | tar xz -C "$CLP_HOME/samples" &
 SAMPLE_DOWNLOAD_PID=$!
 
+# Generate sample log file for garbage collector testing.
+cat <<EOF > /tmp/clp/samples/test-gc.jsonl
+{"timestamp": $(date +%s%3N), "level": "INFO", "message": "User login successful"}
+{"timestamp": $(date +%s%3N), "level": "ERROR", "message": "Database connection failed"}
+EOF
+
 cat <<EOF | kind create cluster --name clp-test --config=-
   kind: Cluster
   apiVersion: kind.x-k8s.io/v1alpha4

--- a/tools/deployment/package-helm/test.sh
+++ b/tools/deployment/package-helm/test.sh
@@ -58,7 +58,8 @@ rm -rf "$CLP_HOME"
 mkdir -p  "$CLP_HOME/var/"{data,log}/{database,queue,redis,results_cache} \
           "$CLP_HOME/var/data/"{archives,streams} \
           "$CLP_HOME/var/log/"{compression_scheduler,compression_worker,user} \
-          "$CLP_HOME/var/log/"{garbage_collector,query_scheduler,query_worker,reducer} \
+          "$CLP_HOME/var/log/"{query_scheduler,query_worker,reducer} \
+          "$CLP_HOME/var/log/garbage_collector" \
           "$CLP_HOME/var/tmp" \
           "$CLP_HOME/samples"
 

--- a/tools/deployment/package-helm/test.sh
+++ b/tools/deployment/package-helm/test.sh
@@ -58,7 +58,7 @@ rm -rf "$CLP_HOME"
 mkdir -p  "$CLP_HOME/var/"{data,log}/{database,queue,redis,results_cache} \
           "$CLP_HOME/var/data/"{archives,streams} \
           "$CLP_HOME/var/log/"{compression_scheduler,compression_worker,user} \
-          "$CLP_HOME/var/log/"{query_scheduler,query_worker,reducer} \
+          "$CLP_HOME/var/log/"{garbage_collector,query_scheduler,query_worker,reducer} \
           "$CLP_HOME/var/tmp" \
           "$CLP_HOME/samples"
 

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -63,6 +63,9 @@ clpConfig:
     db_name: "clp-query-results"
     stream_collection_name: "stream-files"
 
+    # Retention period for search results, in minutes. Set to null to disable automatic deletion.
+    retention_period: 60
+
   compression_worker:
     logging_level: "INFO"
 
@@ -112,6 +115,14 @@ clpConfig:
 
     # How large each stream file should be before being split into a new stream file
     target_uncompressed_size: 134217728  # 128 MB
+
+  garbage_collector:
+    logging_level: "INFO"
+
+    # Interval (in minutes) at which garbage collector jobs run
+    sweep_interval:
+      archive: 60
+      search_result: 30
 
   # Location where other data (besides archives) are stored. It will be created if
   # it doesn't exist.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

> [!NOTE]
> This PR is part of the ongoing work for #1309. More PRs will be submitted until the Helm chart is complete and fully functional.

Add the garbage collector component to the Helm chart, enabling automatic cleanup of expired
archives and search results based on configurable retention periods.

Changes:
- Add `retention_period` configuration to `results_cache` in values.yaml (default: 60 minutes)
- Add `garbage_collector` configuration section in values.yaml with `logging_level` and
  `sweep_interval` settings
- Add `garbage_collector` and `results_cache.retention_period` fields to configmap.yaml
- Create garbage-collector deployment with:
  - Conditional deployment (only when `archive_output.retention_period` or
    `results_cache.retention_period` is set)
  - Init containers to wait for `db-table-creator` and `results-cache-indices-creator` jobs
  - Access to shared-data-archives and shared-data-streams volumes for cleanup operations
- Create garbage-collector-logs PV and PVC for component logging
- Update test.sh with garbage_collector log directory

The garbage collector runs two async tasks:
- Archive garbage collector: Cleans up archives older than `archive_output.retention_period`
- Search result garbage collector: Cleans up search results older than
  `results_cache.retention_period`

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 0. Preparation

Configure retention periods in `values.yaml` for testing:

```yaml
clpConfig:
  archive_output:
    retention_period: null # set null to disable
  results_cache:
    retention_period: 1  # minutes
  sweep_interval:
    archive: 2  # minutes
    search_result: 2  # minutes
```

## 1. Helm chart deployment

```bash
cd tools/deployment/package-helm
./test.sh

# observed "All jobs completed and services are ready."
```

## 2. Log ingestion

Ingested sample logs at `/tmp/clp/samples/test-gc.jsonl` using the WebUI at http://localhost:30000/ingest .

Observed ingestion completed successfully, and the "Uncompressed Size" and "Compressed Size" 
became non-zero after compression: 170.0 B v.s. 683.0 B. (The negative compression ratio is 
expected for tiny files at this scale.)

### 3. Perform a search query in the WebUI

Visited http://localhost:30000/search and executed a search with query string "message:*login*".
Observed results returned successfully.

### 4. Verify garbage collection of search results

Wait for 3 minutes, which should exceed the `results_cache.retention_period` of 1 minute. Also,
the `sweep_interval.search_result` of 2 minute should have allowed the garbage collector to run.

Use MongoDB shell to verify that the search results have been deleted:

```bash
mongosh "mongodb://localhost:30017/clp-query-results"
> use clp-query-results
switched to db clp-query-results
> show collections
results-metadata
stream-files
```

Observed that no collection with name being any integer (which represents search result 
collections) exists, indicating that the search results have been successfully garbage collected.

### 5. Verify garbage collection of archives

Repeated steps 0, 1, 2 with

```yaml
clpConfig:
  archive_output:
    retention_period: 1 # minutes
  results_cache:
    retention_period: 1  # minutes
  sweep_interval:
    archive: 2  # minutes
    search_result: 2  # minutes
```

Wait for 3 minutes, which should exceed the `archive_output.retention_period` of 1 minute. Also, 
the `sweep_interval.archive` of 2 minute should have allowed the garbage collector to run.

Revisit the ingestion page at http://localhost:30000/ingest and check the "Uncompressed Size" and
"Compressed Size" again, which were both reset to zero, indicating that the archives have been
cleaned up.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic garbage collection for archives and search results with configurable retention periods.
  * Periodic sweep scheduling with separate intervals for archive and search-result cleanup.
  * Configurable logging level for garbage-collector operations.
  * Conditional deployment and persistent storage provisioning for garbage-collector when retention is enabled.

* **Chores**
  * Helm chart version bumped to a new development patch.

* **Tests**
  * Added sample logs/data to support garbage-collector testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->