### PR TITLE
fix(clp-mcp-server): Replace `database.name` with `database.names.clp` (fixes #1820).

### DIFF
--- a/components/clp-mcp-server/clp_mcp_server/clp_connector.py
+++ b/components/clp-mcp-server/clp_mcp_server/clp_connector.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import aiomysql
 import msgpack
-from clp_py_utils.clp_config import CLP_DEFAULT_DATASET_NAME
+from clp_py_utils.clp_config import CLP_DEFAULT_DATASET_NAME, ClpDbNameType
 from pymongo import AsyncMongoClient
 
 from clp_mcp_server.constants import (
@@ -32,7 +32,7 @@ class ClpConnector:
             "port": clp_config.database.port,
             "user": CLP_DB_USER,
             "password": CLP_DB_PASS,
-            "db": clp_config.database.name,
+            "db": clp_config.database.names[ClpDbNameType.CLP],
         }
 
         self._webui_addr = f"http://{clp_config.webui.host}:{clp_config.webui.port}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

PR #1606 changed the database configuration interface from `database.name` (single string) to
`database.names` (dictionary with `ClpDbNameType.CLP` and `ClpDbNameType.SPIDER` keys). The MCP
server was not updated to use this new interface, causing an `AttributeError` on startup.

This PR updates `clp_connector.py` to use the new interface.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Built the project:
   ```shell
   task
   ```

2. Configured the MCP server in `build/clp-package/etc/clp-config.yaml`:
   ```yaml
   mcp_server:
     host: localhost
     port: 8000
   ```

3. Started the CLP package:
   ```shell
   cd build/clp-package
   ./sbin/start-clp.sh
   ```

4. Compressed sample logs:
   ```shell
   ./sbin/compress.sh --timestamp=timestamp ~/samples/postgresql.jsonl
   ```
   Output:
   ```
   2025-12-19T05:44:33.210 INFO [compress] Compression job 1 submitted.
   2025-12-19T05:44:35.214 INFO [compress] Compressed 392.84MB into 9.94MB (39.53x). Speed: 211.48MB/s.
   2025-12-19T05:44:35.715 INFO [compress] Compression finished.
   2025-12-19T05:44:35.715 INFO [compress] Compressed 392.84MB into 9.94MB (39.53x). Speed: 183.57MB/s.
   ```

5. Verified the MCP server is alive:
   ```shell
   curl http://localhost:8000/health
   ```
   Output:
   ```
   OK
   ```

6. Initialized an MCP session:
   ```shell
   curl -i -X POST http://localhost:8000/mcp \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{
       "jsonrpc": "2.0",
       "id": 1,
       "method": "initialize",
       "params": {
         "protocolVersion": "2024-11-05",
         "capabilities": {},
         "clientInfo": {"name": "test", "version": "1.0"}
       }
     }'
   ```
   Output (note the `mcp-session-id` header):
   ```
   HTTP/1.1 200 OK
   ...
   mcp-session-id: 539a40d16a584d40b4c1bf100df7ad0a
   ...
   event: message
   data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",...,"serverInfo":{"name":"clp-mcp-server","version":"2.14.1"}}}
   ```

7. Listed available MCP tools:
   ```shell
   curl -X POST http://localhost:8000/mcp \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -H "Mcp-Session-Id: 539a40d16a584d40b4c1bf100df7ad0a" \
     -d '{
       "jsonrpc": "2.0",
       "id": 2,
       "method": "tools/list",
       "params": {}
     }'
   ```
   Output:
   ```
   event: message
   data: {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"get_instructions",...},{"name":"get_nth_page",...},{"name":"hello_world",...},{"name":"search_by_kql",...},{"name":"search_by_kql_with_timestamp_range",...}]}}
   ```

8. Invoked the `get_instructions` tool (required before other tools):
   ```shell
   curl -X POST http://localhost:8000/mcp \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -H "Mcp-Session-Id: 539a40d16a584d40b4c1bf100df7ad0a" \
     -d '{
       "jsonrpc": "2.0",
       "id": 4,
       "method": "tools/call",
       "params": {
         "name": "get_instructions",
         "arguments": {}
       }
     }'
   ```
   Output:
   ```
   event: message
   data: {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"You are an AI assistant for querying the CLP log database using CLP-KQL (CKQL)..."}],...,"isError":false}}
   ```

9. Invoked the `search_by_kql` tool:
   ```shell
   curl -X POST http://localhost:8000/mcp \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -H "Mcp-Session-Id: 539a40d16a584d40b4c1bf100df7ad0a" \
     -d '{
       "jsonrpc": "2.0",
       "id": 5,
       "method": "tools/call",
       "params": {
         "name": "search_by_kql",
         "arguments": {
           "kql_query": "1"
         }
       }
     }'
   ```
   Output:
   ```
   event: message
   data: {"jsonrpc":"2.0","id":5,"result":{"content":[{"type":"text","text":"{\"items\":[\"timestamp: 2023-03-27T00:31:55.999Z, message: {...}\\n, link: http://localhost:4000/streamFile?...\",...],\"num_total_pages\":4,\"num_total_items\":38,\"num_items_per_page\":10,\"has_next\":true,\"has_previous\":false}"}],...,"isError":false}}
   ```
   ✅ Observed results are getting returned.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal database configuration handling to improve code organization and maintainability. This change does not affect user-facing functionality or application behaviour.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->