### PR TITLE
fix(ci): Improve workflow efficiency by optimizing runner usage and eliminating duplicate runs

### DIFF
--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -38,8 +38,10 @@ jobs:
           # Skip duplicate runs for the same content (e.g., when both push and pull_request trigger)
           concurrent_skipping: "same_content"
           skip_after_successful_duplicate: "true"
-          # Always run for scheduled builds and manual triggers
-          do_not_skip: '["schedule", "workflow_dispatch"]'
+          # Always run for scheduled builds and manual triggers.
+          # NOTE: This is a JSON array string (required by the action), with escaped quotes for
+          # yamllint compliance.
+          do_not_skip: "[\"schedule\", \"workflow_dispatch\"]"
 
   filter-relevant-changes:
     name: "filter-relevant-changes"

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -8,8 +8,6 @@ on:
       - "components/core/tools/scripts/lib_install/macos/**"
       - "docs/**"
   push:
-    branches:
-      - "main"
     paths-ignore: *ignored_paths
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
@@ -28,8 +26,25 @@ concurrency:
   cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
 
 jobs:
+  skip-duplicate-check:
+    name: "skip-duplicate-check"
+    runs-on: "ubuntu-24.04"
+    outputs:
+      should_skip: "${{steps.skip_check.outputs.should_skip}}"
+    steps:
+      - id: "skip_check"
+        uses: "step-security/skip-duplicate-actions@v5"
+        with:
+          # Skip duplicate runs for the same content (e.g., when both push and pull_request trigger)
+          concurrent_skipping: "same_content"
+          skip_after_successful_duplicate: "true"
+          # Always run for scheduled builds and manual triggers
+          do_not_skip: '["schedule", "workflow_dispatch"]'
+
   filter-relevant-changes:
     name: "filter-relevant-changes"
+    needs: "skip-duplicate-check"
+    if: "needs.skip-duplicate-check.outputs.should_skip != 'true'"
     # This job only performs git operations to detect changed paths, so we use a GitHub-hosted
     # runner to avoid consuming self-hosted runner resources needed for heavier build jobs.
     runs-on: "ubuntu-24.04"

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -33,7 +33,7 @@ jobs:
       should_skip: "${{steps.skip_check.outputs.should_skip}}"
     steps:
       - id: "skip_check"
-        uses: "step-security/skip-duplicate-actions@v5"
+        uses: "fkirc/skip-duplicate-actions@v5"
         with:
           # Skip duplicate runs for the same content (e.g., when both push and pull_request trigger)
           concurrent_skipping: "same_content"

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -28,12 +28,9 @@ concurrency:
 jobs:
   filter-relevant-changes:
     name: "filter-relevant-changes"
-    runs-on: &runner >-
-      ${{
-        github.repository_owner == 'y-scope'
-        && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
-        || 'ubuntu-24.04'
-      }}
+    # This job only performs git operations to detect changed paths, so we use a GitHub-hosted
+    # runner to avoid consuming self-hosted runner resources needed for heavier build jobs.
+    runs-on: "ubuntu-24.04"
     outputs:
       centos_stream_9_image_changed: "${{steps.filter.outputs.centos_stream_9_image}}"
       manylinux_2_28_x86_64_image_changed: "${{steps.filter.outputs.manylinux_2_28_x86_64_image}}"
@@ -104,7 +101,14 @@ jobs:
     name: "centos-stream-9-deps-image"
     if: "needs.filter-relevant-changes.outputs.centos_stream_9_image_changed == 'true'"
     needs: "filter-relevant-changes"
-    runs-on: *runner
+    # Define a reusable runner configuration for jobs that require Docker and benefit from
+    # self-hosted runner resources. Falls back to GitHub-hosted runners for non-y-scope forks.
+    runs-on: &runner >-
+      ${{
+        github.repository_owner == 'y-scope'
+        && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -8,6 +8,8 @@ on:
       - "components/core/tools/scripts/lib_install/macos/**"
       - "docs/**"
   push:
+    branches:
+      - "main"
     paths-ignore: *ignored_paths
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -27,21 +27,7 @@ concurrency:
 
 jobs:
   skip-duplicate-check:
-    name: "skip-duplicate-check"
-    runs-on: "ubuntu-24.04"
-    outputs:
-      should_skip: "${{steps.skip_check.outputs.should_skip}}"
-    steps:
-      - id: "skip_check"
-        uses: "fkirc/skip-duplicate-actions@v5"
-        with:
-          # Skip duplicate runs for the same content (e.g., when both push and pull_request trigger)
-          concurrent_skipping: "same_content"
-          skip_after_successful_duplicate: "true"
-          # Always run for scheduled builds and manual triggers.
-          # NOTE: This is a JSON array string (required by the action), with escaped quotes for
-          # yamllint compliance.
-          do_not_skip: "[\"schedule\", \"workflow_dispatch\"]"
+    uses: "./.github/workflows/skip-duplicate-check.yaml"
 
   filter-relevant-changes:
     name: "filter-relevant-changes"

--- a/.github/workflows/skip-duplicate-check.yaml
+++ b/.github/workflows/skip-duplicate-check.yaml
@@ -1,0 +1,40 @@
+name: "skip-duplicate-check"
+
+# Reusable workflow to skip duplicate runs when both push and pull_request events trigger on the
+# same commit. Other workflows can call this and check the `should_skip` output to avoid redundant
+# work.
+#
+# Usage:
+#   jobs:
+#     skip-check:
+#       uses: "./.github/workflows/skip-duplicate-check.yaml"
+#
+#     my-job:
+#       needs: "skip-check"
+#       if: "needs.skip-check.outputs.should_skip != 'true'"
+#       ...
+
+on:
+  workflow_call:
+    outputs:
+      should_skip:
+        description: "Whether the workflow run should be skipped"
+        value: "${{jobs.check.outputs.should_skip}}"
+
+jobs:
+  check:
+    name: "skip-duplicate-check"
+    runs-on: "ubuntu-24.04"
+    outputs:
+      should_skip: "${{steps.skip_check.outputs.should_skip}}"
+    steps:
+      - id: "skip_check"
+        uses: "fkirc/skip-duplicate-actions@v5"
+        with:
+          # Skip duplicate runs for the same content (e.g., when both push and pull_request trigger)
+          concurrent_skipping: "same_content"
+          skip_after_successful_duplicate: "true"
+          # Always run for scheduled builds and manual triggers.
+          # NOTE: This is a JSON array string (required by the action), with escaped quotes for
+          # yamllint compliance.
+          do_not_skip: "[\"schedule\", \"workflow_dispatch\"]"


### PR DESCRIPTION
## Description

Improve CI workflow efficiency with two changes:

### 1. Use GitHub-hosted runner for lightweight path filtering job
The `filter-relevant-changes` job only performs git operations to detect changed paths. Moving it to a GitHub-hosted runner avoids consuming self-hosted runner resources needed for heavier build jobs.

### 2. Use skip-duplicate-actions to prevent duplicate workflow runs
When pushing to a PR branch, both `push` and `pull_request` events trigger, causing duplicate workflow runs. This PR adds [fkirc/skip-duplicate-actions](https://github.com/fkirc/skip-duplicate-actions) to detect and skip duplicate runs.

**How it works:**
- When both `push` and `pull_request` trigger on the same commit, the duplicate is skipped
- Scheduled builds and manual triggers always run (`do_not_skip`)
- Downstream jobs are skipped automatically when `filter-relevant-changes` is skipped

**Why this action:**
- Used by 9,234+ repositories including [haskell-language-server](https://github.com/haskell/haskell-language-server), [CNCF TOC](https://github.com/cncf/toc), and [MegaLinter](https://github.com/oxsecurity/megalinter)
- Note: step-security/skip-duplicate-actions is a fork that requires a paid subscription; we use the original fkirc version which is free

## Validation performed

- Verified YAML syntax
- Reviewed fkirc/skip-duplicate-actions documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable check to detect and skip duplicate workflow runs, reducing unnecessary builds.
  * Made downstream pipeline steps conditional so jobs run only when appropriate via the new skip output.
  * Reworked runner configuration to prefer self-hosted when available with a GitHub-hosted fallback for reliability.
  * Clarified workflow comments and alignment for maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212854499651194