### PR TITLE
ci: Add workflow to automatically retry failed jobs

### DIFF
--- a/.github/workflows/retry-failed-jobs.yaml
+++ b/.github/workflows/retry-failed-jobs.yaml
@@ -1,0 +1,41 @@
+name: "retry-failed-jobs"
+
+# This workflow automatically retries failed jobs from other workflows to handle transient failures
+# such as:
+# - Runner acquisition timeouts ("The job was not acquired by Runner of type self-hosted even after
+#   multiple attempts")
+# - Self-hosted runners being temporarily unavailable due to maintenance or failures
+#
+# How it works:
+# 1. Triggers when a monitored workflow completes (success or failure)
+# 2. If the workflow failed on its first attempt, re-runs only the failed jobs
+# 3. Uses a GitHub-hosted runner to avoid the same runner acquisition issues
+#
+# To add retry support for another workflow, add its name to the `workflows` list below.
+
+on:
+  workflow_run:
+    workflows:
+      - "clp-artifact-build"
+    types:
+      - "completed"
+
+jobs:
+  retry:
+    name: "retry-failed-jobs"
+    # Only retry if:
+    # - The workflow failed (not cancelled or successful)
+    # - This is the first attempt (prevents infinite retry loops)
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.run_attempt == 1
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Re-run failed jobs"
+        env:
+          GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+        run: >-
+          gh run rerun ${{github.event.workflow_run.id}}
+          --failed
+          --repo ${{github.repository}}
+        shell: "bash"

--- a/.github/workflows/retry-failed-jobs.yaml
+++ b/.github/workflows/retry-failed-jobs.yaml
@@ -20,6 +20,9 @@ on:
     types:
       - "completed"
 
+permissions:
+  actions: "write"
+
 jobs:
   retry:
     name: "retry-failed-jobs"
@@ -31,11 +34,20 @@ jobs:
       && github.event.workflow_run.run_attempt == 1
     runs-on: "ubuntu-24.04"
     steps:
+      - name: "Log retry information"
+        run: |
+          echo "Retrying failed jobs for workflow run: ${{github.event.workflow_run.id}}"
+          echo "Original workflow: ${{github.event.workflow_run.name}}"
+          echo "Triggered by: ${{github.event.workflow_run.event}}"
+          echo "Conclusion: ${{github.event.workflow_run.conclusion}}"
+        shell: "bash"
+
       - name: "Re-run failed jobs"
         env:
           GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
         run: >-
           gh run rerun ${{github.event.workflow_run.id}}
           --failed
-          --repo ${{github.repository}}
+          --repo ${{github.repository}} ||
+          (echo "Failed to rerun workflow run ${{github.event.workflow_run.id}}" && exit 1)
         shell: "bash"


### PR DESCRIPTION
## Description

Add a new workflow that monitors other workflows and automatically retries failed jobs on the first attempt. This handles transient failures such as:
- Runner acquisition timeouts ("The job was not acquired by Runner of type self-hosted even after multiple attempts")
- Self-hosted runners being temporarily unavailable due to maintenance or failures

### How it works
1. Triggers when a monitored workflow completes (via `workflow_run` event)
2. If the workflow failed on its first attempt, re-runs only the failed jobs
3. Uses a GitHub-hosted runner to avoid the same runner acquisition issues

### Benefits
- No maintenance required - doesn't need to know about individual jobs
- Extensible - add more workflows to the `workflows` list as needed
- Decoupled - monitored workflows don't need any changes

### Note
The `workflow_run` event only triggers workflows on the default branch. Once this PR is merged to `main`, the retry workflow will automatically handle failures from workflows running on **any branch**, including PR branches.

## Validation performed

- Reviewed workflow syntax
- Verified `workflow_run` event behavior per GitHub Actions documentation

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888440132222
  - https://app.asana.com/0/0/1212861692233191