### PR TITLE
WIP - change /var/tmp dir to tmpfs

### DIFF
--- a/components/job-orchestration/job_orchestration/garbage_collector/archive_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/archive_garbage_collector.py
@@ -202,7 +202,7 @@ async def archive_garbage_collector(
     validate_storage_type(archive_output_config, storage_engine)
 
     sweep_interval_secs = clp_config.garbage_collector.sweep_interval.archive * MIN_TO_SECONDS
-    recovery_file = clp_config.logs_directory / f"{ARCHIVE_GARBAGE_COLLECTOR_NAME}.tmp"
+    recovery_file = clp_config.tmp_directory / f"{ARCHIVE_GARBAGE_COLLECTOR_NAME}.tmp"
 
     logger.info(f"{ARCHIVE_GARBAGE_COLLECTOR_NAME} started.")
     try:

--- a/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
+++ b/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
@@ -64,7 +64,7 @@ spec:
               subPath: "clp-config.yaml"
               readOnly: true
             - name: "tmp"
-              mountPath: "/var/log"
+              mountPath: "/var/tmp"
             - name: {{ include "clp.volumeName" (dict
                 "component_category" "garbage-collector"
                 "name" "logs"

--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -411,6 +411,7 @@ services:
     volumes:
       - *volume_clp_config_readonly
       - *volume_clp_logs
+      - *volume_clp_tmp
       - "${CLP_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/archives"
       - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_STREAM_OUTPUT_DIR_HOST:-empty}:/var/data/streams"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes an issue where `archive_garbage_collector.py` was writing its recovery file to the logs directory (`clp_config.logs_directory`) instead of the temporary directory.

This aligns with the project's convention of using dedicated temporary directories for temporary files.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Verified that `clp_config.tmp_directory` is set to `/var/tmp` in both Docker Compose and Helm deployments.
* Confirmed the Docker Compose garbage-collector service now has the `/var/tmp` volume mount.
* Confirmed the Helm deployment mounts the tmp emptyDir at `/var/tmp`.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888430394537