### PR TITLE
feat(clp-s): Add --sanitize-invalid-json option for opt-in JSON sanitization

### DIFF
--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -704,6 +704,7 @@ set(SOURCE_FILES_unitTest
         tests/test-clp_s-end_to_end.cpp
         tests/test-clp_s-range_index.cpp
         tests/test-clp_s-search.cpp
+        tests/test-clp_s-StringUtils.cpp
         tests/test-EncodedVariableInterpreter.cpp
         tests/test-encoding_methods.cpp
         tests/test-ffi_IrUnitHandlerReq.cpp

--- a/components/core/src/clp_s/CommandLineArguments.cpp
+++ b/components/core/src/clp_s/CommandLineArguments.cpp
@@ -257,6 +257,12 @@ CommandLineArguments::parse_arguments(int argc, char const** argv) {
                     po::bool_switch(&m_structurize_arrays),
                     "Structurize arrays instead of compressing them as clp strings."
             )(
+                    "sanitize-invalid-json",
+                    po::bool_switch(&m_sanitize_invalid_json),
+                    "Sanitize invalid JSON by escaping unescaped control characters (0x00-0x1F),"
+                    " replacing invalid UTF-8 sequences with U+FFFD, and handling invalid"
+                    " surrogate escapes. When disabled (default), parsing fails on invalid JSON."
+            )(
                     "disable-log-order",
                     po::bool_switch(&m_disable_log_order),
                     "Do not record log order at ingestion time; Do not record the archive range"

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -113,6 +113,8 @@ public:
 
     bool get_structurize_arrays() const { return m_structurize_arrays; }
 
+    bool get_sanitize_invalid_json() const { return m_sanitize_invalid_json; }
+
     bool get_ordered_decompression() const { return m_ordered_decompression; }
 
     size_t get_target_ordered_chunk_size() const { return m_target_ordered_chunk_size; }
@@ -202,6 +204,7 @@ private:
     bool m_no_retain_float_format{false};
     bool m_single_file_archive{false};
     bool m_structurize_arrays{false};
+    bool m_sanitize_invalid_json{false};
     bool m_ordered_decompression{false};
     size_t m_target_ordered_chunk_size{};
     bool m_print_ordered_chunk_stats{false};

--- a/components/core/src/clp_s/JsonFileIterator.cpp
+++ b/components/core/src/clp_s/JsonFileIterator.cpp
@@ -12,12 +12,14 @@ namespace clp_s {
 JsonFileIterator::JsonFileIterator(
         clp::ReaderInterface& reader,
         size_t max_document_size,
+        std::string path,
         size_t buf_size
 )
         : m_buf_size(buf_size),
           m_max_document_size(max_document_size),
           m_buf(new char[buf_size + simdjson::SIMDJSON_PADDING]),
-          m_reader(reader) {
+          m_reader(reader),
+          m_path(std::move(path)) {
     read_new_json();
 }
 
@@ -95,8 +97,10 @@ bool JsonFileIterator::read_new_json() {
             }
             size_t bytes_added = m_buf_occupied - old_buf_occupied;
             SPDLOG_WARN(
-                    "Escaped {} control character(s) in JSON: [{}]. Buffer expanded by {} bytes ({} -> {}).",
+                    "Escaped {} control character(s) in JSON{}: [{}]. Buffer expanded by {} bytes "
+                    "({} -> {}).",
                     total_sanitized,
+                    m_path.empty() ? "" : fmt::format(" in file '{}'", m_path),
                     char_details,
                     bytes_added,
                     old_buf_occupied,

--- a/components/core/src/clp_s/JsonFileIterator.cpp
+++ b/components/core/src/clp_s/JsonFileIterator.cpp
@@ -252,6 +252,11 @@ bool JsonFileIterator::get_json(simdjson::ondemand::document_stream::iterator& i
                             old_buf_occupied,
                             m_buf_occupied
                     );
+                } else {
+                    // Sanitization made no changes - report the original error to avoid infinite
+                    // loop
+                    m_error_code = m_doc_it.error();
+                    return false;
                 }
 
                 // Re-setup the document stream and restart iteration
@@ -313,6 +318,11 @@ bool JsonFileIterator::get_json(simdjson::ondemand::document_stream::iterator& i
                             old_buf_occupied,
                             m_buf_occupied
                     );
+                } else {
+                    // Sanitization made no changes - report the original error to avoid infinite
+                    // loop
+                    m_error_code = simdjson::error_code::UTF8_ERROR;
+                    return false;
                 }
 
                 // Re-setup the document stream and restart iteration

--- a/components/core/src/clp_s/JsonFileIterator.cpp
+++ b/components/core/src/clp_s/JsonFileIterator.cpp
@@ -107,12 +107,11 @@ bool JsonFileIterator::read_new_json() {
                     m_buf_occupied
             );
 
-            error = m_parser
-                            .iterate_many(
+            error = m_parser.iterate_many(
                                     m_buf,
                                     /* length of data */ m_buf_occupied,
                                     /* batch size of data to parse*/ m_buf_occupied
-                            )
+            )
                             .get(m_stream);
         }
 

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -81,6 +81,20 @@ private:
      */
     [[nodiscard]] size_t skip_whitespace_and_get_truncated_bytes();
 
+    /**
+     * Sanitizes invalid UTF-8 sequences in the buffer by replacing them with U+FFFD,
+     * updates buffer tracking variables, and logs a warning if changes were made.
+     * @return true if sanitization made changes, false otherwise
+     */
+    [[nodiscard]] bool sanitize_and_log_utf8();
+
+    /**
+     * Sanitizes unescaped control characters in the buffer by escaping them to \\u00XX format,
+     * updates buffer tracking variables, and logs a warning if changes were made.
+     * @return true if sanitization made changes, false otherwise
+     */
+    [[nodiscard]] bool sanitize_and_log_json();
+
     size_t m_truncated_bytes{0};
     size_t m_next_document_position{0};
     size_t m_bytes_read{0};

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -21,12 +21,14 @@ public:
 
      * @param reader the input stream containing JSON
      * @param max_document_size the maximum allowed size of a single document
+     * @param sanitize_invalid_json whether to sanitize invalid JSON (control chars, invalid UTF-8)
      * @param path optional path to the file being read (used for logging)
      * @param buf_size the initial buffer size
      */
     explicit JsonFileIterator(
             clp::ReaderInterface& reader,
             size_t max_document_size,
+            bool sanitize_invalid_json,
             std::string path = {},
             size_t buf_size = 1024 * 1024 /* 1 MiB default */
     );
@@ -89,6 +91,7 @@ private:
     char* m_buf{nullptr};
     clp::ReaderInterface& m_reader;
     std::string m_path;
+    bool m_sanitize_invalid_json{false};
     simdjson::ondemand::parser m_parser;
     simdjson::ondemand::document_stream m_stream;
     bool m_eof{false};

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -1,6 +1,8 @@
 #ifndef CLP_S_JSONFILEITERATOR_HPP
 #define CLP_S_JSONFILEITERATOR_HPP
 
+#include <string>
+
 #include <simdjson.h>
 
 #include "../clp/ReaderInterface.hpp"
@@ -19,11 +21,13 @@ public:
 
      * @param reader the input stream containing JSON
      * @param max_document_size the maximum allowed size of a single document
+     * @param path optional path to the file being read (used for logging)
      * @param buf_size the initial buffer size
      */
     explicit JsonFileIterator(
             clp::ReaderInterface& reader,
             size_t max_document_size,
+            std::string path = {},
             size_t buf_size = 1024 * 1024 /* 1 MiB default */
     );
     ~JsonFileIterator();
@@ -84,6 +88,7 @@ private:
     size_t m_max_document_size{0};
     char* m_buf{nullptr};
     clp::ReaderInterface& m_reader;
+    std::string m_path;
     simdjson::ondemand::parser m_parser;
     simdjson::ondemand::document_stream m_stream;
     bool m_eof{false};

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -13,7 +13,7 @@ public:
     /**
      * An iterator over an input stream containing json objects. JSON is parsed
      * using simdjson::parse_many. This allows simdjson to efficiently find
-     * delimeters between JSON objects, and if enabled parse JSON ahead of time
+     * delimiters between JSON objects, and if enabled parse JSON ahead of time
      * in another thread while the JSON is being iterated over.
      *
      * The buffer grows automatically if there are JSON objects larger than the buffer size.
@@ -85,15 +85,24 @@ private:
      * Sanitizes invalid UTF-8 sequences in the buffer by replacing them with U+FFFD,
      * updates buffer tracking variables, and logs a warning if changes were made.
      * @return true if sanitization made changes, false otherwise
+     * @note May reallocate m_buf if buffer expansion is needed. m_buf_size is updated accordingly.
      */
-    [[nodiscard]] bool sanitize_and_log_utf8();
+    [[nodiscard]] bool sanitize_invalid_utf8_and_log();
 
     /**
      * Sanitizes unescaped control characters in the buffer by escaping them to \\u00XX format,
      * updates buffer tracking variables, and logs a warning if changes were made.
      * @return true if sanitization made changes, false otherwise
+     * @note May reallocate m_buf if buffer expansion is needed. m_buf_size is updated accordingly.
      */
-    [[nodiscard]] bool sanitize_and_log_json();
+    [[nodiscard]] bool sanitize_control_chars_and_log();
+
+    /**
+     * Reinitializes the document stream after buffer sanitization.
+     * Resets iteration state to start from the beginning of the buffer.
+     * @return true on success, false if iteration setup fails (m_error_code is set on failure)
+     */
+    [[nodiscard]] bool reinitialize_document_stream();
 
     size_t m_truncated_bytes{0};
     size_t m_next_document_position{0};

--- a/components/core/src/clp_s/JsonFileIterator.hpp
+++ b/components/core/src/clp_s/JsonFileIterator.hpp
@@ -41,9 +41,11 @@ public:
     [[nodiscard]] size_t truncated_bytes() const { return m_truncated_bytes; }
 
     /**
-     * @return total number of bytes read from the file
+     * @return total number of bytes read from the file, plus any bytes added by sanitization
      */
-    [[nodiscard]] size_t get_num_bytes_read() const { return m_bytes_read; }
+    [[nodiscard]] size_t get_num_bytes_read() const {
+        return m_bytes_read + m_sanitization_bytes_added;
+    }
 
     /**
      * Note: this method can not be const because checking if a simdjson iterator is at the end
@@ -76,6 +78,7 @@ private:
     size_t m_truncated_bytes{0};
     size_t m_next_document_position{0};
     size_t m_bytes_read{0};
+    size_t m_sanitization_bytes_added{0};
     size_t m_buf_size{0};
     size_t m_buf_occupied{0};
     size_t m_max_document_size{0};

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -668,7 +668,7 @@ auto JsonParser::ingest_json(
         Path const& path,
         std::string const& archive_creator_id
 ) -> bool {
-    JsonFileIterator json_file_iterator(*reader, m_max_document_size);
+    JsonFileIterator json_file_iterator(*reader, m_max_document_size, path.path);
     if (simdjson::error_code::SUCCESS != json_file_iterator.get_error()) {
         SPDLOG_ERROR(
                 "Encountered error - {} - while trying to parse {} after parsing 0 bytes",

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -144,6 +144,7 @@ JsonParser::JsonParser(JsonParserOption const& option)
           m_structurize_arrays(option.structurize_arrays),
           m_record_log_order(option.record_log_order),
           m_retain_float_format(option.retain_float_format),
+          m_sanitize_invalid_json(option.sanitize_invalid_json),
           m_input_paths(option.input_paths),
           m_network_auth(option.network_auth) {
     if (false == m_timestamp_key.empty()) {
@@ -223,7 +224,7 @@ void JsonParser::parse_obj_in_array(simdjson::ondemand::object line, int32_t par
         }
 
         cur_field = *object_it_stack.top();
-        cur_key = cur_field.unescaped_key(true);
+        cur_key = cur_field.unescaped_key(m_sanitize_invalid_json);
         cur_value = cur_field.value();
 
         switch (cur_value.type()) {
@@ -302,7 +303,7 @@ void JsonParser::parse_obj_in_array(simdjson::ondemand::object line, int32_t par
                 break;
             }
             case simdjson::ondemand::json_type::string: {
-                std::string_view value = cur_value.get_string(true);
+                std::string_view value = cur_value.get_string(m_sanitize_invalid_json);
                 if (value.find(' ') != std::string::npos) {
                     node_id = m_archive_writer
                                       ->add_node(node_id_stack.top(), NodeType::ClpString, cur_key);
@@ -407,7 +408,7 @@ void JsonParser::parse_array(simdjson::ondemand::array array, int32_t parent_nod
                 break;
             }
             case simdjson::ondemand::json_type::string: {
-                std::string_view value = cur_value.get_string(true);
+                std::string_view value = cur_value.get_string(m_sanitize_invalid_json);
                 if (value.find(' ') != std::string::npos) {
                     node_id = m_archive_writer->add_node(parent_node_id, NodeType::ClpString, "");
                 } else {
@@ -452,7 +453,7 @@ void JsonParser::parse_line(
     do {
         if (false == object_stack.empty()) {
             cur_field = *object_it_stack.top();
-            cur_key = cur_field.unescaped_key(true);
+            cur_key = cur_field.unescaped_key(m_sanitize_invalid_json);
             line = cur_field.value();
         }
 
@@ -555,7 +556,7 @@ void JsonParser::parse_line(
                 break;
             }
             case simdjson::ondemand::json_type::string: {
-                std::string_view value = line.get_string(true);
+                std::string_view value = line.get_string(m_sanitize_invalid_json);
                 auto const matches_timestamp
                         = m_archive_writer->matches_timestamp(node_id_stack.top(), cur_key);
                 if (matches_timestamp) {
@@ -668,7 +669,8 @@ auto JsonParser::ingest_json(
         Path const& path,
         std::string const& archive_creator_id
 ) -> bool {
-    JsonFileIterator json_file_iterator(*reader, m_max_document_size, path.path);
+    JsonFileIterator
+            json_file_iterator(*reader, m_max_document_size, m_sanitize_invalid_json, path.path);
     if (simdjson::error_code::SUCCESS != json_file_iterator.get_error()) {
         SPDLOG_ERROR(
                 "Encountered error - {} - while trying to parse {} after parsing 0 bytes",

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -40,6 +40,7 @@ struct JsonParserOption {
     bool record_log_order{true};
     bool retain_float_format{false};
     bool single_file_archive{false};
+    bool sanitize_invalid_json{false};
     NetworkAuthOption network_auth{};
 };
 
@@ -239,6 +240,7 @@ private:
     bool m_structurize_arrays{false};
     bool m_record_log_order{true};
     bool m_retain_float_format{false};
+    bool m_sanitize_invalid_json{false};
 
     absl::flat_hash_map<std::pair<uint32_t, NodeType>, std::pair<int32_t, bool>>
             m_ir_node_to_archive_node_id_mapping;

--- a/components/core/src/clp_s/Utils.hpp
+++ b/components/core/src/clp_s/Utils.hpp
@@ -118,6 +118,29 @@ public:
             size_t simdjson_padding
     );
 
+    /**
+     * Sanitizes a buffer by replacing invalid UTF-8 sequences with the Unicode replacement
+     * character (U+FFFD). This is used to fix malformed data that contains invalid UTF-8
+     * which would cause JSON parsing errors.
+     *
+     * @param buf Pointer to pointer to the buffer. May be reallocated if expansion is needed.
+     *            The caller's pointer will be updated to point to the new buffer if reallocation
+     *            occurs. The caller is responsible for deleting the buffer.
+     * @param buf_size Current allocated size of the buffer (excluding simdjson padding).
+     *                 This parameter is modified by reference and will be updated if the buffer
+     *                 is reallocated to reflect the new buffer size.
+     * @param buf_occupied Number of bytes currently used in the buffer.
+     * @param simdjson_padding Amount of padding required after buffer content.
+     * @return Result containing new buf_occupied and counts of each type of invalid sequence
+     *         replaced.
+     */
+    static JsonSanitizeResult sanitize_utf8_buffer(
+            char*& buf,
+            size_t& buf_size,
+            size_t buf_occupied,
+            size_t simdjson_padding
+    );
+
 private:
     /**
      * Converts a character into its two byte hexadecimal representation.

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -107,6 +107,7 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     option.single_file_archive = command_line_arguments.get_single_file_archive();
     option.structurize_arrays = command_line_arguments.get_structurize_arrays();
     option.record_log_order = command_line_arguments.get_record_log_order();
+    option.sanitize_invalid_json = command_line_arguments.get_sanitize_invalid_json();
 
     clp_s::JsonParser parser(option);
     if (false == parser.ingest()) {

--- a/components/core/tests/test-clp_s-StringUtils.cpp
+++ b/components/core/tests/test-clp_s-StringUtils.cpp
@@ -60,7 +60,7 @@ auto can_parse_json(std::string_view json) -> bool {
     simdjson::ondemand::parser parser;
     simdjson::padded_string padded(json);
     auto result = parser.iterate(padded);
-    return !result.error();
+    return false == result.error();
 }
 }  // namespace
 

--- a/components/core/tests/test-clp_s-StringUtils.cpp
+++ b/components/core/tests/test-clp_s-StringUtils.cpp
@@ -1,0 +1,316 @@
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include <catch2/catch_test_macros.hpp>
+#include <simdjson.h>
+
+#include "../src/clp_s/Utils.hpp"
+
+using clp_s::JsonSanitizeResult;
+using clp_s::StringUtils;
+
+// We use C++14 string literals (the `s` suffix) to construct strings containing embedded null bytes
+// and control characters. Without the `s` suffix, std::string's constructor from a C-string literal
+// stops at the first null byte, truncating the test input. Additionally, we use string concatenation
+// (e.g., "\x00" "end") to prevent hex escape sequences from being extended by following hex digits.
+using namespace std::string_literals;
+
+namespace {
+/**
+ * Helper to create a buffer with simdjson padding and run sanitization.
+ * @param input The input string to sanitize
+ * @return The sanitized string
+ * @note If sanitize_json_buffer reallocates the buffer, the new buffer pointer is returned
+ *       and the original buffer is automatically deleted by sanitize_json_buffer. This helper
+ *       correctly handles both cases (reallocation and no reallocation) by always deleting
+ *       the final buffer pointer.
+ */
+auto sanitize_string(std::string_view input) -> std::string {
+    size_t buf_size = input.size();
+    size_t buf_occupied = input.size();
+    char* buf = new char[buf_size + simdjson::SIMDJSON_PADDING];
+    std::memcpy(buf, input.data(), input.size());
+
+    try {
+        auto const result = StringUtils::sanitize_json_buffer(
+                buf,
+                buf_size,
+                buf_occupied,
+                simdjson::SIMDJSON_PADDING
+        );
+        std::string output(buf, result.new_buf_occupied);
+        // Delete the buffer (may be reallocated, but buf points to the current buffer)
+        delete[] buf;
+        return output;
+    } catch (...) {
+        // If sanitization failed, buf still points to the original buffer
+        delete[] buf;
+        throw;
+    }
+}
+
+/**
+ * Helper to verify that a sanitized JSON string can be parsed by simdjson.
+ * @param json The JSON string to parse
+ * @return true if parsing succeeds, false otherwise
+ */
+auto can_parse_json(std::string_view json) -> bool {
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string padded(json);
+    auto result = parser.iterate(padded);
+    return !result.error();
+}
+}  // namespace
+
+TEST_CASE("sanitize_json_buffer_no_changes", "[clp_s][StringUtils]") {
+    // Valid JSON without control characters should pass through unchanged
+    SECTION("simple object") {
+        std::string input = R"({"key": "value"})";
+        REQUIRE(sanitize_string(input) == input);
+    }
+
+    SECTION("object with escaped characters") {
+        std::string input = R"({"key": "line1\nline2\ttab"})";
+        REQUIRE(sanitize_string(input) == input);
+    }
+
+    SECTION("object with unicode escapes") {
+        std::string input = R"({"key": "null char: \u0000"})";
+        REQUIRE(sanitize_string(input) == input);
+    }
+
+    SECTION("multiple objects") {
+        std::string input = R"({"a": "1"}{"b": "2"})";
+        REQUIRE(sanitize_string(input) == input);
+    }
+
+    SECTION("control chars outside strings are unchanged") {
+        // Control chars outside strings aren't valid JSON anyway,
+        // but we don't touch them - let the JSON parser report the error
+        std::string input = "{\x01\"key\": \"value\"}";
+        REQUIRE(sanitize_string(input) == input);
+    }
+}
+
+TEST_CASE("sanitize_json_buffer_escapes_control_chars", "[clp_s][StringUtils]") {
+    SECTION("null byte in string value") {
+        auto input = "{\"key\": \"val\x00ue\"}"s;
+        std::string expected = R"({"key": "val\u0000ue"})";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+
+    SECTION("multiple null bytes") {
+        auto input = "{\"key\": \"\x00\x00\x00\"}"s;
+        std::string expected = R"({"key": "\u0000\u0000\u0000"})";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+
+    SECTION("various control characters") {
+        // Test 0x01 (SOH), 0x02 (STX), 0x1F (US)
+        auto input = "{\"key\": \"a\x01" "b\x02" "c\x1F" "d\"}"s;
+        std::string expected = R"({"key": "a\u0001b\u0002c\u001fd"})";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+
+    SECTION("control char in key") {
+        auto input = "{\"ke\x00y\": \"value\"}"s;
+        std::string expected = R"({"ke\u0000y": "value"})";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+
+    SECTION("mixed valid escapes and control chars") {
+        auto input = "{\"key\": \"line1\\nhas\x00null\"}"s;
+        std::string expected = R"({"key": "line1\nhas\u0000null"})";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+}
+
+TEST_CASE("sanitize_json_buffer_handles_escapes_correctly", "[clp_s][StringUtils]") {
+    SECTION("escaped quote should not toggle string state") {
+        // The \" should not end the string
+        std::string input = R"({"key": "quote:\"value"})";
+        REQUIRE(sanitize_string(input) == input);
+    }
+
+    SECTION("escaped backslash before quote") {
+        // \\" means escaped backslash followed by end of string
+        std::string input = R"({"key": "backslash:\\"})";
+        REQUIRE(sanitize_string(input) == input);
+    }
+
+    SECTION("control char after escaped backslash") {
+        // \\\x00 means escaped backslash followed by a control char still inside the string
+        auto input = "{\"key\": \"slash:\\\\\x00" "end\"}"s;
+        std::string expected = R"({"key": "slash:\\\u0000end"})";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+
+    SECTION("control char after escaped quote") {
+        auto input = "{\"key\": \"quote:\\\"\x00" "after\"}"s;
+        std::string expected = R"({"key": "quote:\"\u0000after"})";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+
+    SECTION("control char as invalid escape sequence target") {
+        // \<control-char> is not a valid JSON escape sequence, but we leave it as-is
+        // since the sanitizer treats any char after backslash as an escape target.
+        // This JSON is invalid anyway (bad escape sequence) and will fail parsing.
+        auto input = "{\"key\": \"bad:\\\x00" "end\"}"s;
+        auto expected = "{\"key\": \"bad:\\\x00" "end\"}"s;
+        REQUIRE(sanitize_string(input) == expected);
+    }
+
+    SECTION("triple backslash followed by control char") {
+        // \\\ followed by \x00: first \\ is escaped backslash, third \ starts escape sequence.
+        // The third backslash makes the null appear to be an escape target, so it's not escaped.
+        auto input = "{\"key\": \"\\\\\\\x00" "end\"}"s;
+        auto expected = "{\"key\": \"\\\\\\\x00" "end\"}"s;
+        REQUIRE(sanitize_string(input) == expected);
+    }
+}
+
+TEST_CASE("sanitize_json_buffer_result_is_valid_json", "[clp_s][StringUtils]") {
+    SECTION("sanitized null byte produces valid JSON") {
+        auto input = "{\"key\": \"val\x00ue\"}"s;
+        std::string sanitized = sanitize_string(input);
+        REQUIRE(can_parse_json(sanitized));
+    }
+
+    SECTION("sanitized multiple control chars produces valid JSON") {
+        auto input = "{\"data\": \"\x01\x02\x03\x04\x05\"}"s;
+        std::string sanitized = sanitize_string(input);
+        REQUIRE(can_parse_json(sanitized));
+    }
+}
+
+TEST_CASE("sanitize_json_buffer_handles_buffer_growth", "[clp_s][StringUtils]") {
+    // Each control char expands from 1 byte to 6 bytes (\u00XX)
+    // Create input that will require buffer growth
+    SECTION("many control chars requiring expansion") {
+        // 100 null bytes -> 600 bytes after escaping
+        std::string value(100, '\x00');
+        std::string input = "{\"key\": \"" + value + "\"}";
+
+        std::string sanitized = sanitize_string(input);
+
+        // Verify all nulls were escaped
+        REQUIRE(sanitized.find('\x00') == std::string::npos);
+        // Verify correct number of escape sequences
+        size_t count = 0;
+        size_t pos = 0;
+        while ((pos = sanitized.find("\\u0000", pos)) != std::string::npos) {
+            ++count;
+            pos += 6;
+        }
+        REQUIRE(count == 100);
+        // Verify result is valid JSON
+        REQUIRE(can_parse_json(sanitized));
+    }
+}
+
+TEST_CASE("sanitize_json_buffer_jsonl", "[clp_s][StringUtils]") {
+    SECTION("multiple JSON objects with control chars") {
+        auto input = "{\"a\": \"x\x00y\"}\n{\"b\": \"p\x01q\"}"s;
+        std::string expected = "{\"a\": \"x\\u0000y\"}\n{\"b\": \"p\\u0001q\"}";
+        REQUIRE(sanitize_string(input) == expected);
+    }
+}
+
+TEST_CASE("sanitize_json_buffer_truncated_json", "[clp_s][StringUtils]") {
+    SECTION("truncated JSON with unmatched quote - control chars may be escaped incorrectly") {
+        // This tests the edge case documented in the code: if JSON is truncated with unmatched
+        // quotes, string state tracking may be incorrect, potentially escaping control chars
+        // outside of actual JSON strings. This is acceptable since malformed JSON will fail
+        // parsing anyway.
+        //
+        // Input: truncated JSON where the string is not closed, followed by control chars
+        // The sanitizer may incorrectly think it's still in a string and escape the control chars
+        auto input = "{\"key\": \"unclosed string\x00\x01" "after\"}"s;
+        // The sanitizer will escape the control chars because it thinks we're still in a string
+        // (the quote after "unclosed string" is escaped, so the string continues)
+        std::string sanitized = sanitize_string(input);
+        // The control chars should be escaped (behavior may vary based on quote matching)
+        // The important thing is that the function doesn't crash and handles it gracefully
+        REQUIRE((sanitized.find('\x00') == std::string::npos || sanitized.find("\\u0000") != std::string::npos));
+    }
+
+    SECTION("truncated JSON ending mid-string") {
+        // JSON truncated in the middle of a string with control chars (no closing quote)
+        // This simulates a real truncation scenario where the buffer ends mid-string
+        auto input = "{\"key\": \"value\x00\x01" "truncated"s;
+        std::string sanitized = sanitize_string(input);
+        // Should handle gracefully without crashing
+        // Control chars inside the (unclosed) string should be escaped
+        REQUIRE(sanitized.size() >= input.size());
+        // Verify no raw control characters remain (they should be escaped)
+        REQUIRE(sanitized.find('\x00') == std::string::npos);
+        REQUIRE(sanitized.find('\x01') == std::string::npos);
+    }
+
+    SECTION("truncated JSON with control chars after unmatched quote") {
+        // JSON with unmatched quote followed by control chars outside the string
+        // The sanitizer may incorrectly escape these if it thinks we're still in a string
+        auto input = "{\"key\": \"value\x00" "}\x01\x02"s;
+        std::string sanitized = sanitize_string(input);
+        // Function should not crash - behavior may vary but should be consistent
+        REQUIRE(sanitized.size() >= input.size());
+    }
+}
+
+TEST_CASE("sanitize_json_buffer_returns_correct_char_counts", "[clp_s][StringUtils]") {
+    SECTION("counts multiple different control characters") {
+        // Input with: 3x \x00, 2x \x01, 1x \x1f
+        auto input = "{\"a\": \"\x00\x00\x01\x00\x01\x1f\"}"s;
+
+        size_t buf_size = input.size();
+        size_t buf_occupied = input.size();
+        char* buf = new char[buf_size + simdjson::SIMDJSON_PADDING];
+        std::memcpy(buf, input.data(), input.size());
+
+        try {
+            auto const result = StringUtils::sanitize_json_buffer(
+                    buf,
+                    buf_size,
+                    buf_occupied,
+                    simdjson::SIMDJSON_PADDING
+            );
+
+            REQUIRE(result.sanitized_char_counts.size() == 3);
+            REQUIRE(result.sanitized_char_counts.at('\x00') == 3);
+            REQUIRE(result.sanitized_char_counts.at('\x01') == 2);
+            REQUIRE(result.sanitized_char_counts.at('\x1f') == 1);
+
+            delete[] buf;
+        } catch (...) {
+            delete[] buf;
+            throw;
+        }
+    }
+
+    SECTION("returns empty counts when no sanitization needed") {
+        std::string input = R"({"key": "valid value"})";
+
+        size_t buf_size = input.size();
+        size_t buf_occupied = input.size();
+        char* buf = new char[buf_size + simdjson::SIMDJSON_PADDING];
+        std::memcpy(buf, input.data(), input.size());
+
+        try {
+            auto const result = StringUtils::sanitize_json_buffer(
+                    buf,
+                    buf_size,
+                    buf_occupied,
+                    simdjson::SIMDJSON_PADDING
+            );
+
+            REQUIRE(result.sanitized_char_counts.empty());
+            REQUIRE(result.new_buf_occupied == input.size());
+
+            delete[] buf;
+        } catch (...) {
+            delete[] buf;
+            throw;
+        }
+    }
+}

--- a/components/core/tests/test-clp_s-StringUtils.cpp
+++ b/components/core/tests/test-clp_s-StringUtils.cpp
@@ -332,12 +332,15 @@ auto sanitize_utf8_string(std::string_view input) -> std::string {
  */
 auto count_replacement_chars(std::string_view s) -> size_t {
     size_t count = 0;
-    for (size_t i = 0; i + 2 < s.size(); ++i) {
+    size_t i = 0;
+    while (i + 2 < s.size()) {
         if (static_cast<unsigned char>(s[i]) == 0xEF && static_cast<unsigned char>(s[i + 1]) == 0xBF
             && static_cast<unsigned char>(s[i + 2]) == 0xBD)
         {
             ++count;
-            i += 2;  // Skip past the replacement char
+            i += 3;  // Skip past the replacement char (3 bytes for U+FFFD)
+        } else {
+            ++i;
         }
     }
     return count;

--- a/components/core/tests/test-clp_s-StringUtils.cpp
+++ b/components/core/tests/test-clp_s-StringUtils.cpp
@@ -8,7 +8,7 @@
 
 #include "../src/clp_s/Utils.hpp"
 
-using clp_s::JsonSanitizeResult;
+using clp_s::BufferSanitizeResult;
 using clp_s::StringUtils;
 
 // We use C++14 string literals (the `s` suffix) to construct strings containing embedded null bytes
@@ -23,7 +23,7 @@ namespace {
  * Result structure containing both the sanitization result and the output string.
  */
 struct SanitizeResultWithOutput {
-    JsonSanitizeResult result;
+    BufferSanitizeResult result;
     std::string output;
 };
 


### PR DESCRIPTION
# Description

Add a new `--sanitize-invalid-json` option that provides consistent, opt-in sanitization of invalid JSON during ingestion.

## Previous Behavior (Inconsistent)

| Issue | Previous Behavior |
|-------|-------------------|
| Invalid UTF-8 sequences | ❌ Fails with `UTF8_ERROR` |
| Unescaped control characters (0x00-0x1F) | ❌ Fails with `UNESCAPED_CHARS` |
| Invalid surrogate escapes (e.g., `\uD800`) | ✅ Silently replaced with U+FFFD |

The inconsistency arose because `get_string(true)` and `unescaped_key(true)` were hardcoded, which silently handled invalid surrogate escapes while other malformed JSON caused hard failures.

## New Behavior (Consistent)

**`--sanitize-invalid-json=false` or not specified (default - strict mode):**

| Issue | Behavior |
|-------|----------|
| Invalid UTF-8 sequences | ❌ Fails with `UTF8_ERROR` |
| Unescaped control characters | ❌ Fails with `UNESCAPED_CHARS` |
| Invalid surrogate escapes | ❌ Fails (no silent replacement) |

**`--sanitize-invalid-json=true` (permissive mode):**

| Issue | Behavior |
|-------|----------|
| Invalid UTF-8 sequences | ✅ Replaced with U+FFFD, warning logged |
| Unescaped control characters | ✅ Escaped to `\u00XX`, warning logged |
| Invalid surrogate escapes | ✅ Replaced with U+FFFD |

## Motivation

In rare circumstances, we have observed malformed JSON in log data:
- Null bytes (`0x00`) or other control characters from C-string handling bugs
- Invalid UTF-8 sequences from encoding issues or corrupted data
- Invalid Unicode surrogate escapes (e.g., unpaired surrogates)

This change provides users explicit control over how to handle malformed JSON:
- **Default (strict)**: Fail fast on any malformed JSON for data integrity, or be explicit with `--sanitize-invalid-json=false`
- **Permissive**: Sanitize and continue for maximum data recovery with `--sanitize-invalid-json=true`

## Changes

- Add `--sanitize-invalid-json` option to CommandLineArguments (default: false)
- Add `StringUtils::sanitize_utf8_buffer()` for UTF-8 validation and replacement with U+FFFD
- Update `JsonFileIterator` to conditionally sanitize on `UTF8_ERROR` and `UNESCAPED_CHARS` errors during both initial parsing and document iteration
- Update `JsonParser` to use conditional `get_string(m_sanitize_invalid_json)` and `unescaped_key(m_sanitize_invalid_json)` instead of hardcoded `true`
- Track sanitization byte changes for accurate byte counting

## Code Quality & Efficiency Improvements

Recent refactoring improved the implementation:

**Code quality:**
- Renamed `JsonSanitizeResult` to `BufferSanitizeResult` for clarity
- Extracted helper methods with descriptive names (`sanitize_invalid_utf8_and_log`, `sanitize_control_chars_and_log`, `reinitialize_document_stream`)
- Added defensive null pointer checks
- Fixed typos and documentation
- Used named constants instead of magic strings

**Efficiency:**
- Lazy-copy approach: zero allocation when no sanitization is needed
- Bulk range copying instead of byte-by-byte operations
- Single pass through the data with deferred copying

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

- Built and ran in Docker container (`clp-core-dependencies-aarch64-manylinux_2_28:dev`)
- Tested control character sanitization:
  - Without flag: fails with `UNESCAPED_CHARS` ✓
  - `--sanitize-invalid-json=true`: succeeds, logs warning about escaped characters ✓
- Tested invalid UTF-8 sanitization:
  - Without flag: fails with `UTF8_ERROR` ✓
  - `--sanitize-invalid-json=true`: succeeds, logs warning about replaced sequences ✓
- Verified `--help` shows new option with description

## Unit Tests

Comprehensive test coverage for both `sanitize_json_buffer()` and `sanitize_utf8_buffer()`:

- **Valid input passthrough**: ASCII, multibyte UTF-8 (2/3/4-byte), JSON with UTF-8, empty strings
- **Control character escaping**: Null bytes, various control chars (0x00-0x1F), chars in keys/values
- **Escape sequence handling**: Escaped quotes, escaped backslashes, control chars after escapes
- **Invalid UTF-8 replacement**: 0xFF, 0xFE, orphan continuation bytes, truncated sequences
- **Edge cases**: Overlong encodings, surrogate code points, code points above U+10FFFF
- **Buffer management**: Growth with many control chars, correct replacement counts
- **Null/empty buffer handling**: Defensive checks

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSON data sanitization capabilities with new `--sanitize-invalid-json` command-line option to handle invalid encoding during compression. Escapes control characters in JSON and replaces invalid UTF-8 sequences with replacement characters.

* **Tests**
  * Added comprehensive test coverage for JSON and UTF-8 sanitization functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212888454684699