### PR TITLE
fix(clp-package): Ensure `--count` and `--count-by-time` arguments are mutually exclusive in sbin search scripts (fixes #1859).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/scripts/native/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/search.py
@@ -288,6 +288,10 @@ def main(argv):
     else:
         logger.setLevel(logging.INFO)
 
+    if parsed_args.count and parsed_args.count_by_time is not None:
+        logger.error("--count and --count-by-time are mutually exclusive.")
+        return -1
+
     if (
         parsed_args.begin_time is not None
         and parsed_args.end_time is not None

--- a/components/clp-package-utils/clp_package_utils/scripts/search.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/search.py
@@ -85,6 +85,11 @@ def main(argv):
         "--raw", action="store_true", help="Output the search results as raw logs."
     )
     parsed_args = args_parser.parse_args(argv[1:])
+
+    if parsed_args.count and parsed_args.count_by_time is not None:
+        logger.error("--count and --count-by-time are mutually exclusive.")
+        return -1
+
     if parsed_args.verbose:
         logger.setLevel(logging.DEBUG)
     else:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Adds validation to reject using `--count` and `--count-by-time` together in `search.sh`, as these options are mutually exclusive. Previously, using both options together would cause a `KeyError: 'group_tags'` because the second option's `AggregationConfig` would overwrite the first one's configuration.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.
  * TODO: add docs for the search script usages. Then there we should document the options are exclusive to each other.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Built the package:
```shell
task && cd build/clp-package && ./sbin/start-clp.sh
```
```
2026-01-15T14:21:03.613 INFO [controller] Started CLP.
```

* Compressed sample logs:
```shell
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl
```
```
2026-01-15T14:21:11.565 INFO [compress] Compression job 1 submitted.
2026-01-15T14:21:13.569 INFO [compress] Compressed 392.84MB into 9.94MB (39.53x). Speed: 207.53MB/s.
2026-01-15T14:21:14.070 INFO [compress] Compression finished.
2026-01-15T14:21:14.071 INFO [compress] Compressed 392.84MB into 9.94MB (39.53x). Speed: 183.93MB/s.
```

* Verified that using both `--count` and `--count-by-time` now fails with a clear error message:
```shell
./sbin/search.sh --count --count-by-time 1 "*"
```
```
2026-01-15T14:21:20.806 ERROR [search] --count and --count-by-time are mutually exclusive.
```

* Verified that `--count` works individually:
```shell
./sbin/search.sh --count "*"
```
```
tags: [] count: 1000000
```

* Verified that `--count-by-time` works individually:
```shell
./sbin/search.sh --count-by-time 60000 "*"
```
->
```
timestamp: 1679876760000 count: 1351
timestamp: 1679876820000 count: 130543
timestamp: 1679876880000 count: 257459
timestamp: 1679876940000 count: 221434
timestamp: 1679877000000 count: 194047
timestamp: 1679877060000 count: 127016
timestamp: 1679877120000 count: 68150
```


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search functionality now includes improved validation that prevents conflicting counting mode options from being used simultaneously, ensuring only one counting method is active at a time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->