### PR TITLE
fix(helm): Ensure `log_ingestor` is explicitly null in configmap when disabled (fixes #1881).

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.2-dev.18"
+version: "0.1.2-dev.19"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.7.1-dev"

--- a/tools/deployment/package-helm/templates/configmap.yaml
+++ b/tools/deployment/package-helm/templates/configmap.yaml
@@ -123,6 +123,8 @@ data:
       host: "localhost"
       logging_level: {{ .logging_level | quote }}
       port: 3002
+    {{- else }}
+    log_ingestor: null
     {{- end }}
     package:
       query_engine: {{ .Values.clpConfig.package.query_engine | quote }}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

> [!NOTE]
This PR is part of the ongoing work for #1309. More PRs will be submitted until the Helm chart is complete and fully functional.

Sets the `log_ingestor` in `tools/deployment/package-helm/templates/configmap.yaml` as `null` when the `log_ingestor` is configured to be disabled (also `null`) in `values.yaml`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Applied below changes to values.yaml:
```
diff --git a/tools/deployment/package-helm/values.yaml b/tools/deployment/package-helm/values.yaml
--- a/tools/deployment/package-helm/values.yaml	(revision 4d38a7892b43e86d8b93aa6b18e87e949b0ec2c2)
+++ b/tools/deployment/package-helm/values.yaml	(date 1768794180678)
@@ -88,16 +88,11 @@
 
 clpConfig:
   package:
-    storage_engine: "clp-s"
-    query_engine: "clp-s"
+    storage_engine: "clp"
+    query_engine: "clp"
 
   # API server config
-  api_server:
-    port: 30301
-    default_max_num_query_results: 1000
-    query_job_polling:
-      initial_backoff_ms: 100
-      max_backoff_ms: 5000
+  api_server: null
 
   # Location (e.g., directory) containing any logs you wish to compress. Must be reachable by all
   # workers.
```
Ran tools/deployment/package-helm/set-up-test.sh and observed "All jobs completed and services are ready."

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.1.2-dev.19
  * Internal configuration enhancements for improved deployment management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->