### PR TITLE
fix(toolchains): Temporarily lock `nextest` to v0.9.122 as a workaround for #1906.

### DIFF
--- a/taskfiles/toolchains.yaml
+++ b/taskfiles/toolchains.yaml
@@ -103,6 +103,7 @@ tasks:
         EOF
 
       # Disable Rustup's auto self update at the end to avoid unexpected checksum mismatches.
+      # NOTE: Temporarily lock `nextest` to v0.9.122 as a workaround for #1906.
       - |-
         . "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
         rustup toolchain install nightly --allow-downgrade --component clippy,rustfmt


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

A CI failure has been reported in #1906.

As a workaround, we Temporarily lock `nextest` to v0.9.122 to by pass the issue, since it seems like v0.9.124 won't be released very soon.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
