### PR TITLE
fix(toolchains): Unlcok `nextest` version to always install the latest; Add `--locked` option when installing `nextest` (fixes #1906).

### DIFF
--- a/taskfiles/toolchains.yaml
+++ b/taskfiles/toolchains.yaml
@@ -102,6 +102,7 @@ tasks:
         export CARGO_TARGET_DIR="{{.G_RUST_BUILD_DIR}}"
         EOF
 
+      # Disable Rustup's auto self update at the end to avoid unexpected checksum mismatches.
       - |-
         . "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
         rustup toolchain install nightly --allow-downgrade --component clippy,rustfmt


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes #1906 by:

* We would still install the latest version of `nextest`, dropping the temporary changes introduced in #1907.
* We add `--locked` option when installing `nextest` to adapt to the new requirement added in v0.9.124 (released as a fix to the issue). Related PR: https://github.com/nextest-rs/nextest/pull/3000

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows pass.
* [x] Tested in Spider: https://github.com/y-scope/spider/pull/279

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development toolchain configuration to use lock-file-based dependency installation for improved reproducibility and maintainability of the build environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->