### PR TITLE
fix(clp-rust-utils): Configure AWS region and credentials in base config to avoid default provider resolution (fixes #1915).

### DIFF
--- a/components/clp-rust-utils/src/s3/client.rs
+++ b/components/clp-rust-utils/src/s3/client.rs
@@ -22,7 +22,7 @@ pub async fn create_new_client(
     region_id: &str,
     endpoint: Option<&NonEmptyString>,
 ) -> Client {
-    let credential = Credentials::new(
+    let credentials = Credentials::new(
         access_key_id,
         secret_access_key,
         None,
@@ -30,7 +30,7 @@ pub async fn create_new_client(
         "clp-credentials-provider",
     );
     let base_config = aws_config::defaults(BehaviorVersion::latest())
-        .credentials_provider(credential)
+        .credentials_provider(credentials)
         .region(Region::new(region_id.to_string()))
         .load()
         .await;

--- a/components/clp-rust-utils/src/sqs/client.rs
+++ b/components/clp-rust-utils/src/sqs/client.rs
@@ -18,7 +18,7 @@ pub async fn create_new_client(
     region_id: &str,
     endpoint: Option<&NonEmptyString>,
 ) -> Client {
-    let credential = Credentials::new(
+    let credentials = Credentials::new(
         access_key_id,
         secret_access_key,
         None,
@@ -26,7 +26,7 @@ pub async fn create_new_client(
         "clp-credentials-provider",
     );
     let base_config = aws_config::defaults(BehaviorVersion::latest())
-        .credentials_provider(credential)
+        .credentials_provider(credentials)
         .region(Region::new(region_id.to_string()))
         .load()
         .await;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title suggests, this PR implements the suggested fix in #1915 to avoid unnecessary IMDS lookups.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Created both S3 scanning and SQS listening jobs. Ensure that with the fix applied, there is no IMDS lookup overhead. log-ingestor log:
  ```
  {"timestamp":"2026-01-28T20:34:02.705660Z","level":"INFO","fields":{"message":"Server started at 0.0.0.0:3002"},"filename":"components/log-ingestor/src/bin/log_ingestor.rs","line_number":103}
  {"timestamp":"2026-01-28T20:34:16.492677Z","level":"INFO","fields":{"message":"Create SQS listener ingestion job.","config":"SqsListenerConfig { base: BaseConfig { bucket_name: NonEmptyString(\"lzh-test\"), key_prefix: NonEmptyString(\"test-1769632456\"), region: Some(NonEmptyString(\"us-east-2\")), endpoint_url: None, dataset: None, timestamp_key: None, unstructured: false }, queue_url: NonEmptyString(\"https://sqs.us-east-2.amazonaws.com/568954113123/log-ingestor-sqs-test\") }"},"filename":"components/log-ingestor/src/routes.rs","line_number":218}
  {"timestamp":"2026-01-28T20:34:16.520597Z","level":"INFO","fields":{"message":"Created SQS listener ingestion job.","job_id":"5dd9d9a2-5f4d-471b-9b9f-d0a40051d08d"},"filename":"components/log-ingestor/src/routes.rs","line_number":226}
  {"timestamp":"2026-01-28T20:34:23.139606Z","level":"INFO","fields":{"message":"Received new object metadata from SQS.","object":"ObjectMetadata { bucket: NonEmptyString(\"lzh-test\"), key: NonEmptyString(\"test-1769632456/log_1769632457.clp.zstd\"), size: 6748 }"},"filename":"components/log-ingestor/src/ingestion_job/sqs_listener.rs","line_number":103}
  {"timestamp":"2026-01-28T20:34:27.732227Z","level":"INFO","fields":{"message":"Received new object metadata from SQS.","object":"ObjectMetadata { bucket: NonEmptyString(\"lzh-test\"), key: NonEmptyString(\"test-1769632456/log_1769632462.clp.zstd\"), size: 6731 }"},"filename":"components/log-ingestor/src/ingestion_job/sqs_listener.rs","line_number":103}
  {"timestamp":"2026-01-28T20:34:36.143491Z","level":"INFO","fields":{"message":"Received new object metadata from SQS.","object":"ObjectMetadata { bucket: NonEmptyString(\"lzh-test\"), key: NonEmptyString(\"test-1769632456/log_1769632467.clp.zstd\"), size: 6776 }"},"filename":"components/log-ingestor/src/ingestion_job/sqs_listener.rs","line_number":103}
  {"timestamp":"2026-01-28T20:34:41.682829Z","level":"INFO","fields":{"message":"Received new object metadata from SQS.","object":"ObjectMetadata { bucket: NonEmptyString(\"lzh-test\"), key: NonEmptyString(\"test-1769632456/log_1769632475.clp.zstd\"), size: 6754 }"},"filename":"components/log-ingestor/src/ingestion_job/sqs_listener.rs","line_number":103}
  {"timestamp":"2026-01-28T20:34:46.256316Z","level":"INFO","fields":{"message":"Received new object metadata from SQS.","object":"ObjectMetadata { bucket: NonEmptyString(\"lzh-test\"), key: NonEmptyString(\"test-1769632456/log_1769632481.clp.zstd\"), size: 6721 }"},"filename":"components/log-ingestor/src/ingestion_job/sqs_listener.rs","line_number":103}
  {"timestamp":"2026-01-28T20:35:10.734166Z","level":"INFO","fields":{"message":"Create S3 scanner ingestion job.","config":"S3ScannerConfig { base: BaseConfig { bucket_name: NonEmptyString(\"lzh-test\"), key_prefix: NonEmptyString(\"test-1769632511\"), region: Some(NonEmptyString(\"us-east-2\")), endpoint_url: None, dataset: None, timestamp_key: None, unstructured: false }, scanning_interval_sec: 30, start_after: None }"},"filename":"components/log-ingestor/src/routes.rs","line_number":167}
  {"timestamp":"2026-01-28T20:35:10.734596Z","level":"INFO","fields":{"message":"Created S3 scanner ingestion job.","job_id":"5b7dac86-74ec-4a9b-88b8-dc111be87654"},"filename":"components/log-ingestor/src/routes.rs","line_number":175}
  {"timestamp":"2026-01-28T20:40:16.514338Z","level":"INFO","fields":{"message":"Submitting CLP compression job..."},"filename":"components/log-ingestor/src/compression/compression_job_submitter.rs","line_number":132}
  {"timestamp":"2026-01-28T20:40:16.516975Z","level":"INFO","fields":{"message":"Compression job submitted with ID: 1"},"filename":"components/log-ingestor/src/compression/compression_job_submitter.rs","line_number":144}
  {"timestamp":"2026-01-28T20:40:19.520901Z","level":"INFO","fields":{"message":"Compression job 1 completed successfully."},"filename":"components/log-ingestor/src/compression/compression_job_submitter.rs","line_number":187}
  ```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined internal AWS client configuration for S3 and SQS to simplify initialization and ownership.
  * Adjusted internal handling of region and endpoint setup and corrected an internal credential provider identifier.
  * No changes to functionality, public interfaces, or exported declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->