### PR TITLE
docs(presto): Add `--wait` flag to docker compose up commands for better startup feedback (fixes #1495).

### DIFF
--- a/docs/src/user-docs/guides-using-presto.md
+++ b/docs/src/user-docs/guides-using-presto.md
@@ -131,13 +131,13 @@ Using Presto with CLP requires:
 5. Start a Presto cluster by running:
 
     ```bash
-    docker compose up --detach
+    docker compose up --wait
     ```
 
     * To use more than one Presto worker, you can use the `--scale` option as follows:
 
       ```bash
-      docker compose up --scale presto-worker=<num-workers>
+      docker compose up --wait --scale presto-worker=<num-workers>
       ```
 
       * Replace `<num-workers>` with the number of Presto worker nodes you want to run.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Add the `--wait` flag to `docker compose up` commands in the Presto integration guide so that Docker Compose waits until services are running and healthy before returning. This provides better visibility into service startup failures instead of exiting silently.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 1. Verify docs build successfully

**Task:** Ensure the documentation builds with no errors or warnings.

**Command:**
```bash
task docs:serve
```

**Output** (relevant portion):
```
build succeeded.

The HTML pages are in ../build/docs/html.
```

No errors or warnings were produced.

## 2. Verify rendered page content

**Task:** Confirm the updated commands appear correctly on the rendered Presto guide page.

Opened `http://127.0.0.1:8080/user-docs/guides-using-presto.html` and verified:
- The basic startup command now reads `docker compose up --wait`.
- The scaled startup command now reads
  `docker compose up --wait --scale presto-worker=<num-workers>`.
- No other commands (`docker compose stop`, `docker compose down`, `docker compose exec`) were
  modified.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Presto setup guide to use compose commands that wait for services to be ready before continuing, both for initial startup and when scaling workers.
  * This change improves setup reliability, reduces race conditions and initialization-related errors, and shortens troubleshooting time during local or staged deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->