### PR TITLE
build(docker): Add `--pull` flag to all Docker build commands to ensure the latest base images are used (fixes #1051).

### DIFF
--- a/components/core/tools/docker-images/clp-core-ubuntu-jammy/build.sh
+++ b/components/core/tools/docker-images/clp-core-ubuntu-jammy/build.sh
@@ -14,6 +14,7 @@ build_dir="$1"
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 build_cmd=(
     docker build
+    --pull
     --tag clp-core-x86-ubuntu-jammy:dev
     "$build_dir"
     --file "${script_dir}/Dockerfile"

--- a/components/core/tools/docker-images/clp-env-base-centos-stream-9/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-centos-stream-9/build.sh
@@ -9,6 +9,7 @@ component_root="${script_dir}/../../../"
 
 build_cmd=(
     docker build
+    --pull
     --tag clp-core-dependencies-x86-centos-stream-9:dev
     "$component_root"
     --file "${script_dir}/Dockerfile"

--- a/components/core/tools/docker-images/clp-env-base-manylinux_2_28-aarch64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-manylinux_2_28-aarch64/build.sh
@@ -9,6 +9,7 @@ component_root="${script_dir}/../../../"
 
 build_cmd=(
     docker buildx build
+    --pull
     --platform linux/arm64
     --tag clp-core-dependencies-aarch64-manylinux_2_28:dev
     "$component_root"

--- a/components/core/tools/docker-images/clp-env-base-manylinux_2_28-x86_64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-manylinux_2_28-x86_64/build.sh
@@ -9,6 +9,7 @@ component_root="${script_dir}/../../../"
 
 build_cmd=(
     docker buildx build
+    --pull
     --platform linux/amd64
     --tag clp-core-dependencies-x86-manylinux_2_28:dev
     "$component_root"

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/build.sh
@@ -9,6 +9,7 @@ component_root="${script_dir}/../../../"
 
 build_cmd=(
     docker buildx build
+    --pull
     --platform linux/arm64
     --tag clp-core-dependencies-aarch64-musllinux_1_2:dev
     "$component_root"

--- a/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86_64/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86_64/build.sh
@@ -9,6 +9,7 @@ component_root="${script_dir}/../../../"
 
 build_cmd=(
     docker buildx build
+    --pull
     --platform linux/amd64
     --tag clp-core-dependencies-x86-musllinux_1_2:dev
     "$component_root"

--- a/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/build.sh
+++ b/components/core/tools/docker-images/clp-env-base-ubuntu-jammy/build.sh
@@ -9,6 +9,7 @@ component_root=${script_dir}/../../../
 
 build_cmd=(
     docker build
+    --pull
     --tag clp-core-dependencies-x86-ubuntu-jammy:dev
     "$component_root"
     --file "${script_dir}/Dockerfile"

--- a/tools/docker-images/clp-package/build.sh
+++ b/tools/docker-images/clp-package/build.sh
@@ -30,6 +30,7 @@ new_image_id=""
 
 build_cmd=(
     docker build
+    --pull
     --iidfile "$temp_iid_file"
     "$repo_root"
     --file "${script_dir}/Dockerfile"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Add the `--pull` flag to all Docker build scripts (`docker build` and `docker buildx build`) to ensure base images are always pulled fresh from the registry. This prevents builds from using stale cached base images that may have missing security updates.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 0. Verify `--pull` is present in every build script

**Task:** Confirm `--pull` immediately follows `docker build` or `docker buildx build` in all 8
scripts.

**Command:**
```bash
for f in $(grep -rn "docker build\b\|docker buildx build" --include="build.sh" -l); do
    echo "=== $f ==="
    grep -A1 "docker build" "$f"
    echo
done
```

**Output:**
```
=== tools/docker-images/clp-package/build.sh ===
    docker build
    --pull

=== components/core/tools/docker-images/clp-env-base-manylinux_2_28-x86_64/build.sh ===
    docker buildx build
    --pull

=== components/core/tools/docker-images/clp-core-ubuntu-jammy/build.sh ===
    docker build
    --pull

=== components/core/tools/docker-images/clp-env-base-centos-stream-9/build.sh ===
    docker build
    --pull

=== components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/build.sh ===
    docker buildx build
    --pull

=== components/core/tools/docker-images/clp-env-base-ubuntu-jammy/build.sh ===
    docker build
    --pull

=== components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86_64/build.sh ===
    docker buildx build
    --pull

=== components/core/tools/docker-images/clp-env-base-manylinux_2_28-aarch64/build.sh ===
    docker buildx build
    --pull
```

All 8 build scripts now include `--pull` immediately after the `docker build` / `docker buildx
build` command.

## 1. Build CLP package

**Task:** Verify the `clp-package` Docker image builds successfully with the `--pull` flag in
`tools/docker-images/clp-package/build.sh` (the script invoked by `task`).

**Command:**
```bash
task
```

**Output:**
```
...
#30 exporting manifest list sha256:190cd68e5f13faa68efb8d61743cbbc78b92c5285d7cc053365bb36f6b9ad6e6 0.0s done
#30 naming to moby-dangling@sha256:190cd68e5f13faa68efb8d61743cbbc78b92c5285d7cc053365bb36f6b9ad6e6 done
#30 unpacking to moby-dangling@sha256:190cd68e5f13faa68efb8d61743cbbc78b92c5285d7cc053365bb36f6b9ad6e6 done
#30 DONE 0.1s
task: [package] echo '0.8.1-dev' > '/home/junhao/workspace/clp/build/clp-package/VERSION'
```

Build completed successfully.

## 2. Start CLP

**Task:** Verify CLP starts successfully with the image built using `--pull`.

**Command:**
```bash
cd build/clp-package
./sbin/start-clp.sh
```

**Output:**
```
...
 Container clp-package-0cc6-api-server-1 Healthy
 Container clp-package-0cc6-query-scheduler-1 Healthy
 Container clp-package-0cc6-compression-worker-1 Healthy
 Container clp-package-0cc6-webui-1 Healthy
2026-02-01T11:18:55.524 INFO [controller] Started CLP.
```

All containers started and passed health checks.

## 3. Test compression

**Task:** Verify compression works correctly.

**Command:**
```bash
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl
```

**Output:**
```
2026-02-01T11:19:00.199 INFO [compress] Compression job 1 submitted.
2026-02-01T11:19:02.201 INFO [compress] Compressed 392.84MB into 9.94MB (39.53x). Speed: 205.93MB/s.
2026-02-01T11:19:02.702 INFO [compress] Compression finished.
2026-02-01T11:19:02.702 INFO [compress] Compressed 392.84MB into 9.94MB (39.53x). Speed: 183.79MB/s.
```

Compression job completed successfully.

## 4. Stop CLP

**Task:** Verify CLP stops cleanly.

**Command:**
```bash
./sbin/stop-clp.sh
```

**Output:**
```
...
 Network clp-package-0cc6_default Removed
2026-02-01T11:19:28.015 INFO [controller] Stopped CLP.
```

All containers stopped and removed successfully.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Docker image builds now automatically pull the latest base images before building, ensuring containers use current dependencies and security patches across all build configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->