### PR TITLE
fix(clp-package): Remove unused staged-streams volume mount from the api-server service (fixes #1810).

### DIFF
--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -584,7 +584,6 @@ services:
     volumes:
       - *volume_clp_config_readonly
       - *volume_clp_logs
-      - "${CLP_STAGED_STREAM_OUTPUT_DIR_HOST:-empty}:/var/data/staged-streams"
       - "${CLP_STREAM_OUTPUT_DIR_HOST:-empty}:/var/data/streams"
     depends_on:
       db-table-creator:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Remove the `staged-streams` volume mount from the `api-server` service in `docker-compose-all.yaml`. The API server does not read or write staged streams; only the query-worker requires this mount.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 0. Build CLP package

**Command:**
```bash
task
```

Build completed successfully.

## 1. Start CLP and verify container mounts

Configured `clp-config.yaml` with S3 storage for `stream_output` to
exercise the staged-streams path:

```yaml
stream_output:
  storage:
    type: "s3"
    staging_directory: "var/data/staged-streams"
    s3_config:
      region_code: "us-east-2"
      bucket: "yscope-junhao-test"
      key_prefix: "/"
      aws_authentication:
        type: "credentials"
        credentials: ...
```

**Command:**
```bash
./sbin/start-clp.sh
```

All containers started and passed health checks.

**API server mounts** (`docker inspect --format '{{range .Mounts}}...'`):
```
/var/log
/var/data/streams
/etc/clp-config.yaml
```

No `staged-streams` mount on the API server.

**Query-worker mounts:**
```
/var/log
/var/data/archives
/opt/clp/.aws
/var/data/staged-streams
/var/data/streams
/etc/clp-config.yaml
```

The query-worker retains `/var/data/staged-streams`.

## 2. Compress data and query via the API server

Compressed sample data (`./sbin/compress.sh`), then submitted a search query and fetched results directly from the API server's `/query_results` SSE endpoint:

```bash
# Submit search
curl http://<api-server>:3001/query -X POST \
    -H "Content-Type: application/json" \
    -d '{"query_string":"SELECT","dataset":"default","max_num_results":10}'
# => {"query_results_uri":"/query_results/5"}

# Fetch results (API server reads from S3, not staged-streams)
curl -N http://<api-server>:3001/query_results/5
# => data: {"timestamp":"2023-03-27 00:26:41.483","pid":7845,...,"ps":"SELECT",...}
#    data: {"timestamp":"2023-03-27 00:26:46.201","pid":7854,...,"ps":"SELECT",...}
#    ...  (10 results streamed successfully)
```

The API server successfully read query results from S3 without the `staged-streams` mount.

## 3. Stop CLP

```
2026-02-02T01:23:44.400 INFO [controller] Stopped CLP.
```
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a volume mapping from the api-server service in the Docker Compose configuration, which may affect access to staged-streams data within the container.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->