### PR TITLE
fix(webui): Use numeric value for VirtualTable `scroll.x` to fix console warning with dev server (fixes #1892).

### DIFF
--- a/components/webui/client/src/pages/IngestPage/Jobs/index.tsx
+++ b/components/webui/client/src/pages/IngestPage/Jobs/index.tsx
@@ -36,7 +36,7 @@ const Jobs = () => {
                 dataSource={jobs}
                 pagination={false}
                 rowKey={(record) => record.key}
-                scroll={{y: 400, x: true}}
+                scroll={{y: 400, x: 1}}
                 tableLayout={"fixed"}/>
         </DashboardCard>
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Change `scroll.x` from `true` to `1` in the `VirtualTable` component on the Ingest page to
eliminate the console warning:

```
Warning: `scroll.x` in virtual table must be number.
```

rc-table's `VirtualTable` only accepts `number` for `scroll.x` (unlike the regular `Table` which accepts `number | true | string`). The value `1` is what rc-table falls back to internally, so this
change preserves the existing behaviour.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 0. Build CLP package

**Task:** Verify the project builds successfully with the change.

**Command:**
```bash
task
```

**Output:**
```
...
#30 exporting manifest list sha256:9fc6e521f84e4a9333887b0fde4b452d423a0282c8da99f3b0723b667d5b267e 0.0s done
#30 naming to moby-dangling@sha256:9fc6e521f84e4a9333887b0fde4b452d423a0282c8da99f3b0723b667d5b267e done
#30 unpacking to moby-dangling@sha256:9fc6e521f84e4a9333887b0fde4b452d423a0282c8da99f3b0723b667d5b267e done
#30 DONE 7.5s
task: [package] echo '0.8.1-dev' > '/home/junhao/workspace/clp/build/clp-package/VERSION'
```

Build completed successfully.

## 1. Start CLP and compress data

**Task:** Start CLP and run a compression job so the VirtualTable on the Ingest page is populated
with data (the warning only triggers when the table renders rows).

**Commands:**
```bash
cd build/clp-package
./sbin/start-clp.sh
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl
```

**Output:**
```
...
 Container clp-package-2d7a-webui-1 Healthy
2026-02-01T11:13:19.741 INFO [controller] Started CLP.

2026-02-01T11:14:02.054 INFO [compress] Compression job 1 submitted.
2026-02-01T11:14:04.057 INFO [compress] Compressed 392.84MB into 9.94MB (39.53x). Speed: 204.75MB/s.
2026-02-01T11:14:04.558 INFO [compress] Compression finished.
```

## 2. Start the webui dev server

**Task:** The `scroll.x` warning only appears in the dev server (the production build suppresses
React warnings). Start the Vite dev server for the webui client.

**Commands:**
```bash
cd components/webui
npm run dev
```

The Vite client dev server started on `http://localhost:8087` and the Fastify server on port 3000.

## 3. Verify no `scroll.x` warning with the fix

**Task:** Open the Ingest page in the browser and check the console for the `scroll.x` warning.

Opened `http://localhost:8087` in Chrome. The page shows the Ingest view with the Compression Jobs
table populated with one completed job. Checked the browser console—**no `scroll.x` warning**. The
only console messages are Vite connection logs and a React DevTools notice.

## 4. Revert the fix and confirm the warning appears

**Task:** Revert the change (set `scroll.x` back to `true`) and confirm the warning reappears.

Reverted `components/webui/client/src/pages/IngestPage/Jobs/index.tsx` to use `scroll={{y: 400, x: true}}`. Vite HMR hot-updated the module. The browser console immediately showed:

```
Warning: `scroll.x` in virtual table must be number.
```

## 5. Re-apply the fix and confirm the warning is gone

**Task:** Re-apply the fix (`x: 1`) and confirm the warning disappears.

Changed back to `scroll={{y: 400, x: 1}}`. After Vite HMR and a full page reload, the console
showed **no `scroll.x` warning**—only Vite connection logs and the React DevTools notice.

## 6. Stop CLP

**Command:**
```bash
cd build/clp-package
./sbin/stop-clp.sh
```

**Output:**
```
...
 Network clp-package-2d7a_default Removed
2026-02-01T11:14:42.591 INFO [controller] Stopped CLP.
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal scrolling behaviour in data table displays to ensure proper column visibility and user navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->