### PR TITLE
feat(integration-tests): Set up testing infrastructure for python binding library `yscope_clp_core`.

### DIFF
--- a/integration-tests/tests/python-wheels/test_yscope_clp_core/__init__.py
+++ b/integration-tests/tests/python-wheels/test_yscope_clp_core/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the CLP core python binding library."""

--- a/integration-tests/tests/python-wheels/test_yscope_clp_core/test_yscope_clp_core.py
+++ b/integration-tests/tests/python-wheels/test_yscope_clp_core/test_yscope_clp_core.py
@@ -1,0 +1,11 @@
+"""Integration tests for the CLP core python binding library."""
+
+import inspect
+
+from yscope_clp_core import clp_s
+
+
+def test_docstring_access() -> None:
+    """Verify that `yscope_clp_core` is accessible by inspecting its API docstring."""
+    doc = inspect.getdoc(clp_s)
+    assert doc is not None

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -622,8 +622,8 @@ tasks:
       # Repair the wheel and place it in the final build directory
       - |-
         {{- if eq "true" .WITH_CORE}}
-        uv run --no-cache \
-          auditwheel repair "{{.TMP_DIR}}"/*.whl --wheel-dir "{{.G_PYTHON_WHEELS_BUILD_DIR}}"
+          uv run --no-cache \
+            auditwheel repair "{{.TMP_DIR}}"/*.whl --wheel-dir "{{.G_PYTHON_WHEELS_BUILD_DIR}}"
         {{- else}}
           cp "{{.TMP_DIR}}"/*.whl "{{.G_PYTHON_WHEELS_BUILD_DIR}}"
         {{- end}}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -601,18 +601,29 @@ tasks:
   python-wheels-yscope-clp-core:
     vars:
       TMP_DIR: "{{.G_BUILD_DIR}}/tmp-{{.TASK}}"
+      WITH_CORE: "{{if eq \"false\" .WITH_CORE}}false{{else}}true{{end}}"
     dir: "{{.G_PYTHON_WHEELS_YSCOPE_CLP_CORE_DIR}}"
-    deps: ["core"]
     cmds:
       - "mkdir -p '{{.TMP_DIR}}'"
       - defer: "rm -rf '{{.TMP_DIR}}'"
 
+      # Set up final build directory
+      - "mkdir -p '{{.G_PYTHON_WHEELS_BUILD_DIR}}'"
+      - "rm -rf '{{.G_PYTHON_WHEELS_BUILD_DIR}}'/yscope_clp_core-*.whl"
+
       # Build the wheel into the temporary directory
       - |-
-        export YSCOPE_CLP_CORE_CLP_S_EXE="{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+        {{- if eq "true" .WITH_CORE}}
+          task core
+          export YSCOPE_CLP_CORE_CLP_S_EXE="{{.G_CORE_COMPONENT_BUILD_DIR}}/clp-s"
+        {{- end}}
         uv run --no-cache python3 -m build --wheel --outdir "{{.TMP_DIR}}"
 
-      # Repair the wheel and place it in the final build directory.
+      # Repair the wheel and place it in the final build directory
       - |-
+        {{- if eq "true" .WITH_CORE}}
         uv run --no-cache \
           auditwheel repair "{{.TMP_DIR}}"/*.whl --wheel-dir "{{.G_PYTHON_WHEELS_BUILD_DIR}}"
+        {{- else}}
+          cp "{{.TMP_DIR}}"/*.whl "{{.G_PYTHON_WHEELS_BUILD_DIR}}"
+        {{- end}}

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -785,7 +785,11 @@ tasks:
         - "{{.G_COMPONENTS_DIR}}/job-orchestration"
     requires:
       vars: ["RUFF_CHECK_FLAGS", "RUFF_FORMAT_FLAGS"]
-    deps: ["venv"]
+    deps:
+      - task: "venv"
+      - task: ":tests:integration:install-python-wheels-yscope-clp-core"
+        vars:
+          WITH_CORE: "false"
     cmds:
       - for:
           var: "UV_PYTHON_PROJECTS_IGNORE_ERRORS"

--- a/taskfiles/tests/integration.yaml
+++ b/taskfiles/tests/integration.yaml
@@ -36,3 +36,26 @@ tasks:
     dir: "{{.G_INTEGRATION_TESTS_DIR}}"
     deps: ["::package"]
     cmd: "uv run pytest -m package"
+
+  install-python-wheels-yscope-clp-core:
+    internal: true
+    vars:
+      WITH_CORE: "{{if eq \"false\" .WITH_CORE}}false{{else}}true{{end}}"
+    dir: "{{.G_INTEGRATION_TESTS_DIR}}"
+    deps:
+      - task: "::python-wheels-yscope-clp-core"
+        vars:
+          WITH_CORE: "{{.WITH_CORE}}"
+    cmd: |-
+      uv venv --allow-existing
+      uv pip install --force-reinstall "{{.G_PYTHON_WHEELS_BUILD_DIR}}"/yscope_clp_core-*.whl
+
+  python-wheels-yscope-clp-core:
+    env:
+      CLP_BUILD_DIR: "{{.G_BUILD_DIR}}"
+    dir: "{{.G_INTEGRATION_TESTS_DIR}}"
+    deps:
+      - task: "install-python-wheels-yscope-clp-core"
+        vars:
+          WITH_CORE: "true"
+    cmd: "uv run pytest -m yscope_clp_core"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR sets up the basic infrastructure for writing integration tests for `yscope-clp-core`. While the setup itself is straightforward, the main problem it addresses is running Python linting against the integration test project when `yscope-clp-core` is installed:
* Pure linting does not require code execution, so it doesn't need to build the `clp-s` binary
* Pure linting environment may not be capable of building `clp-s` (GitHub CI)
* `auditwheel repair` fails when `clp-s` is missing because its purpose is to bundle required shared libraries into the wheel

Introducing a `WITH_CORE` flag for `task python-wheels-yscope-clp-core` allows flexible workflows. The core binary is included only when it is required.

This PR precedes #1934 to allow tests for `ClpArchiveWriter` to be written directly, with minimal infrastructure overhead.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] `task lint:py` and `task tests:integration:python-wheels-yscope-clp-core` pass independently. The CI passes as well.
 
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for the Python CLP core binding library.
  * Introduced docstring accessibility validation to ensure proper API documentation exposure.

* **Chores**
  * Updated build system configuration to support optional core functionality.
  * Enhanced test workflow dependencies and build processes for improved flexibility and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->