### PR TITLE
chore: Bump version to `0.9.1-dev` for the next development cycle.

### DIFF
--- a/components/clp-mcp-server/pyproject.toml
+++ b/components/clp-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clp-mcp-server"
-version = "0.8.1-dev"
+version = "0.9.1-dev"
 description = "MCP server for CLP"
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/clp-mcp-server/uv.lock
+++ b/components/clp-mcp-server/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "clp-mcp-server"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiomysql" },
@@ -381,7 +381,7 @@ dev = [
 
 [[package]]
 name = "clp-py-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "../clp-py-utils" }
 dependencies = [
     { name = "boto3" },

--- a/components/clp-package-utils/pyproject.toml
+++ b/components/clp-package-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clp-package-utils"
-version = "0.8.1-dev"
+version = "0.9.1-dev"
 description = "Utilities for the CLP package."
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/clp-package-utils/uv.lock
+++ b/components/clp-package-utils/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "clp-package-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },
@@ -249,7 +249,7 @@ dev = [
 
 [[package]]
 name = "clp-py-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { directory = "../clp-py-utils" }
 dependencies = [
     { name = "boto3" },
@@ -387,7 +387,7 @@ wheels = [
 
 [[package]]
 name = "job-orchestration"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { directory = "../job-orchestration" }
 dependencies = [
     { name = "brotli" },

--- a/components/clp-py-utils/pyproject.toml
+++ b/components/clp-py-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clp-py-utils"
-version = "0.8.1-dev"
+version = "0.9.1-dev"
 description = "Utilities for other Python packages in CLP."
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/clp-py-utils/uv.lock
+++ b/components/clp-py-utils/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "clp-package-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { directory = "../clp-package-utils" }
 dependencies = [
     { name = "brotli" },
@@ -239,7 +239,7 @@ dev = [
 
 [[package]]
 name = "clp-py-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -387,7 +387,7 @@ wheels = [
 
 [[package]]
 name = "job-orchestration"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { directory = "../job-orchestration" }
 dependencies = [
     { name = "brotli" },

--- a/components/core/src/clp/version.hpp
+++ b/components/core/src/clp/version.hpp
@@ -2,7 +2,7 @@
 #define CLP_VERSION_HPP
 
 namespace clp {
-constexpr char cVersion[] = "0.8.1-dev";
+constexpr char cVersion[] = "0.9.1-dev";
 }  // namespace clp
 
 #endif  // CLP_VERSION_HPP

--- a/components/core/src/glt/version.hpp
+++ b/components/core/src/glt/version.hpp
@@ -2,7 +2,7 @@
 #define GLT_VERSION_HPP
 
 namespace glt {
-constexpr char cVersion[] = "0.8.1-dev";
+constexpr char cVersion[] = "0.9.1-dev";
 }  // namespace glt
 
 #endif  // GLT_VERSION_HPP

--- a/components/job-orchestration/pyproject.toml
+++ b/components/job-orchestration/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "job-orchestration"
-version = "0.8.1-dev"
+version = "0.9.1-dev"
 description = "Scheduler and worker cluster for CLP's distributed architecture."
 authors = [{name = "YScope Inc.", email = "dev@yscope.com"}]
 readme = "README.md"

--- a/components/job-orchestration/uv.lock
+++ b/components/job-orchestration/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "clp-package-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { directory = "../clp-package-utils" }
 dependencies = [
     { name = "brotli" },
@@ -239,7 +239,7 @@ dev = [
 
 [[package]]
 name = "clp-py-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { directory = "../clp-py-utils" }
 dependencies = [
     { name = "boto3" },
@@ -377,7 +377,7 @@ wheels = [
 
 [[package]]
 name = "job-orchestration"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },

--- a/integration-tests/uv.lock
+++ b/integration-tests/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "clp-mcp-server"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "../components/clp-mcp-server" }
 dependencies = [
     { name = "aiomysql" },
@@ -501,7 +501,7 @@ dev = [
 
 [[package]]
 name = "clp-package-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "../components/clp-package-utils" }
 dependencies = [
     { name = "brotli" },
@@ -536,7 +536,7 @@ dev = [
 
 [[package]]
 name = "clp-py-utils"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "../components/clp-py-utils" }
 dependencies = [
     { name = "boto3" },
@@ -999,7 +999,7 @@ wheels = [
 
 [[package]]
 name = "job-orchestration"
-version = "0.8.1.dev0"
+version = "0.9.1.dev0"
 source = { editable = "../components/job-orchestration" }
 dependencies = [
     { name = "brotli" },

--- a/python-wheels/yscope-clp-core/pyproject.toml
+++ b/python-wheels/yscope-clp-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yscope-clp-core"
-version = "0.7.1-beta.1"
+version = "0.9.1-dev"
 description = "YScope CLP (Compressed Log Processor) Core Python Distribution"
 readme = "README.md"
 authors = [

--- a/python-wheels/yscope-clp-core/uv.lock
+++ b/python-wheels/yscope-clp-core/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "yscope-clp-core"
-version = "0.7.1b1"
+version = "0.9.1.dev0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -40,7 +40,7 @@ vars:
   G_UTILS_TASKFILE: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
   # Versions
-  G_PACKAGE_VERSION: "0.8.1-dev"
+  G_PACKAGE_VERSION: "0.9.1-dev"
 
   # Build parameters
   # NOTE: Defaulting to an empty string is safe since CMake ignores an empty string.

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.3-dev.2"
+version: "0.1.4-dev.1"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
-appVersion: "0.8.1-dev"
+appVersion: "0.9.1-dev"
 home: "https://github.com/y-scope/clp"
 icon: "https://github.com/y-scope/clp/raw/main/docs/src/clp-logo.png"
 sources: ["https://github.com/y-scope/clp"]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Bump version to `0.9.1-dev` for the next development cycle.

Updated components:
- `clp-mcp-server`
- `clp-package-utils`
- `clp-py-utils`
- `job-orchestration`
- `yscope-clp-core`
- Core libraries (`clp` and `glt`)
- Global `taskfile.yaml` version variable (`G_PACKAGE_VERSION`)
- Helm chart configuration (chart version and appVersion)

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- **Task:** Verify all version strings updated from `0.8.1-dev` to `0.9.1-dev`.
  - **Command:**
    ```shell
    grep -rn "0\.8\.1-dev\|0\.8\.1\.dev0" --include="*.toml" --include="*.yaml" --include="*.hpp" --include="*.lock" .
    ```
  - **Output:** No matches found.
  - **Explanation:** Confirms no old version strings (`0.8.1-dev` / `0.8.1.dev0`) remain in
    any versioned file.

- **Task:** Verify the changed file set matches PR #1876.
  - **Command:**
    ```shell
    git diff --stat
    ```
  - **Output:**
    ```
    components/clp-mcp-server/pyproject.toml     | 2 +-
    components/clp-mcp-server/uv.lock            | 4 ++--
    components/clp-package-utils/pyproject.toml  | 2 +-
    components/clp-package-utils/uv.lock         | 6 +++---
    components/clp-py-utils/pyproject.toml       | 2 +-
    components/clp-py-utils/uv.lock              | 6 +++---
    components/core/src/clp/version.hpp          | 2 +-
    components/core/src/glt/version.hpp          | 2 +-
    components/job-orchestration/pyproject.toml  | 2 +-
    components/job-orchestration/uv.lock         | 6 +++---
    integration-tests/uv.lock                    | 8 ++++----
    python-wheels/yscope-clp-core/pyproject.toml | 2 +-
    python-wheels/yscope-clp-core/uv.lock        | 2 +-
    taskfile.yaml                                | 2 +-
    tools/deployment/package-helm/Chart.yaml     | 4 ++--
    15 files changed, 26 insertions(+), 26 deletions(-)
    ```
  - **Explanation:** All 13 files match the same set changed in PR #1876, and 2 more new ones 
    in yscope-clp-core were also updated appropriately. No other files have changed
    since then. No files were missed and no extra files were modified.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped project version across all components from 0.8.1-dev to 0.9.1-dev, ensuring consistency across the entire codebase including Python packages, C++ core components, and build tooling configurations.
  * Updated Helm Chart deployment configuration, incrementing the chart version from 0.1.3-dev.2 to 0.1.4-dev.1 and aligning the application version with the new development release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->