### PR TITLE
fix(taskfile): Remove redundant checksum validation from antlr-jar task

### DIFF
--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -156,15 +156,9 @@ tasks:
   antlr-jar:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_DEPS_CPP_CHECKSUMS_DIR}}/antlr-jar.md5"
       OUTPUT_FILE: "{{.G_ANTLR_JAR_FILE}}"
     run: "once"
     deps:
-      - task: "yscope-dev-utils:checksum:validate"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS:
-            - "{{.OUTPUT_FILE}}"
       - task: "utils:init"
     cmds:
       - task: "yscope-dev-utils:remote:curl"
@@ -172,13 +166,6 @@ tasks:
           FILE_SHA256: "eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76"
           OUTPUT_FILE: "{{.OUTPUT_FILE}}"
           URL: "https://www.antlr.org/download/antlr-{{.G_ANTLR_VERSION}}-complete.jar"
-
-      # This command must be last
-      - task: "yscope-dev-utils:checksum:compute"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS:
-            - "{{.OUTPUT_FILE}}"
 
   antlr-runtime:
     internal: true


### PR DESCRIPTION
# Description

Removes redundant `yscope-dev-utils:checksum:validate` dependency and `yscope-dev-utils:checksum:compute` command from the `antlr-jar` task in `taskfiles/deps/main.yaml`. The task `yscope-dev-utils:remote:curl` already implements its own checksum handling. There is no breaking change, and no docs need to be updated.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

The task behavior remains unchanged. 

1. Ran `task deps:antlr-jar` (with `internal: true` commented out) with no existing jar file -> Verified the file was downloaded and the hash was verified by `remote:curl`.
2. Ran `task deps:antlr-jar` (with `internal: true` commented out) again -> Verified the task was skipped/reported as up-to-date.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed checksum validation workflow for an internal build dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->