### PR TITLE
feat(clp-s): add variable-dictionary bloom filter build flow

### DIFF
--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -330,6 +330,7 @@ def generate_worker_config(clp_config: ClpConfig) -> WorkerConfig:
     worker_config = WorkerConfig()
     worker_config.package = clp_config.package.model_copy(deep=True)
     worker_config.archive_output = clp_config.archive_output.model_copy(deep=True)
+    worker_config.data_directory = clp_config.data_directory
     worker_config.tmp_directory = clp_config.tmp_directory
 
     worker_config.stream_output = clp_config.stream_output

--- a/components/clp-package-utils/clp_package_utils/scripts/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/compress.py
@@ -101,6 +101,12 @@ def _generate_compress_cmd(
         compress_cmd.append("--unstructured")
     if parsed_args.no_progress_reporting is True:
         compress_cmd.append("--no-progress-reporting")
+    if parsed_args.filter_type is not None:
+        compress_cmd.append("--filter-type")
+        compress_cmd.append(parsed_args.filter_type)
+    if parsed_args.filter_fpr is not None:
+        compress_cmd.append("--filter-fpr")
+        compress_cmd.append(str(parsed_args.filter_fpr))
 
     compress_cmd.append("--logs-list")
     compress_cmd.append(str(logs_list_path))
@@ -157,6 +163,18 @@ def main(argv):
     )
     args_parser.add_argument(
         "--no-progress-reporting", action="store_true", help="Disables progress reporting."
+    )
+    args_parser.add_argument(
+        "--filter-type",
+        type=str,
+        default=None,
+        help="Filter type to build per-archive filters (e.g. bloom).",
+    )
+    args_parser.add_argument(
+        "--filter-fpr",
+        type=float,
+        default=None,
+        help="False positive rate for the filter (only used if filter-type is set).",
     )
     args_parser.add_argument("paths", metavar="PATH", nargs="*", help="Paths to compress.")
     args_parser.add_argument(

--- a/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/native/compress.py
@@ -350,6 +350,18 @@ def main(argv):
         action="store_true",
         help="Treat all inputs as unstructured text logs.",
     )
+    args_parser.add_argument(
+        "--filter-type",
+        type=str,
+        default=None,
+        help="Filter type to build per-archive filters (e.g. bloom).",
+    )
+    args_parser.add_argument(
+        "--filter-fpr",
+        type=float,
+        default=None,
+        help="False positive rate for the filter (only used if filter-type is set).",
+    )
     parsed_args = args_parser.parse_args(argv[1:])
     if parsed_args.verbose:
         logger.setLevel(logging.DEBUG)
@@ -377,7 +389,12 @@ def main(argv):
         logger.exception("Failed to process input.")
         return -1
 
-    clp_output_config = OutputConfig.model_validate(clp_config.archive_output.model_dump())
+    output_config_data = clp_config.archive_output.model_dump()
+    if parsed_args.filter_type is not None:
+        output_config_data["filter_type"] = parsed_args.filter_type
+    if parsed_args.filter_fpr is not None:
+        output_config_data["filter_fpr"] = parsed_args.filter_fpr
+    clp_output_config = OutputConfig.model_validate(output_config_data)
     clp_io_config = ClpIoConfig(input=clp_input_config, output=clp_output_config)
 
     mysql_adapter = SqlAdapter(clp_config.database)

--- a/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
+++ b/components/clp-package-utils/clp_package_utils/scripts/start_clp.py
@@ -81,6 +81,7 @@ def main(
         clp_config.validate_data_dir(True)
         clp_config.validate_logs_dir(True)
         clp_config.validate_tmp_dir(True)
+        clp_config.validate_filters_dir(True)
     except Exception:
         logger.exception("Failed to load config.")
         sys.exit(1)
@@ -90,6 +91,10 @@ def main(
         resolve_host_path_in_container(clp_config.data_directory).mkdir(parents=True, exist_ok=True)
         resolve_host_path_in_container(clp_config.logs_directory).mkdir(parents=True, exist_ok=True)
         resolve_host_path_in_container(clp_config.tmp_directory).mkdir(parents=True, exist_ok=True)
+        filters_dir = resolve_host_path_in_container(clp_config.get_filters_directory())
+        filters_dir.mkdir(parents=True, exist_ok=True)
+        (filters_dir / "staging").mkdir(parents=True, exist_ok=True)
+        (filters_dir / "packs").mkdir(parents=True, exist_ok=True)
         resolve_host_path_in_container(clp_config.archive_output.get_directory()).mkdir(
             parents=True, exist_ok=True
         )

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -139,6 +139,21 @@ if(PROJECT_IS_TOP_LEVEL)
     include(CTest)
 endif()
 
+if(NOT DEFINED CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY)
+    set(CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY "${CMAKE_SOURCE_DIR}/../../build/deps/cpp/antlr4-runtime-src")
+endif()
+
+if(CLP_BUILD_CLP_S_ARCHIVEWRITER OR CLP_BUILD_TESTING)
+    if(NOT EXISTS "${CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY}/runtime/src/misc/MurmurHash.cpp")
+        message(
+            FATAL_ERROR
+            "Couldn't find ANTLR MurmurHash source at "
+            "${CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY}/runtime/src/misc/MurmurHash.cpp. "
+            "Run `task deps:core` to fetch dependencies."
+        )
+    endif()
+endif()
+
 if(BUILD_TESTING AND CLP_BUILD_TESTING)
     set(CLP_ENABLE_TESTS ON)
 endif()
@@ -366,6 +381,14 @@ set(SOURCE_FILES_clp_s_unitTest
     src/clp_s/FileWriter.hpp
     src/clp_s/FloatFormatEncoding.cpp
     src/clp_s/FloatFormatEncoding.hpp
+    src/clp_s/filter/BloomFilter.cpp
+    src/clp_s/filter/BloomFilter.hpp
+    src/clp_s/filter/FilterBuilder.cpp
+    src/clp_s/filter/FilterBuilder.hpp
+    src/clp_s/filter/FilterConfig.cpp
+    src/clp_s/filter/FilterConfig.hpp
+    src/clp_s/filter/FilterFile.cpp
+    src/clp_s/filter/FilterFile.hpp
     src/clp_s/InputConfig.cpp
     src/clp_s/InputConfig.hpp
     src/clp_s/JsonConstructor.cpp
@@ -709,6 +732,7 @@ set(SOURCE_FILES_unitTest
         tests/test-BufferedReader.cpp
         tests/test-clp_s-delta-encode-log-order.cpp
         tests/test-clp_s-end_to_end.cpp
+        tests/test-clp_s-bloom_filter.cpp
         tests/test-clp_s-range_index.cpp
         tests/test-clp_s-search.cpp
         tests/test-EncodedVariableInterpreter.cpp

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -774,6 +774,7 @@ if(CLP_ENABLE_TESTS)
             )
     target_include_directories(unitTest
             PRIVATE
+            ${CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY}/runtime/src
             ${CLP_SQLITE3_INCLUDE_DIRECTORY}
             )
     target_link_libraries(unitTest

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -14,6 +14,7 @@
 #include "../clp/streaming_archive/Constants.hpp"
 #include "archive_constants.hpp"
 #include "DictionaryWriter.hpp"
+#include "filter/FilterConfig.hpp"
 #include "RangeIndexWriter.hpp"
 #include "Schema.hpp"
 #include "SchemaMap.hpp"
@@ -32,6 +33,8 @@ struct ArchiveWriterOption {
     size_t min_table_size;
     std::vector<std::string> authoritative_timestamp;
     std::string authoritative_timestamp_namespace;
+    FilterConfig filter_config;
+    std::string filter_output_dir;
 };
 
 class ArchiveStats {
@@ -339,6 +342,8 @@ private:
     bool m_print_archive_stats{};
     bool m_single_file_archive{};
     size_t m_min_table_size{};
+    FilterConfig m_filter_config{};
+    std::string m_filter_output_dir;
 
     std::vector<std::string> m_authoritative_timestamp;
     std::string m_authoritative_timestamp_namespace;

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -227,6 +227,19 @@ if(CLP_BUILD_CLP_S_IO)
 endif()
 
 set(
+        CLP_S_FILTER_SOURCES
+        ${CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY}/runtime/src/misc/MurmurHash.cpp
+        filter/BloomFilter.cpp
+        filter/BloomFilter.hpp
+        filter/FilterBuilder.cpp
+        filter/FilterBuilder.hpp
+        filter/FilterConfig.cpp
+        filter/FilterConfig.hpp
+        filter/FilterFile.cpp
+        filter/FilterFile.hpp
+)
+
+set(
         CLP_S_ARCHIVE_WRITER_SOURCES
         archive_constants.hpp
         ArchiveWriter.cpp
@@ -269,6 +282,26 @@ set(
 
 if(CLP_BUILD_CLP_S_ARCHIVEWRITER)
         add_library(
+                clp_s_filter
+                ${CLP_S_FILTER_SOURCES}
+        )
+        add_library(clp_s::filter ALIAS clp_s_filter)
+        target_compile_features(clp_s_filter PRIVATE cxx_std_20)
+        target_include_directories(
+                clp_s_filter
+                PUBLIC
+                ../
+                PRIVATE
+                ${CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY}/runtime/src
+        )
+        target_link_libraries(
+                clp_s_filter
+                PUBLIC
+                clp_s::io
+                clp::string_utils
+        )
+
+        add_library(
                 clp_s_archive_writer
                 ${CLP_S_ARCHIVE_WRITER_SOURCES}
         )
@@ -279,6 +312,7 @@ if(CLP_BUILD_CLP_S_ARCHIVEWRITER)
                 clp_s_archive_writer
                 PUBLIC
                 absl::flat_hash_map
+                clp_s::filter
                 clp_s::clp_dependencies
                 clp_s::io
                 msgpack-cxx
@@ -455,4 +489,5 @@ if(CLP_BUILD_EXECUTABLES)
                 PROPERTIES
                 RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
         )
+
 endif()

--- a/components/core/src/clp_s/CommandLineArguments.hpp
+++ b/components/core/src/clp_s/CommandLineArguments.hpp
@@ -11,6 +11,7 @@
 
 #include "../reducer/types.hpp"
 #include "Defs.hpp"
+#include "filter/FilterConfig.hpp"
 #include "InputConfig.hpp"
 
 namespace clp_s {
@@ -123,6 +124,10 @@ public:
 
     bool get_record_log_order() const { return false == m_disable_log_order; }
 
+    FilterConfig const& get_filter_config() const { return m_filter_config; }
+
+    std::string const& get_var_filter_output_dir() const { return m_var_filter_output_dir; }
+
 private:
     // Methods
     /**
@@ -207,10 +212,14 @@ private:
     bool m_print_ordered_chunk_stats{false};
     size_t m_minimum_table_size{1ULL * 1024 * 1024};  // 1 MiB
     bool m_disable_log_order{false};
+    FilterConfig m_filter_config{};
+    std::string m_var_filter_output_dir;
 
     // MongoDB configuration variables
     std::string m_mongodb_uri;
     std::string m_mongodb_collection;
+
+    // Search query execution variables
     uint64_t m_batch_size{1000};
     uint64_t m_max_num_results{1000};
 

--- a/components/core/src/clp_s/DictionaryWriter.hpp
+++ b/components/core/src/clp_s/DictionaryWriter.hpp
@@ -3,6 +3,8 @@
 #ifndef CLP_S_DICTIONARYWRITER_HPP
 #define CLP_S_DICTIONARYWRITER_HPP
 
+#include <string_view>
+
 #include <absl/container/flat_hash_map.h>
 
 #include "../clp/Defs.h"
@@ -53,6 +55,22 @@ public:
      * @return The size (in-memory) of the data contained in the dictionary
      */
     size_t get_data_size() const { return m_data_size; }
+
+    /**
+     * @return The number of entries in the dictionary
+     */
+    size_t get_num_entries() const { return m_value_to_id.size(); }
+
+    /**
+     * Calls the given function for each dictionary value.
+     * @param fn A callable that accepts std::string_view.
+     */
+    template <typename Fn>
+    void for_each_value(Fn&& fn) const {
+        for (auto const& it : m_value_to_id) {
+            fn(std::string_view{it.first});
+        }
+    }
 
 protected:
     // Types

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -182,6 +182,8 @@ JsonParser::JsonParser(JsonParserOption const& option)
     m_archive_options.id = m_generator();
     m_archive_options.authoritative_timestamp = m_timestamp_column;
     m_archive_options.authoritative_timestamp_namespace = m_timestamp_namespace;
+    m_archive_options.filter_config = option.filter_config;
+    m_archive_options.filter_output_dir = option.filter_output_dir;
 
     m_archive_writer = std::make_unique<ArchiveWriter>();
     m_archive_writer->open(m_archive_options);

--- a/components/core/src/clp_s/JsonParser.hpp
+++ b/components/core/src/clp_s/JsonParser.hpp
@@ -20,6 +20,7 @@
 #include <clp/ReaderInterface.hpp>
 #include <clp_s/ArchiveWriter.hpp>
 #include <clp_s/ErrorCode.hpp>
+#include <clp_s/filter/FilterConfig.hpp>
 #include <clp_s/InputConfig.hpp>
 #include <clp_s/ParsedMessage.hpp>
 #include <clp_s/Schema.hpp>
@@ -41,6 +42,8 @@ struct JsonParserOption {
     bool retain_float_format{false};
     bool single_file_archive{false};
     NetworkAuthOption network_auth{};
+    FilterConfig filter_config{};
+    std::string filter_output_dir{};
 };
 
 class JsonParser {

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -23,6 +23,7 @@ constexpr char cArchiveTablesFile[] = "/0";
 constexpr char cArchiveArrayDictFile[] = "/array.dict";
 constexpr char cArchiveLogDictFile[] = "/log.dict";
 constexpr char cArchiveVarDictFile[] = "/var.dict";
+constexpr char cArchiveVarDictFilterFileName[] = "var.dict.filter";
 
 // Schema tree constants
 constexpr char cRootNodeName[] = "";

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -7,9 +7,9 @@
 #include <string>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 #include <mongocxx/instance.hpp>
-#include <nlohmann/json.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
 
@@ -29,7 +29,6 @@
 #include "search/ast/Expression.hpp"
 #include "search/ast/NarrowTypes.hpp"
 #include "search/ast/OrOfAndForm.hpp"
-#include "search/ast/SearchUtils.hpp"
 #include "search/ast/SetTimestampLiteralPrecision.hpp"
 #include "search/ast/TimestampLiteral.hpp"
 #include "search/EvaluateRangeIndexFilters.hpp"
@@ -107,6 +106,8 @@ bool compress(CommandLineArguments const& command_line_arguments) {
     option.single_file_archive = command_line_arguments.get_single_file_archive();
     option.structurize_arrays = command_line_arguments.get_structurize_arrays();
     option.record_log_order = command_line_arguments.get_record_log_order();
+    option.filter_config = command_line_arguments.get_filter_config();
+    option.filter_output_dir = command_line_arguments.get_var_filter_output_dir();
 
     clp_s::JsonParser parser(option);
     if (false == parser.ingest()) {

--- a/components/core/src/clp_s/filter/BloomFilter.cpp
+++ b/components/core/src/clp_s/filter/BloomFilter.cpp
@@ -1,11 +1,11 @@
 #include "BloomFilter.hpp"
 
+#include <misc/MurmurHash.h>
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
 #include <utility>
-
-#include <misc/MurmurHash.h>
 
 #include "../clp/ErrorCode.hpp"
 #include "../clp/ReaderInterface.hpp"
@@ -16,13 +16,11 @@ constexpr uint32_t kMinNumHashFunctions{1};
 constexpr uint32_t kMaxNumHashFunctions{20};
 
 auto compute_murmur_hash(std::string_view value, uint64_t seed) -> uint64_t {
-    return static_cast<uint64_t>(
-            antlr4::misc::MurmurHash::hashCode(
-                    value.data(),
-                    value.size(),
-                    static_cast<size_t>(seed)
-            )
-    );
+    return static_cast<uint64_t>(antlr4::misc::MurmurHash::hashCode(
+            value.data(),
+            value.size(),
+            static_cast<size_t>(seed)
+    ));
 }
 }  // namespace
 
@@ -57,18 +55,15 @@ BloomFilter::compute_optimal_parameters(size_t expected_num_elements, double fal
             static_cast<double>(bit_array_size) / static_cast<double>(expected_num_elements) * ln2
     );
 
-    uint32_t const capped_num_hash_functions = std::clamp(
-            num_hash_functions,
-            kMinNumHashFunctions,
-            kMaxNumHashFunctions
-    );
+    uint32_t const capped_num_hash_functions
+            = std::clamp(num_hash_functions, kMinNumHashFunctions, kMaxNumHashFunctions);
 
     return {bit_array_size, capped_num_hash_functions};
 }
 
 void BloomFilter::add(std::string_view value) {
     uint64_t const h1 = compute_murmur_hash(value, 0);
-    uint64_t h2 = compute_murmur_hash(value, 0x9e3779b97f4a7c15ULL);
+    uint64_t h2 = compute_murmur_hash(value, 0x9e37'79b9'7f4a'7c15ULL);
     if (0 == h2) {
         h2 = 1;
     }
@@ -79,7 +74,7 @@ void BloomFilter::add(std::string_view value) {
 
 auto BloomFilter::possibly_contains(std::string_view value) const -> bool {
     uint64_t const h1 = compute_murmur_hash(value, 0);
-    uint64_t h2 = compute_murmur_hash(value, 0x9e3779b97f4a7c15ULL);
+    uint64_t h2 = compute_murmur_hash(value, 0x9e37'79b9'7f4a'7c15ULL);
     if (0 == h2) {
         h2 = 1;
     }

--- a/components/core/src/clp_s/filter/BloomFilter.cpp
+++ b/components/core/src/clp_s/filter/BloomFilter.cpp
@@ -1,0 +1,164 @@
+#include "BloomFilter.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+#include <misc/MurmurHash.h>
+
+#include "../clp/ErrorCode.hpp"
+#include "../clp/ReaderInterface.hpp"
+
+namespace clp_s::filter {
+namespace {
+constexpr uint32_t kMinNumHashFunctions{1};
+constexpr uint32_t kMaxNumHashFunctions{20};
+
+auto compute_murmur_hash(std::string_view value, uint64_t seed) -> uint64_t {
+    return static_cast<uint64_t>(
+            antlr4::misc::MurmurHash::hashCode(
+                    value.data(),
+                    value.size(),
+                    static_cast<size_t>(seed)
+            )
+    );
+}
+}  // namespace
+
+BloomFilter::BloomFilter() : m_bit_array_size(64), m_num_hash_functions(1), m_bit_array(8, 0) {}
+
+BloomFilter::BloomFilter(size_t expected_num_elements, double false_positive_rate) {
+    auto [bit_array_size, num_hash_functions]
+            = compute_optimal_parameters(expected_num_elements, false_positive_rate);
+
+    m_bit_array_size = bit_array_size;
+    m_num_hash_functions = num_hash_functions;
+
+    size_t const num_bytes = (m_bit_array_size + 7) / 8;
+    m_bit_array.resize(num_bytes, 0);
+}
+
+auto
+BloomFilter::compute_optimal_parameters(size_t expected_num_elements, double false_positive_rate)
+        -> std::pair<size_t, uint32_t> {
+    if (expected_num_elements == 0 || false_positive_rate <= 0.0 || false_positive_rate >= 1.0) {
+        return {64, 1};
+    }
+
+    double const ln2 = std::log(2.0);
+    double const ln2_squared = ln2 * ln2;
+    auto const bit_array_size = static_cast<size_t>(
+            -static_cast<double>(expected_num_elements) * std::log(false_positive_rate)
+            / ln2_squared
+    );
+
+    auto const num_hash_functions = static_cast<uint32_t>(
+            static_cast<double>(bit_array_size) / static_cast<double>(expected_num_elements) * ln2
+    );
+
+    uint32_t const capped_num_hash_functions = std::clamp(
+            num_hash_functions,
+            kMinNumHashFunctions,
+            kMaxNumHashFunctions
+    );
+
+    return {bit_array_size, capped_num_hash_functions};
+}
+
+void BloomFilter::add(std::string_view value) {
+    uint64_t const h1 = compute_murmur_hash(value, 0);
+    uint64_t h2 = compute_murmur_hash(value, 0x9e3779b97f4a7c15ULL);
+    if (0 == h2) {
+        h2 = 1;
+    }
+    for (uint32_t i = 0; i < m_num_hash_functions; ++i) {
+        set_bit(static_cast<size_t>((h1 + i * h2) % m_bit_array_size));
+    }
+}
+
+auto BloomFilter::possibly_contains(std::string_view value) const -> bool {
+    uint64_t const h1 = compute_murmur_hash(value, 0);
+    uint64_t h2 = compute_murmur_hash(value, 0x9e3779b97f4a7c15ULL);
+    if (0 == h2) {
+        h2 = 1;
+    }
+    for (uint32_t i = 0; i < m_num_hash_functions; ++i) {
+        if (false == test_bit(static_cast<size_t>((h1 + i * h2) % m_bit_array_size))) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void BloomFilter::set_bit(size_t bit_index) {
+    size_t const byte_index = bit_index / 8;
+    size_t const bit_offset = bit_index % 8;
+    m_bit_array[byte_index] |= static_cast<uint8_t>(1u << bit_offset);
+}
+
+auto BloomFilter::test_bit(size_t bit_index) const -> bool {
+    size_t const byte_index = bit_index / 8;
+    size_t const bit_offset = bit_index % 8;
+    return (m_bit_array[byte_index] & static_cast<uint8_t>(1u << bit_offset)) != 0;
+}
+
+void BloomFilter::write_to_file(FileWriter& writer) const {
+    writer.write_numeric_value<uint32_t>(m_num_hash_functions);
+    writer.write_numeric_value<uint64_t>(static_cast<uint64_t>(m_bit_array_size));
+    writer.write_numeric_value<uint64_t>(static_cast<uint64_t>(m_bit_array.size()));
+    if (!m_bit_array.empty()) {
+        writer.write(reinterpret_cast<char const*>(m_bit_array.data()), m_bit_array.size());
+    }
+}
+
+auto BloomFilter::read_from_file(clp::ReaderInterface& reader) -> bool {
+    uint32_t num_hash_functions = 0;
+    if (clp::ErrorCode_Success != reader.try_read_numeric_value(num_hash_functions)) {
+        return false;
+    }
+    if (num_hash_functions < kMinNumHashFunctions || num_hash_functions > kMaxNumHashFunctions) {
+        return false;
+    }
+
+    uint64_t bit_array_size_u64 = 0;
+    if (clp::ErrorCode_Success != reader.try_read_numeric_value(bit_array_size_u64)) {
+        return false;
+    }
+    if (bit_array_size_u64 == 0 || bit_array_size_u64 > std::numeric_limits<size_t>::max()) {
+        return false;
+    }
+    size_t const bit_array_size = static_cast<size_t>(bit_array_size_u64);
+
+    uint64_t bit_array_bytes = 0;
+    if (clp::ErrorCode_Success != reader.try_read_numeric_value(bit_array_bytes)) {
+        return false;
+    }
+    if (bit_array_bytes > std::numeric_limits<size_t>::max()) {
+        return false;
+    }
+    size_t const expected_bit_array_bytes = (bit_array_size + 7) / 8;
+    if (bit_array_bytes != expected_bit_array_bytes) {
+        return false;
+    }
+
+    std::vector<uint8_t> bit_array(static_cast<size_t>(bit_array_bytes));
+    if (!bit_array.empty()) {
+        if (clp::ErrorCode_Success
+            != reader.try_read_exact_length(
+                    reinterpret_cast<char*>(bit_array.data()),
+                    static_cast<size_t>(bit_array_bytes)
+            ))
+        {
+            return false;
+        }
+    }
+
+    m_num_hash_functions = num_hash_functions;
+    m_bit_array_size = bit_array_size;
+    m_bit_array = std::move(bit_array);
+
+    return true;
+}
+}  // namespace clp_s::filter

--- a/components/core/src/clp_s/filter/BloomFilter.hpp
+++ b/components/core/src/clp_s/filter/BloomFilter.hpp
@@ -1,0 +1,43 @@
+#ifndef CLP_S_BLOOM_FILTER_HPP
+#define CLP_S_BLOOM_FILTER_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "../FileWriter.hpp"
+
+namespace clp {
+class ReaderInterface;
+}  // namespace clp
+
+namespace clp_s::filter {
+class BloomFilter {
+public:
+    BloomFilter(size_t expected_num_elements, double false_positive_rate);
+
+    BloomFilter();
+
+    void add(std::string_view value);
+    [[nodiscard]] auto possibly_contains(std::string_view value) const -> bool;
+
+    void write_to_file(FileWriter& writer) const;
+    auto read_from_file(clp::ReaderInterface& reader) -> bool;
+
+private:
+    [[nodiscard]] static auto
+    compute_optimal_parameters(size_t expected_num_elements, double false_positive_rate)
+            -> std::pair<size_t, uint32_t>;
+
+    void set_bit(size_t bit_index);
+    [[nodiscard]] auto test_bit(size_t bit_index) const -> bool;
+
+    size_t m_bit_array_size{0};
+    uint32_t m_num_hash_functions{0};
+    std::vector<uint8_t> m_bit_array;
+};
+}  // namespace clp_s::filter
+
+#endif  // CLP_S_BLOOM_FILTER_HPP

--- a/components/core/src/clp_s/filter/FilterBuilder.cpp
+++ b/components/core/src/clp_s/filter/FilterBuilder.cpp
@@ -1,0 +1,30 @@
+#include "FilterBuilder.hpp"
+
+#include "../clp/string_utils/string_utils.hpp"
+#include "../FileWriter.hpp"
+#include "FilterFile.hpp"
+
+namespace clp_s::filter {
+FilterBuilder::FilterBuilder(FilterConfig const& config, size_t num_elements) : m_config(config) {
+    if (FilterType::Bloom == m_config.type) {
+        m_filter = BloomFilter(num_elements, m_config.false_positive_rate);
+        m_enabled = true;
+    }
+}
+
+void FilterBuilder::add(std::string_view value) {
+    if (false == m_enabled) {
+        return;
+    }
+    std::string lowered(value);
+    clp::string_utils::to_lower(lowered);
+    m_filter.add(lowered);
+}
+
+void FilterBuilder::write(std::string const& filter_path) const {
+    FileWriter writer;
+    writer.open(filter_path, FileWriter::OpenMode::CreateForWriting);
+    write_filter_file(writer, m_config.type, m_filter);
+    writer.close();
+}
+}  // namespace clp_s::filter

--- a/components/core/src/clp_s/filter/FilterBuilder.hpp
+++ b/components/core/src/clp_s/filter/FilterBuilder.hpp
@@ -1,0 +1,26 @@
+#ifndef CLP_S_FILTER_BUILDER_HPP
+#define CLP_S_FILTER_BUILDER_HPP
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+#include "BloomFilter.hpp"
+#include "FilterConfig.hpp"
+
+namespace clp_s::filter {
+class FilterBuilder {
+public:
+    FilterBuilder(FilterConfig const& config, size_t num_elements);
+
+    void add(std::string_view value);
+    void write(std::string const& filter_path) const;
+
+private:
+    FilterConfig m_config;
+    BloomFilter m_filter{};
+    bool m_enabled{false};
+};
+}  // namespace clp_s::filter
+
+#endif  // CLP_S_FILTER_BUILDER_HPP

--- a/components/core/src/clp_s/filter/FilterConfig.cpp
+++ b/components/core/src/clp_s/filter/FilterConfig.cpp
@@ -1,0 +1,25 @@
+#include "FilterConfig.hpp"
+
+#include <string>
+
+namespace clp_s {
+auto parse_filter_type(std::string_view type_str) -> std::optional<FilterType> {
+    if (type_str == "none") {
+        return FilterType::None;
+    }
+    if (type_str == "bloom") {
+        return FilterType::Bloom;
+    }
+    return std::nullopt;
+}
+
+auto filter_type_to_string(FilterType type) -> std::string_view {
+    switch (type) {
+        case FilterType::None:
+            return "none";
+        case FilterType::Bloom:
+            return "bloom";
+    }
+    return "unknown";
+}
+}  // namespace clp_s

--- a/components/core/src/clp_s/filter/FilterConfig.hpp
+++ b/components/core/src/clp_s/filter/FilterConfig.hpp
@@ -1,0 +1,26 @@
+#ifndef CLP_S_FILTER_CONFIG_HPP
+#define CLP_S_FILTER_CONFIG_HPP
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace clp_s {
+/**
+ * Supported filter types for variable dictionaries.
+ */
+enum class FilterType : uint8_t {
+    None = 0,
+    Bloom = 1,
+};
+
+struct FilterConfig {
+    FilterType type{FilterType::None};
+    double false_positive_rate{0.01};
+};
+
+[[nodiscard]] auto parse_filter_type(std::string_view type_str) -> std::optional<FilterType>;
+[[nodiscard]] auto filter_type_to_string(FilterType type) -> std::string_view;
+}  // namespace clp_s
+
+#endif  // CLP_S_FILTER_CONFIG_HPP

--- a/components/core/src/clp_s/filter/FilterFile.cpp
+++ b/components/core/src/clp_s/filter/FilterFile.cpp
@@ -1,0 +1,42 @@
+#include "FilterFile.hpp"
+
+#include <cstring>
+
+#include "../clp/ErrorCode.hpp"
+#include "../clp/ReaderInterface.hpp"
+
+namespace clp_s::filter {
+void write_filter_file(FileWriter& writer, FilterType type, BloomFilter const& filter) {
+    writer.write(kFilterFileMagic, sizeof(kFilterFileMagic));
+    writer.write_numeric_value<uint8_t>(static_cast<uint8_t>(type));
+    if (FilterType::None != type) {
+        filter.write_to_file(writer);
+    }
+}
+
+bool read_filter_file(clp::ReaderInterface& reader, FilterType& out_type, BloomFilter& out_filter) {
+    char magic[sizeof(kFilterFileMagic)]{};
+    if (clp::ErrorCode_Success != reader.try_read_exact_length(magic, sizeof(kFilterFileMagic))) {
+        return false;
+    }
+    if (0 != std::memcmp(magic, kFilterFileMagic, sizeof(kFilterFileMagic))) {
+        return false;
+    }
+
+    uint8_t type_value = 0;
+    if (clp::ErrorCode_Success != reader.try_read_numeric_value(type_value)) {
+        return false;
+    }
+    out_type = static_cast<FilterType>(type_value);
+    if (FilterType::None == out_type) {
+        return true;
+    }
+
+    if (FilterType::Bloom != out_type) {
+        return false;
+    }
+
+    out_filter = BloomFilter();
+    return out_filter.read_from_file(reader);
+}
+}  // namespace clp_s::filter

--- a/components/core/src/clp_s/filter/FilterFile.hpp
+++ b/components/core/src/clp_s/filter/FilterFile.hpp
@@ -1,0 +1,22 @@
+#ifndef CLP_S_FILTER_FILE_HPP
+#define CLP_S_FILTER_FILE_HPP
+
+#include <cstdint>
+
+#include "../FileWriter.hpp"
+#include "BloomFilter.hpp"
+#include "FilterConfig.hpp"
+
+namespace clp {
+class ReaderInterface;
+}  // namespace clp
+
+namespace clp_s { namespace filter {
+constexpr char kFilterFileMagic[4] = {'C', 'L', 'P', 'F'};
+
+void write_filter_file(FileWriter& writer, FilterType type, BloomFilter const& filter);
+
+bool read_filter_file(clp::ReaderInterface& reader, FilterType& out_type, BloomFilter& out_filter);
+}}  // namespace clp_s::filter
+
+#endif  // CLP_S_FILTER_FILE_HPP

--- a/components/core/tests/test-clp_s-bloom_filter.cpp
+++ b/components/core/tests/test-clp_s-bloom_filter.cpp
@@ -1,0 +1,71 @@
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../src/clp_s/filter/BloomFilter.hpp"
+
+namespace {
+constexpr size_t kInsertions = 10'000;
+constexpr size_t kQueries = 10'000;
+constexpr double kFalsePositiveRate = 0.001;
+
+uint64_t make_odd(uint64_t value) {
+    return value * 2 + 1;
+}
+
+uint64_t make_even(uint64_t value) {
+    return value * 2;
+}
+}  // namespace
+
+TEST_CASE("BloomFilter empty filter has no matches", "[clp_s][filter]") {
+    clp_s::filter::BloomFilter filter{0, kFalsePositiveRate};
+
+    for (size_t i = 0; i < kQueries; ++i) {
+        auto const value = make_odd(i);
+        REQUIRE_FALSE(filter.possibly_contains(std::to_string(value)));
+    }
+}
+
+TEST_CASE("BloomFilter true positives and bounded false positives", "[clp_s][filter]") {
+    clp_s::filter::BloomFilter filter{kInsertions, kFalsePositiveRate};
+
+    std::vector<std::string> inserted;
+    inserted.reserve(kInsertions);
+
+    for (size_t i = 0; i < kInsertions; ++i) {
+        auto const value = make_odd(i);
+        inserted.emplace_back(std::to_string(value));
+        filter.add(inserted.back());
+    }
+
+    size_t false_negatives = 0;
+    for (auto const& value : inserted) {
+        if (!filter.possibly_contains(value)) {
+            ++false_negatives;
+        }
+    }
+    REQUIRE(false_negatives == 0);
+
+    size_t false_positives = 0;
+    for (size_t i = 0; i < kQueries; ++i) {
+        auto const value = make_even(i);
+        if (filter.possibly_contains(std::to_string(value))) {
+            ++false_positives;
+        }
+    }
+
+    auto const false_positive_rate
+            = static_cast<double>(false_positives) / static_cast<double>(kQueries);
+    double const sigma = std::sqrt(
+            kFalsePositiveRate * (1.0 - kFalsePositiveRate) / static_cast<double>(kQueries)
+    );
+    double const allowed_false_positive_rate = kFalsePositiveRate + 3.0 * sigma;
+    INFO("False positive rate: " << false_positive_rate);
+    INFO("Allowed max FPR: " << allowed_false_positive_rate);
+    REQUIRE(false_positive_rate <= allowed_false_positive_rate);
+}

--- a/components/job-orchestration/job_orchestration/scheduler/job_config.py
+++ b/components/job-orchestration/job_orchestration/scheduler/job_config.py
@@ -50,6 +50,26 @@ class OutputConfig(BaseModel):
     target_segment_size: int
     target_encoded_file_size: int
     compression_level: int
+    filter_type: str = "none"
+    filter_fpr: float = 0.01
+
+    @field_validator("filter_type")
+    @classmethod
+    def validate_filter_type(cls, value: str) -> str:
+        if value not in {"none", "bloom"}:
+            raise ValueError("filter_type must be one of: none, bloom")
+        return value
+
+    @field_validator("filter_fpr")
+    @classmethod
+    def validate_filter_fpr(cls, value: float, info) -> float:
+        filter_type = info.data.get("filter_type")
+        if filter_type != "none":
+            if not (0.0 < value < 1.0):
+                raise ValueError("filter_fpr must be in the range (0, 1)")
+            if value < 1e-6:
+                raise ValueError("filter_fpr too small (min 1e-6)")
+        return value
 
 
 class ClpIoConfig(BaseModel):

--- a/integration-tests/tests/test_clp_s_filter_build.py
+++ b/integration-tests/tests/test_clp_s_filter_build.py
@@ -1,0 +1,83 @@
+"""Integration tests verifying clp-s builds variable dictionary filters."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.utils.asserting_utils import run_and_assert
+from tests.utils.config import (
+    ClpCorePathConfig,
+    CompressionTestPathConfig,
+    IntegrationTestLogs,
+    IntegrationTestPathConfig,
+)
+from tests.utils.utils import unlink
+
+pytestmark = pytest.mark.core
+
+json_datasets = pytest.mark.parametrize(
+    "test_logs_fixture",
+    [
+        "postgresql",
+    ],
+)
+
+
+@pytest.mark.clp_s
+@json_datasets
+def test_clp_s_builds_var_dict_filters(
+    request: pytest.FixtureRequest,
+    clp_core_path_config: ClpCorePathConfig,
+    integration_test_path_config: IntegrationTestPathConfig,
+    test_logs_fixture: str,
+) -> None:
+    """
+    Validate that clp-s builds variable dictionary filters when enabled.
+
+    :param request:
+    :param clp_core_path_config:
+    :param integration_test_path_config:
+    :param test_logs_fixture:
+    """
+    integration_test_logs: IntegrationTestLogs = request.getfixturevalue(test_logs_fixture)
+
+    test_paths = CompressionTestPathConfig(
+        test_name=f"clp-s-{integration_test_logs.name}-filters",
+        logs_source_dir=integration_test_logs.extraction_dir,
+        integration_test_path_config=integration_test_path_config,
+    )
+    test_paths.clear_test_outputs()
+
+    filters_dir = (
+        integration_test_path_config.test_root_dir
+        / f"clp-s-{integration_test_logs.name}-filters-output"
+    )
+    unlink(filters_dir)
+    filters_dir.mkdir(parents=True, exist_ok=True)
+
+    bin_path = str(clp_core_path_config.clp_s_binary_path)
+    src_path = str(test_paths.logs_source_dir)
+    compression_path = str(test_paths.compression_dir)
+
+    # fmt: off
+    compression_cmd = [
+        bin_path,
+        "c",
+        "--var-filter-type", "bloom",
+        "--var-filter-fpr", "0.001",
+        "--var-filter-output-dir", str(filters_dir),
+        compression_path,
+        src_path,
+    ]
+    # fmt: on
+    run_and_assert(compression_cmd)
+
+    archive_dirs = [p for p in Path(compression_path).iterdir() if p.is_dir()]
+    assert archive_dirs, f"No archives created in {compression_path}"
+
+    for archive_dir in archive_dirs:
+        expected_filter = filters_dir / f"{archive_dir.name}.var.dict.filter"
+        assert expected_filter.is_file(), f"Missing filter: {expected_filter}"
+
+    unlink(filters_dir)
+    test_paths.clear_test_outputs()

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -231,6 +231,9 @@ tasks:
           CMAKE_PACKAGE_NAME: "{{.LIB_NAME}}"
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}"
           INSTALL_PREFIX: "{{.INSTALL_PREFIX}}"
+      - >-
+        echo "set(CLP_ANTLR4_RUNTIME_SOURCE_DIRECTORY \"{{.SOURCE_DIR}}\")"
+        >> "{{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
       # This command must be last
       - task: "yscope-dev-utils:checksum:compute"

--- a/tools/deployment/package-helm/.set-up-common.sh
+++ b/tools/deployment/package-helm/.set-up-common.sh
@@ -11,7 +11,8 @@ set -o pipefail
 create_clp_directories() {
     echo "Creating CLP directories at ${CLP_HOME}..."
     mkdir -p  "$CLP_HOME/var/"{data,log}/{database,queue,redis,results_cache} \
-              "$CLP_HOME/var/data/"{archives,streams,staged-archives,staged-streams} \
+              "$CLP_HOME/var/data/"{archives,filters,streams,staged-archives,staged-streams} \
+              "$CLP_HOME/var/data/filters/"{staging,packs} \
               "$CLP_HOME/var/log/"{compression_scheduler,compression_worker,user} \
               "$CLP_HOME/var/log/"{query_scheduler,query_worker,reducer} \
               "$CLP_HOME/var/log/"{api_server,garbage_collector,log_ingestor,mcp_server} \

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -76,6 +76,11 @@ spec:
               ) | quote }}
               mountPath: "/var/data/staged-archives"
             {{- end }}
+            - name: {{ include "clp.volumeName" (dict
+                "component_category" "shared-data"
+                "name" "filters"
+              ) | quote }}
+              mountPath: "/var/data/filters"
             {{- if .Values.clpConfig.aws_config_directory }}
             - {{- include "clp.awsConfigVolumeMount" . | nindent 14 }}
             {{- end }}
@@ -120,6 +125,11 @@ spec:
             "name" "staged-archives"
           ) | nindent 10 }}
         {{- end }}
+        - {{- include "clp.pvcVolume" (dict
+            "root" .
+            "component_category" "shared-data"
+            "name" "filters"
+          ) | nindent 10 }}
         {{- if .Values.clpConfig.aws_config_directory }}
         - {{- include "clp.awsConfigVolume" . | nindent 10 }}
         {{- end }}

--- a/tools/deployment/package-helm/templates/shared-data-filters-pv.yaml
+++ b/tools/deployment/package-helm/templates/shared-data-filters-pv.yaml
@@ -1,0 +1,8 @@
+{{- include "clp.createStaticPv" (dict
+  "root" .
+  "component_category" "shared-data"
+  "name" "filters"
+  "capacity" "5Gi"
+  "accessModes" (list "ReadWriteMany")
+  "hostPath" (printf "%s/filters" .Values.clpConfig.data_directory)
+) }}

--- a/tools/deployment/package-helm/templates/shared-data-filters-pvc.yaml
+++ b/tools/deployment/package-helm/templates/shared-data-filters-pvc.yaml
@@ -1,0 +1,7 @@
+{{- include "clp.createPvc" (dict
+  "root" .
+  "component_category" "shared-data"
+  "name" "filters"
+  "capacity" "5Gi"
+  "accessModes" (list "ReadWriteMany")
+) }}

--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -304,6 +304,7 @@ services:
       - *volume_clp_logs
       - *volume_clp_tmp
       - "${CLP_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/archives"
+      - "${CLP_DATA_DIR_HOST:-./var/data}/filters:/var/data/filters"
       - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_LOGS_INPUT_DIR_HOST:-empty}:${CLP_LOGS_INPUT_DIR_CONTAINER:-/mnt/logs}:ro"
       - "${CLP_STAGED_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/staged-archives"
@@ -336,6 +337,7 @@ services:
       - *volume_clp_logs
       - *volume_clp_tmp
       - "${CLP_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/archives"
+      - "${CLP_DATA_DIR_HOST:-./var/data}/filters:/var/data/filters"
       - "${CLP_AWS_CONFIG_DIR_HOST:-empty}:/opt/clp/.aws:ro"
       - "${CLP_LOGS_INPUT_DIR_HOST:-empty}:${CLP_LOGS_INPUT_DIR_CONTAINER:-/mnt/logs}"
       - "${CLP_STAGED_ARCHIVE_OUTPUT_DIR_HOST:-empty}:/var/data/staged-archives"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds variable-dictionary Bloom filter building during `clp-s` compression (build-only flow, no packing/query changes).

Main changes:
- Add a `clp_s/filter` module for Bloom filter construction, filter config/type parsing, and filter file I/O.
- Wire filter config through CLI and job orchestration (`filter_type`, `filter_fpr`).
- Build `.var.dict.filter` files during archive write when enabled.
- Keep filter outputs under the data mount (`<data>/filters`) with staging layout for temporary job outputs.
- Add package/deployment plumbing for filters directory config/mount handling.
- Integrate MurmurHash from ANTLR runtime for Bloom hashing and wire required include/source paths in CMake.
- Add tests:
  - C++ unit tests for Bloom filter behavior (positive, mixed, and false-positive-rate sanity checks).
  - Integration test validating filter files are generated during `clp-s` compression.

Scope notes:
- This PR is build-only for filters.
- No filter packing/query-time behavior changes are included.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Unit tests are added and pass.
* [x] Integration tests are added and pass.
* [x] Lint/build checks for touched paths pass in the development environment.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Variable dictionary filtering using Bloom filters is now supported to optimize archive output
  * New configuration options enable users to specify filter type and false-positive rate for dictionary compression

* **Tests**
  * Added comprehensive Bloom filter unit tests and integration tests to validate filter generation and functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->