### PR TITLE
feat(helm): Add `--clp-package-image` CLI arg to setup scripts for local image testing (resolves #2019).

### DIFF
--- a/tools/deployment/package-helm/.set-up-common.sh
+++ b/tools/deployment/package-helm/.set-up-common.sh
@@ -47,6 +47,51 @@ prepare_environment() {
     download_samples
 }
 
+# Loads a local Docker image into the kind cluster and returns the helm --set
+# flags for using it. If image is not specified, returns empty string.
+#
+# @param {string} cluster_name Name of the kind cluster
+# @param {string} [image] Docker image (e.g., "clp-package:dev-junhao-a6bf")
+# @return Prints helm --set flags to stdout
+get_image_helm_args() {
+    local cluster_name=$1
+    local image="${2:-}"
+
+    if [[ -z "${image}" ]]; then
+        return
+    fi
+
+    echo "Loading local image '${image}' into kind cluster..." >&2
+    kind load docker-image "${image}" --name "${cluster_name}" >&2
+
+    # Split "repo:tag" into separate parts
+    local repo="${image%%:*}"
+    local tag="${image#*:}"
+    echo "--set" "image.clpPackage.repository=${repo}" \
+         "--set" "image.clpPackage.tag=${tag}" \
+         "--set" "image.clpPackage.pullPolicy=Never"
+}
+
+# Parses common arguments shared across set-up scripts.
+# Sets CLP_PACKAGE_IMAGE global variable.
+#
+# @param {string[]} args Script arguments
+parse_common_args() {
+    CLP_PACKAGE_IMAGE=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --clp-package-image)
+                CLP_PACKAGE_IMAGE="$2"
+                shift 2
+                ;;
+            *)
+                echo "Unknown argument: $1" >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
 # Generates kind cluster configuration YAML
 #
 # @param {int} num_workers Number of worker nodes (0 for single-node cluster)

--- a/tools/deployment/package-helm/.set-up-common.sh
+++ b/tools/deployment/package-helm/.set-up-common.sh
@@ -81,6 +81,10 @@ parse_common_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --clp-package-image)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "Error: '--clp-package-image' requires a value." >&2
+                    exit 1
+                fi
                 CLP_PACKAGE_IMAGE="$2"
                 shift 2
                 ;;

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.4-dev.2"
+version: "0.1.4-dev.3"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.9.1-dev"

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.1.4-dev.3"
+version: "0.1.4-dev.4"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.9.1-dev"

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -17,6 +17,8 @@ REDUCER_REPLICAS="${REDUCER_REPLICAS:-2}"
 # shellcheck source=.set-up-common.sh
 source "${script_dir}/.set-up-common.sh"
 
+parse_common_args "$@"
+
 echo "=== Multi-node setup with dedicated worker nodes ==="
 echo "Cluster: ${CLUSTER_NAME}"
 echo "Compression nodes: ${NUM_COMPRESSION_NODES}"
@@ -51,12 +53,15 @@ done
 echo "Installing Helm chart..."
 helm uninstall test --ignore-not-found
 sleep 2
+# Word splitting is intentional: get_image_helm_args returns multiple --set flags.
+# shellcheck disable=SC2046
 helm install test "${script_dir}" \
     --set "distributedDeployment=true" \
     --set "compressionWorker.replicas=${COMPRESSION_WORKER_REPLICAS}" \
     --set "compressionWorker.scheduling.nodeSelector.yscope\.io/nodeType=compression" \
     --set "queryWorker.replicas=${QUERY_WORKER_REPLICAS}" \
     --set "queryWorker.scheduling.nodeSelector.yscope\.io/nodeType=query" \
-    --set "reducer.replicas=${REDUCER_REPLICAS}"
+    --set "reducer.replicas=${REDUCER_REPLICAS}" \
+    $(get_image_helm_args "${CLUSTER_NAME}" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-test.sh
+++ b/tools/deployment/package-helm/set-up-test.sh
@@ -11,6 +11,8 @@ CLUSTER_NAME="${CLUSTER_NAME:-clp-test}"
 # shellcheck source=.set-up-common.sh
 source "${script_dir}/.set-up-common.sh"
 
+parse_common_args "$@"
+
 echo "=== Single-node setup ==="
 echo "Cluster: ${CLUSTER_NAME}"
 echo ""
@@ -23,6 +25,9 @@ generate_kind_config 0 | kind create cluster --name "${CLUSTER_NAME}" --config=-
 echo "Installing Helm chart..."
 helm uninstall test --ignore-not-found
 sleep 2
-helm install test "${script_dir}"
+# Word splitting is intentional: get_image_helm_args returns multiple --set flags.
+# shellcheck disable=SC2046
+helm install test "${script_dir}" \
+    $(get_image_helm_args "${CLUSTER_NAME}" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Add a `--clp-package-image` CLI argument to the Helm chart setup scripts
(`set-up-test.sh`, `set-up-multi-dedicated-test.sh`, `set-up-multi-shared-test.sh`) so that a
locally-built Docker image can be loaded into the kind cluster and used for deployment.

```bash
# Use a local image
bash tools/deployment/package-helm/set-up-test.sh --clp-package-image clp-package:dev-junhao-a6bf

# Use default image (backwards compatible — no args needed)
bash tools/deployment/package-helm/set-up-test.sh
```

When `--clp-package-image` is omitted, `CLP_PACKAGE_IMAGE` is empty, `get_image_helm_args` returns
nothing, and the scripts behave exactly as before.

Also hardens `.set-up-common.sh` with two robustness fixes:

- `parse_common_args` now validates that `--clp-package-image` is followed by a non-flag value
  (previously, `set -o nounset` would crash with a confusing "unbound variable" error, or the next
  flag would be silently consumed as the image name).
- `get_image_helm_args` now uses a regex to split `repo:tag` on the last colon whose right side
  contains no `/` (previously, `${image%%:*}` would mis-parse registry ports like
  `localhost:5000/repo:tag`, and images without tags were silently accepted).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 1. Deploy with `--clp-package-image`

```bash
bash tools/deployment/package-helm/set-up-test.sh --clp-package-image clp-package:dev-junhao-a6bf
```

All 14 pods running with 0 restarts.

## 2. Deploy without args (backwards compatibility)

```bash
bash tools/deployment/package-helm/set-up-test.sh
```

All 14 pods running with 0 restarts. Default image pulled from
`ghcr.io/y-scope/clp/clp-package`.

## 3. Unknown argument

```bash
bash tools/deployment/package-helm/set-up-test.sh --bad-arg
# → Unknown argument: --bad-arg (exit 1)
```

## 4. Missing value for `--clp-package-image`

Tests call `parse_common_args` with the given input and check the exit code and output.

| # | Input | Output | Exit |
|---|-------|--------|------|
| 1 | `--clp-package-image` *(end of args)* | `Error: '--clp-package-image' requires a value.` | 1 |
| 2 | `--clp-package-image --other-flag` | `Error: '--clp-package-image' requires a value.` | 1 |
| 3 | `--clp-package-image clp-package:dev-test` | `CLP_PACKAGE_IMAGE=clp-package:dev-test` | 0 |
| 4 | *(no args)* | `CLP_PACKAGE_IMAGE=` | 0 |
| 5 | `--bad-arg` | `Unknown argument: --bad-arg` | 1 |
| 6 | `--clp-package-image --clp-package-image` | `Error: '--clp-package-image' requires a value.` | 1 |

6/6 passed.

## 5. Image reference parsing

Tests call `get_image_helm_args "test-cluster" <input>` and check the generated `--set` flags.

| # | Input | Parsed repo | Parsed tag | Exit |
|---|-------|-------------|------------|------|
| 1 | `clp-package:dev` | `clp-package` | `dev` | 0 |
| 2 | `localhost:5000/repo:v1` | `localhost:5000/repo` | `v1` | 0 |
| 3 | `registry.io:5000/org/repo:latest` | `registry.io:5000/org/repo` | `latest` | 0 |
| 4 | `clp-package` *(no tag)* | — | — | 1 |
| 5 | `localhost:5000/repo` *(port but no tag)* | — | — | 1 |
| 6 | `ghcr.io/y-scope/clp:v0.3.0-rc1` | `ghcr.io/y-scope/clp` | `v0.3.0-rc1` | 0 |
| 7 | `""` *(empty / omitted)* | *(no-op)* | *(no-op)* | 0 |

7/7 passed.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized argument parsing for deployment scripts to support a common image option across test setups.
  * Standardized image handling so test Helm installs can optionally use locally loaded package images via added image-related flags.
  * Updated package Helm chart version to reflect the tooling and deployment invocation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->