### PR TITLE
fix(deployment): Restore `CLP_*_HOST` env vars for bundled services to allow configurable port bindings (fixes #2055).

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -191,6 +191,9 @@ class BaseController(ABC):
         env_vars |= {
             "CLP_DB_NAME": self._clp_config.database.names[ClpDbNameType.CLP],
         }
+        if self._clp_config.compression_scheduler.type == OrchestrationType.SPIDER:
+            env_vars["SPIDER_DB_NAME"] = self._clp_config.database.names[ClpDbNameType.SPIDER]
+
         if BundledService.DATABASE not in self._clp_config.bundled:
             env_vars |= {
                 "CLP_DB_PORT": str(self._clp_config.database.port),
@@ -199,9 +202,8 @@ class BaseController(ABC):
                     self._clp_config.database.host
                 ),
             }
-
-        if self._clp_config.compression_scheduler.type == OrchestrationType.SPIDER:
-            env_vars["SPIDER_DB_NAME"] = self._clp_config.database.names[ClpDbNameType.SPIDER]
+        else:
+            env_vars["CLP_DB_HOST"] = _get_ip_from_hostname(self._clp_config.database.host)
 
         # Credentials
         credentials = self._clp_config.database.credentials
@@ -275,6 +277,8 @@ class BaseController(ABC):
                 "CLP_EXTRA_HOST_QUEUE_NAME": QUEUE_COMPONENT_NAME,
                 "CLP_EXTRA_HOST_QUEUE_ADDR": _resolve_external_host(self._clp_config.queue.host),
             }
+        else:
+            env_vars["CLP_QUEUE_HOST"] = _get_ip_from_hostname(self._clp_config.queue.host)
 
         # Credentials
         env_vars |= {
@@ -359,6 +363,8 @@ class BaseController(ABC):
                 "CLP_EXTRA_HOST_REDIS_NAME": REDIS_COMPONENT_NAME,
                 "CLP_EXTRA_HOST_REDIS_ADDR": _resolve_external_host(self._clp_config.redis.host),
             }
+        else:
+            env_vars["CLP_REDIS_HOST"] = _get_ip_from_hostname(self._clp_config.redis.host)
 
         # Credentials
         env_vars |= {
@@ -463,6 +469,10 @@ class BaseController(ABC):
                     self._clp_config.results_cache.host
                 ),
             }
+        else:
+            env_vars["CLP_RESULTS_CACHE_HOST"] = _get_ip_from_hostname(
+                self._clp_config.results_cache.host
+            )
 
         return env_vars
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

After #1681, `CLP_DB_HOST`, `CLP_QUEUE_HOST`, `CLP_REDIS_HOST`, and
`CLP_RESULTS_CACHE_HOST` are no longer set in `controller.py` for bundled services.
`docker-compose-all.yaml` uses these variables as `host_ip` for port bindings (e.g.,
`host_ip: "${CLP_DB_HOST:-127.0.0.1}"`). Since they are never set for bundled services,
Docker falls back to `127.0.0.1`, making it impossible to expose bundled service ports on
all interfaces via `host: "0.0.0.0"`.

This fix restores the `CLP_*_HOST` environment variable assignments in the bundled branch
of each `_set_up_env_for_*()` method, using `_get_ip_from_hostname()` to resolve the
configured host. When users set e.g. `database.host: "0.0.0.0"`, `CLP_DB_HOST` is now
correctly set to `0.0.0.0` so Docker Compose binds the published port on all interfaces.

Additionally, moved the `SPIDER_DB_NAME` assignment above the bundled check (it is
independent of bundling) to allow the `else` clause to follow directly.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Tested on the actual built package (`task package` to build, then `sbin/start-clp.sh`).

## Scenario 1: Bundled mode (default config)

All services bundled (default `clp-config.yaml`), no external services running.

**Task:** Verify that the default bundled deployment starts, all services become healthy,
and compression works.

**Command:**

```
$ cd build/clp-package
$ ./sbin/start-clp.sh
```

**Output:**

```
2026-03-02T19:30:23.210 INFO [controller] Setting up environment for bundling database...
2026-03-02T19:30:23.213 INFO [controller] Setting up environment for bundling queue...
2026-03-02T19:30:23.214 INFO [controller] Setting up environment for bundling redis...
2026-03-02T19:30:23.215 INFO [controller] Setting up environment for bundling results_cache...
2026-03-02T19:30:23.217 INFO [controller] Setting up environment for database...
2026-03-02T19:30:23.222 INFO [controller] Setting up environment for queue...
2026-03-02T19:30:23.222 INFO [controller] Setting up environment for redis...
2026-03-02T19:30:23.222 INFO [controller] spider_scheduler is not configured, skipping environment setup...
2026-03-02T19:30:23.222 INFO [controller] Setting up environment for results_cache...
2026-03-02T19:30:23.223 INFO [controller] Setting up environment for compression_scheduler...
2026-03-02T19:30:23.223 INFO [controller] Setting up environment for query_scheduler...
2026-03-02T19:30:23.223 INFO [controller] Setting up environment for compression_worker...
2026-03-02T19:30:23.223 INFO [controller] Setting up environment for query_worker...
2026-03-02T19:30:23.224 INFO [controller] Setting up environment for reducer...
2026-03-02T19:30:23.224 INFO [controller] Setting up environment for api_server...
2026-03-02T19:30:23.224 INFO [controller] log_ingestor is only applicable for S3 logs input type, skipping environment setup...
2026-03-02T19:30:23.225 INFO [controller] Setting up environment for webui...
2026-03-02T19:30:23.226 INFO [controller] The MCP Server is not configured, skipping mcp_server creation...
2026-03-02T19:30:23.227 INFO [controller] Setting up environment for garbage_collector...
2026-03-02T19:30:23.393 INFO [controller] Starting CLP using Docker Compose (full deployment)...
...
2026-03-02T19:30:41.597 INFO [controller] Started CLP.
```

**Verification — `.env` now contains bundled host vars:**

```
CLP_DB_HOST=127.0.0.1
CLP_QUEUE_HOST=127.0.0.1
CLP_REDIS_HOST=127.0.0.1
CLP_RESULTS_CACHE_HOST=127.0.0.1
```

**Explanation:** All containers started and became healthy. The `.env` now contains
`CLP_*_HOST` entries set to `127.0.0.1` (the default host config), which Docker Compose
uses for `host_ip` port bindings. Before this fix, these variables were absent and Docker
fell back to the hardcoded `127.0.0.1` default in the compose file — functionally the
same in the default case, but now explicitly set so that users can override them by
configuring `host: "0.0.0.0"`.

**Task:** Verify end-to-end data flow (compression) in bundled mode.

**Command:**

```
$ ./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.log
```

**Output:**

```
2026-03-02T19:31:44.752 INFO [compress] Compression job 1 submitted.
2026-03-02T19:31:49.772 INFO [compress] Compression finished.
2026-03-02T19:31:49.772 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 80.89MB/s.
```

## Scenario 2: All four services external

All four services (`database`, `queue`, `redis`, `results_cache`) unbundled and running
externally on the Docker host.

**Task:** Start 4 external services using the same images as CLP, configure
`bundled: []`, and verify all CLP containers connect to the external services.

**Setup — start four external services on the Docker host:**

```
$ docker run -d --name ext-mariadb \
    -p 3306:3306 \
    -e MYSQL_ROOT_PASSWORD=NCeicP598W0 \
    -e MYSQL_DATABASE=clp-db \
    -e MYSQL_USER=clp-user \
    -e MYSQL_PASSWORD=6ZQL9KwjVOQ \
    mariadb:10-jammy

$ docker run -d --name ext-rabbitmq \
    -p 5672:5672 \
    -e RABBITMQ_DEFAULT_USER=clp-user \
    -e RABBITMQ_DEFAULT_PASS=PBCOZerhNco \
    rabbitmq:3.9.8

$ docker run -d --name ext-redis \
    -p 6379:6379 \
    redis:7.2.4 \
    redis-server --requirepass 'M-MAucilvCZ_Ixr7DJw8VQ'

$ docker run -d --network=host --name ext-mongodb \
    mongo:7.0.1 \
    mongod --replSet rs0 --bind_ip_all
```

(Credentials match `etc/credentials.yaml`. Images match those used by CLP. MongoDB is
started with `--replSet rs0` and `--bind_ip_all`.)

**Config (`etc/clp-config-ext-all.yaml`):**

```yaml
bundled: []

database:
  host: "localhost"
  port: 3306

queue:
  host: "localhost"
  port: 5672

redis:
  host: "localhost"
  port: 6379

results_cache:
  host: "192.168.3.89"
  port: 27017
```

**Command:**

```
$ ./sbin/start-clp.sh --config etc/clp-config-ext-all.yaml
```

**Output:**

```
2026-03-02T19:38:16.167 INFO [controller] database is not included in the 'bundled' configuration, skipping service bundling...
2026-03-02T19:38:16.167 INFO [controller] queue is not configured or part of the 'bundled' configuration, skipping service bundling...
2026-03-02T19:38:16.167 INFO [controller] redis is not configured or part of the 'bundled' configuration, skipping service bundling...
2026-03-02T19:38:16.167 INFO [controller] results_cache is not included in the 'bundled' configuration, skipping service bundling...
2026-03-02T19:38:16.167 INFO [controller] Setting up environment for database...
2026-03-02T19:38:16.169 INFO [controller] Setting up environment for queue...
2026-03-02T19:38:16.169 INFO [controller] Setting up environment for redis...
2026-03-02T19:38:16.169 INFO [controller] spider_scheduler is not configured, skipping environment setup...
2026-03-02T19:38:16.169 INFO [controller] Setting up environment for results_cache...
2026-03-02T19:38:16.169 INFO [controller] Setting up environment for compression_scheduler...
2026-03-02T19:38:16.169 INFO [controller] Setting up environment for query_scheduler...
2026-03-02T19:38:16.170 INFO [controller] Setting up environment for compression_worker...
2026-03-02T19:38:16.170 INFO [controller] Setting up environment for query_worker...
2026-03-02T19:38:16.170 INFO [controller] Setting up environment for reducer...
2026-03-02T19:38:16.170 INFO [controller] Setting up environment for api_server...
2026-03-02T19:38:16.170 INFO [controller] log_ingestor is only applicable for S3 logs input type, skipping environment setup...
2026-03-02T19:38:16.170 INFO [controller] Setting up environment for webui...
2026-03-02T19:38:16.174 INFO [controller] The MCP Server is not configured, skipping mcp_server creation...
2026-03-02T19:38:16.174 INFO [controller] Setting up environment for garbage_collector...
2026-03-02T19:38:16.269 INFO [controller] Starting CLP using Docker Compose (full deployment)...
...
2026-03-02T19:38:24.761 INFO [controller] Started CLP.
```

**Verification — container status:**

```
$ docker ps --filter "name=clp-package-ff29" --format "table {{.Names}}\t{{.Status}}"
NAMES                                      STATUS
clp-package-ff29-reducer-1                 Up 13 seconds
clp-package-ff29-compression-scheduler-1   Up 16 seconds
clp-package-ff29-api-server-1              Up 16 seconds (healthy)
clp-package-ff29-query-scheduler-1         Up 16 seconds (healthy)
clp-package-ff29-garbage-collector-1       Up 16 seconds
clp-package-ff29-webui-1                   Up 16 seconds (healthy)
clp-package-ff29-query-worker-1            Up 19 seconds
clp-package-ff29-compression-worker-1      Up 19 seconds
```

No `database`, `queue`, `redis`, or `results-cache` containers — all are external.

**Verification — `.env` external host entries:**

```
CLP_DATABASE_ENABLED=0
CLP_QUEUE_ENABLED=0
CLP_REDIS_ENABLED=0
CLP_RESULTS_CACHE_ENABLED=0
CLP_DB_PORT=3306
CLP_EXTRA_HOST_DATABASE_NAME=database
CLP_EXTRA_HOST_DATABASE_ADDR=host-gateway
CLP_QUEUE_PORT=5672
CLP_EXTRA_HOST_QUEUE_NAME=queue
CLP_EXTRA_HOST_QUEUE_ADDR=host-gateway
CLP_REDIS_PORT=6379
CLP_EXTRA_HOST_REDIS_NAME=redis
CLP_EXTRA_HOST_REDIS_ADDR=host-gateway
CLP_RESULTS_CACHE_PORT=27017
CLP_EXTRA_HOST_RESULTS_CACHE_NAME=results_cache
CLP_EXTRA_HOST_RESULTS_CACHE_ADDR=192.168.3.89
```

**Explanation:** Database, queue, and redis configured with `localhost` resolved to
Docker's `host-gateway` token. Results cache uses the non-loopback IP directly. No
`CLP_*_HOST` entries present in external mode (correct — these are only set for bundled
services).

**Task:** Verify end-to-end data flow (compression) with all external services.

**Command:**

```
$ ./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.log --config etc/clp-config-ext-all.yaml
```

**Output:**

```
2026-03-02T19:38:57.716 INFO [compress] Compression job 1 submitted.
2026-03-02T19:39:02.732 INFO [compress] Compression finished.
2026-03-02T19:39:02.732 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 83.33MB/s.
```

**Explanation:** Compression job was submitted through external RabbitMQ, stored metadata
in external MariaDB, used external Redis for task coordination, and
`results-cache-indices-creator` successfully created indices on the external MongoDB.
Full data pipeline works with all four services external.

## Scenario 3: Cross-host bundled access (two LXC containers, hosts=0.0.0.0)

Bundled services configured with `host: "0.0.0.0"` so ports are published on all
interfaces. A second machine (LXC container) verifies remote connectivity.

**Task:** Verify that configuring `host: "0.0.0.0"` for bundled services correctly
exposes ports on all interfaces, allowing remote access from another host.

**Setup — create two Ubuntu Noble LXC containers:**

```
$ lxc launch ubuntu:noble clp-server \
    --config security.nesting=true \
    --config security.syscalls.intercept.mknod=true \
    --config security.syscalls.intercept.setxattr=true
$ lxc launch ubuntu:noble clp-client

$ lxc list
+------------+---------+----------------------+------+-----------+-----------+
|    NAME    |  STATE  |         IPV4         | ...  |   TYPE    | SNAPSHOTS |
+------------+---------+----------------------+------+-----------+-----------+
| clp-client | RUNNING | 10.145.61.208 (eth0) | ...  | CONTAINER | 0         |
+------------+---------+----------------------+------+-----------+-----------+
| clp-server | RUNNING | 10.145.61.244 (eth0) | ...  | CONTAINER | 0         |
+------------+---------+----------------------+------+-----------+-----------+
```

Installed Docker and docker-compose-v2 in `clp-server`, pushed the CLP package and all
required Docker images (clp-package, mariadb, rabbitmq, redis, mongo). Installed
`mariadb-client` and `mongosh` in `clp-client`.

**Config (`etc/clp-config-bind-all.yaml`) in clp-server:**

```yaml
database:
  host: "0.0.0.0"

queue:
  host: "0.0.0.0"

redis:
  host: "0.0.0.0"

results_cache:
  host: "0.0.0.0"
```

**Command (in clp-server):**

```
$ cd /opt/clp-package
$ ./sbin/start-clp.sh --config etc/clp-config-bind-all.yaml
```

**Output:**

```
2026-03-02T19:49:18.053 INFO [controller] Setting up environment for bundling database...
2026-03-02T19:49:18.064 INFO [controller] Setting up environment for bundling queue...
2026-03-02T19:49:18.066 INFO [controller] Setting up environment for bundling redis...
2026-03-02T19:49:18.069 INFO [controller] Setting up environment for bundling results_cache...
...
2026-03-02T19:49:39.962 INFO [controller] Started CLP.
```

**Verification — `.env` shows 0.0.0.0 host vars:**

```
CLP_DB_HOST=0.0.0.0
CLP_QUEUE_HOST=0.0.0.0
CLP_REDIS_HOST=0.0.0.0
CLP_RESULTS_CACHE_HOST=0.0.0.0
```

**Verification — ports bound to 0.0.0.0:**

```
$ lxc exec clp-server -- docker ps --format "table {{.Names}}\t{{.Ports}}" | grep -E "database|queue|redis|results"
clp-package-ff29-database-1           0.0.0.0:3306->3306/tcp
clp-package-ff29-queue-1              4369/tcp, 5671/tcp, 15691-15692/tcp, 25672/tcp, 0.0.0.0:5672->5672/tcp
clp-package-ff29-results-cache-1      0.0.0.0:27017->27017/tcp
clp-package-ff29-redis-1              0.0.0.0:6379->6379/tcp
```

**Explanation:** All four bundled service ports are published on `0.0.0.0` instead of the
default `127.0.0.1`. Before this fix, the `CLP_*_HOST` variables were never set for
bundled services, so Docker Compose always fell back to the `127.0.0.1` default in the
compose file, making it impossible to expose bundled services on all interfaces.

**Verification — remote access from clp-client (10.145.61.208) to clp-server
(10.145.61.244):**

```
$ lxc exec clp-client -- mariadb -h 10.145.61.244 -P 3306 -u clp-user -p'...' -e "SHOW DATABASES;"
Database
clp-db
information_schema

$ lxc exec clp-client -- mongosh "mongodb://10.145.61.244:27017/clp-query-results" --eval "db.getCollectionNames()"
[ 'stream-files' ]
```

**Explanation:** Both MariaDB and MongoDB on clp-server are accessible from clp-client,
confirming that the fix correctly propagates the `host: "0.0.0.0"` config through the
`CLP_*_HOST` env vars to Docker Compose's `host_ip` port bindings.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved environment variable configuration for database and service connectivity in different deployment scenarios, ensuring proper host IP resolution and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->