### PR TITLE
fix(clp-package): Restore `CLP_*_PORT` env vars for bundled services (fixes #2065); Separate published ports from connection ports.

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -196,14 +196,17 @@ class BaseController(ABC):
 
         if BundledService.DATABASE not in self._clp_config.bundled:
             env_vars |= {
-                "CLP_DB_PORT": str(self._clp_config.database.port),
+                "CLP_DB_CONNECT_PORT": str(self._clp_config.database.port),
                 "CLP_EXTRA_HOST_DATABASE_NAME": DB_COMPONENT_NAME,
                 "CLP_EXTRA_HOST_DATABASE_ADDR": _resolve_external_host(
                     self._clp_config.database.host
                 ),
             }
         else:
-            env_vars["CLP_DB_HOST"] = _get_ip_from_hostname(self._clp_config.database.host)
+            env_vars |= {
+                "CLP_DB_HOST": _get_ip_from_hostname(self._clp_config.database.host),
+                "CLP_DB_PORT": str(self._clp_config.database.port),
+            }
 
         # Credentials
         credentials = self._clp_config.database.credentials
@@ -273,12 +276,15 @@ class BaseController(ABC):
         # Connection config
         if BundledService.QUEUE not in self._clp_config.bundled:
             env_vars |= {
-                "CLP_QUEUE_PORT": str(self._clp_config.queue.port),
+                "CLP_QUEUE_CONNECT_PORT": str(self._clp_config.queue.port),
                 "CLP_EXTRA_HOST_QUEUE_NAME": QUEUE_COMPONENT_NAME,
                 "CLP_EXTRA_HOST_QUEUE_ADDR": _resolve_external_host(self._clp_config.queue.host),
             }
         else:
-            env_vars["CLP_QUEUE_HOST"] = _get_ip_from_hostname(self._clp_config.queue.host)
+            env_vars |= {
+                "CLP_QUEUE_HOST": _get_ip_from_hostname(self._clp_config.queue.host),
+                "CLP_QUEUE_PORT": str(self._clp_config.queue.port),
+            }
 
         # Credentials
         env_vars |= {
@@ -359,12 +365,15 @@ class BaseController(ABC):
         # Connection config
         if BundledService.REDIS not in self._clp_config.bundled:
             env_vars |= {
-                "CLP_REDIS_PORT": str(self._clp_config.redis.port),
+                "CLP_REDIS_CONNECT_PORT": str(self._clp_config.redis.port),
                 "CLP_EXTRA_HOST_REDIS_NAME": REDIS_COMPONENT_NAME,
                 "CLP_EXTRA_HOST_REDIS_ADDR": _resolve_external_host(self._clp_config.redis.host),
             }
         else:
-            env_vars["CLP_REDIS_HOST"] = _get_ip_from_hostname(self._clp_config.redis.host)
+            env_vars |= {
+                "CLP_REDIS_HOST": _get_ip_from_hostname(self._clp_config.redis.host),
+                "CLP_REDIS_PORT": str(self._clp_config.redis.port),
+            }
 
         # Credentials
         env_vars |= {
@@ -463,16 +472,19 @@ class BaseController(ABC):
         }
         if BundledService.RESULTS_CACHE not in self._clp_config.bundled:
             env_vars |= {
-                "CLP_RESULTS_CACHE_PORT": str(self._clp_config.results_cache.port),
+                "CLP_RESULTS_CACHE_CONNECT_PORT": str(self._clp_config.results_cache.port),
                 "CLP_EXTRA_HOST_RESULTS_CACHE_NAME": RESULTS_CACHE_COMPONENT_NAME,
                 "CLP_EXTRA_HOST_RESULTS_CACHE_ADDR": _resolve_external_host(
                     self._clp_config.results_cache.host
                 ),
             }
         else:
-            env_vars["CLP_RESULTS_CACHE_HOST"] = _get_ip_from_hostname(
-                self._clp_config.results_cache.host
-            )
+            env_vars |= {
+                "CLP_RESULTS_CACHE_HOST": _get_ip_from_hostname(
+                    self._clp_config.results_cache.host
+                ),
+                "CLP_RESULTS_CACHE_PORT": str(self._clp_config.results_cache.port),
+            }
 
         return env_vars
 

--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -233,7 +233,7 @@ services:
       "-u",
       "-m", "clp_py_utils.initialize-results-cache",
       "--uri", "mongodb://${CLP_EXTRA_HOST_RESULTS_CACHE_ADDR:-results_cache}\
-        :${CLP_RESULTS_CACHE_PORT:-27017}/${CLP_RESULTS_CACHE_DB_NAME:-clp-query-results}",
+        :${CLP_RESULTS_CACHE_CONNECT_PORT:-27017}/${CLP_RESULTS_CACHE_DB_NAME:-clp-query-results}",
       "--stream-collection", "${CLP_RESULTS_CACHE_STREAM_COLLECTION_NAME:-stream-files}",
     ]
 
@@ -253,7 +253,7 @@ services:
       "/opt/clp/bin/spider_scheduler",
       "--host", "spider_scheduler",
       "--port", "6000",
-      "--storage_url", "jdbc:mariadb://database:${CLP_DB_PORT:-3306}/\
+      "--storage_url", "jdbc:mariadb://database:${CLP_DB_CONNECT_PORT:-3306}/\
         ${SPIDER_DB_NAME:-spider-db}?\
         user=${SPIDER_DB_USER:-spider-user}\
         &password=${SPIDER_DB_PASS:?Please set a value.}",
@@ -265,14 +265,14 @@ services:
     stop_grace_period: "300s"
     environment:
       BROKER_URL: "amqp://${CLP_QUEUE_USER:-clp-user}:${CLP_QUEUE_PASS:?Please set a value.}\
-        @queue:${CLP_QUEUE_PORT:-5672}"
+        @queue:${CLP_QUEUE_CONNECT_PORT:-5672}"
       CLP_DB_PASS: "${CLP_DB_PASS:?Please set a value.}"
       CLP_DB_USER: "${CLP_DB_USER:-clp-user}"
       CLP_LOGGING_LEVEL: "${CLP_COMPRESSION_SCHEDULER_LOGGING_LEVEL:-INFO}"
       CLP_LOGS_DIR: "/var/log/compression_scheduler"
       PYTHONPATH: "/opt/clp/lib/python3/site-packages"
       RESULT_BACKEND: "redis://default:${CLP_REDIS_PASS:?Please set a value.}\
-        @redis:${CLP_REDIS_PORT:-6379}\
+        @redis:${CLP_REDIS_CONNECT_PORT:-6379}\
         /${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"
     volumes:
       - *volume_clp_config_readonly
@@ -298,7 +298,7 @@ services:
     hostname: "compression_worker"
     environment:
       BROKER_URL: "amqp://${CLP_QUEUE_USER:-clp-user}:${CLP_QUEUE_PASS:?Please set a value.}\
-        @queue:${CLP_QUEUE_PORT:-5672}"
+        @queue:${CLP_QUEUE_CONNECT_PORT:-5672}"
       CLP_CONFIG_PATH: "/etc/clp-config.yaml"
       CLP_HOME: "/opt/clp"
       CLP_LOGGING_LEVEL: "${CLP_COMPRESSION_WORKER_LOGGING_LEVEL:-INFO}"
@@ -306,7 +306,7 @@ services:
       CLP_WORKER_LOG_PATH: "/var/log/compression_worker/worker.log"
       PYTHONPATH: "/opt/clp/lib/python3/site-packages"
       RESULT_BACKEND: "redis://default:${CLP_REDIS_PASS:?Please set a value.}\
-        @redis:${CLP_REDIS_PORT:-6379}\
+        @redis:${CLP_REDIS_CONNECT_PORT:-6379}\
         /${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"
     volumes:
       - *volume_clp_config_readonly
@@ -356,7 +356,7 @@ services:
       "-m", "job_orchestration.executor.start-spider-worker",
       "--host", "compression_worker",
       "--num-workers", "${CLP_COMPRESSION_WORKER_CONCURRENCY:-1}",
-      "--storage-url", "jdbc:mariadb://database:${CLP_DB_PORT:-3306}/\
+      "--storage-url", "jdbc:mariadb://database:${CLP_DB_CONNECT_PORT:-3306}/\
         ${SPIDER_DB_NAME:-spider-db}?\
         user=${SPIDER_DB_USER:-spider-user}\
         &password=${SPIDER_DB_PASS:?Please set a value.}",
@@ -446,14 +446,14 @@ services:
     stop_grace_period: "10s"
     environment:
       BROKER_URL: "amqp://${CLP_QUEUE_USER:-clp-user}:${CLP_QUEUE_PASS:?Please set a value.}\
-        @queue:${CLP_QUEUE_PORT:-5672}"
+        @queue:${CLP_QUEUE_CONNECT_PORT:-5672}"
       CLP_DB_PASS: "${CLP_DB_PASS:?Please set a value.}"
       CLP_DB_USER: "${CLP_DB_USER:-clp-user}"
       CLP_LOGGING_LEVEL: "${CLP_QUERY_SCHEDULER_LOGGING_LEVEL:-INFO}"
       CLP_LOGS_DIR: "/var/log/query_scheduler"
       PYTHONPATH: "/opt/clp/lib/python3/site-packages"
       RESULT_BACKEND: "redis://default:${CLP_REDIS_PASS:?Please set a value.}\
-        @redis:${CLP_REDIS_PORT:-6379}\
+        @redis:${CLP_REDIS_CONNECT_PORT:-6379}\
         /${CLP_REDIS_BACKEND_DB_QUERY:-0}"
     volumes:
       - *volume_clp_config_readonly
@@ -485,7 +485,7 @@ services:
     hostname: "query_worker"
     environment:
       BROKER_URL: "amqp://${CLP_QUEUE_USER:-clp-user}:${CLP_QUEUE_PASS:?Please set a value.}\
-        @queue:${CLP_QUEUE_PORT:-5672}"
+        @queue:${CLP_QUEUE_CONNECT_PORT:-5672}"
       CLP_CONFIG_PATH: "/etc/clp-config.yaml"
       CLP_HOME: "/opt/clp"
       CLP_LOGGING_LEVEL: "${CLP_QUERY_WORKER_LOGGING_LEVEL:-INFO}"
@@ -493,7 +493,7 @@ services:
       CLP_WORKER_LOG_PATH: "/var/log/query_worker/worker.log"
       PYTHONPATH: "/opt/clp/lib/python3/site-packages"
       RESULT_BACKEND: "redis://default:${CLP_REDIS_PASS:?Please set a value.}\
-        @redis:${CLP_REDIS_PORT:-6379}\
+        @redis:${CLP_REDIS_CONNECT_PORT:-6379}\
         /${CLP_REDIS_BACKEND_DB_QUERY:-0}"
     volumes:
       - *volume_clp_config_readonly


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

#1681 stopped emitting `CLP_DB_PORT`, `CLP_QUEUE_PORT`, `CLP_REDIS_PORT`, and
`CLP_RESULTS_CACHE_PORT` for bundled services, causing Docker Compose to fall back to
hardcoded defaults for the `published` port in each service's `ports` section. This makes
it impossible to customize the host-side published port for bundled third-party services
(e.g., to expose the database on port 13306 instead of 3306, or to avoid port conflicts
on the host). This is the port-side analogue of #2055 (which addressed the same
regression for `CLP_*_HOST` variables, fixed in #2056).

A naive fix of simply restoring `CLP_*_PORT` in the bundled branch would break
inter-container connection strings (`BROKER_URL`, `RESULT_BACKEND`, JDBC URLs,
`initialize-results-cache` URI) that reference the same variables: bundled containers
always listen on their default internal ports (3306, 5672, 6379, 27017) regardless of
the user-configured published port.


### `docker-compose-all.yaml`

- **Published ports** (`published:` fields): Unchanged -- still reference `CLP_*_PORT`.
- **Connection strings**: Changed from `CLP_*_PORT` to `CLP_*_CONNECT_PORT` in all
  `BROKER_URL`, `RESULT_BACKEND`, JDBC, and MongoDB URI entries (11 occurrences across
  spider-scheduler, compression-scheduler, compression-worker, spider-compression-worker,
  query-scheduler, query-worker, and results-cache-indices-creator).

This separation ensures:
- **Bundled**: `CLP_*_PORT` is set (custom published port), `CLP_*_CONNECT_PORT` is
  unset (defaults to standard container port in compose).
- **External**: `CLP_*_PORT` is unset (irrelevant, service disabled), `CLP_*_CONNECT_PORT`
  is set (external service port used in connection strings).


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Tested on the actual built package (`task package` to build, then `sbin/start-clp.sh`).

## Scenario 1: Bundled mode (default config)

All services bundled (default `clp-config.yaml`), no external services running.

**Task:** Verify that the default bundled deployment starts, all services become healthy,
and compression works.

**Command:**

```
$ cd build/clp-package
$ ./sbin/start-clp.sh
```

**Output:**

```
2026-03-04T17:49:15.888 INFO [controller] Setting up environment for bundling database...
2026-03-04T17:49:15.889 INFO [controller] Setting up environment for bundling queue...
2026-03-04T17:49:15.890 INFO [controller] Setting up environment for bundling redis...
2026-03-04T17:49:15.890 INFO [controller] Setting up environment for bundling results_cache...
2026-03-04T17:49:15.891 INFO [controller] Setting up environment for database...
2026-03-04T17:49:15.892 INFO [controller] Setting up environment for queue...
2026-03-04T17:49:15.892 INFO [controller] Setting up environment for redis...
2026-03-04T17:49:15.892 INFO [controller] spider_scheduler is not configured, skipping environment setup...
2026-03-04T17:49:15.892 INFO [controller] Setting up environment for results_cache...
2026-03-04T17:49:15.892 INFO [controller] Setting up environment for compression_scheduler...
2026-03-04T17:49:15.893 INFO [controller] Setting up environment for query_scheduler...
2026-03-04T17:49:15.893 INFO [controller] Setting up environment for compression_worker...
2026-03-04T17:49:15.893 INFO [controller] Setting up environment for query_worker...
2026-03-04T17:49:15.893 INFO [controller] Setting up environment for reducer...
2026-03-04T17:49:15.893 INFO [controller] Setting up environment for api_server...
2026-03-04T17:49:15.894 INFO [controller] log_ingestor is only applicable for S3 logs input type, skipping environment setup...
2026-03-04T17:49:15.894 INFO [controller] Setting up environment for webui...
2026-03-04T17:49:15.895 INFO [controller] The MCP Server is not configured, skipping mcp_server creation...
2026-03-04T17:49:15.895 INFO [controller] Setting up environment for garbage_collector...
2026-03-04T17:49:15.959 INFO [controller] Starting CLP using Docker Compose (full deployment)...
...
2026-03-04T17:49:29.034 INFO [controller] Started CLP.
```

**Verification -- `.env` now contains bundled host and port vars:**

```
CLP_DB_HOST=127.0.0.1
CLP_DB_PORT=3306
CLP_QUEUE_HOST=127.0.0.1
CLP_QUEUE_PORT=5672
CLP_REDIS_HOST=127.0.0.1
CLP_REDIS_PORT=6379
CLP_RESULTS_CACHE_HOST=127.0.0.1
CLP_RESULTS_CACHE_PORT=27017
```

**Explanation:** All containers started and became healthy. The `.env` now contains both
`CLP_*_HOST` and `CLP_*_PORT` entries for bundled services. Before this fix, `CLP_*_PORT`
was absent and Docker fell back to the hardcoded defaults in the compose file --
functionally the same in the default case, but now explicitly set so that users can
override them.

**Task:** Verify end-to-end data flow (compression) in bundled mode.

**Command:**

```
$ ./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql-simple.jsonl
```

**Output:**

```
2026-03-04T17:49:54.379 INFO [compress] Compression job 2 submitted.
2026-03-04T17:49:54.881 INFO [compress] Compressed 3.94KB into 1.57KB (2.50x). Speed: 9.08KB/s.
2026-03-04T17:49:55.382 INFO [compress] Compression finished.
2026-03-04T17:49:55.383 INFO [compress] Compressed 3.94KB into 1.57KB (2.50x). Speed: 6.75KB/s.
```

## Scenario 2: Bundled mode with custom ports

All services bundled, but with non-default published ports and `host: "0.0.0.0"`.

**Task:** Verify that custom ports are respected in the Docker port bindings while
inter-container connections still use default internal ports.

**Config (`etc/clp-config-custom-port.yaml`):**

```yaml
database:
  host: "0.0.0.0"
  port: 13306

queue:
  host: "0.0.0.0"
  port: 15672

redis:
  host: "0.0.0.0"
  port: 16379

results_cache:
  host: "0.0.0.0"
  port: 17017
```

**Command:**

```
$ ./sbin/start-clp.sh --config etc/clp-config-custom-port.yaml
```

**Output:**

```
2026-03-04T17:50:45.775 INFO [controller] Setting up environment for bundling database...
...
2026-03-04T17:50:59.698 INFO [controller] Started CLP.
```

**Verification -- `.env` contains custom port vars:**

```
CLP_DB_HOST=0.0.0.0
CLP_DB_PORT=13306
CLP_QUEUE_HOST=0.0.0.0
CLP_QUEUE_PORT=15672
CLP_REDIS_HOST=0.0.0.0
CLP_REDIS_PORT=16379
CLP_RESULTS_CACHE_HOST=0.0.0.0
CLP_RESULTS_CACHE_PORT=17017
```

**Verification -- Docker port bindings use custom ports:**

```
$ docker ps --format "table {{.Names}}\t{{.Ports}}" | grep -E "database|queue|redis|results"
clp-package-7782-redis-1              0.0.0.0:16379->6379/tcp
clp-package-7782-database-1           0.0.0.0:13306->3306/tcp
clp-package-7782-queue-1              ..., 0.0.0.0:15672->5672/tcp
clp-package-7782-results-cache-1      0.0.0.0:17017->27017/tcp
```

**Explanation:** All four bundled services now publish on the user-configured ports
(`13306`, `15672`, `16379`, `17017`) instead of the defaults. The `host_ip` is `0.0.0.0`
as configured. No `CLP_*_CONNECT_PORT` vars are set, so inter-container connection
strings (BROKER_URL, RESULT_BACKEND, JDBC, MongoDB URI) correctly fall back to the
default container-internal ports (3306, 5672, 6379, 27017).

**Task:** Verify end-to-end data flow (compression) with custom ports.

**Command:**

```
$ ./sbin/compress.sh --config etc/clp-config-custom-port.yaml \
    --timestamp-key timestamp ~/samples/postgresql-simple.jsonl
```

**Output:**

```
2026-03-04T17:55:45.252 INFO [compress] Compression job 1 submitted.
2026-03-04T17:55:45.755 INFO [compress] Compressed 3.94KB into 1.57KB (2.50x). Speed: 8.65KB/s.
2026-03-04T17:55:46.257 INFO [compress] Compression finished.
2026-03-04T17:55:46.257 INFO [compress] Compressed 3.94KB into 1.57KB (2.50x). Speed: 6.77KB/s.
```

## Scenario 3: All four services external (non-default ports)

All four services (`database`, `queue`, `redis`, `results_cache`) unbundled and running
externally on the Docker host with non-default ports.

**Task:** Start 4 external services, configure `bundled: []` with non-default ports, and
verify all CLP containers connect to the external services using `CLP_*_CONNECT_PORT`.

**Setup -- start four external services on the Docker host:**

```
$ docker run -d --name ext-mariadb \
    -p 13306:3306 \
    -e MYSQL_ROOT_PASSWORD=qCirQ7pszck \
    -e MYSQL_DATABASE=clp-db \
    -e MYSQL_USER=clp-user \
    -e MYSQL_PASSWORD=rCaJLsBsg2g \
    mariadb:10-jammy

$ docker run -d --name ext-rabbitmq \
    -p 15672:5672 \
    -e RABBITMQ_DEFAULT_USER=clp-user \
    -e RABBITMQ_DEFAULT_PASS=fg0oaBD6jTA \
    rabbitmq:3.9.8

$ docker run -d --name ext-redis \
    -p 16379:6379 \
    redis:7.2.4 \
    redis-server --requirepass 'Cz1tkSufuwgntT2BbNrqIg'

$ docker run -d --network=host --name ext-mongodb \
    mongo:7.0.1 \
    mongod --replSet rs0 --bind_ip_all --port 17017
```

(Credentials match `etc/credentials.yaml`. Images match those used by CLP.)

**Config (`etc/clp-config-ext-all.yaml`):**

```yaml
bundled: []

database:
  host: "localhost"
  port: 13306

queue:
  host: "localhost"
  port: 15672

redis:
  host: "localhost"
  port: 16379

results_cache:
  host: "192.168.3.89"
  port: 17017
```

**Command:**

```
$ ./sbin/start-clp.sh --config etc/clp-config-ext-all.yaml
```

**Output:**

```
2026-03-04T17:57:30.212 INFO [controller] database is not included in the 'bundled' configuration, skipping service bundling...
2026-03-04T17:57:30.213 INFO [controller] queue is not configured or part of the 'bundled' configuration, skipping service bundling...
2026-03-04T17:57:30.213 INFO [controller] redis is not configured or part of the 'bundled' configuration, skipping service bundling...
2026-03-04T17:57:30.213 INFO [controller] results_cache is not included in the 'bundled' configuration, skipping service bundling...
...
2026-03-04T17:57:36.661 INFO [controller] Started CLP.
```

**Verification -- `.env` external connection port entries:**

```
CLP_QUEUE_ENABLED=0
CLP_REDIS_ENABLED=0
CLP_RESULTS_CACHE_ENABLED=0
CLP_DB_CONNECT_PORT=13306
CLP_QUEUE_CONNECT_PORT=15672
CLP_REDIS_CONNECT_PORT=16379
CLP_RESULTS_CACHE_CONNECT_PORT=17017
```

No `CLP_*_PORT` or `CLP_*_HOST` entries (only relevant for bundled). No bundled
database/queue/redis/results-cache containers running.

**Verification -- container status (no bundled 3rd-party services):**

```
$ docker ps --filter "name=clp-package-3bef" --format "table {{.Names}}\t{{.Status}}"
clp-package-3bef-reducer-1                 Up 8 seconds
clp-package-3bef-compression-scheduler-1   Up 11 seconds
clp-package-3bef-api-server-1              Up 11 seconds (healthy)
clp-package-3bef-webui-1                   Up 11 seconds (healthy)
clp-package-3bef-garbage-collector-1       Up 11 seconds
clp-package-3bef-query-scheduler-1         Up 11 seconds (healthy)
clp-package-3bef-compression-worker-1      Up 13 seconds
clp-package-3bef-query-worker-1            Up 13 seconds
```

**Verification -- service logs (external connections on non-default ports):**

- `compression-worker` connected to external queue and redis on custom ports:
  ```
  .> transport:   amqp://clp-user:**@queue:15672//
  .> results:     redis://default:**@redis:16379/1
  ```

- `query-scheduler` connected to external database on custom port:
  ```
  2026-03-04 17:57:34,364 search-job-handler [INFO] Connected to archive database database:13306.
  2026-03-04 17:57:34,365 search-job-handler [INFO] query_scheduler started.
  ```

**Task:** Verify end-to-end data flow (compression) with all external services.

**Command:**

```
$ ./sbin/compress.sh --config etc/clp-config-ext-all.yaml \
    --timestamp-key timestamp ~/samples/postgresql-simple.jsonl
```

**Output:**

```
2026-03-04T17:58:06.018 INFO [compress] Compression job 1 submitted.
2026-03-04T17:58:06.520 INFO [compress] Compressed 3.94KB into 1.57KB (2.50x). Speed: 9.97KB/s.
2026-03-04T17:58:07.021 INFO [compress] Compression finished.
2026-03-04T17:58:07.022 INFO [compress] Compressed 3.94KB into 1.57KB (2.50x). Speed: 6.79KB/s.
```

**Explanation:** All CLP services connected to external services on non-default ports
using `CLP_*_CONNECT_PORT`. Compression job was submitted through external RabbitMQ
(port 15672), stored metadata in external MariaDB (port 13306), used external Redis
(port 16379) for task coordination, and the results-cache-indices-creator connected to
external MongoDB (port 17017). Full data pipeline works with all four services external
on non-default ports.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized connectivity environment variable naming conventions for database, queue, Redis, and cache services across deployment configurations to improve consistency.
  * Enhanced host and port binding in bundled service deployment scenarios for more reliable connectivity management.
  * Updated deployment configuration files to reference standardized variable naming throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->