### PR TITLE
fix(clp-s): Skip empty files during compression to avoid false errors (fixes #1993).

### DIFF
--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -3,11 +3,13 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <stack>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -647,6 +649,15 @@ void JsonParser::parse_line(
 bool JsonParser::ingest() {
     auto archive_creator_id = boost::uuids::to_string(m_generator());
     for (auto const& [path, file_name_in_metadata] : m_input_paths_and_canonical_filenames) {
+        if (InputSource::Filesystem == path.source) {
+            std::error_code ec{};
+            auto const file_size{std::filesystem::file_size(path.path, ec)};
+            if (std::errc{} == ec && 0 == file_size) {
+                SPDLOG_INFO("Skipping empty file: {}", path.path);
+                continue;
+            }
+        }
+
         auto reader{try_create_reader(path, m_network_auth)};
         if (nullptr == reader) {
             std::ignore = m_archive_writer->close();

--- a/components/core/src/clp_s/log_converter/log_converter.cpp
+++ b/components/core/src/clp_s/log_converter/log_converter.cpp
@@ -71,6 +71,15 @@ auto convert_files(CommandLineArguments const& command_line_arguments) -> bool {
     }
 
     for (auto const& path : command_line_arguments.get_input_paths()) {
+        if (clp_s::InputSource::Filesystem == path.source) {
+            std::error_code ec{};
+            auto const file_size{std::filesystem::file_size(path.path, ec)};
+            if (std::errc{} == ec && 0 == file_size) {
+                SPDLOG_INFO("Skipping empty file: {}", path.path);
+                continue;
+            }
+        }
+
         auto reader{clp_s::try_create_reader(path, command_line_arguments.get_network_auth())};
         if (nullptr == reader) {
             SPDLOG_ERROR("Failed to open input {} for reading.", path.path);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

When compressing a directory containing empty files (e.g., empty syslog rotation files), `clp-s`
fails with errors because `try_deduce_reader_type()` returns `FileType::Unknown` for empty files —
there are no bytes to inspect for type detection.

This PR adds an empty-file check in both clp-s compression code paths — the `log-converter`
(`--unstructured` mode in CLP-JSON `compress.sh`) and `JsonParser::ingest()` (structured JSON mode) — so that empty filesystem files are skipped with an informational log message instead of causing task failures.

This brings clp-s behaviour in line with CLP-TEXT (`clp` binary), which already handles empty files
gracefully by iterating over zero messages without error.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 1. Unstructured compression with `~/samples/hive-24hr` (clp-s, `--unstructured`)

**Task:** Verify that compressing `~/samples/hive-24hr` — which contains empty syslog rotation
files — with `--unstructured` no longer fails with "Received input that was not unstructured
logtext".

**Command:**
```bash
cd build/clp-package
./sbin/start-clp.sh

./sbin/compress.sh --unstructured ~/samples/hive-24hr
```

**Output:**
```
2026-03-04T15:54:45.531 INFO [compress] Compression job 1 submitted.
2026-03-04T15:54:52.045 INFO [compress] Compressed 483.00MB into 4.52MB (106.78x). Speed: 97.81MB/s.
2026-03-04T15:54:58.557 INFO [compress] Compressed 571.48MB into 6.80MB (84.00x). Speed: 49.91MB/s.
2026-03-04T15:55:15.585 INFO [compress] Compressed 893.13MB into 14.98MB (59.61x). Speed: 31.36MB/s.
2026-03-04T15:55:20.092 INFO [compress] Compressed 1.18GB into 22.69MB (53.44x). Speed: 36.75MB/s.
2026-03-04T15:55:22.096 INFO [compress] Compressed 1.50GB into 30.88MB (49.65x). Speed: 43.82MB/s.
2026-03-04T15:55:31.113 INFO [compress] Compressed 1.81GB into 38.79MB (47.82x). Speed: 42.15MB/s.
2026-03-04T15:55:32.115 INFO [compress] Compressed 2.13GB into 46.84MB (46.51x). Speed: 48.40MB/s.
2026-03-04T15:55:32.615 INFO [compress] Compression finished.
2026-03-04T15:55:32.616 INFO [compress] Compressed 2.44GB into 54.57MB (45.81x). Speed: 55.35MB/s.
```

**Explanation:** The compression job completes successfully with no task errors. Previously, the
empty syslog rotation files would cause task failures with "Received input that was not unstructured
logtext". Now they are skipped gracefully and all 2.44 GB of data compresses into 54.57 MB.

## 2. Structured JSON compression with empty files (clp-s)

**Task:** Verify that compressing a directory containing an empty file in structured JSON mode also
succeeds.

**Command:**
```bash
mkdir -p /tmp/test-empty-json2
echo '{"timestamp": "2024-01-01T00:00:00.000Z", "msg": "hello"}' > /tmp/test-empty-json2/data.jsonl
touch /tmp/test-empty-json2/empty.jsonl

./sbin/compress.sh --timestamp-key timestamp /tmp/test-empty-json2
```

**Output:**
```
2026-03-04T15:34:41.879 INFO [compress] Compression job 3 submitted.
2026-03-04T15:34:42.381 INFO [compress] Compressed 58.00B into 608.00B (0.10x). Speed: 119.77B/s.
2026-03-04T15:34:42.882 INFO [compress] Compression finished.
2026-03-04T15:34:42.882 INFO [compress] Compressed 58.00B into 608.00B (0.10x). Speed: 114.18B/s.
```

**Explanation:** The structured JSON compression also handles the empty file gracefully — no
"Could not deduce content type" error.

## 3. CLP-TEXT consistency check

**Task:** Verify that CLP-TEXT (`clp` binary) already handles empty files gracefully, confirming
this fix makes clp-s consistent.

**Command:**
```bash
# Switch to clp-text config
cp etc/clp-config.template.text.yaml etc/clp-config.yaml
./sbin/stop-clp.sh && ./sbin/start-clp.sh

./sbin/compress.sh /tmp/test-empty
```

**Output:**
```
2026-03-04T15:36:41.276 INFO [compress] Compression job 5 submitted.
2026-03-04T15:36:41.777 INFO [compress] Compressed 30.00B into 195.00B (0.15x). Speed: 69.14B/s.
2026-03-04T15:36:42.278 INFO [compress] Compression finished.
2026-03-04T15:36:42.279 INFO [compress] Compressed 30.00B into 195.00B (0.15x). Speed: 51.43B/s.
```

**Explanation:** CLP-TEXT successfully compresses the directory with the empty file — no errors. Both
engines now handle empty files gracefully.

## 4. Regression check: normal JSON compression

**Task:** Verify that normal JSON compression (without empty files) is not affected.

**Command:**
```bash
# Restore clp-s config
cp etc/clp-config.template.json.yaml etc/clp-config.yaml
./sbin/stop-clp.sh && ./sbin/start-clp.sh

./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl
```

**Output:**
```
2026-03-04T15:55:39.069 INFO [compress] Compression job 2 submitted.
2026-03-04T15:55:41.573 INFO [compress] Compression finished.
2026-03-04T15:55:41.573 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 182.53MB/s.
```

**Explanation:** Normal JSON compression continues to work correctly with no regressions.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of empty input files from filesystem sources. The system now detects and gracefully skips empty files during the ingestion and parsing workflows, preventing unnecessary processing attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->