### PR TITLE
fix(helm): Remove unused `directory` fields from `archive_output.storage` and `stream_output.storage` in `values.yaml` (fixes #2074).

### DIFF
--- a/docs/src/user-docs/guides-docker-compose-deployment.md
+++ b/docs/src/user-docs/guides-docker-compose-deployment.md
@@ -82,7 +82,7 @@ To configure CLP for multi-host deployment, you'll need to:
 
    * For each service, set the `host` and `port` fields to the actual hostname/IP and port where you
      plan to run the specific service.
-   * When using local filesystem storage (i.e., not S3), set `logs_input.storage.directory`,
+   * When using local filesystem storage (i.e., not S3), set `logs_input.directory`,
      `archive_output.storage.directory`, and `stream_output.storage.directory` to directories on the
      shared filesystem.
 

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.2.0-dev.1"
+version: "0.2.0-dev.2"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.9.1-dev"

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -186,9 +186,6 @@ clpConfig:
   archive_output:
     storage:
       type: "fs"
-      # NOTE: This directory must not overlap with any path used in CLP's execution container. An
-      # error will be raised if so.
-      directory: "/tmp/clp/var/data/archives"
 
     # Retention period for archives, in minutes. Set to null to disable automatic deletion.
     retention_period: null
@@ -214,9 +211,6 @@ clpConfig:
   stream_output:
     storage:
       type: "fs"
-      # NOTE: This directory must not overlap with any path used in CLP's execution container. An
-      # error will be raised if so.
-      directory: "/tmp/clp/var/data/streams"
 
     # How large each stream file should be before being split into a new stream file
     target_uncompressed_size: 134217728  # 128 MB


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

`archive_output.storage.directory` and `stream_output.storage.directory` in the Helm chart's
`values.yaml` are dangling references — they are defined but never consumed by any template. The
configmap template hardcodes the directories instead:

https://github.com/y-scope/clp/blob/dbc1799b187e034bec4578c058e9dfa1c87f05fb/tools/deployment/package-helm/templates/configmap.yaml#L25

https://github.com/y-scope/clp/blob/dbc1799b187e034bec4578c058e9dfa1c87f05fb/tools/deployment/package-helm/templates/configmap.yaml#L169

These hardcoded paths (`/var/data/archives` and `/var/data/streams`) match the PVC mount points, so
the `directory` fields in `values.yaml` have no effect. They appear to be leftovers from when the
clp-package used host-mounted directories (removed in #2023).

This PR removes the unused `directory` fields and their comments from both `archive_output.storage` and `stream_output.storage` in `values.yaml`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 1. Helm template renders identically

**Task:** Verify that removing the `directory` fields from `values.yaml` does not change the
rendered Kubernetes manifests.

**Command:**

```
$ cd tools/deployment/package-helm
$ helm template clp . | grep -B2 -A5 'archive_output:\|stream_output:'
```

**Output:**

```
        initial_backoff_ms: 100
        max_backoff_ms: 5000
    archive_output:
      compression_level: 3
      storage:
        directory: "/var/data/archives"
        type: "fs"
      retention_period: null
--
      retention_period: 60
      stream_collection_name: "stream-files"
    stream_output:
      storage:
        directory: "/var/data/streams"
        type: "fs"
      target_uncompressed_size: 134217728
    tmp_directory: "/var/tmp"
```

**Explanation:** The rendered configmap still contains the hardcoded `directory` values
(`/var/data/archives` and `/var/data/streams`) from the template — these come from
`configmap.yaml`, not `values.yaml`. The output is identical before and after this change.

## 2. No remaining references to removed fields in Helm chart

**Task:** Verify that no Helm template or helper references the removed `directory` fields.

**Command:**

```
$ grep -r 'archive_output.storage.directory\|stream_output.storage.directory' \
    tools/deployment/package-helm/
```

**Output:**

```
(no output)
```

**Explanation:** No templates or helpers reference the removed fields.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the multi-host deployment guide with corrected local filesystem storage configuration paths to ensure proper log directory setup.

* **Chores**
  * Bumped Helm Chart version to 0.2.0-dev.2.
  * Removed directory configuration entries for archive and stream output storage from deployment configuration values, streamlining the deployment setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->