### PR TITLE
docs(helm): Document that admin tools don't work with K8s `fs` storage deployments.

### DIFF
--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -429,9 +429,9 @@ How to compress and search unstructured text logs.
 
 :::{note}
 By default (`allowHostAccessForSbinScripts: true`), the database and results cache are exposed on
-NodePorts, allowing you to use `sbin/` scripts from the CLP package. Download a
-[release][clp-releases] matching the chart's `appVersion`, then update the following configurations
-in `etc/clp-config.yaml`:
+NodePorts, allowing you to use `sbin/compress.sh` and `sbin/search.sh` from the CLP package.
+Download a [release][clp-releases] matching the chart's `appVersion`, then update the following
+configurations in `etc/clp-config.yaml`:
 
 ```yaml
 database:
@@ -443,6 +443,12 @@ results_cache:
 Alternatively, use the Web UI ([clp-json][webui-clp-json] or [clp-text][webui-clp-text]) to compress
 logs and search interactively, or the [API server][api-server] to submit queries and view results
 programmatically.
+
+The [admin tools][admin-tools] (`sbin/admin-tools/archive-manager.sh` and
+`sbin/admin-tools/dataset-manager.sh`) are **not supported** in Kubernetes deployments with
+filesystem storage (`archive_output.storage.type: "fs"`). Those scripts require direct filesystem
+access to the archive directory via Docker bind mounts, which is not possible when archives are
+backed by PVCs inside the cluster.
 :::
 
 ---
@@ -537,6 +543,7 @@ To tear down a `kubeadm` cluster:
 * [Using object storage][s3-storage]: Configuring S3 storage
 * [Configuring retention periods][retention-guide]: Setting up data retention policies
 
+[admin-tools]: reference-sbin-scripts/admin-tools.md
 [aks]: https://azure.microsoft.com/en-us/products/kubernetes-service
 [api-server]: guides-using-the-api-server.md
 [Cilium]: https://cilium.io/

--- a/docs/src/user-docs/reference-sbin-scripts/admin-tools.md
+++ b/docs/src/user-docs/reference-sbin-scripts/admin-tools.md
@@ -87,6 +87,11 @@ named `default`.
 
 ### Limitations
 
+* `archive-manager.sh` is not supported for Kubernetes (Helm) deployments when using filesystem
+  storage (`archive_output.storage.type: "fs"`). See the [note above](#admin-tools) for details.
+
+* `archive-manager.sh` doesn't support managing archives stored on object storage.
+
 * `archive-manager.sh` assumes that archive timestamps and the timestamps specified by the user
   are in the **UTC** time zone. (This is because CLP currently doesn't support parsing time zone
   information from log events that have it.) Using the script on archives with non-UTC timestamps
@@ -98,9 +103,6 @@ named `default`.
   ```cpp
   adjusted_epoch_timestamp_millis = epoch_timestamp_millis - signed_utc_offset_millis
   ```
-
-* `archive-manager.sh` doesn't support managing archives stored on object storage. This limitation
-  will be addressed in a future release.
 
 ---
 
@@ -142,3 +144,8 @@ directory.
     ```
 
     * Replace `<dataset_0>`, `<dataset_1>`, etc. with the names of the datasets to delete.
+
+### Limitations
+
+* `dataset-manager.sh` is not supported for Kubernetes (Helm) deployments when using filesystem
+  storage (`archive_output.storage.type: "fs"`). See the [note above](#admin-tools) for details.

--- a/docs/src/user-docs/reference-sbin-scripts/admin-tools.md
+++ b/docs/src/user-docs/reference-sbin-scripts/admin-tools.md
@@ -88,7 +88,9 @@ named `default`.
 ### Limitations
 
 * `archive-manager.sh` is not supported for Kubernetes (Helm) deployments when using filesystem
-  storage (`archive_output.storage.type: "fs"`). See the [note above](#admin-tools) for details.
+  storage (`archive_output.storage.type: "fs"`). The script relies on bind-mounting the archive
+  directory into a Docker container, which is not possible when archives are backed by
+  PersistentVolumeClaims inside the cluster.
 
 * `archive-manager.sh` doesn't support managing archives stored on object storage.
 
@@ -148,4 +150,6 @@ directory.
 ### Limitations
 
 * `dataset-manager.sh` is not supported for Kubernetes (Helm) deployments when using filesystem
-  storage (`archive_output.storage.type: "fs"`). See the [note above](#admin-tools) for details.
+  storage (`archive_output.storage.type: "fs"`). The script relies on bind-mounting the archive
+  directory into a Docker container, which is not possible when archives are backed by
+  PersistentVolumeClaims inside the cluster.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says. See the docs contents for details.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

The docs built and rendered without artifacts.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified support status for admin tool scripts in Kubernetes deployments, noting they are unsupported when using filesystem-backed or object storage-backed archives.
  * Updated deployment guidance and script references for exposing services and configuring deployments.
  * Added a dedicated limitations section and linked admin-tools guidance in related references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->