### PR TITLE
fix(clp-package): Add dataset to metadata database after input paths are processed for compression jobs (fixes #2091).

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -295,6 +295,12 @@ def search_and_schedule_new_tasks(
     :param task_manager:
     :param db_context:
     """
+    existing_datasets: set[str] = set()
+    if StorageEngine.CLP_S == clp_config.package.storage_engine:
+        existing_datasets = fetch_existing_datasets(
+            db_context.cursor, clp_metadata_db_connection_config["table_prefix"]
+        )
+
     logger.debug("Search and schedule new tasks")
 
     # Poll for new compression jobs
@@ -392,9 +398,6 @@ def search_and_schedule_new_tasks(
         paths_to_compress_buffer.flush()
 
         if StorageEngine.CLP_S == clp_config.package.storage_engine:
-            existing_datasets: set[str] = fetch_existing_datasets(
-                db_context.cursor, clp_metadata_db_connection_config["table_prefix"]
-            )
             table_prefix = clp_metadata_db_connection_config["table_prefix"]
             dataset = clp_io_config.input.dataset
             _ensure_dataset_exists(

--- a/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/compression_scheduler.py
@@ -238,12 +238,6 @@ def search_and_schedule_new_tasks(
     :param task_manager:
     :param db_context:
     """
-    existing_datasets: set[str] = set()
-    if StorageEngine.CLP_S == clp_config.package.storage_engine:
-        existing_datasets = fetch_existing_datasets(
-            db_context.cursor, clp_metadata_db_connection_config["table_prefix"]
-        )
-
     logger.debug("Search and schedule new tasks")
 
     # Poll for new compression jobs
@@ -256,16 +250,6 @@ def search_and_schedule_new_tasks(
             msgpack.unpackb(brotli.decompress(job_row["clp_config"]))
         )
         input_config = clp_io_config.input
-        table_prefix = clp_metadata_db_connection_config["table_prefix"]
-        dataset = input_config.dataset
-
-        _ensure_dataset_exists(
-            clp_config,
-            db_context,
-            table_prefix,
-            dataset,
-            existing_datasets,
-        )
 
         # Prepare paths buffer
         paths_to_compress_buffer = PathsToCompressBuffer(
@@ -333,6 +317,20 @@ def search_and_schedule_new_tasks(
             )
             return
         paths_to_compress_buffer.flush()
+
+        if StorageEngine.CLP_S == clp_config.package.storage_engine:
+            existing_datasets: set[str] = fetch_existing_datasets(
+                db_context.cursor, clp_metadata_db_connection_config["table_prefix"]
+            )
+            table_prefix = clp_metadata_db_connection_config["table_prefix"]
+            dataset = clp_io_config.input.dataset
+            _ensure_dataset_exists(
+                clp_config,
+                db_context,
+                table_prefix,
+                dataset,
+                existing_datasets,
+            )
 
         _batch_and_submit_tasks(
             clp_config,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR addresses issue #2091 by calling `_ensure_dataset_exists()` after input paths are processed for a compression job, not before.

_**Note:** My only concern with this implementation is that this fix only protects against path-processing failures. Datasets will still be added to the metadata database if the compression job fails in the core. I tested the idea of calling `_ensure_dataset_exists()` from `_complete_compression_job()` instead, and while that did strictly fix the issue (in the sense that failed jobs were no longer adding their datasets to the metadata database), it also broke all compression, because compression jobs need the dataset to exist in the metadata database before the compression job starts._

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Ran the replication steps described in issue #2091; datasets are only added to the metadata database if the paths in the compression command are valid.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dataset validation in the compression scheduler now occurs per job after input paths are enumerated and buffered, and is performed only when the CLP_S storage engine is active, improving per-job validation timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->