### PR TITLE
fix(helm): Pre-create shared-data PVs in `set-up-multi-dedicated-test.sh` to avoid node-affinity conflict with `nodeSelector` (fixes #2099).

### DIFF
--- a/docs/src/dev-docs/design-deployment-orchestration.md
+++ b/docs/src/dev-docs/design-deployment-orchestration.md
@@ -244,8 +244,10 @@ Services require persistent storage for logs, data, archives, and streams.
 * **Docker Compose**: Uses bind mounts for host directories and named volumes for database data.
   Conditional mounts use variable interpolation to mount empty tmpfs when not needed.
 * **Kubernetes**: Uses dynamically provisioned PersistentVolumeClaims for persistent data (database,
-  results cache, archives, streams) and `emptyDir` volumes for ephemeral state (Redis, staging
-  directories). Service logs are emitted to pod stdout/stderr.
+  results cache) and `emptyDir` volumes for ephemeral state (Redis, staging directories). Service
+  logs are emitted to pod stdout/stderr. For shared-data volumes (archives, streams), single-node
+  deployments use dynamic provisioning while distributed `fs` deployments require pre-provisioned
+  PersistentVolumes backed by shared storage (e.g., NFS/CephFS).
 
 ### Deployment types
 

--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -132,8 +132,11 @@ this section for testing or development.
    require shared local storage between workers. If you use S3 storage, you can skip this section.
    :::
 
-   If storage type is set to `fs`, users must manually provision the persistent volumes and update
-   `accessModes` of PVCs.
+   If storage type is set to `fs`, the shared-data directories (`/var/data/archives`,
+   `/var/data/streams`) must be accessible from all worker nodes (e.g., via NFS/CephFS mounted at
+   the same path). Users must pre-create PersistentVolumes backed by this shared storage and use
+   `claimRef` to bind them to the chart's PVCs (`<release>-clp-shared-data-archives` and
+   `<release>-clp-shared-data-streams`).
 
 2. **External databases** (recommended for production):
    * See the [external database setup guide][external-db-guide] for using external

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.2.1-dev.1"
+version: "0.2.1-dev.2"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.10.1-dev"

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -54,11 +54,10 @@ done
 # dynamically provisioned node-local volumes. Without this, the local-path-provisioner pins PVs to
 # whichever node claims them first, which conflicts with nodeSelector when workers are on dedicated
 # node pools.
-echo "Creating shared-data directories on all nodes..."
-for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
-    docker exec "${node}" mkdir -p /var/data/archives /var/data/streams
-    docker exec "${node}" chmod 777 /var/data/archives /var/data/streams
-done
+# Pre-create shared-data directories under CLP_HOME, which kind's extraMounts expose on every node.
+# Without a shared path, hostPath PVs would only contain data on the node that wrote it.
+shared_data_dir="${CLP_HOME}/data"
+mkdir -p "${shared_data_dir}/archives" "${shared_data_dir}/streams"
 
 echo "Creating shared-data PersistentVolumes..."
 kubectl apply -f - <<EOF
@@ -75,8 +74,7 @@ spec:
     namespace: default
     name: test-clp-shared-data-archives
   hostPath:
-    path: /var/data/archives
-
+    path: ${shared_data_dir}/archives
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -91,8 +89,7 @@ spec:
     namespace: default
     name: test-clp-shared-data-streams
   hostPath:
-    path: /var/data/streams
-
+    path: ${shared_data_dir}/streams
 EOF
 
 echo "Installing Helm chart..."

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -54,6 +54,12 @@ done
 # dynamically provisioned node-local volumes. Without this, the local-path-provisioner pins PVs to
 # whichever node claims them first, which conflicts with nodeSelector when workers are on dedicated
 # node pools.
+echo "Creating shared-data directories on all nodes..."
+for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+    docker exec "${node}" mkdir -p /var/data/archives /var/data/streams
+    docker exec "${node}" chmod 777 /var/data/archives /var/data/streams
+done
+
 echo "Creating shared-data PersistentVolumes..."
 kubectl apply -f - <<EOF
 apiVersion: v1
@@ -70,7 +76,7 @@ spec:
     name: test-clp-shared-data-archives
   hostPath:
     path: /var/data/archives
-    type: DirectoryOrCreate
+
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -86,7 +92,7 @@ spec:
     name: test-clp-shared-data-streams
   hostPath:
     path: /var/data/streams
-    type: DirectoryOrCreate
+
 EOF
 
 echo "Installing Helm chart..."

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -55,7 +55,7 @@ done
 # whichever node claims them first, which conflicts with nodeSelector when workers are on dedicated
 # node pools.
 echo "Creating shared-data PersistentVolumes..."
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -64,8 +64,7 @@ spec:
   capacity:
     storage: 50Gi
   accessModes: [ReadWriteOnce]
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: standard
+  storageClassName: ""
   claimRef:
     namespace: default
     name: test-clp-shared-data-archives
@@ -81,8 +80,7 @@ spec:
   capacity:
     storage: 20Gi
   accessModes: [ReadWriteOnce]
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: standard
+  storageClassName: ""
   claimRef:
     namespace: default
     name: test-clp-shared-data-streams

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -55,7 +55,7 @@ done
 # whichever node claims them first, which conflicts with nodeSelector when workers are on dedicated
 # node pools.
 echo "Creating shared-data PersistentVolumes..."
-kubectl apply -f - <<'PVEOF'
+kubectl apply -f - <<'EOF'
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -89,7 +89,7 @@ spec:
   hostPath:
     path: /var/data/streams
     type: DirectoryOrCreate
-PVEOF
+EOF
 
 echo "Installing Helm chart..."
 helm uninstall test --ignore-not-found

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -58,6 +58,7 @@ done
 # Without a shared path, hostPath PVs would only contain data on the node that wrote it.
 shared_data_dir="${CLP_HOME}/data"
 mkdir -p "${shared_data_dir}/archives" "${shared_data_dir}/streams"
+chmod 777 "${shared_data_dir}/archives" "${shared_data_dir}/streams"
 
 echo "Creating shared-data PersistentVolumes..."
 kubectl apply -f - <<EOF

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -50,6 +50,47 @@ for ((i = NUM_COMPRESSION_NODES; i < total_workers; i++)); do
     kubectl label node "${worker_nodes[$i]}" yscope.io/nodeType=query --overwrite
 done
 
+# Pre-create shared-data PVs with hostPath (no node affinity) so PVCs bind to them instead of
+# dynamically provisioned node-local volumes. Without this, the local-path-provisioner pins PVs to
+# whichever node claims them first, which conflicts with nodeSelector when workers are on dedicated
+# node pools.
+echo "Creating shared-data PersistentVolumes..."
+kubectl apply -f - <<'PVEOF'
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-clp-shared-data-archives
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes: [ReadWriteOnce]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard
+  claimRef:
+    namespace: default
+    name: test-clp-shared-data-archives
+  hostPath:
+    path: /var/data/archives
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-clp-shared-data-streams
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes: [ReadWriteOnce]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard
+  claimRef:
+    namespace: default
+    name: test-clp-shared-data-streams
+  hostPath:
+    path: /var/data/streams
+    type: DirectoryOrCreate
+PVEOF
+
 echo "Installing Helm chart..."
 helm uninstall test --ignore-not-found
 sleep 2


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Running `set-up-multi-dedicated-test.sh` leaves the query-worker pods permanently `Pending`.

#2023 correctly switched the Helm chart from static host-path PVs to dynamic provisioning. In production, distributed `fs` deployments use a shared-filesystem StorageClass (e.g., NFS/CephFS) that provisions volumes accessible from all nodes. However, `set-up-multi-dedicated-test.sh` was not updated to reflect this expected usage — it relies on kind's default `local-path-provisioner`, which creates node-local PVs with node affinity to the first consumer's node. In the dedicated-node test, the shared-data PVs bind to a compression node (where the first non-`nodeSelector` pods land), but the query workers are constrained to query nodes via `nodeSelector`. The Kubernetes scheduler cannot satisfy both the PV's node affinity and the pod's `nodeSelector`, so the query-worker pods stay `Pending`.

Before #2023, this was not an issue because the chart itself created static `hostPath` PVs with no node affinity. Kind's `extraMounts` expose the same host directories on every node, so any pod could mount them regardless of which node it landed on. When #2023 removed those static PVs, the test script needed to take over that responsibility — but this step was missed.

This PR fixes the test script by pre-creating static `hostPath` PVs with `claimRef` before `helm install`. The `claimRef` pre-binds each PV to its corresponding PVC, preventing `local-path-provisioner` from dynamically provisioning node-local volumes. Since `hostPath` PVs carry no node affinity and kind's `extraMounts` make the same host directories available on all nodes, pods on any node can mount the volumes. This mirrors what a production deployment would do — the cluster admin provisions shared PVs outside of Helm.

This PR also updates the K8s deployment guide and the deployment orchestration design doc to clarify that distributed `fs` deployments require pre-provisioned PersistentVolumes backed by shared storage.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## All three `set-up-*-test.sh` scripts — all pods reach Running state

### `set-up-test.sh` (single-node)

```
$ ./set-up-test.sh
...
All jobs completed and services are ready.
```

All 13 pods reached `Running`/`Completed` on the single control-plane node.

### `set-up-multi-shared-test.sh` (multi-node, shared workers)

```
$ ./set-up-multi-shared-test.sh
...
All jobs completed and services are ready.
```

All 17 pods reached `Running`/`Completed` across 2 worker nodes.

### `set-up-multi-dedicated-test.sh` (multi-node, dedicated workers)

```
$ ./set-up-multi-dedicated-test.sh
...
All jobs completed and services are ready.
```

All 17 pods reached `Running`/`Completed` across 4 worker nodes. Query workers landed on
query-labeled nodes, compression workers on compression-labeled nodes — previously the query workers
were stuck `Pending` indefinitely.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Kubernetes storage behaviour for single-node vs distributed filesystem deployments and confirmed service logs continue to be emitted to pod stdout/stderr.
  * Expanded multi-node guidance to require a shared filesystem for archives/streams and to pre-provision PersistentVolumes bound to the chart’s PVCs.

* **Chores**
  * Tooling updated to pre-create shared persistent volumes for archives/streams prior to install flows.
  * Bumped Helm chart version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->