### PR TITLE
fix(localstack): Lock `localstack` docker image version to 4.14 as a workaround for #2118.

### DIFF
--- a/tools/scripts/localstack/start.py
+++ b/tools/scripts/localstack/start.py
@@ -9,6 +9,7 @@ import logging
 import subprocess
 import sys
 
+# Lock `localstack` image version to 4.14 as a workaround for #2118.
 _LOCALSTACK_IMAGE: str = "localstack/localstack:4.14"
 
 logging.basicConfig(
@@ -51,7 +52,7 @@ def main() -> int:
         return 1
 
     logger.info("Starting LocalStack container '%s' on port %d", args.name, args.port)
-    logger.info("Pulling LocalStack image version 4.14.")
+    logger.info("Pulling LocalStack image .")
     result = subprocess.run(
         [docker_executable, "pull", _LOCALSTACK_IMAGE], capture_output=True, text=True, check=False
     )

--- a/tools/scripts/localstack/start.py
+++ b/tools/scripts/localstack/start.py
@@ -51,14 +51,14 @@ def main() -> int:
         return 1
 
     logger.info("Starting LocalStack container '%s' on port %d", args.name, args.port)
-    logger.info("Pulling latest LocalStack image.")
+    logger.info("Pulling LocalStack image version 4.14.")
     result = subprocess.run(
         [docker_executable, "pull", _LOCALSTACK_IMAGE], capture_output=True, text=True, check=False
     )
     if result.returncode != 0:
-        logger.error("Failed to pull the latest LocalStack image:\n%s", result.stderr)
+        logger.error("Failed to pull LocalStack image:\n%s", result.stderr)
         return result.returncode
-    logger.info("Successfully pulled latest LocalStack image.")
+    logger.info("Successfully pulled LocalStack image.")
 
     localstack_start_cmd = [
         "docker",

--- a/tools/scripts/localstack/start.py
+++ b/tools/scripts/localstack/start.py
@@ -9,7 +9,7 @@ import logging
 import subprocess
 import sys
 
-_LOCALSTACK_IMAGE: str = "localstack/localstack:latest"
+_LOCALSTACK_IMAGE: str = "localstack/localstack:4.14"
 
 logging.basicConfig(
     level=logging.INFO,

--- a/tools/scripts/localstack/start.py
+++ b/tools/scripts/localstack/start.py
@@ -52,7 +52,7 @@ def main() -> int:
         return 1
 
     logger.info("Starting LocalStack container '%s' on port %d", args.name, args.port)
-    logger.info("Pulling LocalStack image .")
+    logger.info("Pulling LocalStack image.")
     result = subprocess.run(
         [docker_executable, "pull", _LOCALSTACK_IMAGE], capture_output=True, text=True, check=False
     )


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

We pin the latest community version of localstack (4.14) available on [Github Releases](https://github.com/localstack/localstack/releases).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- `task tests:rust-all`
- Pipeline now passes

Latest Tag - fails after asking for auth token or snooze ack.

```bash
name="localstack"
docker run --detach --name "$name" --publish 4566:4566 localstack/localstack:latest
sleep 25
docker ps -a --filter "name=^/${name}$" --format '{{.Names}} {{.Status}}'
docker logs "$name"
docker rm -f "$name"
```

Using 4.14:

```bash
name="localstack"
docker run --detach --name "$name" --publish 4566:4566 localstack/localstack:4.14
sleep 25
docker ps -a --filter "name=^/${name}$" --format '{{.Names}} {{.Status}}'
docker logs "$name"
docker rm -f "$name"
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the LocalStack Docker image to version 4.14 to ensure consistent local environment behaviour.
  * Updated related log messages to reference the LocalStack image and to reflect successful or failed pull outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->