### PR TITLE
feat(log-ingestor)!: Switch buffer submission from soft timeout to hard timeout; Move buffer config from package config to job config (resolves #2136).

### DIFF
--- a/components/clp-py-utils/clp_py_utils/clp_config.py
+++ b/components/clp-py-utils/clp_py_utils/clp_config.py
@@ -778,9 +778,6 @@ class ApiServer(BaseModel):
 class LogIngestor(BaseModel):
     host: DomainStr = "localhost"
     port: Port = 3002
-    buffer_flush_timeout: PositiveInt = 300  # seconds
-    buffer_flush_threshold: PositiveInt = 4096 * 1024 * 1024  # 4 GiB
-    channel_capacity: PositiveInt = 10
     logging_level: LoggingLevelRust = "INFO"
 
 

--- a/components/clp-rust-utils/src/clp_config/package/config.rs
+++ b/components/clp-rust-utils/src/clp_config/package/config.rs
@@ -226,10 +226,6 @@ impl Default for StreamOutputStorage {
 pub struct LogIngestor {
     pub host: String,
     pub port: u16,
-    #[serde(rename = "buffer_flush_timeout")]
-    pub buffer_flush_timeout_sec: u64,
-    pub buffer_flush_threshold: u64,
-    pub channel_capacity: usize,
     pub logging_level: String,
 }
 
@@ -238,9 +234,6 @@ impl Default for LogIngestor {
         Self {
             host: "localhost".to_owned(),
             port: 3002,
-            buffer_flush_timeout_sec: 300,
-            buffer_flush_threshold: 4096 * 1024 * 1024, // 4 GiB
-            channel_capacity: 10,
             logging_level: "INFO".to_owned(),
         }
     }

--- a/components/clp-rust-utils/src/job_config/ingestion.rs
+++ b/components/clp-rust-utils/src/job_config/ingestion.rs
@@ -166,6 +166,7 @@ pub mod s3 {
 
     /// Configuration for buffer behavior.
     #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+    #[serde(default)]
     pub struct BufferConfig {
         /// Size-based flush threshold in bytes.
         ///
@@ -224,3 +225,34 @@ pub mod s3 {
 
 /// Represents the unique identifier for an ingestion job in CLP DB.
 pub type JobId = u64;
+
+#[cfg(test)]
+mod tests {
+    use super::s3::BufferConfig;
+
+    #[test]
+    fn test_buffer_config_partial_override() -> Result<(), serde_json::Error> {
+        let config: BufferConfig = serde_json::from_str(r#"{"timeout_sec": 60}"#)?;
+        let default_config = BufferConfig::default();
+        assert_eq!(config.timeout_sec, 60);
+        assert_eq!(
+            config.flush_threshold_bytes,
+            default_config.flush_threshold_bytes
+        );
+        assert_eq!(config.channel_capacity, default_config.channel_capacity);
+        Ok(())
+    }
+
+    #[test]
+    fn test_buffer_config_empty_object_uses_defaults() -> Result<(), serde_json::Error> {
+        let config: BufferConfig = serde_json::from_str("{}")?;
+        let default_config = BufferConfig::default();
+        assert_eq!(
+            config.flush_threshold_bytes,
+            default_config.flush_threshold_bytes
+        );
+        assert_eq!(config.timeout_sec, default_config.timeout_sec);
+        assert_eq!(config.channel_capacity, default_config.channel_capacity);
+        Ok(())
+    }
+}

--- a/components/clp-rust-utils/src/job_config/ingestion.rs
+++ b/components/clp-rust-utils/src/job_config/ingestion.rs
@@ -65,6 +65,10 @@ pub mod s3 {
         /// Whether to treat the ingested objects as unstructured logs. Defaults to `false`.
         #[serde(default = "default_unstructured")]
         pub unstructured: bool,
+
+        /// Per-job ingestion buffer config.
+        #[serde(default)]
+        pub buffer_config: BufferConfig,
     }
 
     /// Configuration for a SQS listener job.
@@ -158,6 +162,47 @@ pub mod s3 {
         #[serde(default)]
         #[schema(value_type = String, min_length = 1)]
         pub start_after: Option<NonEmptyString>,
+    }
+
+    /// Configuration for buffer behavior.
+    #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+    pub struct BufferConfig {
+        /// Size-based flush threshold in bytes.
+        ///
+        /// The buffer is flushed to create a compression job once the total size of buffered
+        /// objects exceeds this threshold.
+        ///
+        /// Defaults to 4 GiB.
+        pub flush_threshold_bytes: u64,
+
+        /// Time-based flush threshold in seconds.
+        ///
+        /// This is a hard timeout. The buffer is flushed to create a compression job when the
+        /// oldest buffered object has remained in the buffer for at least this duration,
+        /// regardless of the total buffered size. The timer is not reset by newly ingested
+        /// objects.
+        ///
+        /// Defaults to 300 seconds (5 minutes).
+        pub timeout_sec: u64,
+
+        /// Capacity of the internal buffer channel.
+        ///
+        /// Defines the maximum number of objects that can be queued before being processed by the
+        /// buffer. Increasing this value may improve throughput at the cost of higher memory
+        /// usage.
+        ///
+        /// Defaults to 16.
+        pub channel_capacity: usize,
+    }
+
+    impl Default for BufferConfig {
+        fn default() -> Self {
+            Self {
+                flush_threshold_bytes: 4 * 1024 * 1024 * 1024,
+                timeout_sec: 300,
+                channel_capacity: 16,
+            }
+        }
     }
 
     const fn default_unstructured() -> bool {

--- a/components/clp-rust-utils/src/job_config/ingestion.rs
+++ b/components/clp-rust-utils/src/job_config/ingestion.rs
@@ -192,7 +192,9 @@ pub mod s3 {
         /// buffer. Increasing this value may improve throughput at the cost of higher memory
         /// usage.
         ///
-        /// Defaults to 16.
+        /// Defaults to 16. Must be a positive integer. The behavior for values less than 1 is
+        /// undefined.
+        #[schema(minimum = 1)]
         pub channel_capacity: usize,
     }
 

--- a/components/log-ingestor/src/compression/buffer.rs
+++ b/components/log-ingestor/src/compression/buffer.rs
@@ -58,7 +58,7 @@ impl<Submitter: BufferSubmitter> Buffer<Submitter> {
     ///
     /// # Returns
     ///
-    /// `Ok(())` on success.
+    /// Whether a submission was triggered by reaching the size threshold.
     ///
     /// # Errors
     ///
@@ -68,17 +68,19 @@ impl<Submitter: BufferSubmitter> Buffer<Submitter> {
     pub async fn add(
         &mut self,
         object_metadata_to_ingest: Vec<CompressionBufferEntry>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
+        let mut submission_triggered = false;
         for entry in object_metadata_to_ingest {
             self.total_size += entry.size;
             self.buf.push(entry.id);
 
             if self.total_size >= self.size_threshold {
                 self.submit().await?;
+                submission_triggered = true;
             }
         }
 
-        Ok(())
+        Ok(submission_triggered)
     }
 
     /// Submits the buffered object metadata for processing.
@@ -99,6 +101,13 @@ impl<Submitter: BufferSubmitter> Buffer<Submitter> {
         self.submitter.submit(&self.buf).await?;
         self.clear();
         Ok(())
+    }
+
+    /// # Returns
+    ///
+    /// Whether the buffer is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.buf.is_empty()
     }
 
     fn clear(&mut self) {

--- a/components/log-ingestor/src/compression/listener.rs
+++ b/components/log-ingestor/src/compression/listener.rs
@@ -121,11 +121,21 @@ impl Listener {
     /// # Returns
     ///
     /// A newly created instance of [`Listener`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`anyhow::Error`] if `channel_capacity` is 0, since [`mpsc::channel`] requires a positive
+    ///   capacity.
     pub fn spawn<Submitter: BufferSubmitter + Send + 'static>(
         buffer: Buffer<Submitter>,
         timeout: Duration,
         channel_capacity: usize,
-    ) -> Self {
+    ) -> Result<Self> {
+        if channel_capacity == 0 {
+            anyhow::bail!("channel capacity must be greater than 0");
+        }
         let (sender, receiver) = mpsc::channel(channel_capacity);
         let task = ListenerTask {
             buffer,
@@ -140,11 +150,11 @@ impl Listener {
             })
         });
 
-        Self {
+        Ok(Self {
             sender,
             cancel_token,
             handle,
-        }
+        })
     }
 
     /// Shuts down the listener and waits for the underlying task to complete.

--- a/components/log-ingestor/src/compression/listener.rs
+++ b/components/log-ingestor/src/compression/listener.rs
@@ -1,10 +1,10 @@
-use std::{pin::Pin, time::Duration};
+use std::time::Duration;
 
 use anyhow::Result;
 use tokio::{
     select,
     sync::mpsc,
-    time::{Instant, Sleep, sleep_until},
+    time::{Instant, sleep_until},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -28,7 +28,9 @@ impl<Submitter: BufferSubmitter + Send + 'static> ListenerTask<Submitter> {
     /// * Receiving a cancellation signal via the provided [`cancel_token`].
     /// * All senders are closed.
     /// * The buffer's size threshold is reached after receiving new entries.
-    /// * A timeout occurs without receiving new entries.
+    /// * The oldest buffered entry has remained in the buffer for at least the configured timeout
+    ///   duration. The timer starts when entries are first added to an empty buffer and is not
+    ///   reset by subsequent entries.
     ///
     /// # Returns
     ///
@@ -41,13 +43,18 @@ impl<Submitter: BufferSubmitter + Send + 'static> ListenerTask<Submitter> {
     /// * Forwards [`Buffer::add`]'s return values on failure.
     /// * Forwards [`Buffer::submit`]'s return values on failure.
     pub async fn run(mut self, cancel_token: CancellationToken) -> Result<()> {
-        let mut timer: Pin<Box<Sleep>> = Box::pin(sleep_until(Instant::now() + self.timeout));
+        // To avoid reallocating the timer on every reset, we preallocate and pin it. A boolean flag
+        // is used to track whether the timer is active, which defaults to false since the buffer is
+        // initially empty.
+        let timer = sleep_until(Instant::now() + self.timeout);
+        tokio::pin!(timer);
+        let mut timer_active = false;
 
         loop {
             select! {
                 // Cancellation requested.
                 () = cancel_token.cancelled() => {
-                    // TODO: Log the cancellation event when the logger has been integrated.
+                    tracing::info!("Listener task cancelled.");
                     self.buffer.submit().await?;
                     return Ok(());
                 }
@@ -63,18 +70,30 @@ impl<Submitter: BufferSubmitter + Send + 'static> ListenerTask<Submitter> {
                             return Ok(());
                         }
                         Some(entries) => {
-                            self.buffer.add(entries).await?;
+                            let was_empty = self.buffer.is_empty();
+                            let flushed = self.buffer.add(entries).await?;
+                            let is_empty = self.buffer.is_empty();
+
+                            if is_empty {
+                                timer_active = false;
+                            } else if was_empty || flushed {
+                                // Enable the timer if new objects are added to an empty buffer, or
+                                // a flush is triggered but the buffer is not empty after flushing.
+                                // In both cases, the timer should be reset.
+                                timer.as_mut().reset(Instant::now() + self.timeout);
+                                timer_active = true;
+                            }
                         }
                     }
                 }
 
                 // Timer fired.
-                () = &mut timer => {
+                () = &mut timer, if timer_active => {
                     self.buffer.submit().await?;
+                    // The timer will be re-enabled when new entries are received.
+                    timer_active = false;
                 }
             }
-
-            timer.as_mut().reset(Instant::now() + self.timeout);
         }
     }
 }

--- a/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
+++ b/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
@@ -240,6 +240,7 @@ impl ClpDbIngestionConnector {
     /// * Forwards [`sqlx::query::Query::execute`]'s return values on failure.
     /// * Forwards [`sqlx::Transaction::commit`]'s return values on failure.
     /// * Forwards [`serde_json::to_string`]'s return values on failure.
+    /// * Forwards [`Self::create_clp_ingestion_context`]'s return values on failure.
     pub async fn create_ingestion_job(
         &self,
         config: S3IngestionJobConfig,
@@ -269,7 +270,7 @@ impl ClpDbIngestionConnector {
 
         tx.commit().await?;
 
-        Ok(self.create_clp_ingestion_context(job_id, config))
+        self.create_clp_ingestion_context(job_id, config)
     }
 
     /// Gets the status of an ingestion job with the given ID from CLP DB.
@@ -405,11 +406,17 @@ impl ClpDbIngestionConnector {
     ///
     /// A [`ClpIngestionJobContext`] instance, with a newly created listener for receiving ingested
     /// object metadata for compression job submission.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`Listener::spawn`]'s return values on failure.
     fn create_clp_ingestion_context(
         &self,
         job_id: IngestionJobId,
         config: S3IngestionJobConfig,
-    ) -> ClpIngestionJobContext {
+    ) -> anyhow::Result<ClpIngestionJobContext> {
         let compression_state = ClpCompressionState {
             ingestion_job_id: job_id,
             db_pool: self.db_pool.clone(),
@@ -427,19 +434,19 @@ impl ClpDbIngestionConnector {
             Buffer::new(submitter, base_config.buffer_config.flush_threshold_bytes),
             Duration::from_secs(base_config.buffer_config.timeout_sec),
             base_config.buffer_config.channel_capacity,
-        );
+        )?;
         let ingestion_state = ClpIngestionState {
             job_id,
             db_pool: self.db_pool.clone(),
             sender: listener.get_new_sender(),
         };
 
-        ClpIngestionJobContext {
+        Ok(ClpIngestionJobContext {
             config,
             ingestion_state,
             compression_state,
             listener,
-        }
+        })
     }
 
     /// Loads ingestion contexts for all ingestion jobs from CLP DB.
@@ -490,7 +497,7 @@ impl ClpDbIngestionConnector {
                 );
                 continue;
             };
-            recoverable_ingestion_jobs.push(self.create_clp_ingestion_context(job_id, config));
+            self.try_add_ingestion_job_context(job_id, config, &mut recoverable_ingestion_jobs);
         }
 
         let running_jod_id_and_config: Vec<(IngestionJobId, String)> = sqlx::query_as(formatcp!(
@@ -532,7 +539,7 @@ impl ClpDbIngestionConnector {
                 }
                 other @ S3IngestionJobConfig::SqsListener(_) => other,
             };
-            recoverable_ingestion_jobs.push(self.create_clp_ingestion_context(job_id, config));
+            self.try_add_ingestion_job_context(job_id, config, &mut recoverable_ingestion_jobs);
         }
 
         // Load inactive ingestion jobs.
@@ -561,7 +568,7 @@ impl ClpDbIngestionConnector {
                 );
                 continue;
             };
-            inactive_ingestion_jobs.push(self.create_clp_ingestion_context(job_id, config));
+            self.try_add_ingestion_job_context(job_id, config, &mut inactive_ingestion_jobs);
         }
 
         Ok((recoverable_ingestion_jobs, inactive_ingestion_jobs))
@@ -647,6 +654,30 @@ impl ClpDbIngestionConnector {
             })?);
         }
         Ok(config)
+    }
+
+    /// Attempts to create a CLP ingestion context for an ingestion job with the given ID and
+    /// config, and adds the context to the provided buffer.
+    ///
+    /// # NOTE
+    ///
+    /// This method logs errors instead of returning them to the caller to allow best-effort loading
+    /// of ingestion jobs during service start.
+    fn try_add_ingestion_job_context(
+        &self,
+        job_id: IngestionJobId,
+        config: S3IngestionJobConfig,
+        ingestion_job_buffer: &mut Vec<ClpIngestionJobContext>,
+    ) {
+        match self.create_clp_ingestion_context(job_id, config) {
+            Ok(context) => ingestion_job_buffer.push(context),
+            Err(e) => tracing::error!(
+                job_id = ? job_id,
+                error = ? e,
+                "Failed to create CLP ingestion context for an ingestion job during service start. \
+                    The job will be skipped."
+            ),
+        }
     }
 }
 

--- a/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
+++ b/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
@@ -156,11 +156,8 @@ impl ClpIngestionJobContext {
 /// Connector for managing ingestion jobs in CLP DB.
 pub struct ClpDbIngestionConnector {
     db_pool: MySqlPool,
-    channel_capacity: usize,
     aws_authentication: AwsAuthentication,
     archive_output_config: ArchiveOutput,
-    buffer_flush_timeout: Duration,
-    buffer_flush_threshold: u64,
 }
 
 impl ClpDbIngestionConnector {
@@ -192,11 +189,6 @@ impl ClpDbIngestionConnector {
         clp_config: ClpConfig,
         clp_credentials: ClpCredentials,
     ) -> anyhow::Result<(Self, LogIngestorRecoveryContext)> {
-        let log_ingestor_config = clp_config
-            .log_ingestor
-            .as_ref()
-            .expect("log_ingestor configuration is missing");
-
         let aws_authentication = match clp_config.logs_input {
             LogsInput::S3 { config } => config.aws_authentication,
             LogsInput::Fs { .. } => {
@@ -218,11 +210,8 @@ impl ClpDbIngestionConnector {
 
         let connector = Self {
             db_pool: mysql_pool,
-            channel_capacity: log_ingestor_config.channel_capacity,
             aws_authentication,
             archive_output_config: clp_config.archive_output.clone(),
-            buffer_flush_timeout: Duration::from_secs(log_ingestor_config.buffer_flush_timeout_sec),
-            buffer_flush_threshold: log_ingestor_config.buffer_flush_threshold,
         };
 
         let unfinished_compression_jobs = connector.get_unfinished_compression_jobs().await?;
@@ -425,18 +414,19 @@ impl ClpDbIngestionConnector {
             ingestion_job_id: job_id,
             db_pool: self.db_pool.clone(),
         };
+        let base_config = config.as_base_config();
 
         let submitter = CompressionJobSubmitter::new(
             compression_state.clone(),
             self.aws_authentication.clone(),
             &self.archive_output_config,
-            config.as_base_config(),
+            base_config,
         );
 
         let listener = Listener::spawn(
-            Buffer::new(submitter, self.buffer_flush_threshold),
-            self.buffer_flush_timeout,
-            self.channel_capacity,
+            Buffer::new(submitter, base_config.buffer_config.flush_threshold_bytes),
+            Duration::from_secs(base_config.buffer_config.timeout_sec),
+            base_config.buffer_config.channel_capacity,
         );
         let ingestion_state = ClpIngestionState {
             job_id,

--- a/components/log-ingestor/tests/test_compression_listener.rs
+++ b/components/log-ingestor/tests/test_compression_listener.rs
@@ -90,17 +90,14 @@ async fn assert_submission_count_at(
 
 #[tokio::test]
 async fn test_compression_listener() -> Result<()> {
-    const DEFAULT_TIMEOUT_SECONDS: u64 = 3;
+    const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
+    const SLACK: Duration = Duration::from_millis(2);
 
     let submitter = TestBufferSubmitter::new();
     let shared = submitter.shared_store();
 
     let buffer: Buffer<TestBufferSubmitter> = Buffer::new(submitter, 120 * TEST_OBJECT_SIZE);
-    let listener = Listener::spawn(
-        buffer,
-        Duration::from_secs(DEFAULT_TIMEOUT_SECONDS),
-        DEFAULT_LISTENER_CAPACITY,
-    );
+    let listener = Listener::spawn(buffer, DEFAULT_TIMEOUT, DEFAULT_LISTENER_CAPACITY);
 
     let expected_ids: Vec<S3ObjectMetadataId> = (1..=300).collect();
     let mut handlers = Vec::new();
@@ -116,7 +113,7 @@ async fn test_compression_listener() -> Result<()> {
     }
 
     // Sleep to trigger timeout-based submission
-    tokio::time::sleep(Duration::from_secs(DEFAULT_TIMEOUT_SECONDS)).await;
+    tokio::time::sleep(DEFAULT_TIMEOUT + SLACK).await;
 
     // Inspect submitted results and verify total count
     let mut submitted_buffers = shared.lock().await;

--- a/components/log-ingestor/tests/test_compression_listener.rs
+++ b/components/log-ingestor/tests/test_compression_listener.rs
@@ -10,7 +10,10 @@ use log_ingestor::compression::{
     DEFAULT_LISTENER_CAPACITY,
     Listener,
 };
-use tokio::sync::{Mutex, mpsc};
+use tokio::{
+    sync::{Mutex, mpsc},
+    time::Instant,
+};
 
 const TEST_OBJECT_SIZE: u64 = 1024;
 
@@ -52,19 +55,42 @@ async fn send_to_listener(
 
 /// # Returns
 ///
-/// A vector of [`CompressionBufferEntry`] for testing.
+/// A vector of [`CompressionBufferEntry`] for testing, each with size [`TEST_OBJECT_SIZE`].
 fn create_test_buffer_entries(ids: &[S3ObjectMetadataId]) -> Vec<CompressionBufferEntry> {
+    create_test_buffer_entries_with_size(ids, TEST_OBJECT_SIZE)
+}
+
+/// # Returns
+///
+/// A vector of [`CompressionBufferEntry`] with a custom size for each entry.
+fn create_test_buffer_entries_with_size(
+    ids: &[S3ObjectMetadataId],
+    size: u64,
+) -> Vec<CompressionBufferEntry> {
     ids.iter()
-        .map(|id| CompressionBufferEntry {
-            id: *id,
-            size: TEST_OBJECT_SIZE,
-        })
+        .map(|id| CompressionBufferEntry { id: *id, size })
         .collect()
+}
+
+/// Waits until the specified instant and asserts the number of submissions matches the expected
+/// count.
+async fn assert_submission_count_at(
+    instant: Instant,
+    store: &Arc<Mutex<Vec<Vec<S3ObjectMetadataId>>>>,
+    expected: usize,
+    context: &str,
+) {
+    tokio::time::sleep_until(instant).await;
+    assert_eq!(
+        store.lock().await.len(),
+        expected,
+        "unexpected submission count: {context}"
+    );
 }
 
 #[tokio::test]
 async fn test_compression_listener() -> Result<()> {
-    const DEFAULT_TIMEOUT_SECONDS: u64 = 4;
+    const DEFAULT_TIMEOUT_SECONDS: u64 = 3;
 
     let submitter = TestBufferSubmitter::new();
     let shared = submitter.shared_store();
@@ -90,7 +116,7 @@ async fn test_compression_listener() -> Result<()> {
     }
 
     // Sleep to trigger timeout-based submission
-    tokio::time::sleep(Duration::from_secs(DEFAULT_TIMEOUT_SECONDS + 1)).await;
+    tokio::time::sleep(Duration::from_secs(DEFAULT_TIMEOUT_SECONDS)).await;
 
     // Inspect submitted results and verify total count
     let mut submitted_buffers = shared.lock().await;
@@ -112,5 +138,127 @@ async fn test_compression_listener() -> Result<()> {
     listener.shutdown_and_join().await;
     assert!(shared.lock().await.is_empty());
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_listener_hard_timeout() -> Result<()> {
+    const TIMEOUT: Duration = Duration::from_millis(50);
+    const SLACK: Duration = Duration::from_millis(2);
+    const WAIT: Duration = Duration::from_millis(20);
+    const SIZE_THRESHOLD: u64 = 120 * TEST_OBJECT_SIZE;
+
+    let submitter = TestBufferSubmitter::new();
+    let shared = submitter.shared_store();
+
+    let buffer: Buffer<TestBufferSubmitter> = Buffer::new(submitter, SIZE_THRESHOLD);
+    let listener = Listener::spawn(buffer, TIMEOUT, DEFAULT_LISTENER_CAPACITY);
+    let sender = listener.get_new_sender();
+
+    {
+        // Phase 1: Basic hard timeout
+        let t_0 = Instant::now();
+        tokio::time::sleep(WAIT).await; // t_1
+        send_to_listener(create_test_buffer_entries(&[1]), sender.clone()).await;
+        let t_2 = Instant::now();
+        assert!(t_2 - t_0 < TIMEOUT, "send took longer than timeout");
+
+        // At t_0 + timeout, no submission should have triggered because the timer started at t_2
+        // (when the object was ingested), not at t_0 (when the listener started).
+        assert_submission_count_at(
+            t_0 + TIMEOUT,
+            &shared,
+            0,
+            "timer should not have fired at t_0 + timeout",
+        )
+        .await;
+
+        // At t_2 + timeout, the buffer submission triggers by timeout.
+        assert_submission_count_at(
+            t_2 + TIMEOUT + SLACK,
+            &shared,
+            1,
+            "timeout flush of [1] expected",
+        )
+        .await;
+    }
+
+    {
+        // Phase 2: Size flush + leftover hard timeout
+        let t_3 = Instant::now();
+
+        // Ingest two objects. The first object's size meets the threshold, triggering a size flush.
+        // The second object (small) remains in the buffer. The timer resets to t_4 because the
+        // flush left the buffer non-empty.
+        let mut entries = create_test_buffer_entries_with_size(&[2], SIZE_THRESHOLD);
+        entries.extend(create_test_buffer_entries(&[3]));
+        send_to_listener(entries, sender.clone()).await;
+        // Allow the listener task to process the entries and trigger the size flush.
+        tokio::time::sleep(SLACK).await;
+        let t_4 = Instant::now();
+
+        assert_eq!(shared.lock().await.len(), 2, "size flush of [2] expected");
+
+        // At t_3 + timeout, no new submission should trigger because the timer was reset at t_4,
+        // not t_3.
+        assert_submission_count_at(
+            t_3 + TIMEOUT,
+            &shared,
+            2,
+            "timer should not have fired at t_3 + timeout",
+        )
+        .await;
+
+        // At t_4 + timeout, the buffer submission triggers by timeout for the leftover [3].
+        assert_submission_count_at(
+            t_4 + TIMEOUT + SLACK,
+            &shared,
+            3,
+            "timeout flush of [3] expected",
+        )
+        .await;
+    }
+
+    {
+        // Phase 3: Exact threshold flush + subsequent ingest
+        let phase3_ids: Vec<S3ObjectMetadataId> = (4..=123).collect();
+        send_to_listener(create_test_buffer_entries(&phase3_ids), sender.clone()).await;
+        // Allow the listener task to process the entries and trigger the size flush.
+        tokio::time::sleep(SLACK).await;
+        let t_5 = Instant::now();
+
+        assert_eq!(
+            shared.lock().await.len(),
+            4,
+            "size flush of [4..123] expected"
+        );
+
+        tokio::time::sleep(WAIT).await; // t_6
+
+        // Ingest one more object. The buffer was empty, so the timer starts fresh at t_7.
+        send_to_listener(create_test_buffer_entries(&[124]), sender.clone()).await;
+        let t_7 = Instant::now();
+
+        // At t_5 + timeout, no submission should trigger because the timer was set at t_7, not t_5.
+        assert_submission_count_at(
+            t_5 + TIMEOUT,
+            &shared,
+            4,
+            "step 12: timer should not have fired at t_10 + timeout",
+        )
+        .await;
+
+        // At t_7 + timeout, the buffer submission triggers by timeout for [124].
+        assert_submission_count_at(
+            t_7 + TIMEOUT + SLACK,
+            &shared,
+            5,
+            "step 13: timeout flush of [124] expected",
+        )
+        .await;
+    }
+
+    // Clean up.
+    listener.shutdown_and_join().await;
     Ok(())
 }

--- a/components/log-ingestor/tests/test_compression_listener.rs
+++ b/components/log-ingestor/tests/test_compression_listener.rs
@@ -97,7 +97,8 @@ async fn test_compression_listener() -> Result<()> {
     let shared = submitter.shared_store();
 
     let buffer: Buffer<TestBufferSubmitter> = Buffer::new(submitter, 120 * TEST_OBJECT_SIZE);
-    let listener = Listener::spawn(buffer, DEFAULT_TIMEOUT, DEFAULT_LISTENER_CAPACITY);
+    let listener = Listener::spawn(buffer, DEFAULT_TIMEOUT, DEFAULT_LISTENER_CAPACITY)
+        .expect("failed to spawn listener");
 
     let expected_ids: Vec<S3ObjectMetadataId> = (1..=300).collect();
     let mut handlers = Vec::new();
@@ -149,7 +150,8 @@ async fn test_listener_hard_timeout() -> Result<()> {
     let shared = submitter.shared_store();
 
     let buffer: Buffer<TestBufferSubmitter> = Buffer::new(submitter, SIZE_THRESHOLD);
-    let listener = Listener::spawn(buffer, TIMEOUT, DEFAULT_LISTENER_CAPACITY);
+    let listener = Listener::spawn(buffer, TIMEOUT, DEFAULT_LISTENER_CAPACITY)
+        .expect("failed to spawn listener");
     let sender = listener.get_new_sender();
 
     {

--- a/components/log-ingestor/tests/test_compression_listener.rs
+++ b/components/log-ingestor/tests/test_compression_listener.rs
@@ -241,7 +241,7 @@ async fn test_listener_hard_timeout() -> Result<()> {
             t_5 + TIMEOUT,
             &shared,
             4,
-            "step 12: timer should not have fired at t_10 + timeout",
+            "timer should not have fired at t_5 + timeout",
         )
         .await;
 
@@ -250,7 +250,7 @@ async fn test_listener_hard_timeout() -> Result<()> {
             t_7 + TIMEOUT + SLACK,
             &shared,
             5,
-            "step 13: timeout flush of [124] expected",
+            "timeout flush of [124] expected",
         )
         .await;
     }

--- a/components/log-ingestor/tests/test_ingestion_job.rs
+++ b/components/log-ingestor/tests/test_ingestion_job.rs
@@ -8,6 +8,7 @@ use clp_rust_utils::{
     clp_config::{AwsAuthentication, AwsCredentials},
     job_config::ingestion::s3::{
         BaseConfig,
+        BufferConfig,
         S3ScannerConfig,
         SqsListenerConfig,
         ValidatedSqsListenerConfig,
@@ -254,6 +255,7 @@ async fn test_sqs_listener() -> Result<()> {
                     dataset: None,
                     timestamp_key: None,
                     unstructured: false,
+                    buffer_config: BufferConfig::default(),
                 },
             },
         )
@@ -295,6 +297,7 @@ async fn test_s3_scanner() -> Result<()> {
             dataset: None,
             timestamp_key: None,
             unstructured: false,
+            buffer_config: BufferConfig::default(),
         },
         scanning_interval_sec: 1,
         start_after: None,

--- a/components/package-template/src/etc/clp-config.template.json.yaml
+++ b/components/package-template/src/etc/clp-config.template.json.yaml
@@ -17,14 +17,6 @@
 #log_ingestor:
 #  host: "localhost"
 #  port: 3002
-#  # The timeout (in seconds) after which the log buffer is flushed for compression if no new input
-#  # arrives.
-#  buffer_flush_timeout: 300
-#  # The log buffer size (in bytes) that triggers a flush for compression.
-#  buffer_flush_threshold: 4294967296  # 4 GiB
-#  # The capacity of the internal channel used for communication between an ingestion job and the
-#  # log buffer.
-#  channel_capacity: 10
 #  logging_level: "INFO"
 
 ## Location (e.g., directory) containing any logs you wish to compress. Must be reachable by all

--- a/docs/src/_static/generated/log-ingestor-openapi.json
+++ b/docs/src/_static/generated/log-ingestor-openapi.json
@@ -260,27 +260,25 @@
       "BufferConfig": {
         "type": "object",
         "description": "Configuration for buffer behavior.",
-        "required": [
-          "flush_threshold_bytes",
-          "timeout_sec",
-          "channel_capacity"
-        ],
         "properties": {
           "channel_capacity": {
             "type": "integer",
-            "description": "Capacity of the internal buffer channel.\n\nDefines the maximum number of objects that can be queued before being processed by the\nbuffer. Increasing this value may improve throughput at the cost of higher memory\nusage.\n\nDefaults to 16.",
-            "minimum": 0
+            "description": "Capacity of the internal buffer channel.\n\nDefines the maximum number of objects that can be queued before being processed by the\nbuffer. Increasing this value may improve throughput at the cost of higher memory\nusage.\n\nDefaults to 16. Must be a positive integer. The behavior for values less than 1 is\nundefined.",
+            "default": 16,
+            "minimum": 1
           },
           "flush_threshold_bytes": {
             "type": "integer",
             "format": "int64",
             "description": "Size-based flush threshold in bytes.\n\nThe buffer is flushed to create a compression job once the total size of buffered\nobjects exceeds this threshold.\n\nDefaults to 4 GiB.",
+            "default": 4294967296,
             "minimum": 0
           },
           "timeout_sec": {
             "type": "integer",
             "format": "int64",
             "description": "Time-based flush threshold in seconds.\n\nThis is a hard timeout. The buffer is flushed to create a compression job when the\noldest buffered object has remained in the buffer for at least this duration,\nregardless of the total buffered size. The timer is not reset by newly ingested\nobjects.\n\nDefaults to 300 seconds (5 minutes).",
+            "default": 300,
             "minimum": 0
           }
         }

--- a/docs/src/_static/generated/log-ingestor-openapi.json
+++ b/docs/src/_static/generated/log-ingestor-openapi.json
@@ -222,6 +222,10 @@
             "description": "The S3 bucket to ingest from.",
             "minLength": 1
           },
+          "buffer_config": {
+            "$ref": "#/components/schemas/BufferConfig",
+            "description": "Per-job ingestion buffer config."
+          },
           "dataset": {
             "type": "string",
             "description": "The dataset to ingest into. Defaults to `None` (which uses the default dataset).",
@@ -250,6 +254,34 @@
           "unstructured": {
             "type": "boolean",
             "description": "Whether to treat the ingested objects as unstructured logs. Defaults to `false`."
+          }
+        }
+      },
+      "BufferConfig": {
+        "type": "object",
+        "description": "Configuration for buffer behavior.",
+        "required": [
+          "flush_threshold_bytes",
+          "timeout_sec",
+          "channel_capacity"
+        ],
+        "properties": {
+          "channel_capacity": {
+            "type": "integer",
+            "description": "Capacity of the internal buffer channel.\n\nDefines the maximum number of objects that can be queued before being processed by the\nbuffer. Increasing this value may improve throughput at the cost of higher memory\nusage.\n\nDefaults to 16.",
+            "minimum": 0
+          },
+          "flush_threshold_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Size-based flush threshold in bytes.\n\nThe buffer is flushed to create a compression job once the total size of buffered\nobjects exceeds this threshold.\n\nDefaults to 4 GiB.",
+            "minimum": 0
+          },
+          "timeout_sec": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time-based flush threshold in seconds.\n\nThis is a hard timeout. The buffer is flushed to create a compression job when the\noldest buffered object has remained in the buffer for at least this duration,\nregardless of the total buffered size. The timer is not reset by newly ingested\nobjects.\n\nDefaults to 300 seconds (5 minutes).",
+            "minimum": 0
           }
         }
       },

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.2.1-dev.4"
+version: "0.2.1-dev.5"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.10.1-dev"

--- a/tools/deployment/package-helm/templates/configmap.yaml
+++ b/tools/deployment/package-helm/templates/configmap.yaml
@@ -117,9 +117,6 @@ data:
     {{- end }}{{/* with .Values.clpConfig.logs_input */}}
     {{- with .Values.clpConfig.log_ingestor }}
     log_ingestor:
-      buffer_flush_threshold: {{ .buffer_flush_threshold | int }}
-      buffer_flush_timeout: {{ .buffer_flush_timeout | int }}
-      channel_capacity: {{ .channel_capacity | int }}
       host: "localhost"
       logging_level: {{ .logging_level | quote }}
       port: 3002

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -213,14 +213,6 @@ clpConfig:
   # log-ingestor config. Currently, the config is applicable only if `logs_input.type` is "s3".
   log_ingestor:
     port: 30302
-    # The timeout (in seconds) after which the log buffer is flushed for compression if no new input
-    # arrives.
-    buffer_flush_timeout: 300
-    # The log buffer size (in bytes) that triggers a flush for compression.
-    buffer_flush_threshold: 4294967296  # 4 GiB
-    # The capacity of the internal channel used for communication between an ingestion job and the
-    # log buffer.
-    channel_capacity: 10
     logging_level: "INFO"
 
   # Where archives should be output to


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

This PR resolves #2136.

This PR changes the compression listener's timeout behavior from soft to hard timeout, and moves buffer configuration from the per-package `LogIngestor` config to the per-job `BaseConfig`.

## Hard timeout

Previously, the listener reset its timer on every `select!` loop iteration (soft timeout), meaning the buffer would only flush after a full timeout period of inactivity. Now, the timer starts when the first entry is added to an empty buffer and is **not** reset by subsequent entries. This guarantees that the oldest buffered object is submitted within the configured timeout duration, regardless of ingestion rate.

Key implementation changes:
- `Buffer::add` now returns whether a size-threshold flush was triggered.
- `Buffer::is_empty` is added to track buffer state transitions.
- `ListenerTask::run` uses a `timer_active` flag and only resets the timer when the buffer transitions from empty to non-empty, or after a size-threshold flush leaves the buffer non-empty.

## Per-job buffer config

Buffer settings (`flush_threshold_bytes`, `timeout_sec`, `channel_capacity`) are moved from the package-level `LogIngestor` config into a new `BufferConfig` struct embedded in `BaseConfig` (per-job). This allows different ingestion jobs to use different buffer configurations.

The following per-package config fields are removed:
- `buffer_flush_timeout` / `buffer_flush_timeout_sec`
- `buffer_flush_threshold`
- `channel_capacity`

These are removed from the Rust `LogIngestor` struct, the Python `LogIngestor` class, the `ClpDbIngestionConnector` struct, the config template, and the Helm chart values/configmap.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

- All workflows passed.
- Added new test cases for hard timeout behavior in `test_compression_listener.rs`.
- Verified no remaining references to the removed per-package buffer fields across `components/` and `tools/`.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Removed global buffer/channel tuning options and moved buffering configuration to per-job settings with sensible defaults; templates and deployment values updated.

* **Behavior Changes**
  * Buffering and listener timing refined: flush triggers, timer enable/disable and submission signalling adjusted for more predictable, timely flushes; improved startup/error handling for listener creation.

* **Tests**
  * Added and updated tests validating timing, threshold and flush scenarios, including hard-timeout behaviour.

* **Chores**
  * Updated Helm chart version to 0.2.1-dev.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->