### PR TITLE
fix(deployment): Switch webui health checks from TCP to HTTP to detect OOM-thrashing Node.js (fixes #2172).

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.2.1-dev.5"
+version: "0.2.1-dev.6"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.10.1-dev"

--- a/tools/deployment/package-helm/templates/webui-deployment.yaml
+++ b/tools/deployment/package-helm/templates/webui-deployment.yaml
@@ -95,11 +95,12 @@ spec:
           ]
           readinessProbe:
             {{- include "clp.readinessProbeTimings" . | nindent 12 }}
-            tcpSocket: &webui-health-check
+            httpGet: &webui-health-check
+              path: "/"
               port: "webui"
           livenessProbe:
             {{- include "clp.livenessProbeTimings" . | nindent 12 }}
-            tcpSocket: *webui-health-check
+            httpGet: *webui-health-check
       volumes:
         - name: "client-settings"
           configMap:

--- a/tools/deployment/package/docker-compose-all.yaml
+++ b/tools/deployment/package/docker-compose-all.yaml
@@ -404,9 +404,9 @@ services:
       <<: *healthcheck_defaults
       test: [
         "CMD",
-        "bash",
-        "-c",
-        "< /dev/tcp/webui/4000"
+        "curl",
+        "-f",
+        "http://webui:4000/"
       ]
 
   garbage-collector:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The webui container's health checks (Docker Compose and Helm) only test TCP port connectivity (`< /dev/tcp/webui/4000` / `tcpSocket`), which continues to pass even when the Node.js process is OOM-thrashing and unable to serve HTTP requests. This leaves the container in a permanently degraded state that is never detected or restarted.

This PR switches both configurations to use HTTP-based health checks (`curl -f` in Compose, `httpGet` in Helm) against the webui root path (`/`), consistent with how the api-server, mcp-server, and log-ingestor services are already health-checked. Since `curl` is already recently installed
in the `clp-package` image, no image changes are required.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## Scenario 1: Verify curl is available in the clp-package image

**Task:** Confirm that `curl` is already installed in the container image so the Compose healthcheck
can use it without image changes.

**Command:**
```bash
docker run --rm --entrypoint="" \
  $(cat build/clp-package-image.id) \
  which curl
```

**Output:**
```
/usr/bin/curl
```

## Scenario 2: Start CLP and verify webui becomes healthy with HTTP health check

**Task:** Deploy the CLP package with the updated Compose file and confirm the webui container
reaches `healthy` status using the new HTTP-based health check.

**Command:**
```bash
cd build/clp-package
./sbin/start-clp.sh
```

**Output:**
```
 Container clp-package-8164-webui-1 Created
...
 Container clp-package-8164-webui-1 Healthy
2026-04-04T09:27:03.924 INFO [controller] Started CLP.
```

**Explanation:** The webui container passes the new HTTP health check and reaches `healthy` status.

## Scenario 3: Inspect webui container health check details

**Task:** Verify the health check is actually using HTTP (curl) and returning a successful response.

**Command:**
```bash
docker inspect clp-package-8164-webui-1 --format='{{json .State.Health}}' | python3 -m json.tool
```

**Output:**
```json
{
    "Status": "healthy",
    "FailingStreak": 0,
    "Log": [
        {
            "Start": "2026-04-04T05:27:03.263562725-04:00",
            "End": "2026-04-04T05:27:03.298101702-04:00",
            "ExitCode": 0,
            "Output": "...<!doctype html>\n<html lang=\"en\">\n<head>\n    <title>YScope CLP</title>..."
        }
    ]
}
```

**Explanation:** The health check log shows `curl` successfully retrieved the HTML page from `/`
with exit code 0, confirming the HTTP-level check works correctly.

## Scenario 4: Verify HTTP endpoint responds with 200

**Task:** Confirm the webui root path returns HTTP 200, which is the response code `curl -f`
requires to pass.

**Command:**
```bash
curl -f --max-time 2 http://localhost:4000/ -o /dev/null -w "HTTP %{http_code}\n"
```

**Output:**
```
HTTP 200
```

## Scenario 5: End-to-end compression test

**Task:** Verify the overall CLP package still functions correctly with the updated health check.

**Command:**
```bash
cd build/clp-package
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl
```

**Output:**
```
2026-04-04T09:27:19.302 INFO [compress] Compression job 4 submitted.
2026-04-04T09:27:21.306 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 197.98MB/s.
2026-04-04T09:27:21.807 INFO [compress] Compression finished.
2026-04-04T09:27:21.807 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 179.03MB/s.
```

**Explanation:** Compression succeeds end-to-end, confirming no regression from the health check
change.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched health checks from TCP/port probes to HTTP endpoint checks across deployments and compose setups to better reflect service readiness and responsiveness.
  * Bumped the Helm chart package version to indicate the deployment config update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->