### PR TITLE
fix(packaging): Bundle libcrypt.so.1 in universal packages for RHEL9+ compatibility.

### DIFF
--- a/components/core/tools/packaging/common/bundle-libs.sh
+++ b/components/core/tools/packaging/common/bundle-libs.sh
@@ -51,7 +51,7 @@ BINARIES=(clg clo clp clp-s indexer log-converter reducer-server)
 # Libraries provided by the base system (libc, libstdc++, libgcc).
 # These must NOT be bundled — the target system's versions are used instead.
 # Covers both glibc (ld-linux, libc.so) and musl (ld-musl, libc.musl-*).
-EXCLUDE_PATTERN="linux-vdso|ld-linux|ld-musl|libc\.so|libc\.musl|libm\.so|libmvec|libcrypt\.so|libanl|libutil|libnsl|libpthread|libdl|librt\.so|libresolv|libstdc\+\+|libgcc_s"
+EXCLUDE_PATTERN="linux-vdso|ld-linux|ld-musl|libc\.so|libc\.musl|libm\.so|libmvec|libanl|libutil|libnsl|libpthread|libdl|librt\.so|libresolv|libstdc\+\+|libgcc_s"
 
 # --- Prepare staging directory -----------------------------------------------
 


### PR DESCRIPTION
# Description

Bundles `libcrypt.so.1` in universal packages (rpm, deb, apk) by removing it from the `EXCLUDE_PATTERN` in `bundle-libs.sh`.

The `EXCLUDE_PATTERN` was treating `libcrypt.so` as a guaranteed system library like `libc.so` or `libpthread`, but unlike those, `libcrypt.so.1` (the legacy API from glibc's crypt) is not universally available — RHEL9 and newer distros ship only `libcrypt.so.2` (from libxcrypt), requiring a separate `libxcrypt-compat` package.

Three bundled libraries transitively depend on `libcrypt.so.1`:
- `libcurl` → `libssh` → `libcrypt.so.1`
- `libldap` → `libsasl2` → `libcrypt.so.1`

By bundling it, the package becomes truly universal without requiring users to install `libxcrypt-compat` separately. Tradeoff: adds ~200KB to the package but eliminates a hard-to-diagnose runtime dependency on RHEL9+ systems.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* Rebuilt the RPM package and verified it installs and runs correctly on AlmaLinux 9:
  ```
  docker run --rm -v './packages':/pkgs almalinux:9 bash -c \
    'rpm -i /pkgs/clp-core-*.rpm && clp-s --help'
  ```
* Confirmed `ldd /usr/bin/clp-s` reports zero missing libraries after the fix.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging configuration to adjust how application dependencies are bundled during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->