### PR TITLE
refactor(package): Use standard `DESTDIR`/`PREFIX` convention in `bundle-libs.sh`.

### DIFF
--- a/components/core/tools/packaging/alpine-apk/package.sh
+++ b/components/core/tools/packaging/alpine-apk/package.sh
@@ -62,7 +62,8 @@ fi
 
 # --- Bundle binaries and libraries --------------------------------------------
 
-STAGING_DIR="${staging}" \
+DESTDIR="${staging}" \
+PREFIX=/usr \
 BIN_DIR="${BIN_DIR}" \
     "${script_dir}/../common/bundle-libs.sh"
 

--- a/components/core/tools/packaging/common/bundle-libs.sh
+++ b/components/core/tools/packaging/common/bundle-libs.sh
@@ -7,17 +7,20 @@
 # It discovers shared library dependencies via ldd, copies non-system libraries
 # into a lib directory, rewrites RPATHs with patchelf, and strips binaries.
 #
+# Uses standard DESTDIR/PREFIX convention:
+#   DESTDIR  Staging/packaging root (e.g., /tmp/clp-deb-staging)
+#   PREFIX   Runtime install prefix  (e.g., /usr, /usr/local, or "")
+#
 # After this script completes, the staging directory contains:
-#   <staging>/usr/bin/{clg,clo,clp,clp-s,indexer,log-converter,reducer-server}
-#   <staging>/usr/lib/clp/{bundled .so files}
+#   ${DESTDIR}${PREFIX}/bin/{clg,clo,clp,clp-s,indexer,log-converter,reducer-server}
+#   ${DESTDIR}${PREFIX}/lib/clp/{bundled .so files}
 #
 # Required environment variables:
-#   STAGING_DIR  Path to the staging directory (will be created/cleaned)
-#   BIN_DIR      Path to the directory containing compiled binaries
+#   DESTDIR  Path to the staging directory (will be created/cleaned)
+#   BIN_DIR  Path to the directory containing compiled binaries
 #
 # Optional environment variables:
-#   LIB_INSTALL_DIR  Library install path inside the package
-#                    (default: /usr/lib/clp)
+#   PREFIX  Runtime install prefix (default: /usr/local)
 
 set -o errexit
 set -o nounset
@@ -25,8 +28,8 @@ set -o pipefail
 
 # --- Validate inputs --------------------------------------------------------
 
-if [[ -z "${STAGING_DIR:-}" ]]; then
-    echo "ERROR: STAGING_DIR is required" >&2
+if [[ -z "${DESTDIR:-}" ]]; then
+    echo "ERROR: DESTDIR is required" >&2
     exit 1
 fi
 
@@ -40,7 +43,14 @@ if [[ ! -d "${BIN_DIR}" ]]; then
     exit 1
 fi
 
-lib_install_dir="${LIB_INSTALL_DIR:-/usr/lib/clp}"
+# PREFIX unset → /usr/local; PREFIX="" → empty (for tarballs).
+# Non-empty PREFIX must be an absolute path.
+prefix="${PREFIX-/usr/local}"
+if [[ -n "${prefix}" && "${prefix}" != /* ]]; then
+    echo "ERROR: PREFIX must start with '/' or be empty, got: '${prefix}'" >&2
+    exit 1
+fi
+lib_install_dir="${prefix}/lib/clp"
 
 # --- Constants ---------------------------------------------------------------
 
@@ -55,8 +65,8 @@ EXCLUDE_PATTERN="linux-vdso|ld-linux|ld-musl|libc\.so|libc\.musl|libm\.so|libmve
 
 # --- Prepare staging directory -----------------------------------------------
 
-rm -rf "${STAGING_DIR}"
-mkdir -p "${STAGING_DIR}/usr/bin" "${STAGING_DIR}${lib_install_dir}"
+rm -rf "${DESTDIR}"
+mkdir -p "${DESTDIR}${prefix}/bin" "${DESTDIR}${lib_install_dir}"
 
 # --- Collect shared library dependencies -------------------------------------
 
@@ -83,8 +93,8 @@ for bin in "${BINARIES[@]}"; do
         lib_name=$(basename "${lib_path}")
         echo "${lib_name}" | grep -qE "${EXCLUDE_PATTERN}" && continue
 
-        if [[ ! -f "${STAGING_DIR}${lib_install_dir}/${lib_name}" ]]; then
-            cp --dereference "${lib_path}" "${STAGING_DIR}${lib_install_dir}/${lib_name}"
+        if [[ ! -f "${DESTDIR}${lib_install_dir}/${lib_name}" ]]; then
+            cp --dereference "${lib_path}" "${DESTDIR}${lib_install_dir}/${lib_name}"
             echo "    Bundled: ${lib_name}"
         fi
     done
@@ -93,7 +103,7 @@ done
 # --- Patch bundled libraries' RPATH ------------------------------------------
 
 echo "==> Patching bundled libraries..."
-for lib in "${STAGING_DIR}${lib_install_dir}/"*.so*; do
+for lib in "${DESTDIR}${lib_install_dir}/"*.so*; do
     [[ -f "${lib}" ]] || continue
     patchelf --set-rpath "${lib_install_dir}" "${lib}"
 done
@@ -105,9 +115,9 @@ for bin in "${BINARIES[@]}"; do
     bin_path="${BIN_DIR}/${bin}"
     [[ -f "${bin_path}" ]] || continue
 
-    cp "${bin_path}" "${STAGING_DIR}/usr/bin/${bin}"
-    patchelf --set-rpath "${lib_install_dir}" "${STAGING_DIR}/usr/bin/${bin}"
-    strip "${STAGING_DIR}/usr/bin/${bin}"
+    cp "${bin_path}" "${DESTDIR}${prefix}/bin/${bin}"
+    patchelf --set-rpath "${lib_install_dir}" "${DESTDIR}${prefix}/bin/${bin}"
+    strip "${DESTDIR}${prefix}/bin/${bin}"
     echo "    Installed: ${bin}"
 done
 

--- a/components/core/tools/packaging/common/bundle-libs.sh
+++ b/components/core/tools/packaging/common/bundle-libs.sh
@@ -35,6 +35,16 @@ if [[ -z "${DESTDIR:-}" ]]; then
     exit 1
 fi
 
+if [[ "${DESTDIR}" != /* ]]; then
+    echo "ERROR: DESTDIR must be an absolute path, got: '${DESTDIR}'" >&2
+    exit 1
+fi
+
+if [[ "${DESTDIR}" == "/" ]]; then
+    echo "ERROR: DESTDIR must not be /" >&2
+    exit 1
+fi
+
 if [[ -z "${BIN_DIR:-}" ]]; then
     echo "ERROR: BIN_DIR is required" >&2
     exit 1

--- a/components/core/tools/packaging/common/bundle-libs.sh
+++ b/components/core/tools/packaging/common/bundle-libs.sh
@@ -51,7 +51,7 @@ if [[ -z "${BIN_DIR:-}" ]]; then
 fi
 
 if [[ ! -d "${BIN_DIR}" ]]; then
-    echo "ERROR: Binary directory not found: ${BIN_DIR}" >&2
+    echo "ERROR: Binary directory not found: '${BIN_DIR}'" >&2
     exit 1
 fi
 

--- a/components/core/tools/packaging/common/bundle-libs.sh
+++ b/components/core/tools/packaging/common/bundle-libs.sh
@@ -7,8 +7,10 @@
 # It discovers shared library dependencies via ldd, copies non-system libraries
 # into a lib directory, rewrites RPATHs with patchelf, and strips binaries.
 #
-# Uses standard DESTDIR/PREFIX convention:
-#   DESTDIR  Staging/packaging root (e.g., /tmp/clp-deb-staging)
+# Uses DESTDIR/PREFIX convention:
+#   DESTDIR  Staging/packaging root — owned by this script, wiped on each run
+#            (e.g., /tmp/clp-deb-staging). Unlike GNU DESTDIR, this is required
+#            and the directory is fully replaced.
 #   PREFIX   Runtime install prefix  (e.g., /usr, /usr/local, or "")
 #
 # After this script completes, the staging directory contains:
@@ -16,7 +18,7 @@
 #   ${DESTDIR}${PREFIX}/lib/clp/{bundled .so files}
 #
 # Required environment variables:
-#   DESTDIR  Path to the staging directory (will be created/cleaned)
+#   DESTDIR  Staging directory — will be wiped and recreated
 #   BIN_DIR  Path to the directory containing compiled binaries
 #
 # Optional environment variables:

--- a/components/core/tools/packaging/universal-deb/package.sh
+++ b/components/core/tools/packaging/universal-deb/package.sh
@@ -50,7 +50,8 @@ deb_version="${PKG_VERSION/-/\~}-1"
 
 # --- Bundle binaries and libraries ------------------------------------------
 
-STAGING_DIR="${staging}" \
+DESTDIR="${staging}" \
+PREFIX=/usr \
 BIN_DIR="${BIN_DIR}" \
     "${script_dir}/../common/bundle-libs.sh"
 

--- a/components/core/tools/packaging/universal-rpm/package.sh
+++ b/components/core/tools/packaging/universal-rpm/package.sh
@@ -49,7 +49,8 @@ rpm_version="${PKG_VERSION/-/\~}"
 
 # --- Bundle binaries and libraries --------------------------------------------
 
-STAGING_DIR="${staging}" \
+DESTDIR="${staging}" \
+PREFIX=/usr \
 BIN_DIR="${BIN_DIR}" \
     "${script_dir}/../common/bundle-libs.sh"
 


### PR DESCRIPTION
# Description

Refactors `bundle-libs.sh` to use the standard `DESTDIR`/`PREFIX` convention (used by autotools, cmake, and most packaging systems) instead of custom `STAGING_DIR` and `LIB_INSTALL_DIR` variables.

Changes to `bundle-libs.sh`:
- Replace `STAGING_DIR` with `DESTDIR` (staging/packaging root)
- Replace `LIB_INSTALL_DIR` with `PREFIX` (runtime install prefix, default: `/usr/local`)
- Paths are composed as `${DESTDIR}${PREFIX}/bin` and `${DESTDIR}${PREFIX}/lib/clp`
- Added validation: non-empty PREFIX must start with `/`
- Empty PREFIX (`""`) is valid, producing flat `bin/` + `lib/clp/` layout (tarballs)
- Updated header comments to document DESTDIR and PREFIX

Caller updates (`universal-deb`, `universal-rpm`, `alpine-apk`):
- `STAGING_DIR=...` → `DESTDIR=...`
- Added `PREFIX=/usr` to all `bundle-libs.sh` invocations

This produces identical output for existing package formats while enabling future use cases like tarball packaging with `PREFIX=""` or custom prefixes.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* Rebuilt all three package formats (deb, rpm, apk) and verified each installs and runs correctly:
  * deb on Debian bookworm: `dpkg -i /pkgs/clp-core_*.deb && clp-s --help`
  * rpm on AlmaLinux 9: `rpm -i /pkgs/clp-core-*.rpm && clp-s --help`
  * apk on Alpine 3.20: `apk add --allow-untrusted /pkgs/clp-core-*.apk && clp-s --help`
* Confirmed `ldd` reports zero missing libraries for all three.
* Tested `PREFIX=""` (tarball layout) produces `bin/` + `lib/clp/` structure.
* Tested relative PREFIX is rejected with clear error message.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Packaging workflows for Alpine, Debian and RPM now use a consistent DESTDIR + PREFIX staging/install convention.
  * Improved validation and clearer defaults for staging and install paths, including support for empty prefixes for archive-style outputs.
  * Standardized staging and library/binary placement logic to improve build portability, predictability and configuration flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->