### PR TITLE
ci: Add aarch64 deps-image builds for manylinux_2_28 and musllinux_1_2.

### DIFF
--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -15,9 +15,9 @@ on:
   workflow_dispatch:
 
 env:
-  ARM64_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-aarch64-"
+  AARCH64_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-aarch64-"
   BINARIES_ARTIFACT_NAME_PREFIX: "clp-core-binaries-"
-  DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-x86-"
+  X86_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-x86-"
   PYTHON_WHEELS_ARTIFACT_NAME_PREFIX: "clp-python-wheels-"
 
 concurrency:
@@ -138,7 +138,7 @@ jobs:
         env:
           OS_NAME: "centos-stream-9"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}\
             /Dockerfile"
@@ -164,7 +164,7 @@ jobs:
         env:
           OS_NAME: "manylinux_2_28"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
             /Dockerfile"
@@ -190,7 +190,7 @@ jobs:
         env:
           OS_NAME: "musllinux_1_2"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
             /Dockerfile"
@@ -216,7 +216,7 @@ jobs:
         env:
           OS_NAME: "manylinux_2_28"
         with:
-          image_name: "${{env.ARM64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.AARCH64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-aarch64\
             /Dockerfile"
@@ -242,7 +242,7 @@ jobs:
         env:
           OS_NAME: "musllinux_1_2"
         with:
-          image_name: "${{env.ARM64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.AARCH64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-aarch64\
             /Dockerfile"
@@ -268,7 +268,7 @@ jobs:
         env:
           OS_NAME: "ubuntu-jammy"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}\
             /Dockerfile"
@@ -303,7 +303,7 @@ jobs:
         env:
           OS_NAME: "centos-stream-9"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.centos_stream_9_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -343,7 +343,7 @@ jobs:
         env:
           OS_NAME: "manylinux_2_28"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.manylinux_2_28_x86_64_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -381,7 +381,7 @@ jobs:
 
       - uses: "./.github/actions/run-on-image"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.manylinux_2_28_x86_64_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -436,7 +436,7 @@ jobs:
         env:
           OS_NAME: "musllinux_1_2"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.musllinux_1_2_x86_64_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -479,7 +479,7 @@ jobs:
 
       - uses: "./.github/actions/run-on-image"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -616,7 +616,7 @@ jobs:
         env:
           OS_NAME: "ubuntu-jammy"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -673,7 +673,7 @@ jobs:
         env:
           OS_NAME: "ubuntu-jammy"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -146,58 +146,6 @@ jobs:
             ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
           token: "${{secrets.GITHUB_TOKEN}}"
 
-  manylinux_2_28-x86_64-deps-image:
-    name: "manylinux_2_28-x86_64-deps-image"
-    if: "needs.filter-relevant-changes.outputs.manylinux_2_28_x86_64_image_changed == 'true'"
-    needs: "filter-relevant-changes"
-    runs-on: *runner
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
-        with:
-          submodules: "recursive"
-
-      - name: "Work around actions/runner-images/issues/6775"
-        run: "chown $(id -u):$(id -g) -R ."
-        shell: "bash"
-
-      - uses: "./.github/actions/clp-core-build-containers"
-        env:
-          OS_NAME: "manylinux_2_28"
-        with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
-          docker_context: "components/core"
-          docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
-            /Dockerfile"
-          push_deps_image: >-
-            ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
-          token: "${{secrets.GITHUB_TOKEN}}"
-
-  musllinux_1_2-x86_64-deps-image:
-    name: "musllinux_1_2-x86_64-deps-image"
-    if: "needs.filter-relevant-changes.outputs.musllinux_1_2_x86_64_image_changed == 'true'"
-    needs: "filter-relevant-changes"
-    runs-on: *runner
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
-        with:
-          submodules: "recursive"
-
-      - name: "Work around actions/runner-images/issues/6775"
-        run: "chown $(id -u):$(id -g) -R ."
-        shell: "bash"
-
-      - uses: "./.github/actions/clp-core-build-containers"
-        env:
-          OS_NAME: "musllinux_1_2"
-        with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
-          docker_context: "components/core"
-          docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
-            /Dockerfile"
-          push_deps_image: >-
-            ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
-          token: "${{secrets.GITHUB_TOKEN}}"
-
   manylinux_2_28-aarch64-deps-image:
     name: "manylinux_2_28-aarch64-deps-image"
     if: "needs.filter-relevant-changes.outputs.manylinux_2_28_aarch64_image_changed == 'true'"
@@ -224,6 +172,32 @@ jobs:
             ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
           token: "${{secrets.GITHUB_TOKEN}}"
 
+  manylinux_2_28-x86_64-deps-image:
+    name: "manylinux_2_28-x86_64-deps-image"
+    if: "needs.filter-relevant-changes.outputs.manylinux_2_28_x86_64_image_changed == 'true'"
+    needs: "filter-relevant-changes"
+    runs-on: *runner
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          submodules: "recursive"
+
+      - name: "Work around actions/runner-images/issues/6775"
+        run: "chown $(id -u):$(id -g) -R ."
+        shell: "bash"
+
+      - uses: "./.github/actions/clp-core-build-containers"
+        env:
+          OS_NAME: "manylinux_2_28"
+        with:
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
+          docker_context: "components/core"
+          docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
+            /Dockerfile"
+          push_deps_image: >-
+            ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
+          token: "${{secrets.GITHUB_TOKEN}}"
+
   musllinux_1_2-aarch64-deps-image:
     name: "musllinux_1_2-aarch64-deps-image"
     if: "needs.filter-relevant-changes.outputs.musllinux_1_2_aarch64_image_changed == 'true'"
@@ -245,6 +219,32 @@ jobs:
           image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_AARCH64}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-aarch64\
+            /Dockerfile"
+          push_deps_image: >-
+            ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
+          token: "${{secrets.GITHUB_TOKEN}}"
+
+  musllinux_1_2-x86_64-deps-image:
+    name: "musllinux_1_2-x86_64-deps-image"
+    if: "needs.filter-relevant-changes.outputs.musllinux_1_2_x86_64_image_changed == 'true'"
+    needs: "filter-relevant-changes"
+    runs-on: *runner
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          submodules: "recursive"
+
+      - name: "Work around actions/runner-images/issues/6775"
+        run: "chown $(id -u):$(id -g) -R ."
+        shell: "bash"
+
+      - uses: "./.github/actions/clp-core-build-containers"
+        env:
+          OS_NAME: "musllinux_1_2"
+        with:
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
+          docker_context: "components/core"
+          docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
             /Dockerfile"
           push_deps_image: >-
             ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -15,10 +15,10 @@ on:
   workflow_dispatch:
 
 env:
-  AARCH64_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-aarch64-"
+  DEPS_IMAGE_NAME_PREFIX_AARCH64: "clp-core-dependencies-aarch64-"
   BINARIES_ARTIFACT_NAME_PREFIX: "clp-core-binaries-"
   PYTHON_WHEELS_ARTIFACT_NAME_PREFIX: "clp-python-wheels-"
-  X86_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-x86-"
+  DEPS_IMAGE_NAME_PREFIX_X86: "clp-core-dependencies-x86-"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
@@ -138,7 +138,7 @@ jobs:
         env:
           OS_NAME: "centos-stream-9"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}\
             /Dockerfile"
@@ -164,7 +164,7 @@ jobs:
         env:
           OS_NAME: "manylinux_2_28"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
             /Dockerfile"
@@ -190,7 +190,7 @@ jobs:
         env:
           OS_NAME: "musllinux_1_2"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
             /Dockerfile"
@@ -216,7 +216,7 @@ jobs:
         env:
           OS_NAME: "manylinux_2_28"
         with:
-          image_name: "${{env.AARCH64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_AARCH64}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-aarch64\
             /Dockerfile"
@@ -242,7 +242,7 @@ jobs:
         env:
           OS_NAME: "musllinux_1_2"
         with:
-          image_name: "${{env.AARCH64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_AARCH64}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-aarch64\
             /Dockerfile"
@@ -268,7 +268,7 @@ jobs:
         env:
           OS_NAME: "ubuntu-jammy"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}\
             /Dockerfile"
@@ -303,7 +303,7 @@ jobs:
         env:
           OS_NAME: "centos-stream-9"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.centos_stream_9_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -343,7 +343,7 @@ jobs:
         env:
           OS_NAME: "manylinux_2_28"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.manylinux_2_28_x86_64_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -381,7 +381,7 @@ jobs:
 
       - uses: "./.github/actions/run-on-image"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.manylinux_2_28_x86_64_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -436,7 +436,7 @@ jobs:
         env:
           OS_NAME: "musllinux_1_2"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.musllinux_1_2_x86_64_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -479,7 +479,7 @@ jobs:
 
       - uses: "./.github/actions/run-on-image"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -616,7 +616,7 @@ jobs:
         env:
           OS_NAME: "ubuntu-jammy"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -673,7 +673,7 @@ jobs:
         env:
           OS_NAME: "ubuntu-jammy"
         with:
-          image_name: "${{env.X86_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}${{env.OS_NAME}}"
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -15,6 +15,7 @@ on:
   workflow_dispatch:
 
 env:
+  ARM64_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-aarch64-"
   BINARIES_ARTIFACT_NAME_PREFIX: "clp-core-binaries-"
   DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-x86-"
   PYTHON_WHEELS_ARTIFACT_NAME_PREFIX: "clp-python-wheels-"
@@ -37,7 +38,9 @@ jobs:
       }}
     outputs:
       centos_stream_9_image_changed: "${{steps.filter.outputs.centos_stream_9_image}}"
+      manylinux_2_28_aarch64_image_changed: "${{steps.filter.outputs.manylinux_2_28_aarch64_image}}"
       manylinux_2_28_x86_64_image_changed: "${{steps.filter.outputs.manylinux_2_28_x86_64_image}}"
+      musllinux_1_2_aarch64_image_changed: "${{steps.filter.outputs.musllinux_1_2_aarch64_image}}"
       musllinux_1_2_x86_64_image_changed: "${{steps.filter.outputs.musllinux_1_2_x86_64_image}}"
       ubuntu_jammy_image_changed: "${{steps.filter.outputs.ubuntu_jammy_image}}"
       clp_changed: "${{steps.filter.outputs.clp}}"
@@ -77,10 +80,18 @@ jobs:
               - *_deps_images_common_paths
               - "components/core/tools/docker-images/clp-env-base-centos-stream-9/**"
               - "components/core/tools/scripts/lib_install/centos-stream-9/**"
+            manylinux_2_28_aarch64_image:
+              - *_deps_images_common_paths
+              - "components/core/tools/docker-images/clp-env-base-manylinux_2_28-aarch64/**"
+              - "components/core/tools/scripts/lib_install/manylinux_2_28/**"
             manylinux_2_28_x86_64_image:
               - *_deps_images_common_paths
               - "components/core/tools/docker-images/clp-env-base-manylinux_2_28-x86_64/**"
               - "components/core/tools/scripts/lib_install/manylinux_2_28/**"
+            musllinux_1_2_aarch64_image:
+              - *_deps_images_common_paths
+              - "components/core/tools/docker-images/clp-env-base-musllinux_1_2-aarch64/**"
+              - "components/core/tools/scripts/lib_install/musllinux_1_2/**"
             musllinux_1_2_x86_64_image:
               - *_deps_images_common_paths
               - "components/core/tools/docker-images/clp-env-base-musllinux_1_2-x86_64/**"
@@ -182,6 +193,58 @@ jobs:
           image_name: "${{env.DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
           docker_context: "components/core"
           docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-x86_64\
+            /Dockerfile"
+          push_deps_image: >-
+            ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
+          token: "${{secrets.GITHUB_TOKEN}}"
+
+  manylinux_2_28-aarch64-deps-image:
+    name: "manylinux_2_28-aarch64-deps-image"
+    if: "needs.filter-relevant-changes.outputs.manylinux_2_28_aarch64_image_changed == 'true'"
+    needs: "filter-relevant-changes"
+    runs-on: "ubuntu-24.04-arm"
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          submodules: "recursive"
+
+      - name: "Work around actions/runner-images/issues/6775"
+        run: "chown $(id -u):$(id -g) -R ."
+        shell: "bash"
+
+      - uses: "./.github/actions/clp-core-build-containers"
+        env:
+          OS_NAME: "manylinux_2_28"
+        with:
+          image_name: "${{env.ARM64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          docker_context: "components/core"
+          docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-aarch64\
+            /Dockerfile"
+          push_deps_image: >-
+            ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
+          token: "${{secrets.GITHUB_TOKEN}}"
+
+  musllinux_1_2-aarch64-deps-image:
+    name: "musllinux_1_2-aarch64-deps-image"
+    if: "needs.filter-relevant-changes.outputs.musllinux_1_2_aarch64_image_changed == 'true'"
+    needs: "filter-relevant-changes"
+    runs-on: "ubuntu-24.04-arm"
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          submodules: "recursive"
+
+      - name: "Work around actions/runner-images/issues/6775"
+        run: "chown $(id -u):$(id -g) -R ."
+        shell: "bash"
+
+      - uses: "./.github/actions/clp-core-build-containers"
+        env:
+          OS_NAME: "musllinux_1_2"
+        with:
+          image_name: "${{env.ARM64_DEPS_IMAGE_NAME_PREFIX}}${{env.OS_NAME}}"
+          docker_context: "components/core"
+          docker_file: "components/core/tools/docker-images/clp-env-base-${{env.OS_NAME}}-aarch64\
             /Dockerfile"
           push_deps_image: >-
             ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -17,8 +17,8 @@ on:
 env:
   AARCH64_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-aarch64-"
   BINARIES_ARTIFACT_NAME_PREFIX: "clp-core-binaries-"
-  X86_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-x86-"
   PYTHON_WHEELS_ARTIFACT_NAME_PREFIX: "clp-python-wheels-"
+  X86_DEPS_IMAGE_NAME_PREFIX: "clp-core-dependencies-x86-"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"

--- a/docs/src/dev-docs/tooling-containers.md
+++ b/docs/src/dev-docs/tooling-containers.md
@@ -21,6 +21,13 @@ distros using glibc 2.28+, including:
 
 ### clp-core-dependencies-aarch64-manylinux_2_28
 
+* [GitHub Packages page][core-deps-manylinux_2_28-aarch64]
+* Pull command:
+
+  ```bash
+  docker pull ghcr.io/y-scope/clp/clp-core-dependencies-aarch64-manylinux_2_28:main
+  ```
+
 * Path:
 
   ```text
@@ -53,6 +60,13 @@ other distros using musl 1.2, including:
 * Alpine Linux 3.13+
 
 ### clp-core-dependencies-aarch64-musllinux_1_2
+
+* [GitHub Packages page][core-deps-musllinux_1_2-aarch64]
+* Pull command:
+
+  ```bash
+  docker pull ghcr.io/y-scope/clp/clp-core-dependencies-aarch64-musllinux_1_2:main
+  ```
 
 * Path:
 
@@ -233,7 +247,9 @@ Each distro supports an environment variable to override the default package mir
 | `DOCKER_NETWORK` | (auto)  | Override Docker's network mode (e.g., `host`, `bridge`).                       |
 
 [core-deps-centos-stream-9]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-dependencies-x86-centos-stream-9
+[core-deps-manylinux_2_28-aarch64]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-dependencies-aarch64-manylinux_2_28
 [core-deps-manylinux_2_28-x86_64]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-dependencies-x86-manylinux_2_28
+[core-deps-musllinux_1_2-aarch64]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-dependencies-aarch64-musllinux_1_2
 [core-deps-musllinux_1_2-x86_64]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-dependencies-x86-musllinux_1_2
 [core-deps-ubuntu-jammy]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-dependencies-x86-ubuntu-jammy
 [core-ubuntu-jammy]: https://github.com/y-scope/clp/pkgs/container/clp%2Fclp-core-x86-ubuntu-jammy

--- a/docs/src/dev-docs/tooling-gh-workflows.md
+++ b/docs/src/dev-docs/tooling-gh-workflows.md
@@ -40,9 +40,7 @@ flowchart LR
     filter-relevant-changes --> musllinux_1_2-x86_64-binaries
     filter-relevant-changes --> ubuntu-jammy-binaries
     centos-stream-9-deps-image --> centos-stream-9-binaries
-    manylinux_2_28-aarch64-deps-image
     manylinux_2_28-x86_64-deps-image --> manylinux_2_28-x86_64-binaries
-    musllinux_1_2-aarch64-deps-image
     musllinux_1_2-x86_64-deps-image --> musllinux_1_2-x86_64-binaries
     ubuntu-jammy-deps-image --> ubuntu-jammy-binaries
     ubuntu-jammy-deps-image --> package-image

--- a/docs/src/dev-docs/tooling-gh-workflows.md
+++ b/docs/src/dev-docs/tooling-gh-workflows.md
@@ -53,8 +53,8 @@ Arrows between jobs indicate a dependency. The jobs are as follows:
   the following jobs should run.
 * `centos-stream-9-deps-image`: Builds a container image containing the dependencies necessary to
   build CLP-core in a CentOS Stream 9 x86 environment.
-* `manylinux_2_28-aarch64-deps-image`: Builds a container image containing the dependencies necessary
-  to build CLP-core in a manylinux_2_28 arm64 environment.
+* `manylinux_2_28-aarch64-deps-image`: Builds a container image containing the dependencies
+  necessary to build CLP-core in a manylinux_2_28 arm64 environment.
 * `manylinux_2_28-x86_64-deps-image`: Builds a container image containing the dependencies necessary
   to build CLP-core in a manylinux_2_28 x86 environment.
 * `musllinux_1_2-aarch64-deps-image`: Builds a container image containing the dependencies necessary

--- a/docs/src/dev-docs/tooling-gh-workflows.md
+++ b/docs/src/dev-docs/tooling-gh-workflows.md
@@ -30,7 +30,9 @@ shown below.
 }%%
 flowchart LR
     filter-relevant-changes --> centos-stream-9-deps-image
+    filter-relevant-changes --> manylinux_2_28-aarch64-deps-image
     filter-relevant-changes --> manylinux_2_28-x86_64-deps-image
+    filter-relevant-changes --> musllinux_1_2-aarch64-deps-image
     filter-relevant-changes --> musllinux_1_2-x86_64-deps-image
     filter-relevant-changes --> ubuntu-jammy-deps-image
     filter-relevant-changes --> centos-stream-9-binaries
@@ -38,7 +40,9 @@ flowchart LR
     filter-relevant-changes --> musllinux_1_2-x86_64-binaries
     filter-relevant-changes --> ubuntu-jammy-binaries
     centos-stream-9-deps-image --> centos-stream-9-binaries
+    manylinux_2_28-aarch64-deps-image
     manylinux_2_28-x86_64-deps-image --> manylinux_2_28-x86_64-binaries
+    musllinux_1_2-aarch64-deps-image
     musllinux_1_2-x86_64-deps-image --> musllinux_1_2-x86_64-binaries
     ubuntu-jammy-deps-image --> ubuntu-jammy-binaries
     ubuntu-jammy-deps-image --> package-image
@@ -51,8 +55,12 @@ Arrows between jobs indicate a dependency. The jobs are as follows:
   the following jobs should run.
 * `centos-stream-9-deps-image`: Builds a container image containing the dependencies necessary to
   build CLP-core in a CentOS Stream 9 x86 environment.
+* `manylinux_2_28-aarch64-deps-image`: Builds a container image containing the dependencies necessary
+  to build CLP-core in a manylinux_2_28 arm64 environment.
 * `manylinux_2_28-x86_64-deps-image`: Builds a container image containing the dependencies necessary
   to build CLP-core in a manylinux_2_28 x86 environment.
+* `musllinux_1_2-aarch64-deps-image`: Builds a container image containing the dependencies necessary
+  to build CLP-core in a musllinux_1_2 arm64 environment.
 * `musllinux_1_2-x86_64-deps-image`: Builds a container image containing the dependencies necessary
   to build CLP-core in a musllinux_1_2 x86 environment.
 * `ubuntu-jammy-deps-image`: Builds a container image containing the dependencies necessary to build


### PR DESCRIPTION
# Description

Adds CI jobs to build and publish arm64 (aarch64) dependency images for manylinux_2_28 and musllinux_1_2. The aarch64 Dockerfiles and local `build.sh` scripts already exist but had no CI integration.

Changes:
- Add `ARM64_DEPS_IMAGE_NAME_PREFIX` env var for aarch64 image naming
- Add path filters for aarch64 Dockerfile directories
- Add `manylinux_2_28-aarch64-deps-image` job on `ubuntu-24.04-arm`
- Add `musllinux_1_2-aarch64-deps-image` job on `ubuntu-24.04-arm`

The jobs use GitHub-hosted native arm64 runners and publish to ghcr.io when merged to main. Binary builds and tests are not included — only the dependency images for now.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* Code review confirmed new jobs are structurally identical to existing x86_64 deps-image jobs
* Verified aarch64 Dockerfiles exist on disk at the referenced paths
* Verified filter outputs correctly wire to job `if` conditions
* Verified image names produce `clp-core-dependencies-aarch64-{manylinux_2_28,musllinux_1_2}`

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipeline now produces ARM64 dependency images alongside x86_64; added ARM64 dependency-image build jobs and standardized x86 dependency-image naming for clarity.

* **Documentation**
  * Developer tooling and workflow docs updated with ARM64 pull instructions, workflow DAG/job descriptions, and package references for the new ARM64 dependency-image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->