### PR TITLE
fix(package): Use $ORIGIN-relative RPATH instead of absolute paths for relocatable packaging.

### DIFF
--- a/components/core/tools/packaging/common/bundle-libs.sh
+++ b/components/core/tools/packaging/common/bundle-libs.sh
@@ -117,7 +117,7 @@ done
 echo "==> Patching bundled libraries..."
 for lib in "${DESTDIR}${lib_install_dir}/"*.so*; do
     [[ -f "${lib}" ]] || continue
-    patchelf --set-rpath "${lib_install_dir}" "${lib}"
+    patchelf --set-rpath '$ORIGIN' "${lib}"
 done
 
 # --- Install and patch binaries ----------------------------------------------
@@ -128,7 +128,7 @@ for bin in "${BINARIES[@]}"; do
     [[ -f "${bin_path}" ]] || continue
 
     cp "${bin_path}" "${DESTDIR}${prefix}/bin/${bin}"
-    patchelf --set-rpath "${lib_install_dir}" "${DESTDIR}${prefix}/bin/${bin}"
+    patchelf --set-rpath '$ORIGIN/../lib/clp' "${DESTDIR}${prefix}/bin/${bin}"
     strip "${DESTDIR}${prefix}/bin/${bin}"
     echo "    Installed: ${bin}"
 done


### PR DESCRIPTION
# Description

Switches `patchelf --set-rpath` from hardcoded absolute paths (e.g., `/usr/lib/clp`) to `$ORIGIN`-relative paths so binaries find their libraries based on their own location rather than a fixed install prefix.

- Libraries: `$ORIGIN` (finds sibling .so files in the same directory)
- Binaries: `$ORIGIN/../lib/clp` (finds libs relative to the binary)

While the script `components/core/tools/packaging/common/bundle-libs.sh` is originally used only to generate deb/rpm/apk packages where non-relocatable binaries are sufficient. However, new requirements to support the clp core binaries distributed via Python and Go where the install directory is determined at runtime requires the binary to be relocatable.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* Rebuilt all three package formats (deb, rpm, apk) and verified each installs and runs correctly:
  * deb on Debian bookworm: `dpkg -i /pkgs/clp-core_*.deb && clp-s --help`
  * rpm on AlmaLinux 9: `rpm -i /pkgs/clp-core-*.rpm && clp-s --help`
  * apk on Alpine 3.20: `apk add --allow-untrusted /pkgs/clp-core-*.apk && clp-s --help`
* Confirmed `ldd` reports zero missing libraries for all three
* Verified RPATH values: binaries get `$ORIGIN/../lib/clp`, libraries get `$ORIGIN`

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library path resolution to use relative paths instead of absolute paths, improving package portability and deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->