### PR TITLE
refactor(clp-rust-utils)!: Move `buffer_config` from `BaseConfig` to job configs.

### DIFF
--- a/components/clp-rust-utils/src/job_config/ingestion.rs
+++ b/components/clp-rust-utils/src/job_config/ingestion.rs
@@ -28,6 +28,14 @@ pub mod s3 {
                 Self::S3Scanner(config) => &config.base,
             }
         }
+
+        #[must_use]
+        pub const fn as_buffer_config(&self) -> &BufferConfig {
+            match self {
+                Self::SqsListener(config) => &config.buffer_config,
+                Self::S3Scanner(config) => &config.buffer_config,
+            }
+        }
     }
 
     /// Base configuration for ingesting logs from S3.
@@ -65,10 +73,6 @@ pub mod s3 {
         /// Whether to treat the ingested objects as unstructured logs. Defaults to `false`.
         #[serde(default = "default_unstructured")]
         pub unstructured: bool,
-
-        /// Per-job ingestion buffer config.
-        #[serde(default)]
-        pub buffer_config: BufferConfig,
     }
 
     /// Configuration for a SQS listener job.
@@ -76,6 +80,10 @@ pub mod s3 {
     pub struct SqsListenerConfig {
         #[serde(flatten)]
         pub base: BaseConfig,
+
+        /// Per-job ingestion buffer config.
+        #[serde(default)]
+        pub buffer_config: BufferConfig,
 
         /// The SQS queue URL to poll for S3 event notifications. The given queue must be dedicated
         /// to this ingestion job.
@@ -152,6 +160,10 @@ pub mod s3 {
     pub struct S3ScannerConfig {
         #[serde(flatten)]
         pub base: BaseConfig,
+
+        /// Per-job ingestion buffer config.
+        #[serde(default)]
+        pub buffer_config: BufferConfig,
 
         /// The scan interval in seconds. Defaults to 30 seconds.
         #[serde(default = "default_scanning_interval_sec")]

--- a/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
+++ b/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
@@ -422,6 +422,7 @@ impl ClpDbIngestionConnector {
             db_pool: self.db_pool.clone(),
         };
         let base_config = config.as_base_config();
+        let buffer_config = config.as_buffer_config();
 
         let submitter = CompressionJobSubmitter::new(
             compression_state.clone(),
@@ -431,9 +432,9 @@ impl ClpDbIngestionConnector {
         );
 
         let listener = Listener::spawn(
-            Buffer::new(submitter, base_config.buffer_config.flush_threshold_bytes),
-            Duration::from_secs(base_config.buffer_config.timeout_sec),
-            base_config.buffer_config.channel_capacity,
+            Buffer::new(submitter, buffer_config.flush_threshold_bytes),
+            Duration::from_secs(buffer_config.timeout_sec),
+            buffer_config.channel_capacity,
         )?;
         let ingestion_state = ClpIngestionState {
             job_id,

--- a/components/log-ingestor/tests/test_ingestion_job.rs
+++ b/components/log-ingestor/tests/test_ingestion_job.rs
@@ -270,8 +270,8 @@ async fn test_sqs_listener() -> Result<()> {
                     dataset: None,
                     timestamp_key: None,
                     unstructured: false,
-                    buffer_config: BufferConfig::default(),
                 },
+                buffer_config: BufferConfig::default(),
             },
         )
         .await
@@ -312,8 +312,8 @@ async fn test_s3_scanner() -> Result<()> {
             dataset: None,
             timestamp_key: None,
             unstructured: false,
-            buffer_config: BufferConfig::default(),
         },
+        buffer_config: BufferConfig::default(),
         scanning_interval_sec: 1,
         start_after: None,
     };

--- a/docs/src/_static/generated/log-ingestor-openapi.json
+++ b/docs/src/_static/generated/log-ingestor-openapi.json
@@ -222,10 +222,6 @@
             "description": "The S3 bucket to ingest from.",
             "minLength": 1
           },
-          "buffer_config": {
-            "$ref": "#/components/schemas/BufferConfig",
-            "description": "Per-job ingestion buffer config."
-          },
           "dataset": {
             "type": "string",
             "description": "The dataset to ingest into. Defaults to `None` (which uses the default dataset).",
@@ -315,6 +311,10 @@
           {
             "type": "object",
             "properties": {
+              "buffer_config": {
+                "$ref": "#/components/schemas/BufferConfig",
+                "description": "Per-job ingestion buffer config."
+              },
               "scanning_interval_sec": {
                 "type": "integer",
                 "format": "int32",
@@ -342,6 +342,10 @@
               "queue_url"
             ],
             "properties": {
+              "buffer_config": {
+                "$ref": "#/components/schemas/BufferConfig",
+                "description": "Per-job ingestion buffer config."
+              },
               "num_concurrent_listener_tasks": {
                 "type": "integer",
                 "format": "int32",


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Prepares for one-time jobs by moving `buffer_config` off `BaseConfig` and onto both S3ScannerConfig and SqsListenerConfig because one-time jobs do not need a buffer. 

This approach deviates slightly from the proposal which said we'll add a separate `LongRunningConfig` type. I did this because it keeps config.base.* usages and the same JSON shape.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- CI Workflows

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized job configuration structure to improve buffer configuration handling and clarity in ingestion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->