### PR TITLE
chore: Add .gitattributes to enforce LF line endings (fixes #2247).

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Files checked out on Windows can have CRLF line endings, which causes issues with tools that expect LF (e.g., shell scripts, diffs, patch application, and line-ending-sensitive parsers). This PR adds a `.gitattributes` file at the repo root with:

```
* text=auto eol=lf
```

This ensures consistent LF line endings across all platforms regardless of individual Git configuration, matching the approach already used in [y-scope/yscope-log-viewer](https://github.com/y-scope/yscope-log-viewer/blob/HEAD/.gitattributes).

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

1. Verified that `.gitattributes` was created with the expected content:
   ```bash
   cat .gitattributes
   ```
   ```
   * text=auto eol=lf
   ```

2. Verified that Git applies the new attributes correctly:
   ```bash
   git check-attr -a -- .gitattributes
   ```
   ```
   .gitattributes: text: auto
   .gitattributes: eol: lf
   ```

3. Verified that the file is tracked and committed:
   ```bash
   git ls-files .gitattributes
   ```
   ```
   .gitattributes
   ```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git configuration to ensure consistent line ending handling across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->