### PR TITLE
refactor(log-ingestor)!: Rename ingestion API routes to the /s3/* scheme.

### DIFF
--- a/components/log-ingestor/src/routes.rs
+++ b/components/log-ingestor/src/routes.rs
@@ -143,7 +143,7 @@ async fn health() -> &'static str {
 
 #[utoipa::path(
     post,
-    path = "/s3_scanner",
+    path = "/s3/scanner",
     tags = ["IngestionJob"],
     description = "Creates an ingestion job and starts a job instance that periodically scans the \
         specified S3 bucket and key prefix for new objects to ingest.\n\n\
@@ -194,7 +194,7 @@ async fn create_s3_scanner_job(
 
 #[utoipa::path(
     post,
-    path = "/sqs_listener",
+    path = "/s3/listener",
     tags = ["IngestionJob"],
     description = "Creates an ingestion job and starts a job instance that monitors an SQS queue. \
         The queue receives notifications whenever new objects are added to the specified S3 bucket \
@@ -245,7 +245,7 @@ async fn create_sqs_listener_job(
 
 #[utoipa::path(
     post,
-    path = "/job/{job_id}/terminate",
+    path = "/s3/{job_id}/terminate",
     tags = ["IngestionJob"],
     description = "Terminates the ingestion job instance identified by the given job ID.\n\n\
         This operation only terminates the job instance; the job record, including its status and \

--- a/docs/src/_static/generated/log-ingestor-openapi.json
+++ b/docs/src/_static/generated/log-ingestor-openapi.json
@@ -32,37 +32,46 @@
         }
       }
     },
-    "/job/{job_id}/terminate": {
+    "/s3/listener": {
       "post": {
         "tags": [
           "IngestionJob"
         ],
-        "description": "Terminates the ingestion job instance identified by the given job ID.\n\nThis operation only terminates the job instance; the job record, including its status and statistics, is preserved and can still be accessible using the same job ID.\n\nThis operation is idempotent.",
-        "operationId": "terminate_ingestion_job",
-        "parameters": [
-          {
-            "name": "job_id",
-            "in": "path",
-            "description": "The ID of the job to terminate.",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/u64"
+        "description": "Creates an ingestion job and starts a job instance that monitors an SQS queue. The queue receives notifications whenever new objects are added to the specified S3 bucket and key prefix.\n\nThe specified SQS queue must be dedicated to this ingestion job. Upon successful ingestion, the job deletes the corresponding message from the queue to ensure objects are not ingested multiple times.\n\nTo maintain correctness and avoid backpressure, the job may also delete messages that are irrelevant to this ingestion job (for example, messages referring to objects outside the configured bucket or key prefix).",
+        "operationId": "create_sqs_listener_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SqsListenerConfig"
+              }
             }
-          }
-        ],
+          },
+          "required": true
+        },
         "responses": {
           "200": {
-            "description": "",
+            "description": "The ID of the created job.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TerminateResponse"
+                  "$ref": "#/components/schemas/CreationResponse"
                 }
               }
             }
           },
-          "404": {
-            "description": "The specified job ID does not correspond to an ingestion job.",
+          "400": {
+            "description": "Custom endpoint URLs are not supported for SQS listener jobs, or the specified number of concurrent listener tasks is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A prefix conflict was detected. For the same bucket and dataset, only one running ingestion job instance may monitor a given S3 prefix or any of its ancestor or descendant prefixes.",
             "content": {
               "application/json": {
                 "schema": {
@@ -84,7 +93,7 @@
         }
       }
     },
-    "/s3_scanner": {
+    "/s3/scanner": {
       "post": {
         "tags": [
           "IngestionJob"
@@ -145,46 +154,37 @@
         }
       }
     },
-    "/sqs_listener": {
+    "/s3/{job_id}/terminate": {
       "post": {
         "tags": [
           "IngestionJob"
         ],
-        "description": "Creates an ingestion job and starts a job instance that monitors an SQS queue. The queue receives notifications whenever new objects are added to the specified S3 bucket and key prefix.\n\nThe specified SQS queue must be dedicated to this ingestion job. Upon successful ingestion, the job deletes the corresponding message from the queue to ensure objects are not ingested multiple times.\n\nTo maintain correctness and avoid backpressure, the job may also delete messages that are irrelevant to this ingestion job (for example, messages referring to objects outside the configured bucket or key prefix).",
-        "operationId": "create_sqs_listener_job",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SqsListenerConfig"
-              }
+        "description": "Terminates the ingestion job instance identified by the given job ID.\n\nThis operation only terminates the job instance; the job record, including its status and statistics, is preserved and can still be accessible using the same job ID.\n\nThis operation is idempotent.",
+        "operationId": "terminate_ingestion_job",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "description": "The ID of the job to terminate.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/u64"
             }
-          },
-          "required": true
-        },
+          }
+        ],
         "responses": {
           "200": {
-            "description": "The ID of the created job.",
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreationResponse"
+                  "$ref": "#/components/schemas/TerminateResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Custom endpoint URLs are not supported for SQS listener jobs, or the specified number of concurrent listener tasks is invalid.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "A prefix conflict was detected. For the same bucket and dataset, only one running ingestion job instance may monitor a given S3 prefix or any of its ancestor or descendant prefixes.",
+          "404": {
+            "description": "The specified job ID does not correspond to an ingestion job.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Rename log-ingestor API routes according to the proposal outlined in #2166

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Workflows

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Log ingestion API endpoint paths have been updated and reorganized. The S3 scanner creation, SQS listener creation, and job termination endpoints are now available at new paths. Any systems currently integrating with these operations should update their API calls to use the new endpoint paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->