### PR TITLE
ci(clp-artifact-build): Skip workflow for changes to deployment configs, integration tests, and lint-only files.

### DIFF
--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -7,6 +7,11 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
       - "components/core/tools/scripts/lib_install/macos/**"
       - "docs/**"
+      - "integration-tests/**"
+      - "lint-requirements.txt"
+      - "tools/deployment/**"
+      - "tools/scripts/find-broken-docs-links.py"
+      - "tools/scripts/localstack/**"
   push:
     paths-ignore: *ignored_paths
   schedule:


### PR DESCRIPTION
<!-- PR Title: ci(clp-artifact-build): Skip workflow for changes to deployment configs, integration tests, and lint-only files. -->

<!-- markdownlint-disable MD012 -->

# Description

`clp-artifact-build` uses `paths-ignore` to skip the workflow for irrelevant changes, but several paths that don't affect artifact builds are not in the ignore list. This causes the workflow to spin up runners (at least the `filter-relevant-changes` job) for changes that can never trigger any downstream build job.

This PR adds the following paths to `paths-ignore`:

| Path | Reason |
|---|---|
| `integration-tests/**` | Test code; not used by `package-build-deps` or any build task |
| `lint-requirements.txt` | Lint dependencies; only used by `lint:*` tasks |
| `tools/deployment/**` | Deployment configs (Helm chart, Docker Compose, Presto connector); the `package-image` job runs `task package-build-deps` which only depends on `core`/`rust`/`webui`/`python-libs` — not the `package` task that reads `tools/deployment/package/**` |
| `tools/scripts/find-broken-docs-links.py` | Docs-only utility; only used by `docs:check-links` |
| `tools/scripts/localstack/**` | Test utility; only used by `tests:*` tasks |

The existing `clp-package-helm` workflow is unaffected since it uses its own positive `paths` filter that already includes `tools/deployment/package-helm/**`.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

### Scenario 1: Verify newly ignored paths have no build-task references

**Task:** Confirm none of the newly ignored paths are referenced by artifact build tasks (only by lint/docs/test tasks).
**Command:**
```bash
grep -rn "integration.tests\|integration-tests\|lint-requirements\|find-broken-docs-links\|localstack" taskfile.yaml taskfiles/ --include="*.yaml"
```
**Output:**
```
taskfiles/docs.yaml:44:      - "python3 '{{.ROOT_DIR}}/tools/scripts/find-broken-docs-links.py'"
taskfiles/tests/integration.yaml:4:  G_INTEGRATION_TESTS_DIR: "{{.ROOT_DIR}}/integration-tests"
taskfiles/lint.yaml:136:      - "{{.ROOT_DIR}}/lint-requirements.txt"
taskfiles/lint.yaml:880:      - "{{.ROOT_DIR}}/lint-requirements.txt"
taskfiles/lint.yaml:896:          REQUIREMENTS_FILE: "{{.ROOT_DIR}}/lint-requirements.txt"
taskfiles/tests/main.yaml:14:        sh: "uuidgen | tr '[:upper:]' '[:lower:]' | sed 's/^/clp-localstack-rust-/'"
taskfiles/tests/main.yaml:16:        sh: "tools/scripts/localstack/get-free-port.py"
taskfiles/tests/main.yaml:21:        tools/scripts/localstack/start.py \
taskfiles/tests/main.yaml:25:          tools/scripts/localstack/stop.py \
taskfiles/tests/main.yaml:28:        tools/scripts/localstack/create-bucket.py \
```
**Explanation:** All references are in docs, test, or lint tasks — none in artifact build tasks.

### Scenario 2: Verify `tools/deployment/package/**` is not used by the `package-image` job

**Task:** Confirm the `package-image` job only runs `task package-build-deps`, not `task package` (which references `tools/deployment/package/**`).
**Command:**
```bash
grep "task package" .github/workflows/clp-artifact-build.yaml
```
**Output:**
```
            task package-build-deps
```
**Explanation:** The `package-image` job runs `task package-build-deps`, which depends on `core`/`rust`/`webui`/`python-libs`/`deps:spider`/`init` — not the `package` task that reads `tools/deployment/package/**`.

### Scenario 3: Verify the updated paths-ignore list

**Task:** Confirm the final state of the `paths-ignore` anchor.
**Command:**
```bash
sed -n '/paths-ignore:/,/^\s*push:/p' .github/workflows/clp-artifact-build.yaml | head -12
```
**Output:**
```
    paths-ignore: &ignored_paths
      - ".github/*"
      - ".github/ISSUE_TEMPLATE/**"
      - "components/core/tools/scripts/lib_install/macos/**"
      - "docs/**"
      - "integration-tests/**"
      - "lint-requirements.txt"
      - "tools/deployment/**"
      - "tools/scripts/find-broken-docs-links.py"
      - "tools/scripts/localstack/**"
  push:
    paths-ignore: *ignored_paths
```
**Explanation:** The YAML anchor is shared between `pull_request` and `push` triggers, so both are covered.

### Scenario 4: Verify clp-package-helm workflow still triggers on Helm chart changes

**Task:** Confirm the dedicated Helm workflow is unaffected.
**Command:**
```bash
sed -n '/paths:/,/^  push:/p' .github/workflows/clp-package-helm.yaml
```
**Output:**
```
    paths: &monitored_paths
      - ".github/workflows/clp-package-helm.yaml"
      - "taskfile.yaml"
      - "taskfiles/**"
      - "tools/deployment/package-helm/**"
      - "tools/yscope-dev-utils"
  push:
    paths: *monitored_paths
```
**Explanation:** The `clp-package-helm` workflow uses its own positive `paths` filter, so it still triggers on `tools/deployment/package-helm/**` changes independently.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build automation configuration to refine trigger conditions for artifact building workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->