### PR TITLE
fix(clp-package): Enable Docker interactive mode for foreground terminal runs (fixes #2266).

### DIFF
--- a/components/package-template/src/sbin/.common-env.sh
+++ b/components/package-template/src/sbin/.common-env.sh
@@ -70,6 +70,11 @@ if [[ -z "${CLP_DOCKER_SOCK_PATH:-}" ]]; then
 fi
 
 CLP_COMPOSE_RUN_EXTRA_FLAGS=()
-if [[ $- != *i* ]]; then
+# Use interactive mode only for foreground terminal runs; background jobs may still inherit TTYs
+# even though they're not in the foreground process group (indicated by the absence of "+" in the
+# process stat).
+if [[ -t 0 && -t 1 && "$(ps --format=stat= --pid "$$")" == *+* ]]; then
+    CLP_COMPOSE_RUN_EXTRA_FLAGS+=(--interactive=true)
+else
     CLP_COMPOSE_RUN_EXTRA_FLAGS+=(--interactive=false)
 fi


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Problem
PR #1567 introduced a check in `.common-env.sh` that disables Docker Compose interactive mode when the shell is non-interactive (`$- != *i*`). However, this check is too broad: a script run from a foreground terminal is still executed by a non-interactive Bash process (so `$-` does not contain `i`), causing `--interactive=false` to be passed even for foreground terminal runs. This prevents Python code inside the runtime container from reading stdin — for example, a telemetry consent `input()` prompt in `start_clp.py` cannot accept terminal input.

## Solution
Replace the `$- != *i*` check with a more precise three-part condition that only enables interactive mode for true foreground terminal runs:

1. `-t 0` — stdin is attached to a TTY
2. `-t 1` — stdout is attached to a TTY
3. `"$(ps --format=stat= --pid "$$")" == *+*` — the process is in the foreground process group (the `+` flag in the process stat indicates the process is a foreground process group leader)

This ensures:
- **Foreground terminal runs** (e.g., `./sbin/start-clp.sh`) get `--interactive=true`, allowing `input()` prompts to work
- **Background jobs** (e.g., `./sbin/compress.sh &`) get `--interactive=false`, since background processes are not in the foreground process group
- **Piped/redirected runs** (e.g., `./sbin/start-clp.sh > out.log 2>&1`) get `--interactive=false`, since stdin/stdout are not TTYs


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

### Foreground terminal detection logic

**Task**: Verify the new detection logic correctly distinguishes foreground terminal runs from background/redirected runs.

**Command** (foreground via pseudo-TTY):
```bash
script -qc 'source /home/junhao/workspace/2-clp/build/clp-package/sbin/.common-env.sh && echo "CLP_COMPOSE_RUN_EXTRA_FLAGS: ${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}"' /dev/null
```
**Output**:
```
CLP_COMPOSE_RUN_EXTRA_FLAGS: --interactive=true
```

**Command** (redirected stdin/stdout):
```bash
bash -c 'source /home/junhao/workspace/2-clp/build/clp-package/sbin/.common-env.sh && echo "CLP_COMPOSE_RUN_EXTRA_FLAGS: ${CLP_COMPOSE_RUN_EXTRA_FLAGS[@]}"' </dev/null >/tmp/test-result.txt 2>&1 && cat /tmp/test-result.txt
```
**Output**:
```
CLP_COMPOSE_RUN_EXTRA_FLAGS: --interactive=false
```

**Explanation**: Foreground terminal runs correctly get `--interactive=true`, while redirected (non-TTY) runs correctly get `--interactive=false`.

### start-clp.sh with input() prompt (foreground)

**Task**: An `print(input("yes or no: "))` prompt was temporarily added to `start_clp.py` to validate that stdin passthrough works correctly under the new detection logic. This prompt catches `EOFError` for non-interactive runs where stdin is not available. Verify `start-clp.sh` in a foreground terminal run correctly passes the `input()` prompt through to the container.

**Command**:
```bash
cd build/clp-package
./sbin/start-clp.sh
```
**Output**:
```
 Container clp-package-clp-runtime-run-f21d156e507b Creating
 Container clp-package-clp-runtime-run-f21d156e507b Created
yes or no: <USER_INPUT: yes>
yes
...
2026-05-09T08:47:01.840 INFO [controller] Started CLP.
```

**Explanation**: The `input("yes or no: ")` prompt was displayed and accepted terminal input, confirming that stdin passthrough works correctly with `--interactive=true` for foreground terminal runs.

### compress.sh (foreground)

**Task**: Verify compress.sh works correctly in the foreground.

**Command**:
```bash
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl
```
**Output**:
```
 Container clp-package-clp-runtime-run-6bd41d8d6cbe Creating
 Container clp-package-clp-runtime-run-6bd41d8d6cbe Created
2026-05-09T08:47:05.113 INFO [compress] Compression job 1 submitted.
2026-05-09T08:47:08.623 INFO [compress] Compression finished.
2026-05-09T08:47:08.623 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 124.17MB/s.
```

### compress.sh (background, repeated from PR #1567)

**Task**: Verify compress.sh output is forwarded to the terminal when run in the background.

**Command**:
```bash
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl &
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl &
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl &
wait
```
**Output**:
```
Container clp-package-clp-runtime-run-4760c77ef8dc Creating
 Container clp-package-clp-runtime-run-c2dac7ea498b Creating
 Container clp-package-clp-runtime-run-ec9e81ba1c9c Creating
 Container clp-package-clp-runtime-run-4760c77ef8dc Created
 Container clp-package-clp-runtime-run-c2dac7ea498b Created
 Container clp-package-clp-runtime-run-ec9e81ba1c9c Created
2026-05-09T08:47:12.279 INFO [compress] Compression job 2 submitted.
2026-05-09T08:47:12.284 INFO [compress] Compression job 3 submitted.
2026-05-09T08:47:12.306 INFO [compress] Compression job 4 submitted.
...
```

**Explanation**: When `compress.sh` was run with `&`, stdin was detached and outputs of the concurrent commands were correctly forwarded to the console.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of interactive terminal sessions for compose operations, now accurately identifying foreground process contexts rather than relying solely on shell configuration flags.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/y-scope/clp/pull/2267)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->