### PR TITLE
fix(deployment): Auto-initialize MongoDB replica set on fresh volumes

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.3.2-dev.0"
+version: "0.3.2-dev.2"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.12.1-dev"

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.3.2-dev.2"
+version: "0.3.2-dev.3"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.12.1-dev"

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -87,7 +87,7 @@ spec:
             "--concurrency", "{{ .Values.workerConcurrency }}",
             "--loglevel", "WARNING",
             "-Q", "compression",
-            "-n", "compression-worker"
+            "-n", "compression-worker@$(HOSTNAME)"
           ]
       volumes:
         - name: {{ include "clp.volumeName" (dict

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "clp.labels" . | nindent 4 }}
     app.kubernetes.io/component: "compression-worker"
 spec:
-  replicas: {{ .Values.compressionWorker.replicas }}
+  replicas: {{ .Values.scheduling.compressionWorker.replicas }}
   selector:
     matchLabels:
       {{- include "clp.selectorLabels" . | nindent 6 }}
@@ -87,7 +87,7 @@ spec:
             "--concurrency", "{{ .Values.workerConcurrency }}",
             "--loglevel", "WARNING",
             "-Q", "compression",
-            "-n", "compression-worker@$(HOSTNAME)"
+            "-n", "compression-worker"
           ]
       volumes:
         - name: {{ include "clp.volumeName" (dict

--- a/tools/deployment/package-helm/templates/query-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-worker-deployment.yaml
@@ -87,7 +87,7 @@ spec:
             "--concurrency", "{{ .Values.workerConcurrency }}",
             "--loglevel", "WARNING",
             "-Q", "query",
-            "-n", "query-worker"
+            "-n", "query-worker@$(HOSTNAME)"
           ]
       volumes:
         - name: {{ include "clp.volumeName" (dict

--- a/tools/deployment/package-helm/templates/query-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "clp.labels" . | nindent 4 }}
     app.kubernetes.io/component: "query-worker"
 spec:
-  replicas: {{ .Values.queryWorker.replicas }}
+  replicas: {{ .Values.scheduling.queryWorker.replicas }}
   selector:
     matchLabels:
       {{- include "clp.selectorLabels" . | nindent 6 }}
@@ -87,7 +87,7 @@ spec:
             "--concurrency", "{{ .Values.workerConcurrency }}",
             "--loglevel", "WARNING",
             "-Q", "query",
-            "-n", "query-worker@$(HOSTNAME)"
+            "-n", "query-worker"
           ]
       volumes:
         - name: {{ include "clp.volumeName" (dict

--- a/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
@@ -40,6 +40,25 @@ spec:
             "--config", "/etc/mongo/mongod.conf",
             "--bind_ip", "0.0.0.0"
           ]
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "bash"
+                  - "-c"
+                  - |
+                    until mongosh --host localhost:27017 --eval "db.runCommand('ping')" \
+                        --quiet 2>/dev/null; do
+                      sleep 1
+                    done
+                    mongosh --host localhost:27017 --eval '
+                      try { rs.status(); } catch(e) {
+                        rs.initiate({
+                          _id: "rs0",
+                          members: [{_id: 0, host: "localhost:27017"}]
+                        });
+                      }
+                    ' 2>/dev/null || true
           readinessProbe:
             {{- include "clp.readinessProbeTimings" . | nindent 12 }}
             exec: &results-cache-health-check

--- a/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
@@ -47,8 +47,15 @@ spec:
                   - "bash"
                   - "-c"
                   - |
+                    attempts=0
+                    max_attempts=30
                     until mongosh --host localhost:27017 --eval "db.runCommand('ping')" \
                         --quiet 2>/dev/null; do
+                      attempts=$((attempts + 1))
+                      if [ "$attempts" -ge "$max_attempts" ]; then
+                        echo "ERROR: MongoDB did not become ready after ${max_attempts}s" >&2
+                        exit 1
+                      fi
                       sleep 1
                     done
                     mongosh --host localhost:27017 --eval '
@@ -58,7 +65,7 @@ spec:
                           members: [{_id: 0, host: "localhost:27017"}]
                         });
                       }
-                    ' 2>/dev/null || true
+                    '
           readinessProbe:
             {{- include "clp.readinessProbeTimings" . | nindent 12 }}
             exec: &results-cache-health-check


### PR DESCRIPTION
## Summary
- Adds a `postStart` lifecycle hook to the results-cache (MongoDB) StatefulSet that automatically initializes the replica set (`rs0`) when the PVC is fresh/recreated.
- The hook waits for mongod to accept connections, then runs `rs.initiate()` only if `rs.status()` fails (i.e., the replica set is not yet configured). This is idempotent and safe on normal restarts.
- Bumps Helm chart version to `0.3.2-dev.3`.

## Problem
When the results-cache pod's PVC is deleted and recreated (e.g., during disaster recovery or testing), MongoDB starts in `RSGhost` state because `mongod.conf` has `replication.replSetName: "rs0"` but no replica set has been initiated on the fresh data directory. All clients then fail with `"No servers match selector Primary()"`.

Fixes #2257

## Test plan
- [ ] Deploy the Helm chart with a fresh PVC (delete the existing results-cache PVC first)
- [ ] Verify the MongoDB pod starts successfully and transitions to Primary state
- [ ] Verify clients (results-cache-indices-creator job, query workers, web UI) can connect without errors
- [ ] Verify that a normal pod restart (without PVC deletion) still works correctly (idempotent hook)
- [ ] Run `kubectl exec` into the results-cache pod and confirm `rs.status()` shows a healthy primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped deployment version to 0.3.2-dev.3

* **Infrastructure Improvements**
  * Worker replica counts now follow the scheduling configuration for better scaling control
  * Results cache now performs automatic MongoDB replica set initialization on startup for improved cache stability and reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/y-scope/clp/pull/2270)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes https://github.com/y-scope/clp/issues/2257