### PR TITLE
docs: Revert removal of PostgreSQL dataset from resources documentation.

### DIFF
--- a/docs/src/user-docs/resources-datasets.md
+++ b/docs/src/user-docs/resources-datasets.md
@@ -16,6 +16,7 @@ For evaluation results comparing CLP and other tools, see our
 | [cockroachdb][5]                   | JSON   | 9.79 GB           | 528.97 MB     |
 | [elasticsearch][6]                 | JSON   | 7.98 GB           | 165.91 MB     |
 | [spark-event-logs][7]              | JSON   | 1.98 GB           | 211.88 MB     |
+| [postgresql][8]                    | JSON   | 392.84 MB         | 14.59 MB      |
 
 *<sup>†</sup> We will upload the other parts soon.*
 
@@ -32,3 +33,5 @@ For evaluation results comparing CLP and other tools, see our
 [6]: https://zenodo.org/records/10516226
 
 [7]: https://zenodo.org/records/10516345
+
+[8]: https://zenodo.org/records/10516401


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Revert #2028 and restore the `postgresql` dataset entry to the resources documentation.

#2028 removed the dataset because its timestamps, such as `2023-03-27 00:26:35.719 EDT`, could not be parsed after stricter timestamp parsing was introduced. The underlying parsing issue has since been resolved by xxxx, so the dataset can be listed again.

Update: it's found the issue has not been resolved.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

should verify
 that this PR only restores the `postgresql` dataset entry that was removed by #2028.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added PostgreSQL dataset entry to the datasets reference table, including uncompressed and download sizes, with corresponding Zenodo reference link.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/y-scope/clp/pull/2272)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->