### PR TITLE
feat(yscope-clp-core): Emit single-file archives as files instead of directories; Improve `ClpArchiveWriter` lifecycle and API semantics.

### DIFF
--- a/python-wheels/yscope-clp-core/yscope_clp_core/__init__.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/__init__.py
@@ -29,9 +29,9 @@ from yscope_clp_core._except import (
 )
 
 __all__ = [
+    "CLP_SFA_MAGIC_BYTES",
     "ArchiveClosedError",
     "BadArchiveSourceError",
-    "CLP_SFA_MAGIC_BYTES",
     "BadCompressionInputError",
     "ClpArchiveReader",
     "ClpArchiveWriter",

--- a/python-wheels/yscope-clp-core/yscope_clp_core/__init__.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/__init__.py
@@ -1,6 +1,8 @@
 """Public entry points for the yscope_clp_core Python package."""
 
 from yscope_clp_core._api import (
+    CLP_SFA_MAGIC_BYTES,
+    is_clp_json_single_file_archive,
     open_archive,
     search_archive,
 )
@@ -29,6 +31,7 @@ from yscope_clp_core._except import (
 __all__ = [
     "ArchiveClosedError",
     "BadArchiveSourceError",
+    "CLP_SFA_MAGIC_BYTES",
     "BadCompressionInputError",
     "ClpArchiveReader",
     "ClpArchiveWriter",
@@ -42,6 +45,7 @@ __all__ = [
     "LogEvent",
     "SearchKwargs",
     "clp_s",
+    "is_clp_json_single_file_archive",
     "open_archive",
     "search_archive",
 ]

--- a/python-wheels/yscope-clp-core/yscope_clp_core/__init__.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/__init__.py
@@ -19,6 +19,7 @@ from yscope_clp_core._config import (
     SearchKwargs,
 )
 from yscope_clp_core._except import (
+    ArchiveClosedError,
     BadArchiveSourceError,
     BadCompressionInputError,
     ClpCoreError,
@@ -26,6 +27,7 @@ from yscope_clp_core._except import (
 )
 
 __all__ = [
+    "ArchiveClosedError",
     "BadArchiveSourceError",
     "BadCompressionInputError",
     "ClpArchiveReader",

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_api.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_api.py
@@ -28,22 +28,22 @@ from yscope_clp_core._utils import _validate_archive_source
 CLP_SFA_MAGIC_BYTES = b"\xfd\x2f\xc5\x30"
 
 
-def is_clp_json_single_file_archive(input: ArchiveInputSource) -> bool:
+def is_clp_json_single_file_archive(source: ArchiveInputSource) -> bool:
     """
     Detect whether the input source starts with the CLP JSON single-file archive magic bytes.
 
-    :param input: Archive source. Must be either a filesystem path or a binary I/O object.
+    :param source: Archive source. Must be either a filesystem path or a binary I/O object.
     :return: True if the input starts with the CLP SFA magic bytes.
     :raise: Propagates `_validate_archive_source`'s exceptions.
     """
     magic_len = len(CLP_SFA_MAGIC_BYTES)
-    _validate_archive_source(input)
+    _validate_archive_source(source)
 
-    if isinstance(input, (str, os.PathLike)):
-        with Path(input).open("rb") as archive_file:
+    if isinstance(source, (str, os.PathLike)):
+        with Path(source).open("rb") as archive_file:
             return archive_file.read(magic_len) == CLP_SFA_MAGIC_BYTES
 
-    return input.read(magic_len) == CLP_SFA_MAGIC_BYTES
+    return source.read(magic_len) == CLP_SFA_MAGIC_BYTES
 
 
 @overload

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_api.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_api.py
@@ -1,5 +1,7 @@
 """Public APIs for the yscope_clp_core python package."""
 
+import os
+from pathlib import Path
 from typing import (
     Any,
     Literal,
@@ -21,6 +23,27 @@ from yscope_clp_core._config import (
     SearchKwargs,
 )
 from yscope_clp_core._except import ClpCoreRuntimeError
+from yscope_clp_core._utils import _validate_archive_source
+
+CLP_SFA_MAGIC_BYTES = b"\xfd\x2f\xc5\x30"
+
+
+def is_clp_json_single_file_archive(input: ArchiveInputSource) -> bool:
+    """
+    Detect whether the input source starts with the CLP JSON single-file archive magic bytes.
+
+    :param input: Archive source. Must be either a filesystem path or a binary I/O object.
+    :return: True if the input starts with the CLP SFA magic bytes.
+    :raise: Propagates `_validate_archive_source`'s exceptions.
+    """
+    magic_len = len(CLP_SFA_MAGIC_BYTES)
+    _validate_archive_source(input)
+
+    if isinstance(input, (str, os.PathLike)):
+        with Path(input).open("rb") as archive_file:
+            return archive_file.read(magic_len) == CLP_SFA_MAGIC_BYTES
+
+    return input.read(magic_len) == CLP_SFA_MAGIC_BYTES
 
 
 @overload

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -58,6 +58,7 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
         :param file: Archive sink. Must be either a filesystem path or a binary I/O object.
         :param kwargs: Compression specific keyword arguments. See `CompressionKwargs`.
         :raise ClpCoreRuntimeError: if initialization fails.
+        :raise: Propagates `_validate_archive_source`'s exceptions.
         """
         self._is_open: bool = False
 
@@ -99,7 +100,7 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             the CLP compression pipeline currently does not support operating on stdin.
         :raise ArchiveClosedError: If the archive writer is already closed.
         :raise BadCompressionInputError: If the input source type is not supported.
-        :raise ClpCoreRuntimeError: If the input source cannot be processed successfully.
+        :raise: Propagates `_write_stream_to_temp_file`'s exceptions.
         """
         if not self._is_open:
             err_msg = "ClpArchiveWriter already closed."

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -9,7 +9,7 @@ from contextlib import AbstractContextManager, suppress
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import TracebackType
-from typing import Any, cast, IO
+from typing import Any, IO
 
 from typing_extensions import Unpack
 
@@ -177,7 +177,7 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
         else:
             with uuid_archive_path.open("rb") as archive_file:
                 shutil.copyfileobj(
-                    archive_file, cast("IO[bytes]", self._file), length=FILE_OBJ_COPY_CHUNK_SIZE
+                    archive_file, self._file, length=FILE_OBJ_COPY_CHUNK_SIZE
                 )
 
         # Close the archive in case the user calls this function manually

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -24,6 +24,7 @@ from yscope_clp_core._config import (
     SearchKwargs,
 )
 from yscope_clp_core._except import (
+    ArchiveClosedError,
     BadCompressionInputError,
     ClpCoreRuntimeError,
 )
@@ -58,6 +59,8 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
         :param kwargs: Compression specific keyword arguments. See `CompressionKwargs`.
         :raise ClpCoreRuntimeError: if initialization fails.
         """
+        self._is_open: bool = False
+
         self._file: ArchiveInputSource = file
         self._compression_level: int | None = kwargs.get("compression_level")
         self._timestamp_key: str | None = kwargs.get("timestamp_key")
@@ -85,6 +88,8 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             self._temp_archive_dir = TemporaryDirectory()
             self._archive_dir = Path(self._temp_archive_dir.name)
 
+        self._is_open = True
+
     def add(self, source: str | os.PathLike[str] | IO[bytes] | IO[str]) -> None:
         """
         Add an input source to be included in the compressed archive.
@@ -92,9 +97,14 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
         :param source: Input source to add. Must be a filesystem path or an I/O stream. Filesystem
             paths are added directly. Stream inputs are first materialized into temporary files, as
             the CLP compression pipeline currently does not support operating on stdin.
+        :raise ArchiveClosedError: If the archive writer is already closed.
         :raise BadCompressionInputError: If the input source type is not supported.
         :raise ClpCoreRuntimeError: If the input source cannot be processed successfully.
         """
+        if not self._is_open:
+            err_msg = "ClpArchiveWriter already closed."
+            raise ArchiveClosedError(err_msg)
+
         if isinstance(source, (str, os.PathLike)):
             self._files_to_compress.append(Path(source))
         elif isinstance(source, io.IOBase):
@@ -105,14 +115,47 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             err_msg = f"Invalid compression input type for archive {self._archive_dir}."
             raise BadCompressionInputError(err_msg)
 
+    def flush(self) -> None:
+        """
+        :raise ArchiveClosedError: If the archive writer is already closed.
+        :raise io.UnsupportedOperation: Archive writer does not support concepts of flush or append.
+        """
+        if not self._is_open:
+            err_msg = "ClpArchiveWriter already closed."
+            raise ArchiveClosedError(err_msg)
+
+        err_msg = "ClpArchiveWriter does not support flush. Archives are finalized in one pass."
+        raise io.UnsupportedOperation(err_msg)
+
+    def close(self) -> None:
+        """
+        Finalize archive creation and release associated resources.
+
+        The writer is closed after this method is called, regardless of whether archive finalization
+        succeeds. Further operations on the writer will raise `ArchiveClosedError`.
+
+        :raise: Propagates `_compress`'s exceptions.
+        """
+        try:
+            if self._is_open:
+                self._compress()
+        finally:
+            self._is_open = False
+            self._cleanup()
+
     def _compress(self) -> None:
         """
         Perform compression and, if a binary I/O stream was provided at initialization, write the
         archive contents to that stream. Should not be called by the class user.
 
+        :raise ArchiveClosedError: If the archive writer is already closed.
         :raise BadCompressionInputError: If there is nothing to compress.
-        :raise subprocess.CalledProcessError: If the archive compression fails.
+        :raise ClpCoreRuntimeError: If the archive compression fails.
         """
+        if not self._is_open:
+            err_msg = "ClpArchiveWriter already closed."
+            raise ArchiveClosedError(err_msg)
+
         if 0 == len(self._files_to_compress):
             err_msg = f"Nothing to compress for archive {self._archive_dir}."
             raise BadCompressionInputError(err_msg)
@@ -138,7 +181,10 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
                     archive_file, cast("IO[bytes]", self._file), length=FILE_OBJ_COPY_CHUNK_SIZE
                 )
 
-    def close(self) -> None:
+        # Close the archive in case the user calls this function manually
+        self._is_open = False
+
+    def _cleanup(self) -> None:
         """Cleans up all temporary resources used by the archive writer."""
         for p in self._temp_files_to_compress:
             with suppress(OSError):
@@ -166,16 +212,14 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
         :param exc_type:
         :param exc_val:
         :param exc_tb:
-        :raise ClpCoreRuntimeError: If compression fails.
+        :raise: Propagates `_compress`'s exceptions.
         """
         try:
-            if exc_type is None:
+            if exc_type is None and self._is_open:
                 self._compress()
-        except Exception as e:
-            err_msg = f"Failed to compress archive {self._archive_dir}."
-            raise ClpCoreRuntimeError(err_msg) from e
         finally:
-            self.close()
+            self._is_open = False
+            self._cleanup()
 
 
 class ClpArchiveReader(AbstractContextManager["ClpArchiveReader", None], Iterator[LogEvent]):

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -176,9 +176,7 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             shutil.move(str(uuid_archive_path), self._archive_path)
         else:
             with uuid_archive_path.open("rb") as archive_file:
-                shutil.copyfileobj(
-                    archive_file, self._file, length=FILE_OBJ_COPY_CHUNK_SIZE
-                )
+                shutil.copyfileobj(archive_file, self._file, length=FILE_OBJ_COPY_CHUNK_SIZE)
 
         # Close the archive in case the user calls this function manually
         self._is_open = False

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -121,12 +121,10 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
     def flush(self) -> None:
         """
         Flush is a no-op since archive appending is currently no supported.
-
-        :raise ArchiveClosedError: If the archive writer is already closed.
         """
         if not self._is_open:
-            err_msg = "ClpArchiveWriter already closed."
-            raise ArchiveClosedError(err_msg)
+            # Should throw `ArchiveClosedError` once flush is properly supported
+            pass
 
     def close(self) -> None:
         """

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import warnings
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, suppress
 from pathlib import Path
@@ -119,15 +120,13 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
 
     def flush(self) -> None:
         """
+        Flush is a no-op since archive appending is currently no supported.
+
         :raise ArchiveClosedError: If the archive writer is already closed.
-        :raise io.UnsupportedOperation: Archive writer does not support concepts of flush or append.
         """
         if not self._is_open:
             err_msg = "ClpArchiveWriter already closed."
             raise ArchiveClosedError(err_msg)
-
-        err_msg = "ClpArchiveWriter does not support flush. Archives are finalized in one pass."
-        raise io.UnsupportedOperation(err_msg)
 
     def close(self) -> None:
         """

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import subprocess
 import sys
-import warnings
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, suppress
 from pathlib import Path
@@ -119,9 +118,7 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             raise BadCompressionInputError(err_msg)
 
     def flush(self) -> None:
-        """
-        Flush is a no-op since archive appending is currently no supported.
-        """
+        """Flush is a no-op since archive appending is currently no supported."""
         if not self._is_open:
             # Should throw `ArchiveClosedError` once flush is properly supported
             pass

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_archive_io.py
@@ -71,23 +71,24 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
 
         _validate_archive_source(self._file)
 
-        self._archive_dir: Path
-        self._temp_archive_dir: TemporaryDirectory[str] | None = None
+        # Create a temporary directory for the archive to live in, and then:
+        # - move the archive to the specified archive path, or
+        # - feed the archive into the IO[bytes] stream
+        self._temp_archive_dir: TemporaryDirectory[str] = TemporaryDirectory()
+
+        self._archive_path: Path
         if isinstance(self._file, (str, os.PathLike)):
-            self._archive_dir = Path(self._file)
+            self._archive_path = Path(self._file)
             try:
-                if self._archive_dir.is_dir():
-                    shutil.rmtree(self._archive_dir)
-                elif self._archive_dir.is_file():
-                    self._archive_dir.unlink()
+                if self._archive_path.is_dir():
+                    shutil.rmtree(self._archive_path)
+                elif self._archive_path.is_file():
+                    self._archive_path.unlink()
             except Exception as e:
-                err_msg = f"Failed to overwrite archive at {self._archive_dir}."
+                err_msg = f"Failed to overwrite archive at {self._archive_path}."
                 raise ClpCoreRuntimeError(err_msg) from e
         else:
-            # Create a temporary directory for the archive to live in, and feed
-            # the archive into the IO[bytes] stream.
-            self._temp_archive_dir = TemporaryDirectory()
-            self._archive_dir = Path(self._temp_archive_dir.name)
+            self._archive_path = Path(self._temp_archive_dir.name)
 
         self._is_open = True
 
@@ -113,7 +114,7 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             self._files_to_compress.append(temp_file_path)
             self._temp_files_to_compress.append(temp_file_path)
         else:
-            err_msg = f"Invalid compression input type for archive {self._archive_dir}."
+            err_msg = f"Invalid compression input type for archive {self._archive_path}."
             raise BadCompressionInputError(err_msg)
 
     def flush(self) -> None:
@@ -158,7 +159,7 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             raise ArchiveClosedError(err_msg)
 
         if 0 == len(self._files_to_compress):
-            err_msg = f"Nothing to compress for archive {self._archive_dir}."
+            err_msg = f"Nothing to compress for archive {self._archive_path}."
             raise BadCompressionInputError(err_msg)
 
         clp_s_bin_path = _get_clp_exe("clp-s")
@@ -167,17 +168,20 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             compress_cmd.extend(["--compression-level", str(self._compression_level)])
         if self._timestamp_key is not None:
             compress_cmd.extend(["--timestamp-key", self._timestamp_key])
-        compress_cmd.append(str(self._archive_dir))
+        compress_cmd.append(self._temp_archive_dir.name)
         compress_cmd.extend(str(p) for p in self._files_to_compress)
 
         try:
             subprocess.run(compress_cmd, check=True, stderr=subprocess.PIPE, text=True)
         except subprocess.CalledProcessError as e:
-            err_msg = f"Compression for archive {self._archive_dir} failed: {e.stderr.strip()}"
+            err_msg = f"Compression for archive {self._archive_path} failed: {e.stderr.strip()}"
             raise ClpCoreRuntimeError(err_msg) from e
 
-        if self._temp_archive_dir is not None:
-            with _get_single_file_in_dir(self._archive_dir).open("rb") as archive_file:
+        uuid_archive_path: Path = _get_single_file_in_dir(Path(self._temp_archive_dir.name))
+        if isinstance(self._file, (str, os.PathLike)):
+            shutil.move(str(uuid_archive_path), self._archive_path)
+        else:
+            with uuid_archive_path.open("rb") as archive_file:
                 shutil.copyfileobj(
                     archive_file, cast("IO[bytes]", self._file), length=FILE_OBJ_COPY_CHUNK_SIZE
                 )
@@ -191,10 +195,8 @@ class ClpArchiveWriter(AbstractContextManager["ClpArchiveWriter", None]):
             with suppress(OSError):
                 p.unlink()
 
-        if self._temp_archive_dir is not None:
-            with suppress(OSError):
-                self._temp_archive_dir.cleanup()
-            self._temp_archive_dir = None
+        with suppress(OSError):
+            self._temp_archive_dir.cleanup()
 
     def __enter__(self) -> Self:
         return self

--- a/python-wheels/yscope-clp-core/yscope_clp_core/_except.py
+++ b/python-wheels/yscope-clp-core/yscope_clp_core/_except.py
@@ -9,6 +9,10 @@ class ClpCoreRuntimeError(ClpCoreError, RuntimeError):
     """Generic RuntimeError exception for yscope_clp_core."""
 
 
+class ArchiveClosedError(ClpCoreError, ValueError):
+    """Raised when an operation is attempted on a closed archive handler."""
+
+
 class BadArchiveSourceError(ClpCoreError, TypeError):
     """Raised when the archive source has an invalid type."""
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Previously, `ClpArchiveWriter` emitted the CLP JSON single-file archives inside directories. This behavior differed from typical file-oriented compression tools such as `gzip` and `zstd`, where the provided output path corresponds directly to the generated file. This PR updates the writer APIs so single-file archives are emitted as regular files at the caller-provided output path.

The PR also refines the `ClpArchiveWriter` lifecycle and API semantics so that compression, cleanup, and closed-state behavior are clearer and more consistent for callers:
- `close()` now finalizes the archive and cleans up resources.
  -  Previously, `close()` only cleaned up temporary resources. It did not finalize or compress the archive.
- `__exit__()` follows the same lifecycle semantics as `close()`, but for context-manager usage.
- `_cleanup()` is now responsible only for temporary resource cleanup.
  - This is what `close()` used to do.
- Introduces `flush()`, which is a no-op since `ClpArchiveWriter` is not appendable.

Lastly, a small public helper is added for detecting CLP JSON single-file archives through magic-byte inspection.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [X] Works with Tritonparse feature PR: https://github.com/y-scope/tritonparse/pull/2/changes#diff-3bc3c9c8048fe7f269d025f3c8a80453d882d5cd51081fea571206cd6a29d92fR365

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
