### PR TITLE
fix(package-build): Explicitly disable libsnappy for mongoc builds on systems with libsnappy installed (fixes #2294).

### DIFF
--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -415,6 +415,7 @@ tasks:
             - "-DBUILD_SHARED_LIBS_WITH_STATIC_MONGOC=ON"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+            - "-DENABLE_SNAPPY=OFF"
             - "-DENABLE_UNINSTALL=OFF"
           LIB_NAME: "mongocxx"
           TARBALL_SHA256: "19dff3cf834a3e09229260f22a0325820a7e30c78b294db91794dd934776b33a"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

For systems with `libsnappy` installed, currently the mongo-c-driver will include `libsnappy` with `ENABLE_SNAPPY` set to [`AUTO`](https://github.com/mongodb/mongo-c-driver/blob/66cf09c0f26ad13885daf331e419d1df45857275/Earthfile#L49), but it is not required for a successful mongo c driver build used by the reducer server.

With libsnappy:

```
bingranhu@DESKTOP-9ER04S9:~/clp/build/core$ ldd reducer-server
        linux-vdso.so.1 (0x00007ffe6d5fd000)
        libsnappy.so.1 => /lib/x86_64-linux-gnu/libsnappy.so.1 (0x00007594819a0000)
        libzstd.so.1 => /usr/local/lib/libzstd.so.1 (0x00007594814ea000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x0000759481446000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x0000759481000000)
        libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x0000759481985000)
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x000075948196f000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x0000759480c00000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000075948194f000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000759480800000)
        /lib64/ld-linux-x86-64.so.2 (0x00007594819b4000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000759480f19000)
```

Without libsnappy:
```
bingranhu@DESKTOP-9ER04S9:~/clp/build/core$ ldd ~/clp/components/core/build/reducer-server
        linux-vdso.so.1 (0x00007ffe3630b000)
        libzstd.so.1 => /usr/local/lib/libzstd.so.1 (0x0000790502de8000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x0000790502d3c000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x0000790502400000)
        libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x0000790502d21000)
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x0000790502d0d000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x0000790502000000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007905029e0000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000790501c00000)
        /lib64/ld-linux-x86-64.so.2 (0x0000790502f00000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007905028f9000)
```

Since we do not have `libsnappy` in our `reducer-server` Docker image, let's disable it with this PR.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Package starts up successfully and C++ unit tests pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Snappy compression support in the MongoDB C++ driver build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/y-scope/clp/pull/2292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->