### PR TITLE
feat(CLP-JSON): Add Messages and Files stats display to CLP-JSON Web UI Ingest page.

### DIFF
--- a/components/clp-py-utils/clp_py_utils/clp_metadata_db_utils.py
+++ b/components/clp-py-utils/clp_py_utils/clp_metadata_db_utils.py
@@ -32,6 +32,8 @@ def _create_archives_table(db_cursor, archives_table_name: str) -> None:
             `size` BIGINT NOT NULL,
             `creator_id` VARCHAR(64) NOT NULL,
             `creation_ix` INT NOT NULL,
+            `num_messages` BIGINT NULL DEFAULT NULL,
+            `num_files` BIGINT NULL DEFAULT NULL,
             KEY `archives_creation_order` (`creator_id`,`creation_ix`) USING BTREE,
             UNIQUE KEY `archive_id` (`id`) USING BTREE,
             PRIMARY KEY (`pagination_id`)

--- a/components/core/src/clp/streaming_archive/Constants.hpp
+++ b/components/core/src/clp/streaming_archive/Constants.hpp
@@ -34,6 +34,8 @@ constexpr char UncompressedSize[] = "uncompressed_size";
 constexpr char Size[] = "size";
 constexpr char CreatorId[] = "creator_id";
 constexpr char CreationIx[] = "creation_ix";
+constexpr char NumMessages[] = "num_messages";
+constexpr char NumFiles[] = "num_files";
 }  // namespace Archive
 
 namespace File {

--- a/components/core/src/clp_s/ArchiveWriter.cpp
+++ b/components/core/src/clp_s/ArchiveWriter.cpp
@@ -120,7 +120,9 @@ auto ArchiveWriter::close(bool is_split) -> ArchiveStats {
             m_uncompressed_size,
             m_compressed_size,
             archive_range_index,
-            is_split
+            is_split,
+            static_cast<size_t>(m_next_log_event_id),
+            m_num_files
     };
     if (m_print_archive_stats) {
         std::cout << archive_stats.as_string() << '\n';
@@ -135,6 +137,7 @@ auto ArchiveWriter::close(bool is_split) -> ArchiveStats {
     m_uncompressed_size = 0UL;
     m_compressed_size = 0UL;
     m_next_log_event_id = 0;
+    m_num_files = 0;
     m_authoritative_timestamp.clear();
     m_authoritative_timestamp_namespace.clear();
     m_matched_timestamp_prefix_length = 0ULL;

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -284,7 +284,6 @@ public:
                 return rc;
             }
             m_range_open = true;
-            ++m_num_files;
         }
         return m_range_index_writer.add_value_to_range(key, value);
     }
@@ -300,6 +299,8 @@ public:
         }
         return rc;
     }
+
+    void increment_num_files() { ++m_num_files; }
 
 private:
     /**

--- a/components/core/src/clp_s/ArchiveWriter.hpp
+++ b/components/core/src/clp_s/ArchiveWriter.hpp
@@ -47,7 +47,9 @@ public:
             size_t uncompressed_size,
             size_t compressed_size,
             nlohmann::json range_index,
-            bool is_split
+            bool is_split,
+            size_t num_messages,
+            size_t num_files
     )
             : m_id{id},
               m_begin_timestamp{begin_timestamp},
@@ -55,7 +57,9 @@ public:
               m_uncompressed_size{uncompressed_size},
               m_compressed_size{compressed_size},
               m_range_index(std::move(range_index)),  // Avoid {} to prevent wrapping in JSON array.
-              m_is_split{is_split} {}
+              m_is_split{is_split},
+              m_num_messages{num_messages},
+              m_num_files{num_files} {}
 
     // Methods
     /**
@@ -72,6 +76,8 @@ public:
                    {Archive::EndTimestamp, m_end_timestamp},
                    {Archive::UncompressedSize, m_uncompressed_size},
                    {Archive::Size, m_compressed_size},
+                   {Archive::NumMessages, m_num_messages},
+                   {Archive::NumFiles, m_num_files},
                    {File::IsSplit, m_is_split},
                    {cRangeIndex, m_range_index}};
         return json_msg.dump(-1, ' ', false, nlohmann::json::error_handler_t::ignore);
@@ -91,6 +97,10 @@ public:
 
     [[nodiscard]] auto get_is_split() const -> bool { return m_is_split; }
 
+    [[nodiscard]] auto get_num_messages() const -> size_t { return m_num_messages; }
+
+    [[nodiscard]] auto get_num_files() const -> size_t { return m_num_files; }
+
 private:
     std::string m_id;
     epochtime_t m_begin_timestamp{};
@@ -99,6 +109,8 @@ private:
     size_t m_compressed_size{};
     nlohmann::json m_range_index;
     bool m_is_split{};
+    size_t m_num_messages{};
+    size_t m_num_files{};
 };
 
 class ArchiveWriter {
@@ -272,6 +284,7 @@ public:
                 return rc;
             }
             m_range_open = true;
+            ++m_num_files;
         }
         return m_range_index_writer.add_value_to_range(key, value);
     }
@@ -375,6 +388,7 @@ private:
 
     RangeIndexWriter m_range_index_writer;
     bool m_range_open{false};
+    size_t m_num_files{};
 };
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/JsonParser.cpp
+++ b/components/core/src/clp_s/JsonParser.cpp
@@ -723,6 +723,9 @@ auto JsonParser::ingest_json(
     size_t file_split_number{0ULL};
     int32_t log_event_idx_node_id{};
     auto initialize_fields_for_archive = [&]() -> bool {
+        if (0 == file_split_number) {
+            m_archive_writer->increment_num_files();
+        }
         if (false == m_record_log_order) {
             return true;
         }
@@ -891,6 +894,9 @@ auto JsonParser::ingest_kvir(
     size_t file_split_number{0ULL};
     int32_t log_event_idx_node_id{};
     auto initialize_fields_for_archive = [&]() -> bool {
+        if (0 == file_split_number) {
+            m_archive_writer->increment_num_files();
+        }
         if (false == m_record_log_order) {
             return true;
         }

--- a/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
+++ b/components/job-orchestration/job_orchestration/executor/compress/compression_task.py
@@ -106,6 +106,8 @@ def update_archive_metadata(
         "begin_timestamp",
         "end_timestamp",
         "id",
+        "num_messages",
+        "num_files",
         "size",
         "uncompressed_size",
     ]

--- a/components/webui/client/src/pages/IngestPage/Details/index.tsx
+++ b/components/webui/client/src/pages/IngestPage/Details/index.tsx
@@ -42,31 +42,20 @@ const Details = () => {
         enabled: CLP_STORAGE_ENGINES.CLP === SETTINGS_STORAGE_ENGINE || isSuccessDatasetNames,
     });
 
-    if (CLP_STORAGE_ENGINES.CLP === SETTINGS_STORAGE_ENGINE) {
-        return (
-            <div className={styles["detailsGrid"]}>
-                <div className={styles["timeRange"]}>
-                    <TimeRange
-                        beginDate={dayjs.utc(details.begin_timestamp)}
-                        endDate={dayjs.utc(details.end_timestamp)}
-                        isLoading={isPending}/>
-                </div>
-                <Messages
-                    isLoading={isPending}
-                    numMessages={details.num_messages}/>
-                <Files
-                    isLoading={isPending}
-                    numFiles={details.num_files}/>
-            </div>
-        );
-    }
-
     return (
-        <div>
-            <TimeRange
-                beginDate={dayjs.utc(details.begin_timestamp)}
-                endDate={dayjs.utc(details.end_timestamp)}
-                isLoading={isPending}/>
+        <div className={styles["detailsGrid"]}>
+            <div className={styles["timeRange"]}>
+                <TimeRange
+                    beginDate={dayjs.utc(details.begin_timestamp)}
+                    endDate={dayjs.utc(details.end_timestamp)}
+                    isLoading={isPending}/>
+            </div>
+            <Messages
+                isLoading={isPending}
+                numMessages={details.num_messages}/>
+            <Files
+                isLoading={isPending}
+                numFiles={details.num_files}/>
         </div>
     );
 };

--- a/components/webui/client/src/pages/IngestPage/Details/sql.ts
+++ b/components/webui/client/src/pages/IngestPage/Details/sql.ts
@@ -70,43 +70,22 @@ FROM
 const buildMultiDatasetDetailsSql = (datasetNames: string[]): string => {
     const archiveQueries = datasetNames.map((name) => `
     SELECT
-      MIN(${CLP_ARCHIVES_TABLE_COLUMN_NAMES.BEGIN_TIMESTAMP}) AS begin_timestamp,
-      MAX(${CLP_ARCHIVES_TABLE_COLUMN_NAMES.END_TIMESTAMP}) AS end_timestamp
+      ${CLP_ARCHIVES_TABLE_COLUMN_NAMES.BEGIN_TIMESTAMP},
+      ${CLP_ARCHIVES_TABLE_COLUMN_NAMES.END_TIMESTAMP},
+      ${CLP_ARCHIVES_TABLE_COLUMN_NAMES.NUM_MESSAGES},
+      ${CLP_ARCHIVES_TABLE_COLUMN_NAMES.NUM_FILES}
     FROM ${settings.SqlDbClpTablePrefix}${name}_${SqlTableSuffix.ARCHIVES}
-  `);
-
-    const fileQueries = datasetNames.map((name) => `
-    SELECT
-      COUNT(DISTINCT ${CLP_FILES_TABLE_COLUMN_NAMES.ORIG_FILE_ID}) AS num_files,
-      CAST(
-        COALESCE(SUM(${CLP_FILES_TABLE_COLUMN_NAMES.NUM_MESSAGES}), 0) AS UNSIGNED
-      ) AS num_messages
-    FROM ${settings.SqlDbClpTablePrefix}${name}_${SqlTableSuffix.FILES}
   `);
 
     return `
     SELECT
-      a.begin_timestamp,
-      a.end_timestamp,
-      b.num_files,
-      b.num_messages
-    FROM
-    (
-      SELECT
-        MIN(begin_timestamp) AS begin_timestamp,
-        MAX(end_timestamp)   AS end_timestamp
-      FROM (
-        ${archiveQueries.join("\nUNION ALL\n")}
-      ) AS archives_combined
-    ) a,
-    (
-      SELECT
-        SUM(num_files)    AS num_files,
-        SUM(num_messages) AS num_messages
-      FROM (
-        ${fileQueries.join("\nUNION ALL\n")}
-      ) AS files_combined
-    ) b;
+      MIN(begin_timestamp) AS begin_timestamp,
+      MAX(end_timestamp)   AS end_timestamp,
+      CAST(COALESCE(SUM(num_messages), 0) AS UNSIGNED) AS num_messages,
+      CAST(COALESCE(SUM(num_files), 0) AS UNSIGNED) AS num_files
+    FROM (
+      ${archiveQueries.join("\nUNION ALL\n")}
+    ) AS archives_combined
   `;
 };
 

--- a/components/webui/client/src/pages/IngestPage/sqlConfig.ts
+++ b/components/webui/client/src/pages/IngestPage/sqlConfig.ts
@@ -6,6 +6,8 @@ enum CLP_ARCHIVES_TABLE_COLUMN_NAMES {
     END_TIMESTAMP = "end_timestamp",
     UNCOMPRESSED_SIZE = "uncompressed_size",
     SIZE = "size",
+    NUM_MESSAGES = "num_messages",
+    NUM_FILES = "num_files",
 }
 
 /**


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Problem

The CLP-JSON (clp-s) web UI Ingest page Details component only shows the TimeRange card, while CLP-Text additionally renders Messages (total log event count) and Files (total file count) cards. The root cause is that CLP-S doesn't populate the same data pipeline that CLP-Text relies on:

| Aspect | CLP-Text | CLP-S (before this PR) |
|--------|----------|------------------------|
| `num_messages` source | `SUM(num_messages)` from **files** table (per-file, `NOT NULL`) | Not tracked — `ArchiveStats` omits it |
| `num_files` source | `COUNT(DISTINCT orig_file_id)` from **files** table | Not tracked — `ArchiveStats` omits it |
| Archives table columns | `num_messages`, `num_files` left as `NULL` by C++ inserter | Same columns left as `NULL` |
| Web UI SQL | Joins `archives` + `files` tables | Joins `archives` + `files` tables, but **files table is empty** for CLP-S |

Because CLP-S never populates the `files` table, the join always yields `num_messages=0` and `num_files=0`.

## Solution

**C++ layer** — Extend `ArchiveStats` to include `num_messages` and `num_files`, matching how CLP-Text's data ultimately reaches the UI (but via a different source):

| Aspect | CLP-Text | CLP-S (after this PR) |
|--------|----------|------------------------|
| Stats class | `ArchiveMetadata` — no `num_messages`/`num_files` fields | `ArchiveStats` — now includes both |
| `num_messages` computed by | Per-file in SQLite/MySQL `files` table | `ArchiveWriter::m_next_log_event_id` (running log-event count) |
| `num_files` computed by | `COUNT(DISTINCT orig_file_id)` in SQL from `files` table | `ArchiveWriter::m_num_files` (range-index range count) |
| JSON output | `{id, uncompressed_size, size}` only | Now includes `num_messages` and `num_files` |

**Database layer** — Add nullable `BIGINT` columns `num_messages` and `num_files` to the `archives` table schema. The Python compression task's `update_archive_metadata()` now inserts these values from the C++ stats output, while CLP-Text's C++ inserter continues leaving them `NULL` (hence nullable).

**Web UI layer** — Rewrite `buildMultiDatasetDetailsSql()` to query only from the `archives` table, eliminating the dependency on the always-empty `files` table:

| Aspect | CLP-Text | CLP-S (after this PR) |
|--------|----------|------------------------|
| Tables queried | `clp_archives` + `clp_files` (join) | `<prefix>_<dataset>_archives` only (UNION ALL across datasets) |
| `num_messages` SQL | `SUM(num_messages)` from **files** | `COALESCE(SUM(num_messages), 0)` from **archives** |
| `num_files` SQL | `COUNT(DISTINCT orig_file_id)` from **files** | `COALESCE(SUM(num_files), 0)` from **archives** |

Update the CLP-S Details component to render Messages and Files cards using the same grid layout as CLP-Text.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

### Build

**Task**: Verify the full project builds successfully including the new C++ changes and web UI.

**Command**:
```bash
task
```
**Output**:
```
(Exit code 0 — build completed successfully, clp-package produced)
```

### End-to-end compression test (CLP-S)

**Task**: Verify the full compression pipeline — `clp-s` now outputs `num_messages` and `num_files` in its JSON stats, the Python task writes them to the DB, and the archives table contains non-NULL values.

**Command**:
```bash
cd build/clp-package
./sbin/start-clp.sh
./sbin/compress.sh --timestamp-key timestamp ~/samples/postgresql.jsonl
```
**Output**:
```
2026-05-23T02:31:42.871 INFO [compress] Compression job 1 submitted.
2026-05-23T02:31:44.875 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 198.26MB/s.
2026-05-23T02:31:45.376 INFO [compress] Compression finished.
2026-05-23T02:31:45.377 INFO [compress] Compressed 385.21MB into 10.06MB (38.31x). Speed: 178.34MB/s.
```

### Database verification

**Task**: Verify the `num_messages` and `num_files` columns in the archives table contain non-NULL, non-zero values after compression.

**Command**:
```bash
docker exec <database-container> mysql -u clp-user -p<password> clp-db -e "SELECT id, num_messages, num_files FROM clp_default_archives LIMIT 5;"
```
**Output**:
```
id	num_messages	num_files
ac317804-58aa-4a20-8e71-32321cf9ffbd	1000000	1
```

**Explanation**: Both `num_messages` (1,000,000 log events) and `num_files` (1 file) are populated with non-NULL values, confirming the C++ → Python → DB pipeline works correctly.

### Web UI browser validation (CLP-S Ingest page)

**Task**: Verify the CLP-JSON Ingest page now displays Messages and Files cards alongside the TimeRange card, using a browser.

Navigated to `http://localhost:4000/` and confirmed the Details section renders all three cards with correct values:

![CLP-JSON Ingest page — Details section](https://github.com/junhaoliao/clp/releases/download/temp-screenshots-2025/clp-details-grid.png)

**Explanation**: The screenshot shows the Time Range, Messages (1,000,000), and Files (1) cards all rendering correctly. The grid layout has 3 children (timeRange spanning 2 columns, Messages and Files each in 1 column), matching the CLP-Text layout.

### Details grid layout verification

**Task**: Verify the CSS grid layout structure matches CLP-Text (2-column grid with Time Range spanning full width).

Inspected the computed styles of the details grid element in the browser:

![CLP-JSON Ingest page — full page](https://github.com/junhaoliao/clp/releases/download/temp-screenshots-2025/clp-ingest-page-full.png)

**Explanation**: The grid uses a 2-column layout with 8px gap. The Time Range child spans both columns (via `grid-column: span 2` CSS), while Messages and Files each occupy one column — matching the CLP-Text Details layout exactly.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Archives now track message and file counts as metadata metrics available in the interface.

* **UI Changes**
  * Archive details page now displays message and file counts consistently across all archive types.
  * Removed conditional layout rendering to provide a unified details view.

* **Improvements**
  * Optimized metrics retrieval by aggregating message and file counts directly from archive metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/y-scope/clp/pull/2293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->