### PR TITLE
feat: Add single-container package image

### DIFF
--- a/components/clp-package-utils/clp_package_utils/controller.py
+++ b/components/clp-package-utils/clp_package_utils/controller.py
@@ -11,7 +11,6 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from types import MappingProxyType
-from typing import Any
 
 from clp_py_utils.clp_config import (
     API_SERVER_COMPONENT_NAME,
@@ -27,10 +26,8 @@ from clp_py_utils.clp_config import (
     ClpConfig,
     ClpDbNameType,
     ClpDbUserType,
-    COMPRESSION_JOBS_TABLE_NAME,
     COMPRESSION_SCHEDULER_COMPONENT_NAME,
     COMPRESSION_WORKER_COMPONENT_NAME,
-    CONTAINER_INPUT_LOGS_ROOT_DIR,
     DatabaseEngine,
     DB_COMPONENT_NAME,
     DeploymentType,
@@ -39,10 +36,8 @@ from clp_py_utils.clp_config import (
     MCP_SERVER_COMPONENT_NAME,
     OrchestrationType,
     OTEL_COLLECTOR_COMPONENT_NAME,
-    QUERY_JOBS_TABLE_NAME,
     QUERY_SCHEDULER_COMPONENT_NAME,
     QUERY_WORKER_COMPONENT_NAME,
-    QueryEngine,
     QUEUE_COMPONENT_NAME,
     REDIS_COMPONENT_NAME,
     REDUCER_COMPONENT_NAME,
@@ -50,14 +45,8 @@ from clp_py_utils.clp_config import (
     SPIDER_DB_PASS_ENV_VAR_NAME,
     SPIDER_DB_USER_ENV_VAR_NAME,
     SPIDER_SCHEDULER_COMPONENT_NAME,
-    StorageEngine,
     StorageType,
     WEBUI_COMPONENT_NAME,
-)
-from clp_py_utils.clp_metadata_db_utils import (
-    get_archives_table_name,
-    get_datasets_table_name,
-    get_files_table_name,
 )
 from clp_py_utils.core import resolve_host_path_in_container
 
@@ -78,6 +67,7 @@ from clp_package_utils.general import (
     validate_results_cache_config,
     validate_webui_config,
 )
+from clp_package_utils.webui_settings import update_webui_settings
 
 LOG_FILE_ACCESS_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 
@@ -710,117 +700,19 @@ class BaseController(ABC):
             server_settings_json_path,
         )
 
-        # Read, update, and write back client's and server's settings.json
-        clp_db_connection_params = self._clp_config.database.get_clp_connection_params_and_type(
-            True
-        )
-        table_prefix = clp_db_connection_params["table_prefix"]
-        if StorageEngine.CLP_S == self._clp_config.package.storage_engine:
-            archives_table_name = ""
-            files_table_name = ""
-        else:
-            archives_table_name = get_archives_table_name(table_prefix, None)
-            files_table_name = get_files_table_name(table_prefix, None)
-
-        client_settings_json_updates = {
-            "ClpStorageEngine": self._clp_config.package.storage_engine,
-            "ClpQueryEngine": self._clp_config.package.query_engine,
-            "LogsInputType": self._clp_config.logs_input.type,
-            "MaxDatasetsPerQuery": self._clp_config.query_scheduler.max_datasets_per_query,
-            "MongoDbSearchResultsMetadataCollectionName": (
-                self._clp_config.webui.results_metadata_collection_name
-            ),
-            "SqlDbClpArchivesTableName": archives_table_name,
-            "SqlDbClpDatasetsTableName": get_datasets_table_name(table_prefix),
-            "SqlDbClpFilesTableName": files_table_name,
-            "SqlDbClpTablePrefix": table_prefix,
-            "SqlDbCompressionJobsTableName": COMPRESSION_JOBS_TABLE_NAME,
-        }
-
-        server_settings_json_updates = {
-            "SqlDbHost": container_clp_config.database.host,
-            "SqlDbPort": container_clp_config.database.port,
-            "SqlDbName": self._clp_config.database.names[ClpDbNameType.CLP],
-            "SqlDbQueryJobsTableName": QUERY_JOBS_TABLE_NAME,
-            "SqlDbCompressionJobsTableName": COMPRESSION_JOBS_TABLE_NAME,
-            "MongoDbHost": container_clp_config.results_cache.host,
-            "MongoDbPort": container_clp_config.results_cache.port,
-            "MongoDbName": self._clp_config.results_cache.db_name,
-            "MongoDbSearchResultsMetadataCollectionName": (
-                self._clp_config.webui.results_metadata_collection_name
-            ),
-            "MongoDbStreamFilesCollectionName": (
-                self._clp_config.results_cache.stream_collection_name
-            ),
-            "ClientDir": str(container_webui_dir / "client"),
-            "LogViewerDir": str(container_webui_dir / "yscope-log-viewer"),
-            "StreamTargetUncompressedSize": self._clp_config.stream_output.target_uncompressed_size,
-            "ArchiveOutputCompressionLevel": self._clp_config.archive_output.compression_level,
-            "ArchiveOutputTargetArchiveSize": self._clp_config.archive_output.target_archive_size,
-            "ArchiveOutputTargetDictionariesSize": (
-                self._clp_config.archive_output.target_dictionaries_size
-            ),
-            "ArchiveOutputTargetEncodedFileSize": (
-                self._clp_config.archive_output.target_encoded_file_size
-            ),
-            "ArchiveOutputTargetSegmentSize": self._clp_config.archive_output.target_segment_size,
-            "ClpQueryEngine": self._clp_config.package.query_engine,
-            "ClpStorageEngine": self._clp_config.package.storage_engine,
-        }
-
-        stream_storage = self._clp_config.stream_output.storage
-        if StorageType.S3 == stream_storage.type:
-            s3_config = stream_storage.s3_config
-            server_settings_json_updates["StreamFilesDir"] = None
-            server_settings_json_updates["StreamFilesS3Region"] = s3_config.region_code
-            server_settings_json_updates["StreamFilesS3PathPrefix"] = (
-                f"{s3_config.bucket}/{s3_config.key_prefix}"
-            )
-            auth = s3_config.aws_authentication
-            if AwsAuthType.profile == auth.type:
-                server_settings_json_updates["StreamFilesS3Profile"] = auth.profile
-            else:
-                server_settings_json_updates["StreamFilesS3Profile"] = None
-        elif StorageType.FS == stream_storage.type:
-            server_settings_json_updates["StreamFilesDir"] = str(
-                container_clp_config.stream_output.get_directory()
-            )
-            server_settings_json_updates["StreamFilesS3Region"] = None
-            server_settings_json_updates["StreamFilesS3PathPrefix"] = None
-            server_settings_json_updates["StreamFilesS3Profile"] = None
-
-        query_engine = self._clp_config.package.query_engine
-        if QueryEngine.PRESTO == query_engine:
-            server_settings_json_updates["PrestoHost"] = container_clp_config.presto.host
-            server_settings_json_updates["PrestoPort"] = container_clp_config.presto.port
-        else:
-            server_settings_json_updates["PrestoHost"] = None
-            server_settings_json_updates["PrestoPort"] = None
-
-        if StorageType.FS == self._clp_config.logs_input.type:
-            client_settings_json_updates["LogsInputRootDir"] = str(CONTAINER_INPUT_LOGS_ROOT_DIR)
-            server_settings_json_updates["LogsInputRootDir"] = str(CONTAINER_INPUT_LOGS_ROOT_DIR)
-        else:
-            client_settings_json_updates["LogsInputRootDir"] = None
-            server_settings_json_updates["LogsInputRootDir"] = None
-
         resolved_client_settings_json_path = resolve_host_path_in_container(
             client_settings_json_path
         )
-        client_settings_json = self._read_and_update_settings_json(
-            resolved_client_settings_json_path, client_settings_json_updates
-        )
-        with open(resolved_client_settings_json_path, "w") as client_settings_json_file:
-            client_settings_json_file.write(json.dumps(client_settings_json))
-
         resolved_server_settings_json_path = resolve_host_path_in_container(
             server_settings_json_path
         )
-        server_settings_json = self._read_and_update_settings_json(
-            resolved_server_settings_json_path, server_settings_json_updates
+        update_webui_settings(
+            self._clp_config,
+            container_clp_config,
+            resolved_client_settings_json_path,
+            resolved_server_settings_json_path,
+            container_webui_dir,
         )
-        with open(resolved_server_settings_json_path, "w") as settings_json_file:
-            settings_json_file.write(json.dumps(server_settings_json))
 
         env_vars = EnvVarsDict()
 
@@ -1022,46 +914,6 @@ class BaseController(ABC):
         )
 
         return env_vars
-
-    def _read_and_update_settings_json(
-        self, settings_file_path: pathlib.Path, updates: dict[str, Any]
-    ) -> dict[str, Any]:
-        """
-        Reads and updates a settings JSON file.
-
-        :param settings_file_path:
-        :param updates:
-        """
-        with open(settings_file_path, "r") as settings_json_file:
-            settings_object = json.loads(settings_json_file.read())
-        self._update_settings_object("", settings_object, updates)
-
-        return settings_object
-
-    def _update_settings_object(
-        self,
-        parent_key_prefix: str,
-        settings: dict[str, Any],
-        updates: dict[str, Any],
-    ) -> None:
-        """
-        Recursively updates the given settings object with the values from `updates`.
-
-        :param parent_key_prefix: The prefix for keys at this level in the settings dictionary.
-        :param settings: The settings to update.
-        :param updates: The updates.
-        :raise ValueError: If a key in `updates` doesn't exist in `settings`.
-        """
-        for key, value in updates.items():
-            if key not in settings:
-                error_msg = (
-                    f"{parent_key_prefix}{key} is not a valid configuration key for the webui."
-                )
-                raise ValueError(error_msg)
-            if isinstance(value, dict):
-                self._update_settings_object(f"{parent_key_prefix}{key}.", settings[key], value)
-            else:
-                settings[key] = value
 
 
 _DEPLOYMENT_TYPE_TO_COMPOSE_FILE: MappingProxyType[DeploymentType, str] = MappingProxyType(

--- a/components/clp-package-utils/clp_package_utils/webui_settings.py
+++ b/components/clp-package-utils/clp_package_utils/webui_settings.py
@@ -1,0 +1,177 @@
+"""Utilities for updating WebUI settings files in CLP package deployments."""
+
+import json
+import pathlib
+from typing import Any, cast
+
+from clp_py_utils.clp_config import (
+    AwsAuthType,
+    CLP_METADATA_TABLE_PREFIX,
+    ClpConfig,
+    ClpDbNameType,
+    COMPRESSION_JOBS_TABLE_NAME,
+    CONTAINER_INPUT_LOGS_ROOT_DIR,
+    QUERY_JOBS_TABLE_NAME,
+    QueryEngine,
+    StorageEngine,
+    StorageType,
+    StreamS3Storage,
+)
+from clp_py_utils.clp_metadata_db_utils import (
+    get_archives_table_name,
+    get_datasets_table_name,
+    get_files_table_name,
+)
+
+
+def _update_settings_object(
+    parent_key_prefix: str,
+    settings: dict[str, Any],
+    updates: dict[str, Any],
+) -> None:
+    """
+    Recursively updates the given settings object with the values from `updates`.
+
+    :param parent_key_prefix: The prefix for keys at this level in the settings dictionary.
+    :param settings: The settings to update.
+    :param updates: The updates.
+    :raise ValueError: If a key in `updates` doesn't exist in `settings`.
+    """
+    for key, value in updates.items():
+        if key not in settings:
+            error_msg = f"{parent_key_prefix}{key} is not a valid configuration key for the webui."
+            raise ValueError(error_msg)
+        if isinstance(value, dict):
+            _update_settings_object(f"{parent_key_prefix}{key}.", settings[key], value)
+        else:
+            settings[key] = value
+
+
+def _read_and_update_settings_json(
+    settings_file_path: pathlib.Path, updates: dict[str, Any]
+) -> dict[str, Any]:
+    """
+    Reads and updates a settings JSON file.
+
+    :param settings_file_path:
+    :param updates:
+    """
+    settings_object = cast("dict[str, Any]", json.loads(settings_file_path.read_text()))
+    _update_settings_object("", settings_object, updates)
+
+    return settings_object
+
+
+def update_webui_settings(
+    clp_config: ClpConfig,
+    container_clp_config: ClpConfig,
+    client_settings_json_path: pathlib.Path,
+    server_settings_json_path: pathlib.Path,
+    container_webui_dir: pathlib.Path,
+) -> None:
+    """
+    Updates the WebUI client and server settings files for a package deployment.
+
+    :param clp_config:
+    :param container_clp_config:
+    :param client_settings_json_path:
+    :param server_settings_json_path:
+    :param container_webui_dir:
+    """
+    table_prefix = CLP_METADATA_TABLE_PREFIX
+    if StorageEngine.CLP_S == clp_config.package.storage_engine:
+        archives_table_name = ""
+        files_table_name = ""
+    else:
+        archives_table_name = get_archives_table_name(table_prefix, None)
+        files_table_name = get_files_table_name(table_prefix, None)
+
+    client_settings_json_updates = {
+        "ClpStorageEngine": clp_config.package.storage_engine,
+        "ClpQueryEngine": clp_config.package.query_engine,
+        "LogsInputType": clp_config.logs_input.type,
+        "MaxDatasetsPerQuery": clp_config.query_scheduler.max_datasets_per_query,
+        "MongoDbSearchResultsMetadataCollectionName": (
+            clp_config.webui.results_metadata_collection_name
+        ),
+        "SqlDbClpArchivesTableName": archives_table_name,
+        "SqlDbClpDatasetsTableName": get_datasets_table_name(table_prefix),
+        "SqlDbClpFilesTableName": files_table_name,
+        "SqlDbClpTablePrefix": table_prefix,
+        "SqlDbCompressionJobsTableName": COMPRESSION_JOBS_TABLE_NAME,
+    }
+
+    server_settings_json_updates = {
+        "SqlDbHost": container_clp_config.database.host,
+        "SqlDbPort": container_clp_config.database.port,
+        "SqlDbName": clp_config.database.names[ClpDbNameType.CLP],
+        "SqlDbQueryJobsTableName": QUERY_JOBS_TABLE_NAME,
+        "SqlDbCompressionJobsTableName": COMPRESSION_JOBS_TABLE_NAME,
+        "MongoDbHost": container_clp_config.results_cache.host,
+        "MongoDbPort": container_clp_config.results_cache.port,
+        "MongoDbName": clp_config.results_cache.db_name,
+        "MongoDbSearchResultsMetadataCollectionName": (
+            clp_config.webui.results_metadata_collection_name
+        ),
+        "MongoDbStreamFilesCollectionName": clp_config.results_cache.stream_collection_name,
+        "ClientDir": str(container_webui_dir / "client"),
+        "LogViewerDir": str(container_webui_dir / "yscope-log-viewer"),
+        "StreamTargetUncompressedSize": clp_config.stream_output.target_uncompressed_size,
+        "ArchiveOutputCompressionLevel": clp_config.archive_output.compression_level,
+        "ArchiveOutputTargetArchiveSize": clp_config.archive_output.target_archive_size,
+        "ArchiveOutputTargetDictionariesSize": (clp_config.archive_output.target_dictionaries_size),
+        "ArchiveOutputTargetEncodedFileSize": clp_config.archive_output.target_encoded_file_size,
+        "ArchiveOutputTargetSegmentSize": clp_config.archive_output.target_segment_size,
+        "ClpQueryEngine": clp_config.package.query_engine,
+        "ClpStorageEngine": clp_config.package.storage_engine,
+    }
+
+    stream_storage = clp_config.stream_output.storage
+    if StorageType.S3 == stream_storage.type:
+        stream_storage = cast("StreamS3Storage", stream_storage)
+        s3_config = stream_storage.s3_config
+        server_settings_json_updates["StreamFilesDir"] = None
+        server_settings_json_updates["StreamFilesS3Region"] = s3_config.region_code
+        server_settings_json_updates["StreamFilesS3PathPrefix"] = (
+            f"{s3_config.bucket}/{s3_config.key_prefix}"
+        )
+        auth = s3_config.aws_authentication
+        if AwsAuthType.profile == auth.type:
+            server_settings_json_updates["StreamFilesS3Profile"] = auth.profile
+        else:
+            server_settings_json_updates["StreamFilesS3Profile"] = None
+    elif StorageType.FS == stream_storage.type:
+        server_settings_json_updates["StreamFilesDir"] = str(
+            container_clp_config.stream_output.get_directory()
+        )
+        server_settings_json_updates["StreamFilesS3Region"] = None
+        server_settings_json_updates["StreamFilesS3PathPrefix"] = None
+        server_settings_json_updates["StreamFilesS3Profile"] = None
+
+    query_engine = clp_config.package.query_engine
+    if QueryEngine.PRESTO == query_engine:
+        if container_clp_config.presto is None:
+            msg = "presto config is required when query_engine is presto."
+            raise ValueError(msg)
+        server_settings_json_updates["PrestoHost"] = container_clp_config.presto.host
+        server_settings_json_updates["PrestoPort"] = container_clp_config.presto.port
+    else:
+        server_settings_json_updates["PrestoHost"] = None
+        server_settings_json_updates["PrestoPort"] = None
+
+    if StorageType.FS == clp_config.logs_input.type:
+        client_settings_json_updates["LogsInputRootDir"] = str(CONTAINER_INPUT_LOGS_ROOT_DIR)
+        server_settings_json_updates["LogsInputRootDir"] = str(CONTAINER_INPUT_LOGS_ROOT_DIR)
+    else:
+        client_settings_json_updates["LogsInputRootDir"] = None
+        server_settings_json_updates["LogsInputRootDir"] = None
+
+    client_settings_json = _read_and_update_settings_json(
+        client_settings_json_path, client_settings_json_updates
+    )
+    client_settings_json_path.write_text(json.dumps(client_settings_json))
+
+    server_settings_json = _read_and_update_settings_json(
+        server_settings_json_path, server_settings_json_updates
+    )
+    server_settings_json_path.write_text(json.dumps(server_settings_json))

--- a/docs/src/dev-docs/building-single-container-image.md
+++ b/docs/src/dev-docs/building-single-container-image.md
@@ -1,0 +1,49 @@
+# Building the single-container image
+
+The single-container image is layered on top of the regular `clp-package` image. Build it with:
+
+```shell
+task docker-images:package-single
+```
+
+This task first builds the package and base package image, then runs
+`tools/deployment/package/build-single-image.sh`. The resulting image is tagged as
+`clp-package-single:latest`, and its image ID is written to `build/clp-package-single-image.id`.
+
+## Base image reference
+
+The single-container image build creates a temporary local base-image tag,
+`clp-package:single-base`, because Docker `FROM` needs an image reference rather than the raw image
+ID stored in `build/clp-package-image.id`. The tag is removed when the build exits.
+
+## Runtime flow
+
+No repository-side runner is required to start the image. Users run the image directly with
+`docker run`, mounting `clp-config.yaml`, `credentials.yaml`, persistent data/log/tmp directories,
+and any filesystem log-input directories they need. Inside the container, the entrypoint:
+
+* loads the CLP config and credentials;
+* writes a container-runtime config to `/run/clp-single-container/clp-config.yaml`;
+* exports the service credentials and connection values expected by the existing CLP Python
+  initialization scripts;
+* starts Supervisor, which launches the backing services, DB/results-cache initialization jobs,
+  schedulers, workers, API server, log-ingestor, optional MCP server, and WebUI.
+
+The DB and results-cache initialization steps intentionally use the existing Python modules:
+
+* `clp_py_utils.create-db-tables`
+* `clp_py_utils.initialize-results-cache`
+
+Redis does not have a separate initialization step, matching the Docker Compose flow.
+
+## Compliance bundle
+
+The image build itself runs the release-license guard and generates third-party notice files inside
+the image. The separate compliance-bundle task is for release artifact collection:
+
+```shell
+task docker-images:package-single-compliance
+```
+
+The bundle helper collects the notice files from the image and, when `syft` is installed, generates
+SBOM files for release review.

--- a/docs/src/dev-docs/building-single-container-image.md
+++ b/docs/src/dev-docs/building-single-container-image.md
@@ -1,6 +1,7 @@
 # Building the single-container image
 
-The single-container image is layered on top of the regular `clp-package` image. Build it with:
+The single-container image is layered on top of the regular `clp-package` image. Build the release
+artifact flow with:
 
 ```shell
 task docker-images:package-single
@@ -9,6 +10,11 @@ task docker-images:package-single
 This task first builds the package and base package image, then runs
 `tools/deployment/package/build-single-image.sh`. The resulting image is tagged as
 `clp-package-single:latest`, and its image ID is written to `build/clp-package-single-image.id`.
+It then runs `tools/deployment/package/generate-single-image-compliance-bundle.sh` to write the
+release compliance bundle under `build/clp-package-single-compliance`.
+
+Because this is the release artifact flow, `syft` must be available on `PATH` so the compliance
+bundle can include SBOM files.
 
 ## Base image reference
 
@@ -36,14 +42,8 @@ The DB and results-cache initialization steps intentionally use the existing Pyt
 
 Redis does not have a separate initialization step, matching the Docker Compose flow.
 
-## Compliance bundle
+## Compliance Bundle
 
 The image build itself runs the release-license guard and generates third-party notice files inside
-the image. The separate compliance-bundle task is for release artifact collection:
-
-```shell
-task docker-images:package-single-compliance
-```
-
-The bundle helper collects the notice files from the image and, when `syft` is installed, generates
-SBOM files for release review.
+the image. The compliance bundle is generated as part of `task docker-images:package-single`; it
+collects the notice files from the image and generates SBOM files for release review.

--- a/docs/src/dev-docs/index.md
+++ b/docs/src/dev-docs/index.md
@@ -55,6 +55,7 @@ Any design docs describing parts of this project.
 :hidden:
 
 building-package
+building-single-container-image
 :::
 
 :::{toctree}

--- a/docs/src/user-docs/guides-single-container-image.md
+++ b/docs/src/user-docs/guides-single-container-image.md
@@ -1,0 +1,103 @@
+# Single-container image
+
+The single-container image runs the CLP package plus its bundled MariaDB, RabbitMQ, Redis, and
+MongoDB services in one Docker container. It is intended for local evaluation, demos, and
+single-host testing. For production or multi-host deployments, use
+[Docker Compose](guides-docker-compose-deployment.md) or [Kubernetes](guides-k8s-deployment.md).
+
+The examples below publish only CLP-facing ports:
+
+* WebUI: `4000`
+* API server: `3001`
+* log-ingestor: `3002`
+
+MariaDB, RabbitMQ, Redis, and MongoDB bind to loopback inside the container and are not published to
+the host.
+
+## Prepare configuration
+
+Use the same `clp-config.yaml` and `credentials.yaml` format as the Docker Compose package. For
+filesystem ingestion, set `logs_input.directory` to the absolute host directory you want CLP to
+read.
+
+For example:
+
+```yaml
+logs_input:
+  type: "fs"
+  directory: "/home/alice/logs"
+```
+
+Keep `logs_input.directory` as the host path. When CLP starts inside the container, it transforms
+that path under `/mnt/logs`, so the matching Docker mount for `/home/alice/logs` is
+`/mnt/logs/home/alice/logs`.
+
+Mount the credentials file at `/etc/clp-credentials.yaml` and set
+`CLP_SINGLE_CONTAINER_CREDENTIALS_FILE=/etc/clp-credentials.yaml`. The entrypoint rewrites the
+runtime config inside the container to point at that file. Do not put passwords in Docker command
+line flags unless you are deliberately overriding the credentials file for a local test.
+
+If `etc/credentials.yaml` does not exist yet, copy `etc/credentials.template.yaml` and uncomment or
+set the database, queue, and Redis credentials.
+
+## Start
+
+Build or pull the image, then start it with a config file and credentials file:
+
+```shell
+mkdir -p build/clp-package/var/data build/clp-package/var/log build/clp-package/var/tmp
+
+docker run \
+  --detach \
+  --log-driver local \
+  --name clp-package-single \
+  --network bridge \
+  --restart on-failure:3 \
+  --workdir /opt/clp \
+  --mount type=bind,src="$(realpath build/clp-package/etc/clp-config.yaml)",dst=/etc/clp-config.yaml,readonly \
+  --mount type=bind,src="$(realpath build/clp-package/etc/credentials.yaml)",dst=/etc/clp-credentials.yaml,readonly \
+  --mount type=bind,src="$(realpath build/clp-package/var/data)",dst=/var/data \
+  --mount type=bind,src="$(realpath build/clp-package/var/log)",dst=/var/log \
+  --mount type=bind,src="$(realpath build/clp-package/var/tmp)",dst=/var/tmp \
+  --mount type=bind,src=/home/alice/logs,dst=/mnt/logs/home/alice/logs,readonly \
+  --env CLP_SINGLE_CONTAINER_CREDENTIALS_FILE=/etc/clp-credentials.yaml \
+  --env CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS=127.0.0.1 \
+  --publish 127.0.0.1:4000:4000 \
+  --publish 127.0.0.1:3001:3001 \
+  --publish 127.0.0.1:3002:3002 \
+  clp-package-single:latest
+```
+
+The WebUI will be available at <http://127.0.0.1:4000>.
+
+To use non-default host ports, change only the host side of the publish flags:
+
+```shell
+--publish 127.0.0.1:4100:4000
+--publish 127.0.0.1:3101:3001
+--publish 127.0.0.1:3102:3002
+```
+
+## MCP server
+
+The MCP server is included but disabled by default. To run it without publishing a host port, add:
+
+```shell
+--env CLP_MCP_SERVER_ENABLED=1
+```
+
+To publish it on localhost, add both flags:
+
+```shell
+--env CLP_MCP_SERVER_ENABLED=1
+--publish 127.0.0.1:8000:8000
+```
+
+## Stop and inspect
+
+```shell
+docker ps --filter name=clp-package-single
+docker rm --force clp-package-single
+```
+
+Service logs are written under the mounted `/var/log` directory.

--- a/docs/src/user-docs/guides-single-container-image.md
+++ b/docs/src/user-docs/guides-single-container-image.md
@@ -5,16 +5,14 @@ MongoDB services in one Docker container. It is intended for local evaluation, d
 single-host testing. For production or multi-host deployments, use
 [Docker Compose](guides-docker-compose-deployment.md) or [Kubernetes](guides-k8s-deployment.md).
 
-The examples below publish only CLP-facing ports:
+For a first run, use the single-container tabs in the [`clp-json` quick-start][clp-json] or
+[`clp-text` quick-start][clp-text]. This page covers custom runtime settings and operational
+details for the image.
 
-* WebUI: `4000`
-* API server: `3001`
-* log-ingestor: `3002`
+The examples below publish only the WebUI port. MariaDB, RabbitMQ, Redis, and MongoDB bind to
+loopback inside the container and are not published to the host.
 
-MariaDB, RabbitMQ, Redis, and MongoDB bind to loopback inside the container and are not published to
-the host.
-
-## Prepare configuration
+## Custom configuration
 
 Use the same `clp-config.yaml` and `credentials.yaml` format as the Docker Compose package. For
 filesystem ingestion, set `logs_input.directory` to the absolute host directory you want CLP to
@@ -32,50 +30,56 @@ Keep `logs_input.directory` as the host path. When CLP starts inside the contain
 that path under `/mnt/logs`, so the matching Docker mount for `/home/alice/logs` is
 `/mnt/logs/home/alice/logs`.
 
-Mount the credentials file at `/etc/clp-credentials.yaml` and set
-`CLP_SINGLE_CONTAINER_CREDENTIALS_FILE=/etc/clp-credentials.yaml`. The entrypoint rewrites the
-runtime config inside the container to point at that file. Do not put passwords in Docker command
-line flags unless you are deliberately overriding the credentials file for a local test.
+Mount the credentials file at `/opt/clp/etc/credentials.yaml`, which matches the default
+`credentials_file_path` in the package config. Do not put passwords in Docker command line flags
+unless you are deliberately overriding the credentials file for a local test.
 
 If `etc/credentials.yaml` does not exist yet, copy `etc/credentials.template.yaml` and uncomment or
 set the database, queue, and Redis credentials.
 
-## Start
+## Custom Docker run
 
-Build or pull the image, then start it with a config file and credentials file:
+Build or pull the image, then start it with explicit config, credentials, and filesystem-ingestion
+mounts:
 
 ```shell
-mkdir -p build/clp-package/var/data build/clp-package/var/log build/clp-package/var/tmp
+export CLP_PACKAGE_DIR="${CLP_PACKAGE_DIR:-$PWD}"
+export CLP_LOGS_INPUT_DIR="/home/alice/logs"
 
 docker run \
   --detach \
-  --log-driver local \
   --name clp-package-single \
-  --network bridge \
-  --restart on-failure:3 \
-  --workdir /opt/clp \
-  --mount type=bind,src="$(realpath build/clp-package/etc/clp-config.yaml)",dst=/etc/clp-config.yaml,readonly \
-  --mount type=bind,src="$(realpath build/clp-package/etc/credentials.yaml)",dst=/etc/clp-credentials.yaml,readonly \
-  --mount type=bind,src="$(realpath build/clp-package/var/data)",dst=/var/data \
-  --mount type=bind,src="$(realpath build/clp-package/var/log)",dst=/var/log \
-  --mount type=bind,src="$(realpath build/clp-package/var/tmp)",dst=/var/tmp \
-  --mount type=bind,src=/home/alice/logs,dst=/mnt/logs/home/alice/logs,readonly \
-  --env CLP_SINGLE_CONTAINER_CREDENTIALS_FILE=/etc/clp-credentials.yaml \
-  --env CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS=127.0.0.1 \
+  --mount "type=bind,src=$(realpath "${CLP_PACKAGE_DIR}/etc/clp-config.yaml"),dst=/etc/clp-config.yaml,readonly" \
+  --mount "type=bind,src=$(realpath "${CLP_PACKAGE_DIR}/etc/credentials.yaml"),dst=/opt/clp/etc/credentials.yaml,readonly" \
+  --mount "type=bind,src=${CLP_LOGS_INPUT_DIR},dst=/mnt/logs${CLP_LOGS_INPUT_DIR},readonly" \
   --publish 127.0.0.1:4000:4000 \
-  --publish 127.0.0.1:3001:3001 \
-  --publish 127.0.0.1:3002:3002 \
   clp-package-single:latest
 ```
 
 The WebUI will be available at <http://127.0.0.1:4000>.
 
+To persist data, logs, and temporary files outside the container, create the directories and add the
+mounts to the `docker run` command:
+
+```shell
+mkdir -p "${CLP_PACKAGE_DIR}/var/data" "${CLP_PACKAGE_DIR}/var/log" "${CLP_PACKAGE_DIR}/var/tmp"
+
+--mount "type=bind,src=$(realpath "${CLP_PACKAGE_DIR}/var/data"),dst=/var/data"
+--mount "type=bind,src=$(realpath "${CLP_PACKAGE_DIR}/var/log"),dst=/var/log"
+--mount "type=bind,src=$(realpath "${CLP_PACKAGE_DIR}/var/tmp"),dst=/var/tmp"
+```
+
+To access the API server or log-ingestor directly from the host, publish their ports explicitly:
+
+```shell
+--publish 127.0.0.1:3001:3001
+--publish 127.0.0.1:3002:3002
+```
+
 To use non-default host ports, change only the host side of the publish flags:
 
 ```shell
 --publish 127.0.0.1:4100:4000
---publish 127.0.0.1:3101:3001
---publish 127.0.0.1:3102:3002
 ```
 
 ## MCP server
@@ -101,3 +105,6 @@ docker rm --force clp-package-single
 ```
 
 Service logs are written under the mounted `/var/log` directory.
+
+[clp-json]: quick-start/clp-json.md
+[clp-text]: quick-start/clp-text.md

--- a/docs/src/user-docs/index.md
+++ b/docs/src/user-docs/index.md
@@ -25,8 +25,9 @@ searching them.
 
 ## Deployment
 
-Dive deeper into deploying CLP with Docker Compose or Kubernetes. In particular, multi-host
-deployments enable horizontal scaling and high availability for production workloads.
+Dive deeper into deploying CLP with Docker Compose, the single-container image, or Kubernetes. In
+particular, multi-host deployments enable horizontal scaling and high availability for production
+workloads.
 
 ::::{grid} 1 1 2 2
 :gutter: 2

--- a/docs/src/user-docs/index.md
+++ b/docs/src/user-docs/index.md
@@ -39,6 +39,13 @@ Deploy CLP using Docker Compose for single or multi-host setups.
 :::
 
 :::{grid-item-card}
+:link: guides-single-container-image
+Single-container image
+^^^
+Run the CLP package and bundled backing services in one local container.
+:::
+
+:::{grid-item-card}
 :link: guides-k8s-deployment
 Kubernetes deployment
 ^^^
@@ -243,6 +250,7 @@ quick-start/clp-text
 :caption: Deployment
 
 guides-docker-compose-deployment
+guides-single-container-image
 guides-k8s-deployment
 :::
 

--- a/docs/src/user-docs/quick-start/clp-json.md
+++ b/docs/src/user-docs/quick-start/clp-json.md
@@ -35,6 +35,56 @@ If CLP fails to start (e.g., due to a port conflict), try adjusting the settings
 
 :::
 
+:::{tab-item} Single container
+:sync: single-container
+
+From the extracted `clp-json` package directory, set the filesystem log input directory in
+`etc/clp-config.yaml`:
+
+```yaml
+logs_input:
+  type: "fs"
+  directory: "/home/alice/logs"
+```
+
+Keep `logs_input.directory` as the host path. The Docker mount below maps that same host directory
+to the path CLP uses inside the container. For other custom single-container settings, see the
+[single-container image guide][single-container-image].
+
+Create local quick-start credentials and start the image:
+
+```bash
+cat > etc/credentials.yaml <<'EOF'
+database:
+  username: "clp-user"
+  password: "pass"
+  root_username: "root"
+  root_password: "root-pass"
+  spider_username: "spider-user"
+  spider_password: "spider-pass"
+queue:
+  username: "clp-user"
+  password: "pass"
+redis:
+  password: "pass"
+EOF
+
+export CLP_LOGS_INPUT_DIR="/home/alice/logs"
+
+docker run \
+  --detach \
+  --name clp-package-single \
+  --mount type=bind,src="$(realpath etc/clp-config.yaml)",dst=/etc/clp-config.yaml,readonly \
+  --mount type=bind,src="$(realpath etc/credentials.yaml)",dst=/opt/clp/etc/credentials.yaml,readonly \
+  --mount type=bind,src="${CLP_LOGS_INPUT_DIR}",dst="/mnt/logs${CLP_LOGS_INPUT_DIR}",readonly \
+  --publish 127.0.0.1:4000:4000 \
+  clp-package-single:latest
+```
+
+The command assumes the image is available locally as `clp-package-single:latest`.
+
+:::
+
 :::{tab-item} Kubernetes (`kind`)
 :sync: kind
 
@@ -125,6 +175,9 @@ results_cache:
 
 ## Compressing JSON logs
 
+::::{tab-set}
+:::{tab-item} Docker Compose and Kubernetes
+
 To compress some JSON logs, run:
 
 ```bash
@@ -135,12 +188,9 @@ sbin/compress.sh --timestamp-key '<timestamp-key>' <path1> [<path2> ...]
   * E.g., if your log events look like
     `{"timestamp": {"iso8601": "2024-01-01 00:01:02.345", ...}}`, you should enter
     `timestamp.iso8601` as the timestamp key.
-
-  :::{caution}
-  Log events without the specified timestamp key will *not* have an assigned timestamp. Currently,
-  these events can only be searched from the command line (when you don't specify a timestamp
-  filter).
-  :::
+  * Log events without the specified timestamp key will *not* have an assigned timestamp.
+    Currently, these events can only be searched from the command line when you don't specify a
+    timestamp filter.
 
 * `<path...>` are paths to JSON log files or directories containing such files.
   * Each JSON log file should contain each log event as a [separate JSON object][clp-json-format],
@@ -153,6 +203,24 @@ Compressed logs will be stored in the directory specified by the `archive_output
 config option in `etc/clp-config.yaml` (`archive_output.storage.directory` defaults to
 `var/data/archives`).
 
+:::
+
+:::{tab-item} Single container
+
+Open [http://localhost:4000/ingest](http://localhost:4000/ingest) and submit a compression job from
+the **Submit Compression Job** form. Select files or directories from the mounted
+`logs_input.directory`; in the example above, that is `/home/alice/logs` on the host and
+`/mnt/logs/home/alice/logs` inside the container.
+
+Set **Timestamp Key** to the field path of the kv-pair that contains the timestamp in each log
+event. If you leave **Dataset** empty, CLP uses the `default` dataset.
+
+Use the **Compression Jobs** table on the same page to monitor the job status and compression
+ratio.
+
+:::
+::::
+
 :::{tip}
 To compress logs from object storage, see [Using object storage][object-storage].
 :::
@@ -160,14 +228,30 @@ To compress logs from object storage, see [Using object storage][object-storage]
 ## Compressing unstructured text logs
 
 clp-json supports compressing unstructured text logs by converting them into JSON. To enable this
-conversion, run the compression script with the `--unstructured` flag:
+conversion, use one of the following methods:
+
+::::{tab-set}
+:::{tab-item} Docker Compose and Kubernetes
+
+Run the compression script with the `--unstructured` flag:
 
 ```bash
 sbin/compress.sh --unstructured <path1> [<path2> ...]
 ```
 
-When `--unstructured` is specified, clp-json will parse the unstructured text and convert each log
-event into a JSON object. During this conversion, it attempts to extract the timestamp and log
+:::
+
+:::{tab-item} Single container
+
+Open [http://localhost:4000/ingest](http://localhost:4000/ingest), select files or directories from
+the mounted `logs_input.directory`, and enable **Unstructured Logs** / **Convert to JSON** before
+submitting the compression job.
+
+:::
+::::
+
+When unstructured conversion is enabled, clp-json will parse the unstructured text and convert each
+log event into a JSON object. During this conversion, it attempts to extract the timestamp and log
 message from each log event and store them as separate key-value pairs. The resulting JSON object
 includes:
 
@@ -191,7 +275,8 @@ will be converted into:
 ```
 
 :::{note}
-When the `--unstructured` flag is used, clp-json will always use `"timestamp"` as the timestamp key.
+When unstructured conversion is enabled, clp-json will always use `"timestamp"` as the timestamp
+key.
 :::
 
 ### Sample logs
@@ -202,8 +287,9 @@ For some sample logs, check out the [open-source datasets][datasets].
 
 ## Searching JSON logs
 
-You can search your compressed logs from CLP's [UI](#searching-from-the-ui) or the
-[command line](#searching-from-the-command-line).
+You can search your compressed logs from CLP's [UI](#searching-from-the-ui) or
+[API server](#searching-via-the-api-server). Docker Compose and Kubernetes deployments also support
+[command-line search](#searching-from-the-command-line).
 
 In clp-json, queries are written as a set of conditions (predicates) on key-value pairs (kv-pairs).
 For example, [Figure 1](#figure-1) shows a query that matches the first log event in
@@ -261,6 +347,12 @@ To search your compressed logs from CLP's UI, open the following URL in your bro
 [http://localhost:4000](http://localhost:4000)
 :::
 
+:::{tab-item} Single container
+:sync: single-container
+
+[http://localhost:4000](http://localhost:4000)
+:::
+
 :::{tab-item} Kubernetes (`kind`)
 :sync: kind
 
@@ -305,8 +397,8 @@ The numbered circles in [Figure 3](#figure-3) correspond to the following elemen
 
 :::{note}
 By default, the UI will only return 1,000 of the latest search results. To perform searches which
-return more results, use the [command line](#searching-from-the-command-line) or
-[API server](#searching-via-the-api-server).
+return more results, use the [API server](#searching-via-the-api-server). Docker Compose and
+Kubernetes deployments can also use the [command line](#searching-from-the-command-line).
 :::
 
 ### Searching via the API server
@@ -316,6 +408,23 @@ To search via the API server:
 ::::{tab-set}
 :::{tab-item} Docker Compose
 :sync: docker
+
+```bash
+curl -X POST "http://localhost:3001/query/submit" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query_string": "<query>",
+    "max_num_results": 1000,
+    "timestamp_begin": null,
+    "timestamp_end": null,
+    "case_sensitive": false
+  }'
+```
+
+:::
+
+:::{tab-item} Single container
+:sync: single-container
 
 ```bash
 curl -X POST "http://localhost:3001/query/submit" \
@@ -357,7 +466,8 @@ For more details on the API, see [Using the API server][api-server].
 
 ### Searching from the command line
 
-To search your compressed logs from the command line, run:
+For Docker Compose or Kubernetes deployments, search your compressed logs from the command line by
+running:
 
 ```bash
 sbin/search.sh '<query>'
@@ -396,6 +506,23 @@ sbin/stop-clp.sh
 
 :::
 
+:::{tab-item} Single container
+:sync: single-container
+
+To inspect the running container:
+
+```bash
+docker ps --filter name=clp-package-single
+```
+
+To stop CLP:
+
+```bash
+docker rm --force clp-package-single
+```
+
+:::
+
 :::{tab-item} Kubernetes (`kind`)
 :sync: kind
 
@@ -419,3 +546,4 @@ kind delete cluster --name clp
 [datasets]: ../resources-datasets.md
 [json-search-syntax]: ../reference-json-search-syntax.md
 [object-storage]: ../guides-using-object-storage/index.md
+[single-container-image]: ../guides-single-container-image.md

--- a/docs/src/user-docs/quick-start/clp-text.md
+++ b/docs/src/user-docs/quick-start/clp-text.md
@@ -51,6 +51,70 @@ package:
 
 :::
 
+:::{tab-item} Single container
+:sync: single-container
+
+From the extracted `clp-text` package directory, set the filesystem log input directory in
+`etc/clp-config.yaml`:
+
+```yaml
+logs_input:
+  type: "fs"
+  directory: "/home/alice/logs"
+```
+
+Keep `logs_input.directory` as the host path. The Docker mount below maps that same host directory
+to the path CLP uses inside the container. For other custom single-container settings, see the
+[single-container image guide][single-container-image].
+
+Create local quick-start credentials and start the image:
+
+```bash
+cat > etc/credentials.yaml <<'EOF'
+database:
+  username: "clp-user"
+  password: "pass"
+  root_username: "root"
+  root_password: "root-pass"
+  spider_username: "spider-user"
+  spider_password: "spider-pass"
+queue:
+  username: "clp-user"
+  password: "pass"
+redis:
+  password: "pass"
+EOF
+
+export CLP_LOGS_INPUT_DIR="/home/alice/logs"
+
+docker run \
+  --detach \
+  --name clp-package-single \
+  --mount type=bind,src="$(realpath etc/clp-config.yaml)",dst=/etc/clp-config.yaml,readonly \
+  --mount type=bind,src="$(realpath etc/credentials.yaml)",dst=/opt/clp/etc/credentials.yaml,readonly \
+  --mount type=bind,src="${CLP_LOGS_INPUT_DIR}",dst="/mnt/logs${CLP_LOGS_INPUT_DIR}",readonly \
+  --publish 127.0.0.1:4000:4000 \
+  clp-package-single:latest
+```
+
+The command assumes the image is available locally as `clp-package-single:latest`.
+
+````{warning}
+**Do not comment out or remove the `package` block in `etc/clp-config.yaml`**; otherwise, the
+storage and query engines will default to `clp-s`, which is optimized for JSON logs rather than
+unstructured text logs.
+
+To use `clp-text`, the `package` block should be configured as follows:
+
+```yaml
+package:
+  storage_engine: "clp"
+  query_engine: "clp"
+```
+````
+
+:::
+
 :::{tab-item} Kubernetes (`kind`)
 :sync: kind
 
@@ -135,6 +199,10 @@ results_cache:
 
 ## Compressing unstructured text logs
 
+::::{tab-set}
+:::{tab-item} Docker Compose
+:sync: docker
+
 To compress some unstructured text logs, run:
 
 ```bash
@@ -150,6 +218,42 @@ Compressed logs will be stored in the directory specified by the `archive_output
 config option in `etc/clp-config.yaml` (`archive_output.storage.directory` defaults to
 `var/data/archives`).
 
+:::
+
+:::{tab-item} Single container
+:sync: single-container
+
+Open [http://localhost:4000/ingest](http://localhost:4000/ingest) and submit a compression job from
+the **Submit Compression Job** form. Select files or directories from the mounted
+`logs_input.directory`; in the example above, that is `/home/alice/logs` on the host and
+`/mnt/logs/home/alice/logs` inside the container.
+
+Use the **Compression Jobs** table on the same page to monitor the job status and compression
+ratio.
+
+:::
+
+:::{tab-item} Kubernetes (`kind`)
+:sync: kind
+
+To compress some unstructured text logs, run:
+
+```bash
+sbin/compress.sh <path1> [<path2> ...]
+```
+
+`<path...>` are paths to unstructured text log files or directories containing such files.
+
+The compression script will output the compression ratio of each dataset you compress, or you can
+use the UI to view overall statistics.
+
+Compressed logs will be stored in the directory specified by the `archive_output.storage.directory`
+config option in `etc/clp-config.yaml` (`archive_output.storage.directory` defaults to
+`var/data/archives`).
+
+:::
+::::
+
 ### Sample logs
 
 For some sample logs, check out the [open-source datasets][datasets].
@@ -158,8 +262,8 @@ For some sample logs, check out the [open-source datasets][datasets].
 
 ## Searching unstructured text logs
 
-You can search your compressed logs from CLP's [UI](#searching-from-the-ui) or the
-[command line](#searching-from-the-command-line).
+You can search your compressed logs from CLP's [UI](#searching-from-the-ui). Docker Compose and
+Kubernetes deployments also support [command-line search](#searching-from-the-command-line).
 
 In clp-text, queries are written as wildcard expressions. A wildcard expression is a plain text
 query where:
@@ -214,6 +318,12 @@ To search your compressed logs from CLP's UI, open the following URL in your bro
 [http://localhost:4000](http://localhost:4000)
 :::
 
+:::{tab-item} Single container
+:sync: single-container
+
+[http://localhost:4000](http://localhost:4000)
+:::
+
 :::{tab-item} Kubernetes (`kind`)
 :sync: kind
 
@@ -257,12 +367,14 @@ The numbered circles in [Figure 3](#figure-3) correspond to the following elemen
 
 :::{note}
 By default, the UI will only return 1,000 of the latest search results. To perform searches which
-return more results, use the [command line](#searching-from-the-command-line).
+return more results with Docker Compose or Kubernetes, use the
+[command line](#searching-from-the-command-line).
 :::
 
 ### Searching from the command line
 
-To search your compressed logs from the command line, run:
+For Docker Compose or Kubernetes deployments, search your compressed logs from the command line by
+running:
 
 ```bash
 sbin/search.sh '<query>'
@@ -297,6 +409,23 @@ sbin/stop-clp.sh
 
 :::
 
+:::{tab-item} Single container
+:sync: single-container
+
+To inspect the running container:
+
+```bash
+docker ps --filter name=clp-package-single
+```
+
+To stop CLP:
+
+```bash
+docker rm --force clp-package-single
+```
+
+:::
+
 :::{tab-item} Kubernetes (`kind`)
 :sync: kind
 
@@ -316,4 +445,5 @@ kind delete cluster --name clp
 ::::
 
 [datasets]: ../resources-datasets.md
+[single-container-image]: ../guides-single-container-image.md
 [text-search-syntax]: ../reference-text-search-syntax.md

--- a/docs/src/user-docs/quick-start/index.md
+++ b/docs/src/user-docs/quick-start/index.md
@@ -7,6 +7,10 @@ For deployments that scale across multiple machines (e.g., for higher throughput
 
 * [Docker Compose deployment][docker-compose-deployment] for advanced Docker Compose configurations
 * [Kubernetes deployment][k8s-deployment] for production Kubernetes clusters
+
+For local evaluation without Docker Compose or Kubernetes, use the single-container tabs in this
+quick start. For custom single-container settings, see the
+[single-container image guide][single-container-image].
 :::
 
 The rest of the guide is organized as follows:
@@ -16,9 +20,9 @@ The rest of the guide is organized as follows:
 * [How to use CLP](#using-clp)
 
 :::{note}
-CLP supports deployment using Docker Compose or Kubernetes. Throughout the guide, some steps will
-differ depending on the chosen orchestration framework. These steps will have a tabbed interface to
-choose your framework.
+CLP supports deployment using Docker Compose, the single-container image, or Kubernetes. Throughout
+the guide, some steps will differ depending on the chosen deployment method. These steps will have a
+tabbed interface to choose your method.
 :::
 
 ---
@@ -41,6 +45,29 @@ To check whether the required tools are installed on your system, run:
 containerd --version
 docker version --format '{{.Server.Version}}'
 docker compose version --short
+```
+
+```{note}
+* If you're not running as root, ensure Docker can be run
+  [without superuser privileges][docker-non-root].
+* If you're using Docker Desktop, ensure version 4.34 or higher is installed.
+```
+
+:::
+
+:::{tab-item} Single container
+:sync: single-container
+
+* [Docker][Docker]
+  * `containerd.io` >= 1.7.18
+  * `docker-ce` >= 27.0.3
+  * `docker-ce-cli` >= 27.0.3
+
+To check whether the required tools are installed on your system, run:
+
+```bash
+containerd --version
+docker version --format '{{.Server.Version}}'
 ```
 
 ```{note}
@@ -117,7 +144,8 @@ The log file above contains two log events represented by two JSON objects print
 other. Whitespace is ignored, so the log events could also appear with no newlines and indentation.
 
 If you're using JSON logs, download and extract the `clp-json` release from the
-[Releases][clp-releases] page, then proceed to the [`clp-json` quick-start][clp-json] guide.
+[Releases][clp-releases] page, then proceed to the [`clp-json` quick-start][clp-json] guide. If
+you're using the single-container image, use the `clp-json` config from the extracted package.
 
 ### clp-text
 
@@ -145,7 +173,8 @@ The log file above contains two log events, both beginning with a timestamp. The
 line, while the second contains multiple lines.
 
 If you're using unstructured text logs, download and extract the `clp-text` release from the
-[Releases][clp-releases] page, then proceed to the [`clp-text` quick-start][clp-text] guide.
+[Releases][clp-releases] page, then proceed to the [`clp-text` quick-start][clp-text] guide. If
+you're using the single-container image, use the `clp-text` config from the extracted package.
 
 ---
 
@@ -182,3 +211,4 @@ How to compress and search unstructured text logs.
 [k8s-deployment]: ../guides-k8s-deployment.md
 [kind]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation
 [kubectl]: https://kubernetes.io/docs/tasks/tools/
+[single-container-image]: ../guides-single-container-image.md

--- a/taskfiles/docker-images.yaml
+++ b/taskfiles/docker-images.yaml
@@ -14,10 +14,4 @@ tasks:
       - "package"
     cmds:
       - "./build-single-image.sh"
-
-  package-single-compliance:
-    dir: "{{.ROOT_DIR}}/tools/deployment/package"
-    deps:
-      - "package-single"
-    cmds:
       - "./generate-single-image-compliance-bundle.sh"

--- a/taskfiles/docker-images.yaml
+++ b/taskfiles/docker-images.yaml
@@ -7,3 +7,17 @@ tasks:
       - ":package-build-deps"
     cmds:
       - "./build.sh"
+
+  package-single:
+    dir: "{{.ROOT_DIR}}/tools/deployment/package"
+    deps:
+      - "package"
+    cmds:
+      - "./build-single-image.sh"
+
+  package-single-compliance:
+    dir: "{{.ROOT_DIR}}/tools/deployment/package"
+    deps:
+      - "package-single"
+    cmds:
+      - "./generate-single-image-compliance-bundle.sh"

--- a/tools/deployment/package/Dockerfile.single
+++ b/tools/deployment/package/Dockerfile.single
@@ -1,0 +1,58 @@
+ARG CLP_PACKAGE_BASE_IMAGE=clp-package:latest
+FROM ${CLP_PACKAGE_BASE_IMAGE}
+
+USER root
+
+COPY single-container/generate-third-party-notices.sh \
+    /usr/local/bin/clp-single-container-generate-third-party-notices
+COPY single-container/validate-release-licenses.sh \
+    /usr/local/bin/clp-single-container-validate-release-licenses
+RUN apt-get update \
+    && chmod 0755 \
+        /usr/local/bin/clp-single-container-generate-third-party-notices \
+        /usr/local/bin/clp-single-container-validate-release-licenses \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
+        gnupg \
+    && curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc \
+        | gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg \
+    && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" \
+        > /etc/apt/sources.list.d/mongodb-org-8.0.list \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        mariadb-server \
+        mongodb-org-server \
+        rabbitmq-server \
+        redis-server \
+        supervisor \
+    && apt-get purge --auto-remove -y \
+        curl \
+        gnupg \
+    && /usr/local/bin/clp-single-container-validate-release-licenses \
+    && /usr/local/bin/clp-single-container-generate-third-party-notices \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY single-container/COMPLIANCE.md /opt/clp/share/doc/clp-single-container/COMPLIANCE.md
+COPY single-container/entrypoint.sh /usr/local/bin/clp-single-container-entrypoint
+COPY single-container/wait-for-files.sh /usr/local/bin/clp-single-container-wait-for-files
+COPY single-container/wait-for-tcp.sh /usr/local/bin/clp-single-container-wait-for-tcp
+COPY single-container/supervisord.conf /etc/supervisor/conf.d/clp-single-container.conf
+RUN chmod 0755 \
+        /usr/local/bin/clp-single-container-entrypoint \
+        /usr/local/bin/clp-single-container-wait-for-files \
+        /usr/local/bin/clp-single-container-wait-for-tcp
+
+ENV CLP_CONFIG_PATH=/etc/clp-config.yaml \
+    CLP_HOME=/opt/clp \
+    MONGODB_CONFIG_OVERRIDE_NOFORK=1 \
+    PYTHONPATH=/opt/clp/lib/python3/site-packages
+
+LABEL org.yscope.clp.third-party-notices="/opt/clp/share/third-party-notices" \
+      org.yscope.clp.single-container.internal-services="mariadb,rabbitmq,redis,mongodb"
+
+EXPOSE 3001 3002 4000 8000
+
+ENTRYPOINT ["/usr/local/bin/clp-single-container-entrypoint"]
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]

--- a/tools/deployment/package/build-single-image.sh
+++ b/tools/deployment/package/build-single-image.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+remove_temp_file_and_base_tag() {
+    if [[ -n "${temp_iid_file:-}" ]]; then
+        rm -f "$temp_iid_file"
+    fi
+    if [[ -n "${base_image_ref:-}" ]]; then
+        docker image remove "$base_image_ref" >/dev/null 2>&1 || true
+    fi
+}
+trap remove_temp_file_and_base_tag EXIT
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+repo_root="${script_dir}/../../.."
+base_iid_file="${repo_root}/build/clp-package-image.id"
+single_iid_file="${repo_root}/build/clp-package-single-image.id"
+
+if [[ ! -s "$base_iid_file" ]]; then
+    echo >&2 \
+        "Error: Base package image ID file '$base_iid_file' does not exist. Run 'task docker-images:package' first."
+    exit 1
+fi
+
+base_image_id="$(tr -d '[:space:]' <"$base_iid_file")"
+base_image_ref="clp-package:single-base"
+docker tag "$base_image_id" "$base_image_ref"
+
+temp_iid_file="$(mktemp)"
+new_image_id=""
+
+build_cmd=(
+    docker build
+    --network host
+    --build-arg "CLP_PACKAGE_BASE_IMAGE=${base_image_ref}"
+    --iidfile "$temp_iid_file"
+    --file "${script_dir}/Dockerfile.single"
+    "$script_dir"
+)
+
+if command -v git >/dev/null && git -C "$script_dir" rev-parse --is-inside-work-tree >/dev/null;
+then
+    build_cmd+=(
+        --label "org.opencontainers.image.revision=$(git -C "$script_dir" rev-parse HEAD)"
+    )
+fi
+
+"${build_cmd[@]}"
+
+if [[ -s "$temp_iid_file" ]]; then
+    new_image_id="$(<"$temp_iid_file")"
+    echo "$new_image_id" > "$single_iid_file"
+
+    docker tag "$new_image_id" "clp-package-single:latest"
+fi

--- a/tools/deployment/package/generate-single-image-compliance-bundle.sh
+++ b/tools/deployment/package/generate-single-image-compliance-bundle.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+repo_root="${script_dir}/../../.."
+
+image_ref="${1:-clp-package-single:latest}"
+output_dir="${2:-${repo_root}/build/clp-package-single-compliance}"
+
+container_id=""
+cleanup() {
+    if [[ -n "$container_id" ]]; then
+        docker rm "$container_id" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+rm -rf "$output_dir"
+mkdir -p "$output_dir"
+
+image_digest="$(docker image inspect "$image_ref" --format '{{index .RepoDigests 0}}' 2>/dev/null || true)"
+image_id="$(docker image inspect "$image_ref" --format '{{.Id}}')"
+
+cat > "${output_dir}/README.md" <<EOF
+# CLP single-container image compliance bundle
+
+Image reference: ${image_ref}
+Image digest: ${image_digest:-not available locally}
+Image ID: ${image_id}
+
+This bundle records third-party components and notices for the exact local image
+used to generate it. For public publication, upload this bundle together with a
+matching corresponding-source bundle for copyleft and source-available
+components.
+EOF
+
+container_id="$(docker create "$image_ref")"
+docker cp "${container_id}:/opt/clp/share/third-party-notices/." \
+    "${output_dir}/third-party-notices"
+docker cp "${container_id}:/opt/clp/share/doc/clp-single-container/COMPLIANCE.md" \
+    "${output_dir}/COMPLIANCE.md"
+
+docker run --rm --entrypoint /bin/sh "$image_ref" -lc \
+    "dpkg-query -W -f='\${Package}\t\${Version}\t\${Architecture}\t\${source:Package}\t\${source:Version}\n' | sort" \
+    > "${output_dir}/debian-packages.tsv"
+
+docker run --rm --entrypoint /bin/sh "$image_ref" -lc \
+    "find /usr/share/doc -maxdepth 2 -name copyright -print | sort" \
+    > "${output_dir}/debian-copyright-file-list.txt"
+
+if command -v syft >/dev/null 2>&1; then
+    syft "$image_ref" -o spdx-json > "${output_dir}/sbom.spdx.json"
+    syft "$image_ref" -o cyclonedx-json > "${output_dir}/sbom.cyclonedx.json"
+else
+    cat > "${output_dir}/SBOM_NOT_GENERATED.txt" <<'EOF'
+The `syft` command was not found, so this script could not generate SBOMs.
+Install syft and rerun this script before publishing the image.
+EOF
+    if [[ "${CLP_SINGLE_CONTAINER_ALLOW_MISSING_SYFT:-0}" == "0" ]]; then
+        echo >&2 "Error: syft is required to generate the release compliance bundle."
+        echo >&2 "Set CLP_SINGLE_CONTAINER_ALLOW_MISSING_SYFT=1 only for local dry-runs."
+        exit 1
+    fi
+fi
+
+cat > "${output_dir}/corresponding-source-notes.md" <<'EOF'
+# Corresponding source notes
+
+For public image publication, publish source artifacts matching the exact image
+digest. At minimum, the source bundle should include:
+
+* CLP source for the image revision.
+* Source packages for GPL/LGPL/MPL and other source-required Debian packages.
+* MongoDB Community Server source matching the bundled `mongodb-org-server`
+  package version.
+* Source and notices for Python and Node.js dependencies reported in the SBOM.
+
+Do not rely on mutable upstream URLs as the only source offer for a released
+image. Archive the exact source artifacts or publish a reviewed written source
+offer that remains valid for the required period.
+EOF
+
+echo "Wrote compliance bundle to ${output_dir}"

--- a/tools/deployment/package/generate-single-image-compliance-bundle.sh
+++ b/tools/deployment/package/generate-single-image-compliance-bundle.sh
@@ -55,15 +55,8 @@ if command -v syft >/dev/null 2>&1; then
     syft "$image_ref" -o spdx-json > "${output_dir}/sbom.spdx.json"
     syft "$image_ref" -o cyclonedx-json > "${output_dir}/sbom.cyclonedx.json"
 else
-    cat > "${output_dir}/SBOM_NOT_GENERATED.txt" <<'EOF'
-The `syft` command was not found, so this script could not generate SBOMs.
-Install syft and rerun this script before publishing the image.
-EOF
-    if [[ "${CLP_SINGLE_CONTAINER_ALLOW_MISSING_SYFT:-0}" == "0" ]]; then
-        echo >&2 "Error: syft is required to generate the release compliance bundle."
-        echo >&2 "Set CLP_SINGLE_CONTAINER_ALLOW_MISSING_SYFT=1 only for local dry-runs."
-        exit 1
-    fi
+    echo >&2 "Error: syft is required to generate the release compliance bundle."
+    exit 1
 fi
 
 cat > "${output_dir}/corresponding-source-notes.md" <<'EOF'

--- a/tools/deployment/package/single-container/COMPLIANCE.md
+++ b/tools/deployment/package/single-container/COMPLIANCE.md
@@ -1,0 +1,24 @@
+# CLP Single-Container Image Compliance Notes
+
+The single-container image is intended to package CLP with its local runtime
+dependencies for development, demos, and constrained deployments. Unlike the
+Docker Compose deployment, publishing this image redistributes third-party
+service binaries in the CLP image.
+
+Before publishing an official image:
+
+1. Generate and publish an SBOM for the exact image digest.
+2. Publish the generated third-party notices from
+   `/opt/clp/share/third-party-notices`.
+3. Publish corresponding source artifacts for copyleft and source-available
+   components in the image.
+4. Keep MongoDB embedded-only. It is bundled solely as CLP's internal
+   results-cache implementation detail and must not be exposed or marketed as a
+   general-purpose MongoDB service.
+5. Keep Redis below version 7.4 unless the license review is updated.
+6. Do not describe the image as Apache-2.0 only. CLP is Apache-2.0, but the
+   image includes third-party components under their own licenses.
+
+The default launcher publishes only CLP-facing ports. MariaDB, RabbitMQ, Redis,
+and MongoDB bind to loopback inside the container by default. Publishing those
+internal service ports requires an explicit debug opt-in.

--- a/tools/deployment/package/single-container/entrypoint.sh
+++ b/tools/deployment/package/single-container/entrypoint.sh
@@ -27,17 +27,12 @@ def emit(name, value):
 clp_home = pathlib.Path(os.environ.get("CLP_HOME", "/opt/clp"))
 input_config_path = pathlib.Path(os.environ["CLP_CONFIG_PATH"])
 runtime_config_path = pathlib.Path("/run/clp-single-container/clp-config.yaml")
-credentials_file_override = os.environ.get("CLP_SINGLE_CONTAINER_CREDENTIALS_FILE")
 
 raw_config = read_yaml_config_file(input_config_path) or {}
 clp_config = ClpConfig.model_validate(raw_config)
 clp_config.make_config_paths_absolute(clp_home)
 
-credentials_file_path = (
-    pathlib.Path(credentials_file_override)
-    if credentials_file_override
-    else clp_config.credentials_file_path
-)
+credentials_file_path = clp_config.credentials_file_path
 if credentials_file_path.is_file():
     clp_config.credentials_file_path = credentials_file_path
     clp_config.database.load_credentials_from_file(credentials_file_path)
@@ -95,16 +90,6 @@ PY
 
 configure_service_environment() {
     prepare_runtime_config
-
-    export CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS="${CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS:-127.0.0.1}"
-    case "$CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS" in
-        127.0.0.1 | 0.0.0.0) ;;
-        *)
-            echo >&2 \
-                "Error: CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS must be 127.0.0.1 or 0.0.0.0."
-            exit 1
-            ;;
-    esac
 
     export CLP_DB_NAME="${CLP_DB_NAME:-${MYSQL_DATABASE:-}}"
     export CLP_DB_USER="${CLP_DB_USER:-${MYSQL_USER:-}}"
@@ -215,7 +200,7 @@ configure_rabbitmq_defaults() {
 default_user = ${RABBITMQ_DEFAULT_USER}
 default_pass = ${RABBITMQ_DEFAULT_PASS}
 log.file = ${RABBITMQ_LOGS}
-listeners.tcp.1 = ${CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS}:5672
+listeners.tcp.1 = 127.0.0.1:5672
 EOF
     cat > /etc/rabbitmq/rabbitmq-env.conf <<'EOF'
 NODENAME=rabbit@localhost

--- a/tools/deployment/package/single-container/entrypoint.sh
+++ b/tools/deployment/package/single-container/entrypoint.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+    exec "$@"
+fi
+
+prepare_runtime_config() {
+    export CLP_CONFIG_PATH="${CLP_CONFIG_PATH:-/etc/clp-config.yaml}"
+    export CLP_HOME="${CLP_HOME:-/opt/clp}"
+
+    eval "$(python3 <<'PY'
+import os
+import pathlib
+import shlex
+
+import yaml
+
+from clp_py_utils.clp_config import ClpConfig, ClpDbNameType, ClpDbUserType, StorageType
+from clp_py_utils.core import read_yaml_config_file
+
+
+def emit(name, value):
+    print(f"export {name}={shlex.quote(str(value))}")
+
+
+clp_home = pathlib.Path(os.environ.get("CLP_HOME", "/opt/clp"))
+input_config_path = pathlib.Path(os.environ["CLP_CONFIG_PATH"])
+runtime_config_path = pathlib.Path("/run/clp-single-container/clp-config.yaml")
+credentials_file_override = os.environ.get("CLP_SINGLE_CONTAINER_CREDENTIALS_FILE")
+
+raw_config = read_yaml_config_file(input_config_path) or {}
+clp_config = ClpConfig.model_validate(raw_config)
+clp_config.make_config_paths_absolute(clp_home)
+
+credentials_file_path = (
+    pathlib.Path(credentials_file_override)
+    if credentials_file_override
+    else clp_config.credentials_file_path
+)
+if credentials_file_path.is_file():
+    clp_config.credentials_file_path = credentials_file_path
+    clp_config.database.load_credentials_from_file(credentials_file_path)
+    if clp_config.queue is not None:
+        clp_config.queue.load_credentials_from_file(credentials_file_path)
+    if clp_config.redis is not None:
+        clp_config.redis.load_credentials_from_file(credentials_file_path)
+
+container_config = clp_config.model_copy(deep=True)
+container_config.transform_for_container()
+runtime_config_path.write_text(yaml.safe_dump(container_config.dump_to_primitive_dict()))
+
+emit("CLP_CONFIG_PATH", runtime_config_path)
+emit("CLP_DB_NAME", clp_config.database.names[ClpDbNameType.CLP])
+emit("SPIDER_DB_NAME", clp_config.database.names[ClpDbNameType.SPIDER])
+emit("CLP_DB_CONNECT_PORT", container_config.database.port)
+emit("CLP_QUEUE_CONNECT_PORT", container_config.queue.port if container_config.queue else 5672)
+emit("CLP_REDIS_CONNECT_PORT", container_config.redis.port if container_config.redis else 6379)
+emit("CLP_REDIS_BACKEND_DB_COMPRESSION", clp_config.redis.compression_backend_database)
+emit("CLP_RESULTS_CACHE_CONNECT_PORT", container_config.results_cache.port)
+emit("CLP_RESULTS_CACHE_DB_NAME", clp_config.results_cache.db_name)
+emit(
+    "CLP_RESULTS_CACHE_STREAM_COLLECTION_NAME",
+    clp_config.results_cache.stream_collection_name,
+)
+emit("CLP_PACKAGE_STORAGE_ENGINE", clp_config.package.storage_engine)
+emit("CLP_REDUCER_UPSERT_INTERVAL", clp_config.reducer.upsert_interval)
+emit(
+    "CLP_LOG_INGESTOR_ENABLED",
+    int(clp_config.log_ingestor is not None and clp_config.logs_input.type == StorageType.S3),
+)
+if clp_config.log_ingestor is not None:
+    emit("CLP_LOG_INGESTOR_LOGGING_LEVEL", clp_config.log_ingestor.logging_level)
+if clp_config.mcp_server is not None:
+    emit("CLP_MCP_LOGGING_LEVEL", clp_config.mcp_server.logging_level)
+
+db_credentials = clp_config.database.credentials
+if ClpDbUserType.CLP in db_credentials:
+    emit("CLP_DB_USER", db_credentials[ClpDbUserType.CLP].username)
+    emit("CLP_DB_PASS", db_credentials[ClpDbUserType.CLP].password)
+if ClpDbUserType.ROOT in db_credentials:
+    emit("CLP_DB_ROOT_USER", db_credentials[ClpDbUserType.ROOT].username)
+    emit("CLP_DB_ROOT_PASS", db_credentials[ClpDbUserType.ROOT].password)
+if ClpDbUserType.SPIDER in db_credentials:
+    emit("SPIDER_DB_USER", db_credentials[ClpDbUserType.SPIDER].username)
+    emit("SPIDER_DB_PASS", db_credentials[ClpDbUserType.SPIDER].password)
+if clp_config.queue is not None and clp_config.queue.username is not None:
+    emit("CLP_QUEUE_USER", clp_config.queue.username)
+    emit("CLP_QUEUE_PASS", clp_config.queue.password)
+if clp_config.redis is not None and clp_config.redis.password is not None:
+    emit("CLP_REDIS_PASS", clp_config.redis.password)
+PY
+)"
+}
+
+configure_service_environment() {
+    prepare_runtime_config
+
+    export CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS="${CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS:-127.0.0.1}"
+    case "$CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS" in
+        127.0.0.1 | 0.0.0.0) ;;
+        *)
+            echo >&2 \
+                "Error: CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS must be 127.0.0.1 or 0.0.0.0."
+            exit 1
+            ;;
+    esac
+
+    export CLP_DB_NAME="${CLP_DB_NAME:-${MYSQL_DATABASE:-}}"
+    export CLP_DB_USER="${CLP_DB_USER:-${MYSQL_USER:-}}"
+    export CLP_DB_PASS="${CLP_DB_PASS:-${MYSQL_PASSWORD:-}}"
+    export CLP_DB_ROOT_USER="${CLP_DB_ROOT_USER:-root}"
+    export CLP_DB_ROOT_PASS="${CLP_DB_ROOT_PASS:-${MYSQL_ROOT_PASSWORD:-}}"
+    export CLP_QUEUE_USER="${CLP_QUEUE_USER:-${RABBITMQ_DEFAULT_USER:-}}"
+    export CLP_QUEUE_PASS="${CLP_QUEUE_PASS:-${RABBITMQ_DEFAULT_PASS:-}}"
+    export CLP_REDIS_PASS="${CLP_REDIS_PASS:-${REDIS_PASSWORD:-}}"
+
+    : "${CLP_DB_NAME:?Please set database.names.clp in CLP config.}"
+    : "${CLP_DB_USER:?Please set database.username in credentials or CLP_DB_USER.}"
+    : "${CLP_DB_PASS:?Please set CLP_DB_PASS or MYSQL_PASSWORD.}"
+    : "${CLP_DB_ROOT_PASS:?Please set CLP_DB_ROOT_PASS or MYSQL_ROOT_PASSWORD.}"
+    : "${CLP_QUEUE_USER:?Please set queue.username in credentials or CLP_QUEUE_USER.}"
+    : "${CLP_QUEUE_PASS:?Please set CLP_QUEUE_PASS or RABBITMQ_DEFAULT_PASS.}"
+    : "${CLP_REDIS_PASS:?Please set CLP_REDIS_PASS or REDIS_PASSWORD.}"
+
+    export MYSQL_DATABASE="${MYSQL_DATABASE:-${CLP_DB_NAME}}"
+    export MYSQL_USER="${MYSQL_USER:-${CLP_DB_USER}}"
+    export MYSQL_PASSWORD="${MYSQL_PASSWORD:-${CLP_DB_PASS}}"
+    export MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-${CLP_DB_ROOT_PASS}}"
+    export RABBITMQ_DEFAULT_USER="${RABBITMQ_DEFAULT_USER:-${CLP_QUEUE_USER}}"
+    export RABBITMQ_DEFAULT_PASS="${RABBITMQ_DEFAULT_PASS:-${CLP_QUEUE_PASS}}"
+    export RABBITMQ_LOGS="${RABBITMQ_LOGS:-/var/log/rabbitmq/rabbitmq.log}"
+    export REDIS_PASSWORD="${REDIS_PASSWORD:-${CLP_REDIS_PASS}}"
+
+    export CLP_DB_CONNECT_PORT="${CLP_DB_CONNECT_PORT:-3306}"
+    export CLP_QUEUE_CONNECT_PORT="${CLP_QUEUE_CONNECT_PORT:-5672}"
+    export CLP_REDIS_CONNECT_PORT="${CLP_REDIS_CONNECT_PORT:-6379}"
+    export CLP_RESULTS_CACHE_CONNECT_PORT="${CLP_RESULTS_CACHE_CONNECT_PORT:-27017}"
+    export CLP_RESULTS_CACHE_DB_NAME="${CLP_RESULTS_CACHE_DB_NAME:-clp-query-results}"
+    export CLP_RESULTS_CACHE_STREAM_COLLECTION_NAME="${CLP_RESULTS_CACHE_STREAM_COLLECTION_NAME:-stream-files}"
+    export CLP_PACKAGE_STORAGE_ENGINE="${CLP_PACKAGE_STORAGE_ENGINE:-clp}"
+    export CLP_COMPRESSION_WORKER_CONCURRENCY="${CLP_COMPRESSION_WORKER_CONCURRENCY:-1}"
+    export CLP_QUERY_WORKER_CONCURRENCY="${CLP_QUERY_WORKER_CONCURRENCY:-1}"
+    export CLP_REDUCER_CONCURRENCY="${CLP_REDUCER_CONCURRENCY:-1}"
+    export CLP_REDUCER_UPSERT_INTERVAL="${CLP_REDUCER_UPSERT_INTERVAL:-100}"
+    export CLP_LOG_INGESTOR_ENABLED="${CLP_LOG_INGESTOR_ENABLED:-0}"
+    export CLP_LOG_INGESTOR_LOGGING_LEVEL="${CLP_LOG_INGESTOR_LOGGING_LEVEL:-INFO}"
+    export CLP_MCP_SERVER_ENABLED="${CLP_MCP_SERVER_ENABLED:-0}"
+    export CLP_MCP_LOGGING_LEVEL="${CLP_MCP_LOGGING_LEVEL:-INFO}"
+    export CLP_LOGS_DIR="${CLP_LOGS_DIR:-/var/log}"
+    export BROKER_URL="amqp://${CLP_QUEUE_USER:-clp-user}:${CLP_QUEUE_PASS:?Please set CLP_QUEUE_PASS.}@queue:${CLP_QUEUE_CONNECT_PORT}"
+    export RESULT_BACKEND="redis://default:${CLP_REDIS_PASS:?Please set CLP_REDIS_PASS.}@redis:${CLP_REDIS_CONNECT_PORT}/${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"
+    export HOST="${HOST:-0.0.0.0}"
+    export NODE_ENV="${NODE_ENV:-production}"
+    export NODE_PATH="${NODE_PATH:-/opt/clp/var/www/webui/server/node_modules}"
+    export PORT="${PORT:-4000}"
+}
+
+initialize_mariadb_data_dir() {
+    if [[ -d /var/data/database/mysql ]]; then
+        return
+    fi
+
+    mariadb-install-db \
+        --user=mysql \
+        --datadir=/var/data/database \
+        --skip-test-db \
+        --auth-root-authentication-method=normal \
+        >/dev/null
+
+    python3 <<'PY' | mariadbd --user=mysql --datadir=/var/data/database --bootstrap
+import os
+import sys
+
+
+def quote_identifier(value):
+    if "\0" in value:
+        raise ValueError("SQL identifier contains a NUL byte.")
+    return f"`{value.replace('`', '``')}`"
+
+
+def quote_string(value):
+    if "\0" in value:
+        raise ValueError("SQL string contains a NUL byte.")
+    return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"
+
+
+values = {
+    "MYSQL_DATABASE": os.environ["MYSQL_DATABASE"],
+    "MYSQL_USER": os.environ["MYSQL_USER"],
+    "MYSQL_PASSWORD": os.environ["MYSQL_PASSWORD"],
+    "MYSQL_ROOT_PASSWORD": os.environ["MYSQL_ROOT_PASSWORD"],
+}
+for name, value in values.items():
+    if value == "":
+        sys.exit(f"{name} must not be empty.")
+
+database = quote_identifier(values["MYSQL_DATABASE"])
+user = quote_string(values["MYSQL_USER"])
+password = quote_string(values["MYSQL_PASSWORD"])
+root_password = quote_string(values["MYSQL_ROOT_PASSWORD"])
+
+print("FLUSH PRIVILEGES;")
+print(f"ALTER USER 'root'@'localhost' IDENTIFIED BY {root_password};")
+print(f"CREATE DATABASE IF NOT EXISTS {database};")
+print(f"CREATE USER IF NOT EXISTS {user}@'%' IDENTIFIED BY {password};")
+print(f"GRANT ALL PRIVILEGES ON {database}.* TO {user}@'%';")
+print("FLUSH PRIVILEGES;")
+PY
+}
+
+configure_rabbitmq_defaults() {
+    mkdir -p /etc/rabbitmq/conf.d
+    cat > /etc/rabbitmq/conf.d/10-clp-defaults.conf <<EOF
+default_user = ${RABBITMQ_DEFAULT_USER}
+default_pass = ${RABBITMQ_DEFAULT_PASS}
+log.file = ${RABBITMQ_LOGS}
+listeners.tcp.1 = ${CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS}:5672
+EOF
+    cat > /etc/rabbitmq/rabbitmq-env.conf <<'EOF'
+NODENAME=rabbit@localhost
+SERVER_ADDITIONAL_ERL_ARGS="-kernel inet_dist_use_interface {127,0,0,1}"
+EOF
+    chown rabbitmq:rabbitmq /etc/rabbitmq/conf.d/10-clp-defaults.conf
+    chown rabbitmq:rabbitmq /etc/rabbitmq/rabbitmq-env.conf
+    chmod 0640 /etc/rabbitmq/conf.d/10-clp-defaults.conf
+    chmod 0640 /etc/rabbitmq/rabbitmq-env.conf
+}
+
+configure_webui_settings() {
+    local client_settings_path="/opt/clp/var/www/webui/client/settings.json"
+    local server_settings_path="/opt/clp/var/www/webui/server/dist/settings.json"
+    if [[ ! -f "$server_settings_path" ]]; then
+        return
+    fi
+
+    python3 - "$server_settings_path" "$client_settings_path" <<'PY'
+import json
+import pathlib
+import sys
+
+server_settings_path = pathlib.Path(sys.argv[1])
+client_settings_path = pathlib.Path(sys.argv[2])
+
+server_settings = json.loads(server_settings_path.read_text())
+server_settings["ClientDir"] = "../client"
+server_settings["LogViewerDir"] = "../yscope-log-viewer"
+server_settings["StreamFilesDir"] = "/var/data/streams"
+server_settings_path.write_text(json.dumps(server_settings, indent=4) + "\n")
+
+if client_settings_path.is_file():
+    client_settings = json.loads(client_settings_path.read_text())
+    client_settings["LogsInputRootDir"] = server_settings["LogsInputRootDir"]
+    client_settings_path.write_text(json.dumps(client_settings, indent=4) + "\n")
+PY
+}
+
+add_local_alias() {
+    local hostname="$1"
+    if ! awk -v hostname="$hostname" '
+        $1 == "127.0.0.1" {
+            for (i = 2; i <= NF; ++i) {
+                if ($i == hostname) {
+                    found = 1
+                }
+            }
+        }
+        END { exit found ? 0 : 1 }
+    ' /etc/hosts; then
+        echo "127.0.0.1 ${hostname}" >> /etc/hosts
+    fi
+}
+
+for hostname in database queue redis results_cache compression_scheduler query_scheduler reducer mcp_server; do
+    add_local_alias "$hostname"
+done
+
+mkdir -p \
+    /data/db \
+    /run/clp-single-container \
+    /run/mysqld \
+    /opt/clp/var/data \
+    /var/data/archives \
+    /var/data/database \
+    /var/data/redis \
+    /var/data/results_cache \
+    /var/data/streams \
+    /var/lib/rabbitmq \
+    /var/log/api_server \
+    /var/log/clp-single-container \
+    /var/log/compression_scheduler \
+    /var/log/compression_worker \
+    /var/log/garbage_collector \
+    /var/log/log_ingestor \
+    /var/log/mcp_server \
+    /var/log/mysql \
+    /var/log/mongodb \
+    /var/log/query_scheduler \
+    /var/log/query_worker \
+    /var/log/rabbitmq \
+    /var/log/reducer \
+    /var/log/redis \
+    /var/log/supervisor \
+    /var/log/webui
+
+chmod 0755 /var/data /var/log
+chmod 1777 /var/tmp
+if [[ ! -e /opt/clp/var/tmp ]]; then
+    ln -s /var/tmp /opt/clp/var/tmp
+fi
+
+chown clp-user:clp-user /var/data /var/log
+chown -R mysql:mysql /run/mysqld /var/data/database /var/log/mysql
+chown -R mongodb:mongodb /var/data/results_cache /var/log/mongodb
+chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /var/log/rabbitmq
+chown -R redis:redis /var/data/redis /var/log/redis
+chown -R clp-user:clp-user \
+    /run/clp-single-container \
+    /opt/clp/var/data \
+    /var/data/archives \
+    /var/data/streams \
+    /var/log/api_server \
+    /var/log/compression_scheduler \
+    /var/log/compression_worker \
+    /var/log/garbage_collector \
+    /var/log/log_ingestor \
+    /var/log/mcp_server \
+    /var/log/query_scheduler \
+    /var/log/query_worker \
+    /var/log/reducer \
+    /var/log/webui
+if [[ "${1:-}" == */supervisord || "${1:-}" == "supervisord" ]]; then
+    configure_service_environment
+    initialize_mariadb_data_dir
+    configure_rabbitmq_defaults
+    configure_webui_settings
+fi
+
+exec "$@"

--- a/tools/deployment/package/single-container/entrypoint.sh
+++ b/tools/deployment/package/single-container/entrypoint.sh
@@ -31,6 +31,7 @@ runtime_config_path = pathlib.Path("/run/clp-single-container/clp-config.yaml")
 raw_config = read_yaml_config_file(input_config_path) or {}
 clp_config = ClpConfig.model_validate(raw_config)
 clp_config.make_config_paths_absolute(clp_home)
+clp_config.validate_api_server()
 
 credentials_file_path = clp_config.credentials_file_path
 if credentials_file_path.is_file():
@@ -52,6 +53,7 @@ emit("CLP_DB_CONNECT_PORT", container_config.database.port)
 emit("CLP_QUEUE_CONNECT_PORT", container_config.queue.port if container_config.queue else 5672)
 emit("CLP_REDIS_CONNECT_PORT", container_config.redis.port if container_config.redis else 6379)
 emit("CLP_REDIS_BACKEND_DB_COMPRESSION", clp_config.redis.compression_backend_database)
+emit("CLP_REDIS_BACKEND_DB_QUERY", clp_config.redis.query_backend_database)
 emit("CLP_RESULTS_CACHE_CONNECT_PORT", container_config.results_cache.port)
 emit("CLP_RESULTS_CACHE_DB_NAME", clp_config.results_cache.db_name)
 emit(
@@ -60,10 +62,19 @@ emit(
 )
 emit("CLP_PACKAGE_STORAGE_ENGINE", clp_config.package.storage_engine)
 emit("CLP_REDUCER_UPSERT_INTERVAL", clp_config.reducer.upsert_interval)
+emit("CLP_API_SERVER_ENABLED", int(clp_config.api_server is not None))
 emit(
     "CLP_LOG_INGESTOR_ENABLED",
     int(clp_config.log_ingestor is not None and clp_config.logs_input.type == StorageType.S3),
 )
+emit(
+    "CLP_GARBAGE_COLLECTOR_ENABLED",
+    int(
+        clp_config.archive_output.retention_period is not None
+        or clp_config.results_cache.retention_period is not None
+    ),
+)
+emit("CLP_GARBAGE_COLLECTOR_LOGGING_LEVEL", clp_config.garbage_collector.logging_level)
 if clp_config.log_ingestor is not None:
     emit("CLP_LOG_INGESTOR_LOGGING_LEVEL", clp_config.log_ingestor.logging_level)
 if clp_config.mcp_server is not None:
@@ -120,6 +131,8 @@ configure_service_environment() {
     export CLP_DB_CONNECT_PORT="${CLP_DB_CONNECT_PORT:-3306}"
     export CLP_QUEUE_CONNECT_PORT="${CLP_QUEUE_CONNECT_PORT:-5672}"
     export CLP_REDIS_CONNECT_PORT="${CLP_REDIS_CONNECT_PORT:-6379}"
+    export CLP_REDIS_BACKEND_DB_COMPRESSION="${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"
+    export CLP_REDIS_BACKEND_DB_QUERY="${CLP_REDIS_BACKEND_DB_QUERY:-0}"
     export CLP_RESULTS_CACHE_CONNECT_PORT="${CLP_RESULTS_CACHE_CONNECT_PORT:-27017}"
     export CLP_RESULTS_CACHE_DB_NAME="${CLP_RESULTS_CACHE_DB_NAME:-clp-query-results}"
     export CLP_RESULTS_CACHE_STREAM_COLLECTION_NAME="${CLP_RESULTS_CACHE_STREAM_COLLECTION_NAME:-stream-files}"
@@ -128,13 +141,15 @@ configure_service_environment() {
     export CLP_QUERY_WORKER_CONCURRENCY="${CLP_QUERY_WORKER_CONCURRENCY:-1}"
     export CLP_REDUCER_CONCURRENCY="${CLP_REDUCER_CONCURRENCY:-1}"
     export CLP_REDUCER_UPSERT_INTERVAL="${CLP_REDUCER_UPSERT_INTERVAL:-100}"
+    export CLP_API_SERVER_ENABLED="${CLP_API_SERVER_ENABLED:-1}"
     export CLP_LOG_INGESTOR_ENABLED="${CLP_LOG_INGESTOR_ENABLED:-0}"
     export CLP_LOG_INGESTOR_LOGGING_LEVEL="${CLP_LOG_INGESTOR_LOGGING_LEVEL:-INFO}"
+    export CLP_GARBAGE_COLLECTOR_ENABLED="${CLP_GARBAGE_COLLECTOR_ENABLED:-1}"
+    export CLP_GARBAGE_COLLECTOR_LOGGING_LEVEL="${CLP_GARBAGE_COLLECTOR_LOGGING_LEVEL:-INFO}"
     export CLP_MCP_SERVER_ENABLED="${CLP_MCP_SERVER_ENABLED:-0}"
     export CLP_MCP_LOGGING_LEVEL="${CLP_MCP_LOGGING_LEVEL:-INFO}"
     export CLP_LOGS_DIR="${CLP_LOGS_DIR:-/var/log}"
     export BROKER_URL="amqp://${CLP_QUEUE_USER:-clp-user}:${CLP_QUEUE_PASS:?Please set CLP_QUEUE_PASS.}@queue:${CLP_QUEUE_CONNECT_PORT}"
-    export RESULT_BACKEND="redis://default:${CLP_REDIS_PASS:?Please set CLP_REDIS_PASS.}@redis:${CLP_REDIS_CONNECT_PORT}/${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"
     export HOST="${HOST:-0.0.0.0}"
     export NODE_ENV="${NODE_ENV:-production}"
     export NODE_PATH="${NODE_PATH:-/opt/clp/var/www/webui/server/node_modules}"
@@ -219,24 +234,26 @@ configure_webui_settings() {
         return
     fi
 
-    python3 - "$server_settings_path" "$client_settings_path" <<'PY'
-import json
+    python3 - "$CLP_CONFIG_PATH" "$server_settings_path" "$client_settings_path" <<'PY'
 import pathlib
 import sys
 
-server_settings_path = pathlib.Path(sys.argv[1])
-client_settings_path = pathlib.Path(sys.argv[2])
+from clp_package_utils.webui_settings import update_webui_settings
+from clp_py_utils.clp_config import ClpConfig
+from clp_py_utils.core import read_yaml_config_file
 
-server_settings = json.loads(server_settings_path.read_text())
-server_settings["ClientDir"] = "../client"
-server_settings["LogViewerDir"] = "../yscope-log-viewer"
-server_settings["StreamFilesDir"] = "/var/data/streams"
-server_settings_path.write_text(json.dumps(server_settings, indent=4) + "\n")
+config_path = pathlib.Path(sys.argv[1])
+server_settings_path = pathlib.Path(sys.argv[2])
+client_settings_path = pathlib.Path(sys.argv[3])
 
-if client_settings_path.is_file():
-    client_settings = json.loads(client_settings_path.read_text())
-    client_settings["LogsInputRootDir"] = server_settings["LogsInputRootDir"]
-    client_settings_path.write_text(json.dumps(client_settings, indent=4) + "\n")
+clp_config = ClpConfig.model_validate(read_yaml_config_file(config_path))
+update_webui_settings(
+    clp_config=clp_config,
+    container_clp_config=clp_config,
+    client_settings_json_path=client_settings_path,
+    server_settings_json_path=server_settings_path,
+    container_webui_dir=pathlib.Path("/opt/clp/var/www/webui"),
+)
 PY
 }
 

--- a/tools/deployment/package/single-container/generate-third-party-notices.sh
+++ b/tools/deployment/package/single-container/generate-third-party-notices.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+output_dir="${1:-/opt/clp/share/third-party-notices}"
+debian_notices_dir="${output_dir}/debian-copyrights"
+
+rm -rf "$output_dir"
+mkdir -p "$debian_notices_dir"
+
+cat > "${output_dir}/README.md" <<'EOF'
+# CLP single-container image third-party notices
+
+This directory is generated at image build time and records third-party
+components installed in the CLP single-container image.
+
+The image contains CLP plus third-party runtime services and libraries under
+their own licenses. The image as a whole should not be described as Apache-2.0
+only. CLP's Apache-2.0 license applies to CLP code; bundled third-party
+components remain under their respective licenses.
+
+MongoDB is bundled only as CLP's embedded results-cache implementation detail.
+It is not intended to be exposed or marketed as a general-purpose MongoDB
+service.
+
+For public image publication, this directory is not sufficient by itself. The
+release must also publish a matching SBOM and corresponding source bundle for
+the exact image digest.
+EOF
+
+dpkg-query -W -f='${Package}\t${Version}\t${Architecture}\t${source:Package}\t${source:Version}\n' \
+    | sort > "${output_dir}/debian-packages.tsv"
+
+missing_copyrights="${output_dir}/missing-debian-copyrights.txt"
+: > "$missing_copyrights"
+while IFS=$'\t' read -r package _version _architecture _source_package _source_version; do
+    copyright_file="/usr/share/doc/${package}/copyright"
+    if [[ -f "$copyright_file" ]]; then
+        cp "$copyright_file" "${debian_notices_dir}/${package}.copyright"
+    else
+        echo "$package" >> "$missing_copyrights"
+    fi
+done < "${output_dir}/debian-packages.tsv"
+
+python3 <<'PY' > "${output_dir}/python-distributions.tsv"
+from importlib import metadata
+
+for dist in sorted(
+    metadata.distributions(),
+    key=lambda item: (item.metadata.get("Name") or item.name).lower(),
+):
+    name = dist.metadata.get("Name") or dist.name
+    version = dist.version
+    license_value = dist.metadata.get("License", "")
+    home_page = dist.metadata.get("Home-page", "")
+    print(f"{name}\t{version}\t{license_value}\t{home_page}")
+PY
+
+webui_package_lock="/opt/clp/var/www/webui/package-lock.json"
+if [[ -f "$webui_package_lock" ]]; then
+    cp "$webui_package_lock" "${output_dir}/webui-package-lock.json"
+fi
+
+find /opt/clp -maxdepth 4 \( -iname 'LICENSE*' -o -iname 'NOTICE*' -o -iname 'COPYING*' \) \
+    -type f -print | sort > "${output_dir}/clp-license-files.txt"

--- a/tools/deployment/package/single-container/supervisord.conf
+++ b/tools/deployment/package/single-container/supervisord.conf
@@ -1,0 +1,140 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/clp-single-container/supervisord.log
+pidfile=/run/clp-single-container-supervisord.pid
+
+[unix_http_server]
+file=/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/sbin/mariadbd --defaults-extra-file=/opt/clp/etc/mysql/conf.d/logging.cnf --user=mysql --bind-address=%(ENV_CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS)s --port=3306 --datadir=/var/data/database
+autorestart=true
+priority=10
+stdout_logfile=/var/log/clp-single-container/mariadb.stdout.log
+stderr_logfile=/var/log/clp-single-container/mariadb.stderr.log
+
+[program:rabbitmq]
+command=/usr/sbin/rabbitmq-server
+autorestart=true
+priority=20
+stdout_logfile=/var/log/clp-single-container/rabbitmq.stdout.log
+stderr_logfile=/var/log/clp-single-container/rabbitmq.stderr.log
+user=rabbitmq
+environment=HOME="/var/lib/rabbitmq",RABBITMQ_LOGS="/var/log/rabbitmq/rabbitmq.log",ERL_EPMD_ADDRESS="127.0.0.1",RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-kernel inet_dist_use_interface {127,0,0,1}"
+
+[program:redis]
+command=/usr/bin/redis-server /opt/clp/etc/redis/redis.conf --dir /var/data/redis --protected-mode no --bind %(ENV_CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS)s --requirepass %(ENV_REDIS_PASSWORD)s
+autorestart=true
+priority=30
+stdout_logfile=/var/log/clp-single-container/redis.stdout.log
+stderr_logfile=/var/log/clp-single-container/redis.stderr.log
+user=redis
+
+[program:mongodb]
+command=/usr/bin/mongod --config /opt/clp/etc/mongo/mongod.conf --dbpath /var/data/results_cache --bind_ip %(ENV_CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS)s
+autorestart=true
+priority=40
+stdout_logfile=/var/log/clp-single-container/mongodb.stdout.log
+stderr_logfile=/var/log/clp-single-container/mongodb.stderr.log
+user=mongodb
+
+[program:db-table-creator]
+command=/bin/bash -c '/usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 3306 python3 -u -m clp_py_utils.create-db-tables --config %(ENV_CLP_CONFIG_PATH)s --storage-engine %(ENV_CLP_PACKAGE_STORAGE_ENGINE)s && touch /run/clp-single-container/db-table-creator.done'
+autorestart=false
+startsecs=0
+priority=100
+stdout_logfile=/var/log/clp-single-container/db-table-creator.stdout.log
+stderr_logfile=/var/log/clp-single-container/db-table-creator.stderr.log
+user=clp-user
+
+[program:results-cache-indices-creator]
+command=/bin/bash -c '/usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 27017 python3 -u -m clp_py_utils.initialize-results-cache --uri mongodb://results_cache:%(ENV_CLP_RESULTS_CACHE_CONNECT_PORT)s/%(ENV_CLP_RESULTS_CACHE_DB_NAME)s --stream-collection %(ENV_CLP_RESULTS_CACHE_STREAM_COLLECTION_NAME)s && touch /run/clp-single-container/results-cache-indices-creator.done'
+autorestart=false
+startsecs=0
+priority=105
+stdout_logfile=/var/log/clp-single-container/results-cache-indices-creator.stdout.log
+stderr_logfile=/var/log/clp-single-container/results-cache-indices-creator.stderr.log
+user=clp-user
+
+[program:compression-scheduler]
+command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u -m job_orchestration.scheduler.compress.compression_scheduler --config %(ENV_CLP_CONFIG_PATH)s
+autorestart=true
+priority=110
+stdout_logfile=/var/log/clp-single-container/compression-scheduler.stdout.log
+stderr_logfile=/var/log/clp-single-container/compression-scheduler.stderr.log
+user=clp-user
+
+[program:compression-worker]
+command=/usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u /opt/clp/lib/python3/site-packages/bin/celery -A job_orchestration.executor.compress worker --concurrency %(ENV_CLP_COMPRESSION_WORKER_CONCURRENCY)s --loglevel WARNING -f /var/log/compression_worker/worker.log -Q compression -n compression-worker@%%h
+autorestart=true
+priority=120
+stdout_logfile=/var/log/clp-single-container/compression-worker.stdout.log
+stderr_logfile=/var/log/clp-single-container/compression-worker.stderr.log
+user=clp-user
+
+[program:query-scheduler]
+command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u -m job_orchestration.scheduler.query.query_scheduler --config %(ENV_CLP_CONFIG_PATH)s
+autorestart=true
+priority=130
+stdout_logfile=/var/log/clp-single-container/query-scheduler.stdout.log
+stderr_logfile=/var/log/clp-single-container/query-scheduler.stderr.log
+user=clp-user
+
+[program:query-worker]
+command=/usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u /opt/clp/lib/python3/site-packages/bin/celery -A job_orchestration.executor.query worker --concurrency %(ENV_CLP_QUERY_WORKER_CONCURRENCY)s --loglevel WARNING -f /var/log/query_worker/worker.log -Q query -n query-worker@%%h
+autorestart=true
+priority=140
+stdout_logfile=/var/log/clp-single-container/query-worker.stdout.log
+stderr_logfile=/var/log/clp-single-container/query-worker.stderr.log
+user=clp-user
+
+[program:reducer]
+command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/results-cache-indices-creator.done -- /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 7000 python3 -u -m job_orchestration.reducer.reducer --config %(ENV_CLP_CONFIG_PATH)s --concurrency %(ENV_CLP_REDUCER_CONCURRENCY)s --upsert-interval %(ENV_CLP_REDUCER_UPSERT_INTERVAL)s
+autorestart=true
+priority=150
+stdout_logfile=/var/log/clp-single-container/reducer.stdout.log
+stderr_logfile=/var/log/clp-single-container/reducer.stderr.log
+user=clp-user
+
+[program:api-server]
+command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done /run/clp-single-container/results-cache-indices-creator.done -- /opt/clp/bin/api_server --host 0.0.0.0 --port 3001 --config %(ENV_CLP_CONFIG_PATH)s
+autorestart=true
+priority=160
+stdout_logfile=/var/log/clp-single-container/api-server.stdout.log
+stderr_logfile=/var/log/clp-single-container/api-server.stderr.log
+user=clp-user
+
+[program:log-ingestor]
+command=/bin/bash -c 'if [[ "${CLP_LOG_INGESTOR_ENABLED:-0}" == "0" ]]; then echo "log-ingestor disabled."; exit 0; fi; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /opt/clp/bin/log-ingestor --config %(ENV_CLP_CONFIG_PATH)s --host 0.0.0.0 --port 3002'
+autorestart=false
+startsecs=0
+priority=165
+stdout_logfile=/var/log/clp-single-container/log-ingestor.stdout.log
+stderr_logfile=/var/log/clp-single-container/log-ingestor.stderr.log
+user=clp-user
+environment=RUST_LOG="%(ENV_CLP_LOG_INGESTOR_LOGGING_LEVEL)s"
+
+[program:mcp-server]
+command=/bin/bash -c 'if [[ "${CLP_MCP_SERVER_ENABLED:-0}" == "0" ]]; then echo "MCP server disabled."; exit 0; fi; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done /run/clp-single-container/results-cache-indices-creator.done -- python3 -u -m clp_mcp_server.clp_mcp_server --host 0.0.0.0 --port 8000 --config-path %(ENV_CLP_CONFIG_PATH)s'
+autorestart=false
+startsecs=0
+priority=168
+stdout_logfile=/var/log/clp-single-container/mcp-server.stdout.log
+stderr_logfile=/var/log/clp-single-container/mcp-server.stderr.log
+user=clp-user
+environment=CLP_LOGGING_LEVEL="%(ENV_CLP_MCP_LOGGING_LEVEL)s",CLP_LOGS_DIR="/var/log/mcp_server"
+
+[program:webui]
+command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done /run/clp-single-container/results-cache-indices-creator.done -- /opt/clp/bin/node-22 /opt/clp/var/www/webui/server/dist/src/main.js
+autorestart=true
+priority=170
+stdout_logfile=/var/log/clp-single-container/webui.stdout.log
+stderr_logfile=/var/log/clp-single-container/webui.stderr.log
+user=clp-user

--- a/tools/deployment/package/single-container/supervisord.conf
+++ b/tools/deployment/package/single-container/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+loglevel=warn
 logfile=/var/log/clp-single-container/supervisord.log
 pidfile=/run/clp-single-container-supervisord.pid
 
@@ -14,7 +15,7 @@ serverurl=unix:///run/supervisor.sock
 supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 
 [program:mariadb]
-command=/usr/sbin/mariadbd --defaults-extra-file=/opt/clp/etc/mysql/conf.d/logging.cnf --user=mysql --bind-address=%(ENV_CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS)s --port=3306 --datadir=/var/data/database
+command=/usr/sbin/mariadbd --defaults-extra-file=/opt/clp/etc/mysql/conf.d/logging.cnf --user=mysql --bind-address=127.0.0.1 --port=3306 --datadir=/var/data/database
 autorestart=true
 priority=10
 stdout_logfile=/var/log/clp-single-container/mariadb.stdout.log
@@ -30,7 +31,7 @@ user=rabbitmq
 environment=HOME="/var/lib/rabbitmq",RABBITMQ_LOGS="/var/log/rabbitmq/rabbitmq.log",ERL_EPMD_ADDRESS="127.0.0.1",RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-kernel inet_dist_use_interface {127,0,0,1}"
 
 [program:redis]
-command=/usr/bin/redis-server /opt/clp/etc/redis/redis.conf --dir /var/data/redis --protected-mode no --bind %(ENV_CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS)s --requirepass %(ENV_REDIS_PASSWORD)s
+command=/usr/bin/redis-server /opt/clp/etc/redis/redis.conf --dir /var/data/redis --protected-mode no --bind 127.0.0.1 --requirepass %(ENV_REDIS_PASSWORD)s
 autorestart=true
 priority=30
 stdout_logfile=/var/log/clp-single-container/redis.stdout.log
@@ -38,7 +39,7 @@ stderr_logfile=/var/log/clp-single-container/redis.stderr.log
 user=redis
 
 [program:mongodb]
-command=/usr/bin/mongod --config /opt/clp/etc/mongo/mongod.conf --dbpath /var/data/results_cache --bind_ip %(ENV_CLP_SINGLE_CONTAINER_INTERNAL_BIND_ADDRESS)s
+command=/usr/bin/mongod --config /opt/clp/etc/mongo/mongod.conf --dbpath /var/data/results_cache --bind_ip 127.0.0.1
 autorestart=true
 priority=40
 stdout_logfile=/var/log/clp-single-container/mongodb.stdout.log

--- a/tools/deployment/package/single-container/supervisord.conf
+++ b/tools/deployment/package/single-container/supervisord.conf
@@ -65,7 +65,7 @@ stderr_logfile=/var/log/clp-single-container/results-cache-indices-creator.stder
 user=clp-user
 
 [program:compression-scheduler]
-command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u -m job_orchestration.scheduler.compress.compression_scheduler --config %(ENV_CLP_CONFIG_PATH)s
+command=/bin/bash -c 'export RESULT_BACKEND="redis://default:${CLP_REDIS_PASS:?Please set CLP_REDIS_PASS.}@redis:${CLP_REDIS_CONNECT_PORT}/${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u -m job_orchestration.scheduler.compress.compression_scheduler --config %(ENV_CLP_CONFIG_PATH)s'
 autorestart=true
 priority=110
 stdout_logfile=/var/log/clp-single-container/compression-scheduler.stdout.log
@@ -73,7 +73,7 @@ stderr_logfile=/var/log/clp-single-container/compression-scheduler.stderr.log
 user=clp-user
 
 [program:compression-worker]
-command=/usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u /opt/clp/lib/python3/site-packages/bin/celery -A job_orchestration.executor.compress worker --concurrency %(ENV_CLP_COMPRESSION_WORKER_CONCURRENCY)s --loglevel WARNING -f /var/log/compression_worker/worker.log -Q compression -n compression-worker@%%h
+command=/bin/bash -c 'export RESULT_BACKEND="redis://default:${CLP_REDIS_PASS:?Please set CLP_REDIS_PASS.}@redis:${CLP_REDIS_CONNECT_PORT}/${CLP_REDIS_BACKEND_DB_COMPRESSION:-1}"; exec /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u /opt/clp/lib/python3/site-packages/bin/celery -A job_orchestration.executor.compress worker --concurrency %(ENV_CLP_COMPRESSION_WORKER_CONCURRENCY)s --loglevel WARNING -f /var/log/compression_worker/worker.log -Q compression -n compression-worker@%%h'
 autorestart=true
 priority=120
 stdout_logfile=/var/log/clp-single-container/compression-worker.stdout.log
@@ -81,7 +81,7 @@ stderr_logfile=/var/log/clp-single-container/compression-worker.stderr.log
 user=clp-user
 
 [program:query-scheduler]
-command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u -m job_orchestration.scheduler.query.query_scheduler --config %(ENV_CLP_CONFIG_PATH)s
+command=/bin/bash -c 'export RESULT_BACKEND="redis://default:${CLP_REDIS_PASS:?Please set CLP_REDIS_PASS.}@redis:${CLP_REDIS_CONNECT_PORT}/${CLP_REDIS_BACKEND_DB_QUERY:-0}"; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u -m job_orchestration.scheduler.query.query_scheduler --config %(ENV_CLP_CONFIG_PATH)s'
 autorestart=true
 priority=130
 stdout_logfile=/var/log/clp-single-container/query-scheduler.stdout.log
@@ -89,7 +89,7 @@ stderr_logfile=/var/log/clp-single-container/query-scheduler.stderr.log
 user=clp-user
 
 [program:query-worker]
-command=/usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u /opt/clp/lib/python3/site-packages/bin/celery -A job_orchestration.executor.query worker --concurrency %(ENV_CLP_QUERY_WORKER_CONCURRENCY)s --loglevel WARNING -f /var/log/query_worker/worker.log -Q query -n query-worker@%%h
+command=/bin/bash -c 'export RESULT_BACKEND="redis://default:${CLP_REDIS_PASS:?Please set CLP_REDIS_PASS.}@redis:${CLP_REDIS_CONNECT_PORT}/${CLP_REDIS_BACKEND_DB_QUERY:-0}"; exec /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 5672 /usr/local/bin/clp-single-container-wait-for-tcp 127.0.0.1 6379 python3 -u /opt/clp/lib/python3/site-packages/bin/celery -A job_orchestration.executor.query worker --concurrency %(ENV_CLP_QUERY_WORKER_CONCURRENCY)s --loglevel WARNING -f /var/log/query_worker/worker.log -Q query -n query-worker@%%h'
 autorestart=true
 priority=140
 stdout_logfile=/var/log/clp-single-container/query-worker.stdout.log
@@ -104,9 +104,20 @@ stdout_logfile=/var/log/clp-single-container/reducer.stdout.log
 stderr_logfile=/var/log/clp-single-container/reducer.stderr.log
 user=clp-user
 
+[program:garbage-collector]
+command=/bin/bash -c 'if [[ "${CLP_GARBAGE_COLLECTOR_ENABLED:-1}" == "0" ]]; then echo "garbage-collector disabled."; exit 0; fi; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done /run/clp-single-container/results-cache-indices-creator.done -- python3 -u -m job_orchestration.garbage_collector.garbage_collector --config %(ENV_CLP_CONFIG_PATH)s'
+autorestart=unexpected
+startsecs=0
+priority=155
+stdout_logfile=/var/log/clp-single-container/garbage-collector.stdout.log
+stderr_logfile=/var/log/clp-single-container/garbage-collector.stderr.log
+user=clp-user
+environment=CLP_LOGGING_LEVEL="%(ENV_CLP_GARBAGE_COLLECTOR_LOGGING_LEVEL)s",CLP_LOGS_DIR="/var/log/garbage_collector"
+
 [program:api-server]
-command=/usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done /run/clp-single-container/results-cache-indices-creator.done -- /opt/clp/bin/api_server --host 0.0.0.0 --port 3001 --config %(ENV_CLP_CONFIG_PATH)s
-autorestart=true
+command=/bin/bash -c 'if [[ "${CLP_API_SERVER_ENABLED:-1}" == "0" ]]; then echo "api-server disabled."; exit 0; fi; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done /run/clp-single-container/results-cache-indices-creator.done -- /opt/clp/bin/api_server --host 0.0.0.0 --port 3001 --config %(ENV_CLP_CONFIG_PATH)s'
+autorestart=unexpected
+startsecs=0
 priority=160
 stdout_logfile=/var/log/clp-single-container/api-server.stdout.log
 stderr_logfile=/var/log/clp-single-container/api-server.stderr.log
@@ -114,7 +125,7 @@ user=clp-user
 
 [program:log-ingestor]
 command=/bin/bash -c 'if [[ "${CLP_LOG_INGESTOR_ENABLED:-0}" == "0" ]]; then echo "log-ingestor disabled."; exit 0; fi; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done -- /opt/clp/bin/log-ingestor --config %(ENV_CLP_CONFIG_PATH)s --host 0.0.0.0 --port 3002'
-autorestart=false
+autorestart=unexpected
 startsecs=0
 priority=165
 stdout_logfile=/var/log/clp-single-container/log-ingestor.stdout.log
@@ -124,7 +135,7 @@ environment=RUST_LOG="%(ENV_CLP_LOG_INGESTOR_LOGGING_LEVEL)s"
 
 [program:mcp-server]
 command=/bin/bash -c 'if [[ "${CLP_MCP_SERVER_ENABLED:-0}" == "0" ]]; then echo "MCP server disabled."; exit 0; fi; exec /usr/local/bin/clp-single-container-wait-for-files /run/clp-single-container/db-table-creator.done /run/clp-single-container/results-cache-indices-creator.done -- python3 -u -m clp_mcp_server.clp_mcp_server --host 0.0.0.0 --port 8000 --config-path %(ENV_CLP_CONFIG_PATH)s'
-autorestart=false
+autorestart=unexpected
 startsecs=0
 priority=168
 stdout_logfile=/var/log/clp-single-container/mcp-server.stdout.log

--- a/tools/deployment/package/single-container/validate-release-licenses.sh
+++ b/tools/deployment/package/single-container/validate-release-licenses.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+get_package_version() {
+    local package="$1"
+    dpkg-query -W -f='${Version}' "$package" 2>/dev/null
+}
+
+strip_epoch() {
+    local version="$1"
+    echo "${version#*:}"
+}
+
+require_package() {
+    local package="$1"
+    local status=""
+    status="$(dpkg-query -W -f='${db:Status-Abbrev}' "$package" 2>/dev/null || true)"
+    if [[ "$status" != ii* ]]; then
+        echo >&2 "Error: Required package '$package' is not installed."
+        exit 1
+    fi
+}
+
+for package in mariadb-server mongodb-org-server rabbitmq-server redis-server supervisor; do
+    require_package "$package"
+done
+
+redis_version="$(strip_epoch "$(get_package_version redis-server)")"
+if dpkg --compare-versions "$redis_version" ge "7.4"; then
+    echo >&2 \
+        "Error: redis-server $redis_version is not allowed in the single-container image. Use < 7.4."
+    exit 1
+fi
+
+mongodb_copyright="/usr/share/doc/mongodb-org-server/copyright"
+if [[ ! -f "$mongodb_copyright" ]] || ! grep -qi "SSPL" "$mongodb_copyright"; then
+    echo >&2 "Error: MongoDB server license notice is missing or does not mention SSPL."
+    exit 1
+fi
+
+mariadb_copyright="/usr/share/doc/mariadb-server/copyright"
+if [[ ! -f "$mariadb_copyright" ]] || ! grep -qi "GPL-2" "$mariadb_copyright"; then
+    echo >&2 "Error: MariaDB server GPL-2 license notice is missing."
+    exit 1
+fi
+
+for build_only_package in curl gnupg; do
+    status="$(dpkg-query -W -f='${db:Status-Abbrev}' "$build_only_package" 2>/dev/null || true)"
+    if [[ "$status" == ii* ]]; then
+        echo >&2 "Error: Build-only package '$build_only_package' is still installed."
+        exit 1
+    fi
+done

--- a/tools/deployment/package/single-container/wait-for-files.sh
+++ b/tools/deployment/package/single-container/wait-for-files.sh
@@ -16,7 +16,7 @@ if [[ "${#files[@]}" -eq 0 || "$#" -eq 0 ]]; then
     exit 1
 fi
 
-for _ in $(seq 1 "${CLP_SINGLE_CONTAINER_WAIT_ATTEMPTS:-120}"); do
+for _ in $(seq 1 120); do
     all_files_exist=true
     for file in "${files[@]}"; do
         if [[ ! -e "$file" ]]; then

--- a/tools/deployment/package/single-container/wait-for-files.sh
+++ b/tools/deployment/package/single-container/wait-for-files.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+files=()
+while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--" ]]; then
+        shift
+        break
+    fi
+    files+=("$1")
+    shift
+done
+
+if [[ "${#files[@]}" -eq 0 || "$#" -eq 0 ]]; then
+    echo "Usage: $0 <file>... -- <command> [args...]" >&2
+    exit 1
+fi
+
+for _ in $(seq 1 "${CLP_SINGLE_CONTAINER_WAIT_ATTEMPTS:-120}"); do
+    all_files_exist=true
+    for file in "${files[@]}"; do
+        if [[ ! -e "$file" ]]; then
+            all_files_exist=false
+            break
+        fi
+    done
+
+    if [[ "$all_files_exist" == "true" ]]; then
+        exec "$@"
+    fi
+
+    sleep 1
+done
+
+echo "Timed out waiting for files: ${files[*]}" >&2
+exit 1

--- a/tools/deployment/package/single-container/wait-for-tcp.sh
+++ b/tools/deployment/package/single-container/wait-for-tcp.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="$1"
+port="$2"
+shift 2
+
+for _ in $(seq 1 120); do
+    if timeout 1 bash -c "</dev/tcp/${host}/${port}" >/dev/null 2>&1; then
+        exec "$@"
+    fi
+    sleep 1
+done
+
+echo "Timed out waiting for ${host}:${port}" >&2
+exit 1


### PR DESCRIPTION
# Description

Adds a single-container package image for local evaluation, demos, and single-host testing. The image layers on top of the existing `clp-package` image and bundles MariaDB, RabbitMQ, Redis, MongoDB, and `supervisord` in one container.

The runtime flow is kept close to the Docker Compose package flow:

* Users run the image directly with `docker run`, mounting `clp-config.yaml`, `credentials.yaml`, and persistent data/log/tmp directories.
* The container entrypoint loads the mounted config and credentials, rewrites a container-runtime config, and exports the service connection values expected by CLP components.
* The container uses the existing Python DB table and results-cache initialization modules.
* Redis has no separate init step.
* Backing service ports bind to loopback inside the container and are not published to the host by default.
* The MCP server is included but disabled by default and only published when explicitly requested.

This also adds release-license checks, third-party notice generation, a compliance bundle task for release review, and user/developer docs for the new image.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* `grep -R "run-single-container" -n docs/src tools/deployment/package || true` returned no matches.
* `bash -n` on all edited shell scripts.
* Parsed `tools/deployment/package/single-container/supervisord.conf` with Python `configparser`.
* `git diff --check`
* `task deps:core`
* `task docs:site`
* `CLP_SINGLE_CONTAINER_ALLOW_MISSING_SYFT=1 task docker-images:package-single-compliance`
* `docker run --rm --entrypoint /usr/local/bin/clp-single-container-validate-release-licenses clp-package-single:latest`
* Built and launched `clp-package-single:latest` with config/credentials files and `~/samples/big` mounted as log input.
* Verified container health:
  * API health: `http://127.0.0.1:3101/health` returned `API server is running`.
  * WebUI: `http://127.0.0.1:4100/` returned HTTP 200.
  * Published host ports were only CLP-facing ports: WebUI, API server, and log-ingestor.
  * MariaDB, RabbitMQ, Redis, and MongoDB were reachable on `127.0.0.1` inside the container.
  * Long-running services were `RUNNING` under Supervisor; one-shot init and disabled optional services exited as expected.
* Validated WebUI workflow with Playwright using `~/samples/big/spark-event-logs-1`:
  * Created dataset `spark_event_logs_1` with timestamp key `Timestamp`.
  * Compression completed with `98.22%` space savings, `2.0 GiB` uncompressed, `36.1 MiB` compressed.
  * Search for `SparkListenerLogStart` returned `6512 results in 3.476 seconds`.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html