### PR TITLE
fix(helm): Use localhost in bundled results-cache init URI (fixes #2302).

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.3.2-dev.8"
+version: "0.3.2-dev.9"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.12.1-dev"

--- a/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
@@ -71,7 +71,7 @@ spec:
                 sleep 1
               done
               python3 -u -m clp_py_utils.initialize-results-cache \
-                --uri "mongodb://{{ include "clp.resultsCacheHost" . }}:{{ include "clp.resultsCachePort" . | int }}/{{ .Values.clpConfig.results_cache.db_name }}" \
+                --uri "mongodb://127.0.0.1:{{ include "clp.resultsCachePort" . | int }}/{{ .Values.clpConfig.results_cache.db_name }}" \
                 --stream-collection {{ .Values.clpConfig.results_cache.stream_collection_name | quote }}
               touch /tmp/init-complete
               sleep infinity


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes #2302 by using 127.0.0.1 in the sidecar. This is valid because all containers in a pod share the same network.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

The reproduction steps no longer fail.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for the results cache to improve local connectivity and deployment stability.
  * Bumped Helm chart version to reflect the deployment configuration update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->