### PR TITLE
feat(helm): Make all container images configurable in `values.yaml` (resolves #2047).

### DIFF
--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -196,7 +196,7 @@ image:
     tag: "latest"
 
   # Override third-party container images (useful for private registries or AWS Marketplace ECR).
-  # All images are configurable in values.yaml. See the chart's values.yaml for the full list.
+  # See the chart's values.yaml for the full list of configurable images.
   database:
     mariadb:
       repository: "mariadb"

--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -197,25 +197,24 @@ image:
 
   # Override third-party container images (useful for private registries or AWS Marketplace ECR).
   # See the chart's values.yaml for the full list of configurable images.
-  database:
-    mariadb:
-      repository: "mariadb"
-      tag: "10.11.16"
-    mysql:
-      repository: "mysql"
-      tag: "8.0.46"
-  redis:
-    repository: "redis"
-    tag: "7.4.8"
+  mariadb:
+    repository: "mariadb"
+    tag: "10.11.16"
+  mysql:
+    repository: "mysql"
+    tag: "8.0.46"
   queue:
     repository: "rabbitmq"
     tag: "4.2.6"
+  redis:
+    repository: "redis"
+    tag: "7.4.8"
   resultsCache:
     repository: "mongo"
     tag: "8.0.21"
   kubectl:
     repository: "bitnami/kubectl"
-    digest: "sha256:98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"
+    digest: "sha256:98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"  # v1.36.0
 
 # Adjust worker concurrency
 workerConcurrency: 16

--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -195,6 +195,28 @@ image:
     pullPolicy: "Never"  # Use "Never" for local images, "IfNotPresent" for remote
     tag: "latest"
 
+  # Override third-party container images (useful for private registries or AWS Marketplace ECR).
+  # All images are configurable in values.yaml. See the chart's values.yaml for the full list.
+  database:
+    mariadb:
+      repository: "mariadb"
+      tag: "10.11.16"
+    mysql:
+      repository: "mysql"
+      tag: "8.0.46"
+  redis:
+    repository: "redis"
+    tag: "7.4.8"
+  queue:
+    repository: "rabbitmq"
+    tag: "4.2.6"
+  resultsCache:
+    repository: "mongo"
+    tag: "8.0.21"
+  kubectl:
+    repository: "bitnami/kubectl"
+    tag: "sha256-98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"
+
 # Adjust worker concurrency
 workerConcurrency: 16
 

--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -215,7 +215,7 @@ image:
     tag: "8.0.21"
   kubectl:
     repository: "bitnami/kubectl"
-    tag: "sha256-98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"
+    digest: "sha256:98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"
 
 # Adjust worker concurrency
 workerConcurrency: 16

--- a/tools/deployment/package-helm/.set-up-common.sh
+++ b/tools/deployment/package-helm/.set-up-common.sh
@@ -45,7 +45,7 @@ prepare_environment() {
 # flags for using it. If image is not specified, returns empty string.
 #
 # @param {string} cluster_name Name of the kind cluster
-# @param {string} component Image component name (e.g., "clpPackage", "redis", "database")
+# @param {string} component Flat image component name (e.g., "clpPackage", "redis", "queue")
 # @param {string} [image] Docker image (e.g., "clp-package:dev-junhao-a6bf")
 # @return Prints helm --set flags to stdout
 get_image_helm_args() {

--- a/tools/deployment/package-helm/.set-up-common.sh
+++ b/tools/deployment/package-helm/.set-up-common.sh
@@ -45,11 +45,13 @@ prepare_environment() {
 # flags for using it. If image is not specified, returns empty string.
 #
 # @param {string} cluster_name Name of the kind cluster
+# @param {string} component Image component name (e.g., "clpPackage", "redis", "database")
 # @param {string} [image] Docker image (e.g., "clp-package:dev-junhao-a6bf")
 # @return Prints helm --set flags to stdout
 get_image_helm_args() {
     local cluster_name=$1
-    local image="${2:-}"
+    local component=$2
+    local image="${3:-}"
 
     if [[ -z "${image}" ]]; then
         return
@@ -67,9 +69,9 @@ get_image_helm_args() {
         echo "Error: '${image}' is not a valid image reference (expected repo:tag)." >&2
         return 1
     fi
-    echo "--set" "image.clpPackage.repository=${repo}" \
-         "--set" "image.clpPackage.tag=${tag}" \
-         "--set" "image.clpPackage.pullPolicy=Never"
+    echo "--set" "image.${component}.repository=${repo}" \
+         "--set" "image.${component}.tag=${tag}" \
+         "--set" "image.${component}.pullPolicy=Never"
 }
 
 # Parses common arguments shared across set-up scripts.

--- a/tools/deployment/package-helm/.set-up-common.sh
+++ b/tools/deployment/package-helm/.set-up-common.sh
@@ -74,38 +74,12 @@ get_image_helm_args() {
          "--set" "image.${component}.pullPolicy=Never"
 }
 
-# Returns helm --set flags for all component images that have been specified via CLI flags.
-# Uses the global variables set by parse_common_args.
-#
-# @param {string} cluster_name Name of the kind cluster
-# @return Prints helm --set flags to stdout
-get_all_image_helm_args() {
-    local cluster_name=$1
-    local args=""
-    local component_args
-
-    component_args=$(get_image_helm_args "${cluster_name}" "clpPackage" "${CLP_PACKAGE_IMAGE}") && args="${args} ${component_args}"
-    component_args=$(get_image_helm_args "${cluster_name}" "database.mariadb" "${DATABASE_IMAGE}") && args="${args} ${component_args}"
-    component_args=$(get_image_helm_args "${cluster_name}" "redis" "${REDIS_IMAGE}") && args="${args} ${component_args}"
-    component_args=$(get_image_helm_args "${cluster_name}" "queue" "${QUEUE_IMAGE}") && args="${args} ${component_args}"
-    component_args=$(get_image_helm_args "${cluster_name}" "resultsCache" "${RESULTS_CACHE_IMAGE}") && args="${args} ${component_args}"
-    component_args=$(get_image_helm_args "${cluster_name}" "kubectl" "${KUBECTL_IMAGE}") && args="${args} ${component_args}"
-
-    echo "${args# }"
-}
-
 # Parses common arguments shared across set-up scripts.
-# Sets CLP_PACKAGE_IMAGE, DATABASE_IMAGE, REDIS_IMAGE, QUEUE_IMAGE,
-# RESULTS_CACHE_IMAGE, KUBECTL_IMAGE, and ENABLE_PRESTO global variables.
+# Sets CLP_PACKAGE_IMAGE and ENABLE_PRESTO global variables.
 #
 # @param {string[]} args Script arguments
 parse_common_args() {
     CLP_PACKAGE_IMAGE=""
-    DATABASE_IMAGE=""
-    REDIS_IMAGE=""
-    QUEUE_IMAGE=""
-    RESULTS_CACHE_IMAGE=""
-    KUBECTL_IMAGE=""
     ENABLE_PRESTO="false"
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -115,46 +89,6 @@ parse_common_args() {
                     exit 1
                 fi
                 CLP_PACKAGE_IMAGE="$2"
-                shift 2
-                ;;
-            --database-image)
-                if [[ $# -lt 2 || "$2" == --* ]]; then
-                    echo "Error: '--database-image' requires a value." >&2
-                    exit 1
-                fi
-                DATABASE_IMAGE="$2"
-                shift 2
-                ;;
-            --redis-image)
-                if [[ $# -lt 2 || "$2" == --* ]]; then
-                    echo "Error: '--redis-image' requires a value." >&2
-                    exit 1
-                fi
-                REDIS_IMAGE="$2"
-                shift 2
-                ;;
-            --queue-image)
-                if [[ $# -lt 2 || "$2" == --* ]]; then
-                    echo "Error: '--queue-image' requires a value." >&2
-                    exit 1
-                fi
-                QUEUE_IMAGE="$2"
-                shift 2
-                ;;
-            --results-cache-image)
-                if [[ $# -lt 2 || "$2" == --* ]]; then
-                    echo "Error: '--results-cache-image' requires a value." >&2
-                    exit 1
-                fi
-                RESULTS_CACHE_IMAGE="$2"
-                shift 2
-                ;;
-            --kubectl-image)
-                if [[ $# -lt 2 || "$2" == --* ]]; then
-                    echo "Error: '--kubectl-image' requires a value." >&2
-                    exit 1
-                fi
-                KUBECTL_IMAGE="$2"
                 shift 2
                 ;;
             --presto)

--- a/tools/deployment/package-helm/.set-up-common.sh
+++ b/tools/deployment/package-helm/.set-up-common.sh
@@ -74,12 +74,38 @@ get_image_helm_args() {
          "--set" "image.${component}.pullPolicy=Never"
 }
 
+# Returns helm --set flags for all component images that have been specified via CLI flags.
+# Uses the global variables set by parse_common_args.
+#
+# @param {string} cluster_name Name of the kind cluster
+# @return Prints helm --set flags to stdout
+get_all_image_helm_args() {
+    local cluster_name=$1
+    local args=""
+    local component_args
+
+    component_args=$(get_image_helm_args "${cluster_name}" "clpPackage" "${CLP_PACKAGE_IMAGE}") && args="${args} ${component_args}"
+    component_args=$(get_image_helm_args "${cluster_name}" "database.mariadb" "${DATABASE_IMAGE}") && args="${args} ${component_args}"
+    component_args=$(get_image_helm_args "${cluster_name}" "redis" "${REDIS_IMAGE}") && args="${args} ${component_args}"
+    component_args=$(get_image_helm_args "${cluster_name}" "queue" "${QUEUE_IMAGE}") && args="${args} ${component_args}"
+    component_args=$(get_image_helm_args "${cluster_name}" "resultsCache" "${RESULTS_CACHE_IMAGE}") && args="${args} ${component_args}"
+    component_args=$(get_image_helm_args "${cluster_name}" "kubectl" "${KUBECTL_IMAGE}") && args="${args} ${component_args}"
+
+    echo "${args# }"
+}
+
 # Parses common arguments shared across set-up scripts.
-# Sets CLP_PACKAGE_IMAGE and ENABLE_PRESTO global variables.
+# Sets CLP_PACKAGE_IMAGE, DATABASE_IMAGE, REDIS_IMAGE, QUEUE_IMAGE,
+# RESULTS_CACHE_IMAGE, KUBECTL_IMAGE, and ENABLE_PRESTO global variables.
 #
 # @param {string[]} args Script arguments
 parse_common_args() {
     CLP_PACKAGE_IMAGE=""
+    DATABASE_IMAGE=""
+    REDIS_IMAGE=""
+    QUEUE_IMAGE=""
+    RESULTS_CACHE_IMAGE=""
+    KUBECTL_IMAGE=""
     ENABLE_PRESTO="false"
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -89,6 +115,46 @@ parse_common_args() {
                     exit 1
                 fi
                 CLP_PACKAGE_IMAGE="$2"
+                shift 2
+                ;;
+            --database-image)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "Error: '--database-image' requires a value." >&2
+                    exit 1
+                fi
+                DATABASE_IMAGE="$2"
+                shift 2
+                ;;
+            --redis-image)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "Error: '--redis-image' requires a value." >&2
+                    exit 1
+                fi
+                REDIS_IMAGE="$2"
+                shift 2
+                ;;
+            --queue-image)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "Error: '--queue-image' requires a value." >&2
+                    exit 1
+                fi
+                QUEUE_IMAGE="$2"
+                shift 2
+                ;;
+            --results-cache-image)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "Error: '--results-cache-image' requires a value." >&2
+                    exit 1
+                fi
+                RESULTS_CACHE_IMAGE="$2"
+                shift 2
+                ;;
+            --kubectl-image)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "Error: '--kubectl-image' requires a value." >&2
+                    exit 1
+                fi
+                KUBECTL_IMAGE="$2"
                 shift 2
                 ;;
             --presto)

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.3.2-dev.9"
+version: "0.3.2-dev.10"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.12.1-dev"

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -161,6 +161,6 @@ helm install test "${script_dir}" \
     --set "scheduling.webui.nodeSelector.yscope\.io/nodeType=core" \
     --set "scheduling.mcpServer.nodeSelector.yscope\.io/nodeType=core" \
     $(get_presto_helm_args) \
-    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
+    $(get_all_image_helm_args "${CLUSTER_NAME}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -161,6 +161,6 @@ helm install test "${script_dir}" \
     --set "scheduling.webui.nodeSelector.yscope\.io/nodeType=core" \
     --set "scheduling.mcpServer.nodeSelector.yscope\.io/nodeType=core" \
     $(get_presto_helm_args) \
-    $(get_all_image_helm_args "${CLUSTER_NAME}")
+    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-dedicated-test.sh
@@ -161,6 +161,6 @@ helm install test "${script_dir}" \
     --set "scheduling.webui.nodeSelector.yscope\.io/nodeType=core" \
     --set "scheduling.mcpServer.nodeSelector.yscope\.io/nodeType=core" \
     $(get_presto_helm_args) \
-    $(get_image_helm_args "${CLUSTER_NAME}" "${CLP_PACKAGE_IMAGE}")
+    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-multi-shared-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-shared-test.sh
@@ -51,6 +51,6 @@ helm install test "${script_dir}" \
     --set "scheduling.reducer.replicas=${REDUCER_REPLICAS}" \
     --set "scheduling.prestoWorker.replicas=${PRESTO_WORKER_REPLICAS}" \
     $(get_presto_helm_args) \
-    $(get_image_helm_args "${CLUSTER_NAME}" "${CLP_PACKAGE_IMAGE}")
+    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-multi-shared-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-shared-test.sh
@@ -51,6 +51,6 @@ helm install test "${script_dir}" \
     --set "scheduling.reducer.replicas=${REDUCER_REPLICAS}" \
     --set "scheduling.prestoWorker.replicas=${PRESTO_WORKER_REPLICAS}" \
     $(get_presto_helm_args) \
-    $(get_all_image_helm_args "${CLUSTER_NAME}")
+    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-multi-shared-test.sh
+++ b/tools/deployment/package-helm/set-up-multi-shared-test.sh
@@ -51,6 +51,6 @@ helm install test "${script_dir}" \
     --set "scheduling.reducer.replicas=${REDUCER_REPLICAS}" \
     --set "scheduling.prestoWorker.replicas=${PRESTO_WORKER_REPLICAS}" \
     $(get_presto_helm_args) \
-    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
+    $(get_all_image_helm_args "${CLUSTER_NAME}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-test.sh
+++ b/tools/deployment/package-helm/set-up-test.sh
@@ -30,6 +30,6 @@ sleep 2
 # shellcheck disable=SC2046
 helm install test "${script_dir}" \
     $(get_presto_helm_args) \
-    $(get_all_image_helm_args "${CLUSTER_NAME}")
+    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-test.sh
+++ b/tools/deployment/package-helm/set-up-test.sh
@@ -30,6 +30,6 @@ sleep 2
 # shellcheck disable=SC2046
 helm install test "${script_dir}" \
     $(get_presto_helm_args) \
-    $(get_image_helm_args "${CLUSTER_NAME}" "${CLP_PACKAGE_IMAGE}")
+    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/set-up-test.sh
+++ b/tools/deployment/package-helm/set-up-test.sh
@@ -30,6 +30,6 @@ sleep 2
 # shellcheck disable=SC2046
 helm install test "${script_dir}" \
     $(get_presto_helm_args) \
-    $(get_image_helm_args "${CLUSTER_NAME}" "clpPackage" "${CLP_PACKAGE_IMAGE}")
+    $(get_all_image_helm_args "${CLUSTER_NAME}")
 
 wait_for_cluster_ready

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -521,6 +521,7 @@ should be the job name suffix.
 {{- define "clp.waitFor" -}}
 name: "wait-for-{{ .name }}"
 image: {{ include "clp.image.ref" (dict "root" .root "component" "kubectl") | quote }}
+imagePullPolicy: {{ .root.Values.image.kubectl.pullPolicy | quote }}
 command: [
   "kubectl", "wait",
   {{- if eq .type "service" }}

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -125,27 +125,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Creates an image reference for a component.
+Creates a container image reference from .Values.image.
 
-For components with variants (e.g., database with mariadb/mysql), pass the "variant" parameter.
-If no variant is provided, the component is looked up directly under .Values.image.
-
-When a "digest" field is present in the image config, the reference uses the format
-repository@digest. Otherwise, it uses repository:tag.
-
-For the clpPackage component, if no tag is specified, the chart's appVersion is used as a default.
-For all other components, the tag must be specified in values.yaml.
+Renders repository@digest when "digest" is set; otherwise, renders repository:tag. clpPackage
+defaults to Chart.AppVersion when "tag" is omitted; other components require "tag".
 
 @param {object} root Root template context (required)
-@param {string} component Key under .Values.image (e.g., "clpPackage", "redis", "database")
-@param {string} [variant] Sub-key for components with variants (e.g., "mariadb" or "mysql" for "database")
+@param {string} component Key under .Values.image (e.g., "clpPackage", "redis")
 @return {string} Full image reference (repository@digest or repository:tag)
 */}}
-{{- define "clp.image.ref" -}}
+{{- define "clp.imageRef" -}}
 {{- $img := index .root.Values.image .component -}}
-{{- if hasKey . "variant" -}}
-  {{- $img = index $img .variant -}}
-{{- end -}}
 {{- if $img.digest -}}
 {{- printf "%s@%s" $img.repository $img.digest -}}
 {{- else -}}
@@ -520,7 +510,7 @@ should be the job name suffix.
 */}}
 {{- define "clp.waitFor" -}}
 name: "wait-for-{{ .name }}"
-image: {{ include "clp.image.ref" (dict "root" .root "component" "kubectl") | quote }}
+image: {{ include "clp.imageRef" (dict "root" .root "component" "kubectl") | quote }}
 imagePullPolicy: {{ .root.Values.image.kubectl.pullPolicy | quote }}
 command: [
   "kubectl", "wait",

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -130,19 +130,25 @@ Creates an image reference for a component.
 For components with variants (e.g., database with mariadb/mysql), pass the "variant" parameter.
 If no variant is provided, the component is looked up directly under .Values.image.
 
+When a "digest" field is present in the image config, the reference uses the format
+repository@digest. Otherwise, it uses repository:tag.
+
 For the clpPackage component, if no tag is specified, the chart's appVersion is used as a default.
 For all other components, the tag must be specified in values.yaml.
 
 @param {object} root Root template context (required)
 @param {string} component Key under .Values.image (e.g., "clpPackage", "redis", "database")
 @param {string} [variant] Sub-key for components with variants (e.g., "mariadb" or "mysql" for "database")
-@return {string} Full image reference (repository:tag)
+@return {string} Full image reference (repository@digest or repository:tag)
 */}}
 {{- define "clp.image.ref" -}}
 {{- $img := index .root.Values.image .component -}}
 {{- if hasKey . "variant" -}}
   {{- $img = index $img .variant -}}
 {{- end -}}
+{{- if $img.digest -}}
+{{- printf "%s@%s" $img.repository $img.digest -}}
+{{- else -}}
 {{- $tag := $img.tag -}}
 {{- if not $tag -}}
   {{- if eq .component "clpPackage" -}}
@@ -152,6 +158,7 @@ For all other components, the tag must be specified in values.yaml.
   {{- end -}}
 {{- end -}}
 {{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -125,22 +125,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Creates image reference for the CLP Package.
+Creates an image reference for a component.
 
+For components with variants (e.g., database with mariadb/mysql), pass the "variant" parameter.
+If no variant is provided, the component is looked up directly under .Values.image.
+
+For the clpPackage component, if no tag is specified, the chart's appVersion is used as a default.
+For all other components, the tag must be specified in values.yaml.
+
+@param {object} root Root template context (required)
+@param {string} component Key under .Values.image (e.g., "clpPackage", "redis", "database")
+@param {string} [variant] Sub-key for components with variants (e.g., "mariadb" or "mysql" for "database")
 @return {string} Full image reference (repository:tag)
 */}}
 {{- define "clp.image.ref" -}}
-{{- $tag := .Values.image.clpPackage.tag | default .Chart.AppVersion }}
-{{- printf "%s:%s" .Values.image.clpPackage.repository $tag }}
-{{- end }}
-
-{{/*
-Creates image reference for the kubectl image.
-
-@return {string} Full image reference (repository@digest)
-*/}}
-{{- define "clp.kubectl.image.ref" -}}
-{{- printf "%s@%s" .Values.image.kubectl.repository .Values.image.kubectl.digest }}
+{{- $img := index .root.Values.image .component -}}
+{{- if hasKey . "variant" -}}
+  {{- $img = index $img .variant -}}
+{{- end -}}
+{{- $tag := $img.tag -}}
+{{- if not $tag -}}
+  {{- if eq .component "clpPackage" -}}
+    {{- $tag = .root.Chart.AppVersion -}}
+  {{- else -}}
+    {{- fail (printf "image.%s.tag is required" .component) -}}
+  {{- end -}}
+{{- end -}}
+{{- printf "%s:%s" $img.repository $tag -}}
 {{- end }}
 
 {{/*
@@ -502,7 +513,7 @@ should be the job name suffix.
 */}}
 {{- define "clp.waitFor" -}}
 name: "wait-for-{{ .name }}"
-image: {{ include "clp.kubectl.image.ref" .root | quote }}
+image: {{ include "clp.image.ref" (dict "root" .root "component" "kubectl") | quote }}
 command: [
   "kubectl", "wait",
   {{- if eq .type "service" }}

--- a/tools/deployment/package-helm/templates/api-server-deployment.yaml
+++ b/tools/deployment/package-helm/templates/api-server-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "api-server"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             {{- include "clp.telemetryEnv" . | nindent 12 }}

--- a/tools/deployment/package-helm/templates/api-server-deployment.yaml
+++ b/tools/deployment/package-helm/templates/api-server-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "api-server"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             {{- include "clp.telemetryEnv" . | nindent 12 }}

--- a/tools/deployment/package-helm/templates/compression-scheduler-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-scheduler-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         {{- end }}
       containers:
         - name: "compression-scheduler"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/compression-scheduler-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-scheduler-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         {{- end }}
       containers:
         - name: "compression-scheduler"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: "compression-worker"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: "compression-worker"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/database-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/database-statefulset.yaml
@@ -25,8 +25,8 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "database"
-          image: {{ include "clp.image.ref" (dict "root" . "component" "database" "variant" .Values.clpConfig.database.type) }}
-          imagePullPolicy: {{ (index .Values.image.database .Values.clpConfig.database.type).pullPolicy | quote }}
+          image: {{ include "clp.imageRef" (dict "root" . "component" .Values.clpConfig.database.type) | quote }}
+          imagePullPolicy: {{ (index .Values.image .Values.clpConfig.database.type).pullPolicy | quote }}
           env:
             - name: "MYSQL_DATABASE"
               value: {{ .Values.clpConfig.database.names.clp | quote }}

--- a/tools/deployment/package-helm/templates/database-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/database-statefulset.yaml
@@ -25,13 +25,8 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "database"
-          image: >-
-            {{- if eq .Values.clpConfig.database.type "mysql" }}
-              mysql:8.0.46
-            {{- else }}
-              mariadb:10.11.16
-            {{- end }}
-          imagePullPolicy: "Always"
+          image: {{ include "clp.image.ref" (dict "root" . "component" "database" "variant" .Values.clpConfig.database.type) }}
+          imagePullPolicy: {{ (index .Values.image.database .Values.clpConfig.database.type).pullPolicy | quote }}
           env:
             - name: "MYSQL_DATABASE"
               value: {{ .Values.clpConfig.database.names.clp | quote }}

--- a/tools/deployment/package-helm/templates/db-table-creator-job.yaml
+++ b/tools/deployment/package-helm/templates/db-table-creator-job.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: "db-table-creator"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/templates/db-table-creator-job.yaml
+++ b/tools/deployment/package-helm/templates/db-table-creator-job.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: "db-table-creator"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
+++ b/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "garbage-collector"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
+++ b/tools/deployment/package-helm/templates/garbage-collector-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "garbage-collector"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/templates/log-ingestor-deployment.yaml
+++ b/tools/deployment/package-helm/templates/log-ingestor-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           ) | nindent 10 }}
       containers:
         - name: "log-ingestor"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             {{- include "clp.telemetryEnv" . | nindent 12 }}

--- a/tools/deployment/package-helm/templates/log-ingestor-deployment.yaml
+++ b/tools/deployment/package-helm/templates/log-ingestor-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           ) | nindent 10 }}
       containers:
         - name: "log-ingestor"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             {{- include "clp.telemetryEnv" . | nindent 12 }}

--- a/tools/deployment/package-helm/templates/mcp-server-deployment.yaml
+++ b/tools/deployment/package-helm/templates/mcp-server-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "mcp-server"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/templates/mcp-server-deployment.yaml
+++ b/tools/deployment/package-helm/templates/mcp-server-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "mcp-server"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/templates/presto-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/presto-worker-deployment.yaml
@@ -32,6 +32,7 @@ spec:
           ) | nindent 10 }}
         - name: "setup-configs"
           image: {{ include "clp.image.ref" (dict "root" . "component" "kubectl") | quote }}
+          imagePullPolicy: {{ .Values.image.kubectl.pullPolicy | quote }}
           command: ["/bin/sh", "/scripts/presto-worker-setup-configs.sh"]
           volumeMounts:
             - name: "presto-config"

--- a/tools/deployment/package-helm/templates/presto-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/presto-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             "name" "presto-coordinator"
           ) | nindent 10 }}
         - name: "setup-configs"
-          image: {{ include "clp.kubectl.image.ref" . | quote }}
+          image: {{ include "clp.image.ref" (dict "root" . "component" "kubectl") | quote }}
           command: ["/bin/sh", "/scripts/presto-worker-setup-configs.sh"]
           volumeMounts:
             - name: "presto-config"

--- a/tools/deployment/package-helm/templates/presto-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/presto-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             "name" "presto-coordinator"
           ) | nindent 10 }}
         - name: "setup-configs"
-          image: {{ include "clp.image.ref" (dict "root" . "component" "kubectl") | quote }}
+          image: {{ include "clp.imageRef" (dict "root" . "component" "kubectl") | quote }}
           imagePullPolicy: {{ .Values.image.kubectl.pullPolicy | quote }}
           command: ["/bin/sh", "/scripts/presto-worker-setup-configs.sh"]
           volumeMounts:

--- a/tools/deployment/package-helm/templates/query-scheduler-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-scheduler-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
       containers:
         - name: "query-scheduler"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/query-scheduler-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-scheduler-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
       containers:
         - name: "query-scheduler"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/query-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-worker-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: "query-worker"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/query-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-worker-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: "query-worker"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - {{- include "clp.celeryBrokerUrlEnvVar" . | nindent 14 }}

--- a/tools/deployment/package-helm/templates/queue-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/queue-statefulset.yaml
@@ -25,7 +25,7 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "queue"
-          image: {{ include "clp.image.ref" (dict "root" . "component" "queue") }}
+          image: {{ include "clp.imageRef" (dict "root" . "component" "queue") | quote }}
           imagePullPolicy: {{ .Values.image.queue.pullPolicy | quote }}
           env:
             - name: "RABBITMQ_DEFAULT_USER"

--- a/tools/deployment/package-helm/templates/queue-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/queue-statefulset.yaml
@@ -25,8 +25,8 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "queue"
-          image: "rabbitmq:4.2.6"
-          imagePullPolicy: "Always"
+          image: {{ include "clp.image.ref" (dict "root" . "component" "queue") }}
+          imagePullPolicy: {{ .Values.image.queue.pullPolicy | quote }}
           env:
             - name: "RABBITMQ_DEFAULT_USER"
               valueFrom:

--- a/tools/deployment/package-helm/templates/redis-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/redis-statefulset.yaml
@@ -25,7 +25,7 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "redis"
-          image: {{ include "clp.image.ref" (dict "root" . "component" "redis") }}
+          image: {{ include "clp.imageRef" (dict "root" . "component" "redis") | quote }}
           imagePullPolicy: {{ .Values.image.redis.pullPolicy | quote }}
           env:
             - name: "REDIS_PASSWORD"

--- a/tools/deployment/package-helm/templates/redis-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/redis-statefulset.yaml
@@ -25,8 +25,8 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "redis"
-          image: "redis:7.4.8"
-          imagePullPolicy: "Always"
+          image: {{ include "clp.image.ref" (dict "root" . "component" "redis") }}
+          imagePullPolicy: {{ .Values.image.redis.pullPolicy | quote }}
           env:
             - name: "REDIS_PASSWORD"
               valueFrom:

--- a/tools/deployment/package-helm/templates/reducer-deployment.yaml
+++ b/tools/deployment/package-helm/templates/reducer-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "reducer"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_HOME"

--- a/tools/deployment/package-helm/templates/reducer-deployment.yaml
+++ b/tools/deployment/package-helm/templates/reducer-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "reducer"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_HOME"

--- a/tools/deployment/package-helm/templates/results-cache-indices-creator-job.yaml
+++ b/tools/deployment/package-helm/templates/results-cache-indices-creator-job.yaml
@@ -17,7 +17,7 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: "results-cache-indices-creator"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "PYTHONPATH"

--- a/tools/deployment/package-helm/templates/results-cache-indices-creator-job.yaml
+++ b/tools/deployment/package-helm/templates/results-cache-indices-creator-job.yaml
@@ -17,7 +17,7 @@ spec:
       restartPolicy: "OnFailure"
       containers:
         - name: "results-cache-indices-creator"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "PYTHONPATH"

--- a/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
@@ -25,7 +25,7 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "results-cache"
-          image: {{ include "clp.image.ref" (dict "root" . "component" "resultsCache") }}
+          image: {{ include "clp.imageRef" (dict "root" . "component" "resultsCache") | quote }}
           imagePullPolicy: {{ .Values.image.resultsCache.pullPolicy | quote }}
           ports:
             - name: "results-cache"
@@ -57,7 +57,7 @@ spec:
             {{- include "clp.livenessProbeTimings" . | nindent 12 }}
             exec: *results-cache-health-check
         - name: "results-cache-init"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "PYTHONPATH"

--- a/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
+++ b/tools/deployment/package-helm/templates/results-cache-statefulset.yaml
@@ -25,8 +25,8 @@ spec:
         ) | nindent 6 }}
       containers:
         - name: "results-cache"
-          image: "mongo:8.0.21"
-          imagePullPolicy: "Always"
+          image: {{ include "clp.image.ref" (dict "root" . "component" "resultsCache") }}
+          imagePullPolicy: {{ .Values.image.resultsCache.pullPolicy | quote }}
           ports:
             - name: "results-cache"
               containerPort: 27017
@@ -57,7 +57,7 @@ spec:
             {{- include "clp.livenessProbeTimings" . | nindent 12 }}
             exec: *results-cache-health-check
         - name: "results-cache-init"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "PYTHONPATH"

--- a/tools/deployment/package-helm/templates/webui-deployment.yaml
+++ b/tools/deployment/package-helm/templates/webui-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "webui"
-          image: "{{ include "clp.image.ref" . }}"
+          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/templates/webui-deployment.yaml
+++ b/tools/deployment/package-helm/templates/webui-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - {{- include "clp.waitForResultsCache" . | nindent 10 }}
       containers:
         - name: "webui"
-          image: "{{ include "clp.image.ref" (dict "root" . "component" "clpPackage") }}"
+          image: {{ include "clp.imageRef" (dict "root" . "component" "clpPackage") | quote }}
           imagePullPolicy: "{{ .Values.image.clpPackage.pullPolicy }}"
           env:
             - name: "CLP_DB_PASS"

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -9,15 +9,14 @@ image:
     repository: "ghcr.io/y-scope/clp/clp-package"
     pullPolicy: "Always"
     tag: "main"
-  database:
-    mariadb:
-      repository: "mariadb"
-      pullPolicy: "Always"
-      tag: "10.11.16"
-    mysql:
-      repository: "mysql"
-      pullPolicy: "Always"
-      tag: "8.0.46"
+  mariadb:
+    repository: "mariadb"
+    pullPolicy: "Always"
+    tag: "10.11.16"
+  mysql:
+    repository: "mysql"
+    pullPolicy: "Always"
+    tag: "8.0.46"
   curl:
     repository: "curlimages/curl"
     pullPolicy: "IfNotPresent"

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -25,7 +25,7 @@ image:
   kubectl:
     repository: "bitnami/kubectl"
     pullPolicy: "IfNotPresent"
-    tag: "sha256-98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"  # v1.36.0
+    digest: "sha256:98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"  # v1.36.0
   otelCollector:
     repository: >-
       ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -9,6 +9,15 @@ image:
     repository: "ghcr.io/y-scope/clp/clp-package"
     pullPolicy: "Always"
     tag: "main"
+  database:
+    mariadb:
+      repository: "mariadb"
+      pullPolicy: "Always"
+      tag: "10.11.16"
+    mysql:
+      repository: "mysql"
+      pullPolicy: "Always"
+      tag: "8.0.46"
   curl:
     repository: "curlimages/curl"
     pullPolicy: "IfNotPresent"
@@ -16,7 +25,7 @@ image:
   kubectl:
     repository: "bitnami/kubectl"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"  # v1.36.0
+    tag: "sha256-98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"  # v1.36.0
   otelCollector:
     repository: >-
       ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
@@ -30,6 +39,18 @@ image:
     repository: "ghcr.io/y-scope/presto/prestissimo-worker"
     pullPolicy: "IfNotPresent"
     tag: "clp-v0.10.0-fix.1"
+  queue:
+    repository: "rabbitmq"
+    pullPolicy: "Always"
+    tag: "4.2.6"
+  redis:
+    repository: "redis"
+    pullPolicy: "Always"
+    tag: "7.4.8"
+  resultsCache:
+    repository: "mongo"
+    pullPolicy: "Always"
+    tag: "8.0.21"
 
 # - If false: Single-node deployment.
 #   - Pods automatically tolerate control-plane taints.


### PR DESCRIPTION

# Description

Third-party container images (MariaDB, MySQL, MongoDB, RabbitMQ, Redis, kubectl) were hardcoded directly in Helm template files. Only the CLP package image was configurable through values.yaml. This made it impossible to use private registry mirrors or prepare the chart for AWS Marketplace, which requires all image references to be in values.yaml.


Changes:

- Added `image.database` (with `mariadb`/`mysql` variants), `image.queue`, `image.redis`, `image.resultsCache` entries to `values.yaml`. The database image is selected based on `clpConfig.database.type`.
- Generalized the `clp.image.ref` helper template to accept a `component` parameter (and optional `variant` for database). The `AppVersion` fallback only applies to `clpPackage`; all other components require an explicit tag.
- Removed `clp.kubectl.image.ref` helper (merged into the generalized `clp.image.ref`).
- Updated all four statefulset templates (database, queue, redis, results-cache) to use the helper instead of hardcoded images. `imagePullPolicy` is now configurable per component.
- Updated the K8s deployment docs to show the new configurable image entries.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
```
helm template test .
helm lint tools/deployment/package-helm/
./tools/deployment/package-helm/set-up-test.sh
```
```
./tools/deployment/package-helm/set-up-test.sh --clp-package-image ghcr.io/y-scope/clp/clp-package:main
```
<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-component configurable container images for bundled services (database: MariaDB/MySQL, queue, results cache, Redis, RabbitMQ, kubectl helper and app packages) via Helm values, supporting repository, tag or digest and pullPolicy.

* **Documentation**
  * Deployment guide example updated to show overriding third‑party image repositories, tags and digests.

* **Chores**
  * Helm chart version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->