### PR TITLE
feat(clp-s): Wait to flush top-N results from an archive until after scanning all ERTs.

### DIFF
--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -88,7 +88,7 @@ ResultsCacheOutputHandler::ResultsCacheOutputHandler(
     }
 }
 
-ErrorCode ResultsCacheOutputHandler::flush() {
+ErrorCode ResultsCacheOutputHandler::finish() {
     size_t count = 0;
     while (false == m_latest_results.empty()) {
         auto result = std::move(*m_latest_results.top());

--- a/components/core/src/clp_s/OutputHandlerImpl.hpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.hpp
@@ -175,7 +175,7 @@ public:
     // Methods inherited from OutputHandler
     /**
      * Flushes the output handler after all tables are searched.
-     * @return ErrorCodeSuccess on success
+     * @return ErrorCodeSuccess on success.
      * @return ErrorCodeFailureDbBulkWrite on failure to write results to the results cache.
      */
     auto finish() -> ErrorCode override;

--- a/components/core/src/clp_s/OutputHandlerImpl.hpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.hpp
@@ -174,11 +174,11 @@ public:
 
     // Methods inherited from OutputHandler
     /**
-     * Flushes the output handler after each table that gets searched.
+     * Flushes the output handler after all tables are searched.
      * @return ErrorCodeSuccess on success
-     * @return ErrorCodeFailureDbBulkWrite on failure to write results to the results cache
+     * @return ErrorCodeFailureDbBulkWrite on failure to write results to the results cache.
      */
-    ErrorCode flush() override;
+    auto finish() -> ErrorCode override;
 
     void write(
             std::string_view message,

--- a/components/core/src/clp_s/OutputHandlerImpl.hpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.hpp
@@ -174,6 +174,13 @@ public:
 
     // Methods inherited from OutputHandler
     /**
+     * No-op for this handler. The results heap is drained in `finish()` so that
+     * `max_num_results` is enforced across all ERTs in the archive.
+     * @return ErrorCodeSuccess
+     */
+    [[nodiscard]] auto flush() -> ErrorCode override { return ErrorCode::ErrorCodeSuccess; }
+
+    /**
      * Flushes the output handler after all tables are searched.
      * @return ErrorCodeSuccess on success.
      * @return ErrorCodeFailureDbBulkWrite on failure to write results to the results cache.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR changes the flushing behaviour of clp-s when writing the top-N results from an archive to the results cache from flushing results after scanning each ERT to flushing only after scanning all ERTs. This can increase time to first result, but significantly reduces the number of results we send to mongodb for queries that return a large number of results.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that results appear in the webui look as expected (executing `message: *` query against `hive-24hr` dataset)

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Result caching now writes cached results only after all tables are searched, performing batched inserts at the end of a search to ensure final consistency.
  * Reduced intermediate writes during multi-table searches, improving bulk-write efficiency and strengthening error handling for the final commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->