### PR TITLE
feat(clp-s::search): Instrument search with OpenTelemetry traces.

### DIFF
--- a/components/core/.clang-format
+++ b/components/core/.clang-format
@@ -6,8 +6,8 @@ IncludeCategories:
   # External library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   - Regex: "<(absl|antlr4|archive|boost|bsoncxx|catch2|curl|date|fmt|log_surgeon|lzma\
-|mongocxx|msgpack|mysql|nlohmann|openssl|outcome|regex_utils|simdjson|spdlog|sqlite3|string_utils\
-|xxhash|yaml-cpp|ystdlib|zstd)"
+|mongocxx|msgpack|mysql|nlohmann|openssl|opentelemetry|outcome|regex_utils|simdjson|spdlog\
+|sqlite3|string_utils|xxhash|yaml-cpp|ystdlib|zstd)"
     Priority: 3
 
   # Project library headers

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -210,6 +210,16 @@ if(CLP_NEED_NLOHMANN_JSON)
     endif()
 endif()
 
+if(CLP_NEED_OPENTELEMETRY_CPP)
+    # NOTE: We don't restrict the discovery to specific `COMPONENTS` because the OTLP HTTP exporter
+    # and trace SDK targets are required in addition to the API, and the package config exports all
+    # built targets regardless.
+    find_package(opentelemetry-cpp 1.27.0 CONFIG REQUIRED)
+    if(opentelemetry-cpp_FOUND)
+        message(STATUS "Found opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
+    endif()
+endif()
+
 if(CLP_NEED_SIMDJSON)
     find_package(simdjson REQUIRED)
     if(simdjson_FOUND)

--- a/components/core/cmake/Options/options.cmake
+++ b/components/core/cmake/Options/options.cmake
@@ -166,6 +166,7 @@ function(set_clp_binaries_dependencies)
         CLP_NEED_MONGOCXX
         CLP_NEED_MSGPACKCXX
         CLP_NEED_NLOHMANN_JSON
+        CLP_NEED_OPENTELEMETRY_CPP
         CLP_NEED_SIMDJSON
         CLP_NEED_SPDLOG
         CLP_NEED_SQLITE
@@ -207,6 +208,7 @@ function(set_clp_tests_dependencies)
         CLP_NEED_MARIADB
         CLP_NEED_MONGOCXX
         CLP_NEED_NLOHMANN_JSON
+        CLP_NEED_OPENTELEMETRY_CPP
         CLP_NEED_SIMDJSON
         CLP_NEED_SPDLOG
         CLP_NEED_SQLITE
@@ -378,6 +380,7 @@ function(set_clp_s_search_dependencies)
     set_clp_need_flags(
         CLP_NEED_ABSL
         CLP_NEED_LOG_SURGEON
+        CLP_NEED_OPENTELEMETRY_CPP
         CLP_NEED_SIMDJSON
         CLP_NEED_SPDLOG
     )
@@ -556,6 +559,7 @@ function (convert_clp_dependency_properties_to_variables)
         CLP_NEED_MSGPACKCXX
         CLP_NEED_NLOHMANN_JSON
         CLP_NEED_OPENSSL
+        CLP_NEED_OPENTELEMETRY_CPP
         CLP_NEED_SIMDJSON
         CLP_NEED_SPDLOG
         CLP_NEED_SQLITE

--- a/components/core/src/clp_s/ArchiveReader.hpp
+++ b/components/core/src/clp_s/ArchiveReader.hpp
@@ -166,6 +166,14 @@ public:
      */
     [[nodiscard]] std::vector<int32_t> const& get_schema_ids() const { return m_schema_ids; }
 
+    /**
+     * @param schema_id
+     * @return The number of messages stored under the given schema in the archive.
+     */
+    [[nodiscard]] auto get_schema_num_messages(int32_t schema_id) const -> uint64_t {
+        return m_id_to_schema_metadata.at(schema_id).num_messages();
+    }
+
     void set_projection(std::shared_ptr<search::Projection> projection) {
         m_projection = projection;
     }

--- a/components/core/src/clp_s/clp-s.cpp
+++ b/components/core/src/clp_s/clp-s.cpp
@@ -1,7 +1,6 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
-#include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -41,6 +40,8 @@
 #include "search/OutputHandler.hpp"
 #include "search/Projection.hpp"
 #include "search/SchemaMatch.hpp"
+#include "search/SearchTelemetry.hpp"
+#include "search/TelemetryInitializer.hpp"
 #include "SingleFileArchiveDefs.hpp"
 
 using namespace clp_s::search;
@@ -79,6 +80,11 @@ bool search_archive(
         std::shared_ptr<ast::Expression> expr,
         int reducer_socket_fd
 );
+
+auto populate_total_archive_records(
+        std::shared_ptr<clp_s::ArchiveReader> const& archive_reader,
+        SearchTelemetry& telemetry
+) -> void;
 
 bool compress(CommandLineArguments const& command_line_arguments) {
     auto archives_dir = std::filesystem::path(command_line_arguments.get_archives_dir());
@@ -132,6 +138,13 @@ bool search_archive(
         int reducer_socket_fd
 ) {
     auto const& query = command_line_arguments.get_query();
+    auto telemetry{collect_query_shape_metrics(
+            expr,
+            command_line_arguments.get_search_begin_ts(),
+            command_line_arguments.get_search_end_ts()
+    )};
+    populate_query_context(telemetry, query, archive_reader->get_archive_id());
+    SearchTelemetrySpan telemetry_span;
 
     auto timestamp_dict = archive_reader->get_timestamp_dictionary();
     AddTimestampConditions add_timestamp_conditions(
@@ -148,6 +161,8 @@ bool search_archive(
                 command_line_arguments.get_search_begin_ts().value_or(cEpochTimeMin),
                 command_line_arguments.get_search_end_ts().value_or(cEpochTimeMax)
         );
+        telemetry_span.set_error("no authoritative timestamp column");
+        telemetry_span.set_telemetry(telemetry);
         return false;
     }
 
@@ -155,6 +170,8 @@ bool search_archive(
         std::dynamic_pointer_cast<ast::EmptyExpr>(expr))
     {
         SPDLOG_ERROR("Query '{}' is logically false", query);
+        telemetry_span.set_error("query is logically false");
+        telemetry_span.set_telemetry(telemetry);
         return false;
     }
 
@@ -163,6 +180,9 @@ bool search_archive(
             false == command_line_arguments.get_ignore_case()
     };
     if (expr = metadata_filter_pass.run(expr); std::dynamic_pointer_cast<ast::EmptyExpr>(expr)) {
+        telemetry.termination_stage = "range_index_matching";
+        populate_total_archive_records(archive_reader, telemetry);
+        telemetry_span.set_telemetry(telemetry);
         SPDLOG_INFO("No matching metadata ranges for query '{}'", query);
         return true;
     }
@@ -171,6 +191,9 @@ bool search_archive(
     // the timestamp index
     EvaluateTimestampIndex timestamp_index(timestamp_dict);
     if (clp_s::EvaluatedValue::False == timestamp_index.run(expr)) {
+        telemetry.termination_stage = "time_range_matching";
+        populate_total_archive_records(archive_reader, telemetry);
+        telemetry_span.set_telemetry(telemetry);
         SPDLOG_INFO("No matching timestamp ranges for query '{}'", query);
         return true;
     }
@@ -188,6 +211,9 @@ bool search_archive(
             archive_reader->get_schema_map()
     );
     if (expr = match_pass->run(expr); std::dynamic_pointer_cast<ast::EmptyExpr>(expr)) {
+        telemetry.termination_stage = "schema_matching";
+        populate_total_archive_records(archive_reader, telemetry);
+        telemetry_span.set_telemetry(telemetry);
         SPDLOG_INFO("No matching schemas for query '{}'", query);
         return true;
     }
@@ -210,6 +236,8 @@ bool search_archive(
                 ))
             {
                 SPDLOG_ERROR("Can not tokenize invalid column: \"{}\"", column);
+                telemetry_span.set_error("projection column tokenization failed");
+                telemetry_span.set_telemetry(telemetry);
                 return false;
             }
             projection->add_column(
@@ -221,6 +249,8 @@ bool search_archive(
         }
     } catch (std::exception const& e) {
         SPDLOG_ERROR("{}", e.what());
+        telemetry_span.set_error("projection resolution failed");
+        telemetry_span.set_telemetry(telemetry);
         return false;
     }
     projection->resolve_columns(archive_reader->get_schema_tree());
@@ -281,10 +311,14 @@ bool search_archive(
         );
         if (nullptr == output_handler) {
             SPDLOG_ERROR("Failed to create output handler.");
+            telemetry_span.set_error("output handler creation failed");
+            telemetry_span.set_telemetry(telemetry);
             return false;
         }
     } catch (std::exception const& e) {
         SPDLOG_ERROR("Failed to create output handler - {}", e.what());
+        telemetry_span.set_error("output handler creation failed");
+        telemetry_span.set_telemetry(telemetry);
         return false;
     }
 
@@ -294,9 +328,41 @@ bool search_archive(
             expr,
             archive_reader,
             std::move(output_handler),
-            command_line_arguments.get_ignore_case()
+            command_line_arguments.get_ignore_case(),
+            &telemetry
     );
-    return output.filter();
+    auto const success{output.filter()};
+    if (false == success) {
+        telemetry_span.set_error("archive filtering failed");
+    }
+    telemetry_span.set_telemetry(telemetry);
+    return success;
+}
+
+auto populate_total_archive_records(
+        std::shared_ptr<clp_s::ArchiveReader> const& archive_reader,
+        SearchTelemetry& telemetry
+) -> void {
+    if (archive_reader->get_schema_ids().empty()) {
+        try {
+            auto const result{archive_reader->read_metadata()};
+            if (result.has_error()) {
+                auto const error{result.error()};
+                SPDLOG_WARN(
+                        "Failed to read archive metadata for search telemetry: {} - {}",
+                        error.category().name(),
+                        error.message()
+                );
+                return;
+            }
+        } catch (std::exception const& e) {
+            SPDLOG_WARN("Failed to read archive metadata for search telemetry: {}", e.what());
+            return;
+        }
+    }
+    for (auto const schema_id : archive_reader->get_schema_ids()) {
+        telemetry.total_archive_records += archive_reader->get_schema_num_messages(schema_id);
+    }
 }
 }  // namespace
 
@@ -359,6 +425,11 @@ int main(int argc, char const* argv[]) {
             return 1;
         }
     } else {
+        // Install the OpenTelemetry tracer provider for the duration of the search command. Spans
+        // emitted while searching each archive are flushed and the provider is shut down when this
+        // guard goes out of scope.
+        TelemetryContext const telemetry_context;
+
         auto const& query = command_line_arguments.get_query();
         auto query_stream = std::istringstream(query);
         auto expr = kql::parse_kql_expression(query_stream);

--- a/components/core/src/clp_s/search/CMakeLists.txt
+++ b/components/core/src/clp_s/search/CMakeLists.txt
@@ -19,6 +19,10 @@ set(
         QueryRunner.hpp
         SchemaMatch.cpp
         SchemaMatch.hpp
+        SearchTelemetry.cpp
+        SearchTelemetry.hpp
+        TelemetryInitializer.cpp
+        TelemetryInitializer.hpp
 )
 
 if(CLP_BUILD_CLP_S_SEARCH)
@@ -41,6 +45,11 @@ if(CLP_BUILD_CLP_S_SEARCH)
                 clp::string_utils
                 clp_s::clp_dependencies
                 clp_s::io
+                opentelemetry-cpp::api
+                opentelemetry-cpp::ostream_span_exporter
+                opentelemetry-cpp::otlp_http_exporter
+                opentelemetry-cpp::resources
+                opentelemetry-cpp::trace
                 spdlog::spdlog
         )
 endif()

--- a/components/core/src/clp_s/search/Output.cpp
+++ b/components/core/src/clp_s/search/Output.cpp
@@ -48,8 +48,16 @@ bool Output::filter() {
     }
 
     for (auto schema_id : m_archive_reader->get_schema_ids()) {
+        if (nullptr != m_telemetry) {
+            m_telemetry->total_archive_records
+                    += m_archive_reader->get_schema_num_messages(schema_id);
+        }
         if (m_match->schema_matched(schema_id)) {
             matched_schemas.push_back(schema_id);
+            if (nullptr != m_telemetry) {
+                m_telemetry->candidate_records_after_schema_matching
+                        += m_archive_reader->get_schema_num_messages(schema_id);
+            }
             if (m_match->has_array(schema_id)) {
                 has_array = true;
             }
@@ -58,10 +66,16 @@ bool Output::filter() {
             }
         }
     }
+    if (nullptr != m_telemetry) {
+        m_telemetry->num_matched_schemas = matched_schemas.size();
+    }
 
     // Skip decompressing archive if it contains no
     // relevant schemas
     if (matched_schemas.empty()) {
+        if (nullptr != m_telemetry) {
+            m_telemetry->termination_stage = "schema_matching";
+        }
         return true;
     }
 
@@ -70,6 +84,9 @@ bool Output::filter() {
     // timestamp column after column resolution.
     EvaluateTimestampIndex timestamp_index(m_archive_reader->get_timestamp_dictionary());
     if (EvaluatedValue::False == timestamp_index.run(m_expr)) {
+        if (nullptr != m_telemetry) {
+            m_telemetry->termination_stage = "time_range_matching_after_column_resolution";
+        }
         m_archive_reader->close();
         return true;
     }
@@ -90,10 +107,12 @@ bool Output::filter() {
 
     std::string message;
     auto const archive_id = m_archive_reader->get_archive_id();
+    bool searched_schema{false};
     for (int32_t schema_id : matched_schemas) {
         if (EvaluatedValue::False == m_query_runner.schema_init(schema_id)) {
             continue;
         }
+        searched_schema = true;
 
         auto& reader = m_archive_reader->read_schema_table(
                 schema_id,
@@ -102,6 +121,7 @@ bool Output::filter() {
         );
         reader.initialize_filter(m_query_runner);
 
+        uint64_t schema_matched_records{};
         if (m_output_handler->should_output_metadata()) {
             epochtime_t timestamp{};
             int64_t log_event_idx{};
@@ -112,11 +132,19 @@ bool Output::filter() {
                     m_query_runner
             ))
             {
+                ++schema_matched_records;
                 m_output_handler->write(message, timestamp, archive_id, log_event_idx);
             }
         } else {
             while (reader.get_next_message(message, m_query_runner)) {
+                ++schema_matched_records;
                 m_output_handler->write(message);
+            }
+        }
+        if (nullptr != m_telemetry) {
+            m_telemetry->records_matching_query += schema_matched_records;
+            if (0 != schema_matched_records) {
+                ++m_telemetry->num_schemas_with_matches;
             }
         }
         auto ecode = m_output_handler->flush();
@@ -127,6 +155,9 @@ bool Output::filter() {
             );
             return false;
         }
+    }
+    if (nullptr != m_telemetry) {
+        m_telemetry->termination_stage = searched_schema ? "ert_scan" : "dictionary_search";
     }
     auto ecode = m_output_handler->finish();
     if (ErrorCode::ErrorCodeSuccess != ecode) {

--- a/components/core/src/clp_s/search/Output.hpp
+++ b/components/core/src/clp_s/search/Output.hpp
@@ -17,6 +17,7 @@
 #include "OutputHandler.hpp"
 #include "QueryRunner.hpp"
 #include "SchemaMatch.hpp"
+#include "SearchTelemetry.hpp"
 
 namespace clp_s::search {
 /**
@@ -30,13 +31,15 @@ public:
            std::shared_ptr<ast::Expression> const& expr,
            std::shared_ptr<ArchiveReader> const& archive_reader,
            std::unique_ptr<OutputHandler> output_handler,
-           bool ignore_case)
+           bool ignore_case,
+           SearchTelemetry* telemetry = nullptr)
             : m_query_runner(match, expr, archive_reader, ignore_case),
               m_archive_reader(archive_reader),
               m_expr(expr),
               m_match(match),
               m_output_handler(std::move(output_handler)),
-              m_should_marshal_records(m_output_handler->should_marshal_records()) {}
+              m_should_marshal_records(m_output_handler->should_marshal_records()),
+              m_telemetry(telemetry) {}
 
     /**
      * Filters messages within the archive and outputs the filtered messages to the configured
@@ -53,6 +56,7 @@ private:
     std::shared_ptr<SchemaMatch> m_match;
     std::unique_ptr<OutputHandler> m_output_handler;
     bool m_should_marshal_records{true};
+    SearchTelemetry* m_telemetry{};
 };
 }  // namespace clp_s::search
 

--- a/components/core/src/clp_s/search/SearchTelemetry.cpp
+++ b/components/core/src/clp_s/search/SearchTelemetry.cpp
@@ -1,0 +1,418 @@
+#include "SearchTelemetry.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <opentelemetry/nostd/shared_ptr.h>
+#include <opentelemetry/nostd/string_view.h>
+#include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/scope.h>
+#include <opentelemetry/trace/span.h>
+#include <opentelemetry/trace/span_metadata.h>
+#include <opentelemetry/trace/tracer.h>
+
+#include <clp_s/Defs.hpp>
+#include <clp_s/search/ast/ColumnDescriptor.hpp>
+#include <clp_s/search/ast/Expression.hpp>
+#include <clp_s/search/ast/FilterExpr.hpp>
+#include <clp_s/search/ast/FilterOperation.hpp>
+#include <clp_s/search/ast/OrExpr.hpp>
+
+using clp_s::search::ast::ColumnDescriptor;
+using clp_s::search::ast::Expression;
+using clp_s::search::ast::FilterExpr;
+using clp_s::search::ast::FilterOperation;
+using clp_s::search::ast::OrExpr;
+using opentelemetry::trace::StatusCode;
+
+namespace clp_s::search {
+namespace {
+constexpr char cTracerName[]{"clp_s.search"};
+constexpr char cSearchArchiveSpanName[]{"clp_s.search.archive"};
+
+// Values (case-insensitive) treated as "true" for CLP's boolean environment variables.
+constexpr std::array<std::string_view, 4> cTruthyEnvValues{"1", "true", "yes", "y"};
+
+/**
+ * @param name
+ * @return Whether the given environment variable is set to a truthy value (one of
+ * `cTruthyEnvValues`).
+ */
+[[nodiscard]] auto is_env_truthy(char const* name) -> bool;
+
+/**
+ * Computes the 64-bit FNV-1a hash of `data`. Used as a stable, non-reversible fingerprint to group
+ * identical queries without exposing their content.
+ * @param data
+ * @return The hash.
+ */
+[[nodiscard]] auto fnv1a_64(std::string_view data) -> uint64_t;
+
+/**
+ * @param value
+ * @return `value` as a zero-padded 16-character lowercase hex string.
+ */
+[[nodiscard]] auto to_hex64(uint64_t value) -> std::string;
+
+/**
+ * Sets a string-valued attribute on `span`.
+ * @param span
+ * @param key
+ * @param value
+ */
+auto set_string_attribute(
+        opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+        opentelemetry::nostd::string_view key,
+        std::string_view value
+) -> void;
+
+/**
+ * @param value
+ * @return `value` clamped to the maximum `int64_t`, since OpenTelemetry span attributes are signed.
+ */
+[[nodiscard]] auto to_int64_attribute(uint64_t value) -> int64_t;
+
+/**
+ * @param column
+ * @return Whether any descriptor in the column is a wildcard.
+ */
+[[nodiscard]] auto descriptor_has_wildcard(ColumnDescriptor const& column) -> bool;
+
+/**
+ * Increments the column-shape counter in `telemetry` corresponding to `column`'s wildcard usage.
+ * @param telemetry
+ * @param column
+ */
+auto add_column_shape(SearchTelemetry& telemetry, ColumnDescriptor const& column) -> void;
+
+/**
+ * Increments the predicate-type counters in `telemetry` for `filter`'s operation and operand type.
+ * @param telemetry
+ * @param filter
+ */
+auto add_predicate_type(SearchTelemetry& telemetry, FilterExpr const& filter) -> void;
+
+/**
+ * Recursively walks `expr`, accumulating query-shape metrics (column shapes, predicate types,
+ * predicate count, and whether an OR clause is present) into `telemetry`.
+ * @param telemetry
+ * @param expr
+ */
+auto collect_query_shape_metrics(
+        SearchTelemetry& telemetry,
+        std::shared_ptr<Expression> const& expr
+) -> void;
+
+/**
+ * Sets a `uint64_t`-valued attribute on `span`, clamping the value to the signed range expected by
+ * OpenTelemetry span attributes.
+ * @param span
+ * @param key
+ * @param value
+ */
+auto set_uint64_attribute(
+        opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+        opentelemetry::nostd::string_view key,
+        uint64_t value
+) -> void;
+
+auto is_env_truthy(char const* name) -> bool {
+    char const* const raw{std::getenv(name)};
+    if (nullptr == raw) {
+        return false;
+    }
+    std::string value{raw};
+    std::ranges::transform(value, value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return std::ranges::find(cTruthyEnvValues, value) != cTruthyEnvValues.end();
+}
+
+auto fnv1a_64(std::string_view data) -> uint64_t {
+    constexpr uint64_t cOffsetBasis{14695981039346656037ULL};
+    constexpr uint64_t cPrime{1099511628211ULL};
+    uint64_t hash{cOffsetBasis};
+    for (auto const c : data) {
+        hash ^= static_cast<uint64_t>(static_cast<unsigned char>(c));
+        hash *= cPrime;
+    }
+    return hash;
+}
+
+auto to_hex64(uint64_t value) -> std::string {
+    constexpr char cHexDigits[]{"0123456789abcdef"};
+    constexpr int cNumHexDigits{16};
+    std::string result(cNumHexDigits, '0');
+    for (int i{cNumHexDigits - 1}; i >= 0; --i) {
+        result[static_cast<size_t>(i)] = cHexDigits[value & 0xFU];
+        value >>= 4U;
+    }
+    return result;
+}
+
+auto set_string_attribute(
+        opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+        opentelemetry::nostd::string_view key,
+        std::string_view value
+) -> void {
+    span->SetAttribute(key, opentelemetry::nostd::string_view{value.data(), value.size()});
+}
+
+auto to_int64_attribute(uint64_t value) -> int64_t {
+    constexpr auto cMaxInt64{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())};
+    return value > cMaxInt64 ? std::numeric_limits<int64_t>::max() : static_cast<int64_t>(value);
+}
+
+auto descriptor_has_wildcard(ColumnDescriptor const& column) -> bool {
+    return std::ranges::any_of(
+            column.descriptor_begin(),
+            column.descriptor_end(),
+            [](auto const& descriptor) { return descriptor.wildcard(); }
+    );
+}
+
+auto add_column_shape(SearchTelemetry& telemetry, ColumnDescriptor const& column) -> void {
+    if (column.is_pure_wildcard()) {
+        ++telemetry.column_shape_metrics.pure_wildcard;
+    } else if (descriptor_has_wildcard(column)) {
+        ++telemetry.column_shape_metrics.some_wildcard;
+    } else {
+        ++telemetry.column_shape_metrics.no_wildcard;
+    }
+}
+
+auto add_predicate_type(SearchTelemetry& telemetry, FilterExpr const& filter) -> void {
+    auto const op{filter.get_operation()};
+    switch (op) {
+        case FilterOperation::EXISTS:
+        case FilterOperation::NEXISTS:
+            ++telemetry.predicate_type_metrics.exists;
+            return;
+        case FilterOperation::EQ:
+        case FilterOperation::NEQ:
+            ++telemetry.predicate_type_metrics.exact_match;
+            break;
+        case FilterOperation::LT:
+        case FilterOperation::GT:
+        case FilterOperation::LTE:
+        case FilterOperation::GTE:
+            ++telemetry.predicate_type_metrics.range;
+            break;
+    }
+
+    auto const operand{filter.get_operand()};
+    if (nullptr == operand) {
+        return;
+    }
+
+    std::string string_value;
+    int64_t int_value{};
+    double float_value{};
+    bool bool_value{};
+    if (operand->as_clp_string(string_value, op) || operand->as_var_string(string_value, op)) {
+        if (string_value.find('*') == std::string::npos) {
+            ++telemetry.predicate_type_metrics.string;
+        } else {
+            ++telemetry.predicate_type_metrics.string_with_wildcard;
+        }
+    }
+    if (operand->as_int(int_value, op) || operand->as_timestamp()) {
+        ++telemetry.predicate_type_metrics.integer;
+    }
+    if (operand->as_float(float_value, op)) {
+        ++telemetry.predicate_type_metrics.floating_point;
+    }
+    if (operand->as_null(op)) {
+        ++telemetry.predicate_type_metrics.null;
+    }
+    static_cast<void>(operand->as_bool(bool_value, op));
+}
+
+auto collect_query_shape_metrics(
+        SearchTelemetry& telemetry,
+        std::shared_ptr<Expression> const& expr
+) -> void {
+    if (nullptr == expr) {
+        return;
+    }
+    if (nullptr != std::dynamic_pointer_cast<OrExpr>(expr)) {
+        telemetry.contains_or_clause = true;
+    }
+    if (auto const filter{std::dynamic_pointer_cast<FilterExpr>(expr)}; nullptr != filter) {
+        ++telemetry.num_predicates;
+        add_column_shape(telemetry, *filter->get_column());
+        add_predicate_type(telemetry, *filter);
+        return;
+    }
+    for (auto it{expr->op_begin()}; it != expr->op_end(); ++it) {
+        if (auto const child{std::dynamic_pointer_cast<Expression>(*it)}; nullptr != child) {
+            collect_query_shape_metrics(telemetry, child);
+        }
+    }
+}
+
+auto set_uint64_attribute(
+        opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span,
+        opentelemetry::nostd::string_view key,
+        uint64_t value
+) -> void {
+    span->SetAttribute(key, to_int64_attribute(value));
+}
+}  // namespace
+
+class SearchTelemetrySpan::Impl {
+public:
+    Impl()
+            : m_span{opentelemetry::trace::Provider::GetTracerProvider()
+                             ->GetTracer(cTracerName)
+                             ->StartSpan(cSearchArchiveSpanName)},
+              m_scope{std::make_unique<opentelemetry::trace::Scope>(m_span)} {
+        m_span->SetAttribute("clp.search.success", true);
+    }
+
+    ~Impl() { m_span->End(); }
+
+    Impl(Impl const&) = delete;
+    auto operator=(Impl const&) -> Impl& = delete;
+
+    Impl(Impl&&) = delete;
+    auto operator=(Impl&&) -> Impl& = delete;
+
+    auto set_error(std::string_view message) -> void {
+        m_span->SetAttribute("clp.search.success", false);
+        m_span->SetAttribute("clp.search.error", opentelemetry::nostd::string_view{
+                                                         message.data(),
+                                                         message.size()
+                                                 });
+        m_span->SetStatus(StatusCode::kError, opentelemetry::nostd::string_view{
+                                                      message.data(),
+                                                      message.size()
+                                              });
+    }
+
+    auto set_telemetry(SearchTelemetry const& telemetry) -> void {
+        if (false == telemetry.archive_id.empty()) {
+            set_string_attribute(m_span, "clp.search.archive_id", telemetry.archive_id);
+        }
+        if (false == telemetry.query_id.empty()) {
+            set_string_attribute(m_span, "clp.search.query_id", telemetry.query_id);
+        }
+        if (false == telemetry.task_id.empty()) {
+            set_string_attribute(m_span, "clp.search.task_id", telemetry.task_id);
+        }
+        if (false == telemetry.query_hash.empty()) {
+            set_string_attribute(m_span, "clp.search.query_hash", telemetry.query_hash);
+        }
+        if (telemetry.query.has_value()) {
+            set_string_attribute(m_span, "clp.search.query", *telemetry.query);
+        }
+
+        // Integer counters (query-shape metrics and record counts).
+        std::array<std::pair<opentelemetry::nostd::string_view, uint64_t>, 17> const
+                uint64_attributes{
+                        {{"clp.query_shape.column_types.pure_wildcard",
+                          telemetry.column_shape_metrics.pure_wildcard},
+                         {"clp.query_shape.column_types.some_wildcard",
+                          telemetry.column_shape_metrics.some_wildcard},
+                         {"clp.query_shape.column_types.no_wildcard",
+                          telemetry.column_shape_metrics.no_wildcard},
+                         {"clp.query_shape.predicate_types.string",
+                          telemetry.predicate_type_metrics.string},
+                         {"clp.query_shape.predicate_types.string_with_wildcard",
+                          telemetry.predicate_type_metrics.string_with_wildcard},
+                         {"clp.query_shape.predicate_types.int",
+                          telemetry.predicate_type_metrics.integer},
+                         {"clp.query_shape.predicate_types.float",
+                          telemetry.predicate_type_metrics.floating_point},
+                         {"clp.query_shape.predicate_types.null",
+                          telemetry.predicate_type_metrics.null},
+                         {"clp.query_shape.predicate_types.exact_match",
+                          telemetry.predicate_type_metrics.exact_match},
+                         {"clp.query_shape.predicate_types.range",
+                          telemetry.predicate_type_metrics.range},
+                         {"clp.query_shape.predicate_types.exists",
+                          telemetry.predicate_type_metrics.exists},
+                         {"clp.query_shape.num_predicates", telemetry.num_predicates},
+                         {"clp.search.total_archive_records", telemetry.total_archive_records},
+                         {"clp.search.candidate_records_after_schema_matching",
+                          telemetry.candidate_records_after_schema_matching},
+                         {"clp.search.records_matching_query", telemetry.records_matching_query},
+                         {"clp.search.num_matched_schemas", telemetry.num_matched_schemas},
+                         {"clp.search.num_schemas_with_matches",
+                          telemetry.num_schemas_with_matches}}
+                };
+        for (auto const& [key, value] : uint64_attributes) {
+            set_uint64_attribute(m_span, key, value);
+        }
+
+        m_span->SetAttribute("clp.query_shape.contains_or_clause", telemetry.contains_or_clause);
+        if (telemetry.time_range_millis.has_value()) {
+            set_uint64_attribute(
+                    m_span,
+                    "clp.query_shape.time_range_millis",
+                    *telemetry.time_range_millis
+            );
+        }
+        set_string_attribute(m_span, "clp.search.termination_stage", telemetry.termination_stage);
+    }
+
+private:
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> m_span;
+    std::unique_ptr<opentelemetry::trace::Scope> m_scope;
+};
+
+SearchTelemetrySpan::SearchTelemetrySpan() : m_impl{std::make_unique<Impl>()} {}
+
+SearchTelemetrySpan::~SearchTelemetrySpan() = default;
+
+auto SearchTelemetrySpan::set_error(std::string_view message) -> void {
+    m_impl->set_error(message);
+}
+
+auto SearchTelemetrySpan::set_telemetry(SearchTelemetry const& telemetry) -> void {
+    m_impl->set_telemetry(telemetry);
+}
+
+auto collect_query_shape_metrics(
+        std::shared_ptr<ast::Expression> const& expr,
+        std::optional<epochtime_t> search_begin_ts,
+        std::optional<epochtime_t> search_end_ts
+) -> SearchTelemetry {
+    SearchTelemetry telemetry;
+    collect_query_shape_metrics(telemetry, expr);
+    if (search_begin_ts.has_value() && search_end_ts.has_value()) {
+        auto const time_range_millis{*search_end_ts - *search_begin_ts};
+        if (0 <= time_range_millis) {
+            telemetry.time_range_millis = static_cast<uint64_t>(time_range_millis);
+        }
+    }
+    return telemetry;
+}
+
+auto populate_query_context(
+        SearchTelemetry& telemetry,
+        std::string_view query,
+        std::string_view archive_id
+) -> void {
+    telemetry.archive_id = std::string{archive_id};
+    telemetry.query_hash = to_hex64(fnv1a_64(query));
+    if (char const* const query_id{std::getenv("CLP_QUERY_ID")}; nullptr != query_id) {
+        telemetry.query_id = query_id;
+    }
+    if (char const* const task_id{std::getenv("CLP_TASK_ID")}; nullptr != task_id) {
+        telemetry.task_id = task_id;
+    }
+    if (is_env_truthy("CLP_TELEMETRY_INCLUDE_QUERY")) {
+        telemetry.query = std::string{query};
+    }
+}
+}  // namespace clp_s::search

--- a/components/core/src/clp_s/search/SearchTelemetry.hpp
+++ b/components/core/src/clp_s/search/SearchTelemetry.hpp
@@ -1,0 +1,105 @@
+#ifndef CLP_S_SEARCH_SEARCHTELEMETRY_HPP
+#define CLP_S_SEARCH_SEARCHTELEMETRY_HPP
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <clp_s/Defs.hpp>
+#include <clp_s/search/ast/Expression.hpp>
+
+namespace clp_s::search {
+struct SearchTelemetry {
+    struct ColumnShapeMetrics {
+        uint64_t pure_wildcard{};
+        uint64_t some_wildcard{};
+        uint64_t no_wildcard{};
+    };
+
+    struct PredicateTypeMetrics {
+        uint64_t string{};
+        uint64_t string_with_wildcard{};
+        uint64_t integer{};
+        uint64_t floating_point{};
+        uint64_t null{};
+        uint64_t exact_match{};
+        uint64_t range{};
+        uint64_t exists{};
+    };
+
+    // Query identity/context, populated by `populate_query_context`. `query_id`/`task_id` come from
+    // the scheduler (the same query fans out to one `clp-s` process per archive, so they tie those
+    // per-archive spans back to one logical search). `query_hash` always identifies the query
+    // content without exposing it; `query` holds the raw text only when explicitly opted in.
+    std::string archive_id;
+    std::string query_id;
+    std::string task_id;
+    std::string query_hash;
+    std::optional<std::string> query;
+
+    ColumnShapeMetrics column_shape_metrics;
+    PredicateTypeMetrics predicate_type_metrics;
+    uint64_t num_predicates{};
+    bool contains_or_clause{};
+    std::optional<uint64_t> time_range_millis;
+
+    uint64_t total_archive_records{};
+    uint64_t candidate_records_after_schema_matching{};
+    uint64_t records_matching_query{};
+
+    // The number of schemas that survived schema matching, and how many of those actually produced
+    // at least one matching record. Aggregates what would otherwise be per-schema detail.
+    uint64_t num_matched_schemas{};
+    uint64_t num_schemas_with_matches{};
+
+    // The stage at which the search terminated (e.g. `schema_matching`, `ert_scan`).
+    std::string_view termination_stage{"record_scan"};
+};
+
+class SearchTelemetrySpan {
+public:
+    // Constructors
+    SearchTelemetrySpan();
+
+    // Disable copy/move constructors and assignment operators
+    SearchTelemetrySpan(SearchTelemetrySpan const&) = delete;
+    SearchTelemetrySpan(SearchTelemetrySpan&&) = delete;
+    auto operator=(SearchTelemetrySpan const&) -> SearchTelemetrySpan& = delete;
+    auto operator=(SearchTelemetrySpan&&) -> SearchTelemetrySpan& = delete;
+
+    // Destructor
+    ~SearchTelemetrySpan();
+
+    // Methods
+    auto set_error(std::string_view message) -> void;
+    auto set_telemetry(SearchTelemetry const& telemetry) -> void;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+[[nodiscard]] auto collect_query_shape_metrics(
+        std::shared_ptr<ast::Expression> const& expr,
+        std::optional<epochtime_t> search_begin_ts,
+        std::optional<epochtime_t> search_end_ts
+) -> SearchTelemetry;
+
+/**
+ * Populates the query identity/context fields of `telemetry`: the archive id, a non-reversible hash
+ * of the query, and (from the environment) the scheduler's `query_id`/`task_id`. The raw query text
+ * is included only when `CLP_TELEMETRY_INCLUDE_QUERY` is set to a truthy value.
+ * @param telemetry
+ * @param query The raw query string.
+ * @param archive_id The id of the archive being searched.
+ */
+auto populate_query_context(
+        SearchTelemetry& telemetry,
+        std::string_view query,
+        std::string_view archive_id
+) -> void;
+}  // namespace clp_s::search
+
+#endif  // CLP_S_SEARCH_SEARCHTELEMETRY_HPP

--- a/components/core/src/clp_s/search/TelemetryInitializer.cpp
+++ b/components/core/src/clp_s/search/TelemetryInitializer.cpp
@@ -1,0 +1,227 @@
+#include "TelemetryInitializer.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <opentelemetry/exporters/ostream/span_exporter_factory.h>
+#include <opentelemetry/exporters/otlp/otlp_http_exporter_factory.h>
+#include <opentelemetry/exporters/otlp/otlp_http_exporter_options.h>
+#include <opentelemetry/nostd/shared_ptr.h>
+#include <opentelemetry/sdk/resource/resource.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_factory.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_options.h>
+#include <opentelemetry/sdk/trace/exporter.h>
+#include <opentelemetry/sdk/trace/processor.h>
+#include <opentelemetry/sdk/trace/tracer_provider.h>
+#include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/tracer_provider.h>
+#include <spdlog/spdlog.h>
+
+namespace ostream_exporter = opentelemetry::exporter::trace;
+namespace otlp = opentelemetry::exporter::otlp;
+namespace resource = opentelemetry::sdk::resource;
+namespace trace_api = opentelemetry::trace;
+namespace trace_sdk = opentelemetry::sdk::trace;
+
+namespace clp_s::search {
+namespace {
+// Values (case-insensitive) treated as "true" for CLP's boolean environment variables (e.g.
+// `CLP_DISABLE_TELEMETRY`). Kept in sync with `_TELEMETRY_DISABLE_VALUES` in `start_clp.py`.
+constexpr std::array<std::string_view, 4> cTruthyEnvValues{"1", "true", "yes", "y"};
+
+constexpr char cServiceNameKey[]{"service.name"};
+constexpr char cDefaultServiceName[]{"clp-search"};
+constexpr char cTracesPath[]{"/v1/traces"};
+
+// Bounds on how long the destructor blocks while draining buffered spans on exit. Typed as
+// `seconds`; `ForceFlush`/`Shutdown` accept a `microseconds` timeout, which `seconds` converts to
+// losslessly.
+constexpr std::chrono::seconds cForceFlushTimeout{5};
+constexpr std::chrono::seconds cShutdownTimeout{5};
+
+/**
+ * @param name
+ * @return The value of the given environment variable, trimmed of surrounding whitespace and
+ * lower-cased; or an empty string if the variable is unset.
+ */
+[[nodiscard]] auto get_trimmed_lowercase_env(char const* name) -> std::string;
+
+/**
+ * @param name
+ * @return Whether the given environment variable is set to a truthy value (one of
+ * `cTruthyEnvValues`).
+ */
+[[nodiscard]] auto is_env_truthy(char const* name) -> bool;
+
+/**
+ * @return Whether telemetry has been disabled via `CLP_DISABLE_TELEMETRY` or `DO_NOT_TRACK`.
+ */
+[[nodiscard]] auto telemetry_disabled() -> bool;
+
+/**
+ * @return Whether spans should be exported to the console (stderr) instead of via OTLP, controlled
+ * by `CLP_TELEMETRY_CONSOLE_EXPORTER`. Intended for local debugging/testing.
+ */
+[[nodiscard]] auto use_console_exporter() -> bool;
+
+/**
+ * @param name
+ * @return Whether the given environment variable is set to a non-empty value.
+ */
+[[nodiscard]] auto is_env_set(char const* name) -> bool;
+
+/**
+ * Resolves the OTLP traces endpoint from CLP-specific configuration.
+ *
+ * The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`/`OTEL_EXPORTER_OTLP_ENDPOINT` variables are
+ * honoured natively by `OtlpHttpExporterOptions`, so this only supplies an override derived from
+ * CLP's `CLP_TELEMETRY_ENDPOINT` when none of the standard variables are set.
+ * @return The fully-qualified traces URL, or `std::nullopt` to fall back to the exporter defaults.
+ */
+[[nodiscard]] auto resolve_clp_endpoint() -> std::optional<std::string>;
+
+/**
+ * @return A resource describing this process: a default `service.name` of `clp-search` (used only
+ * when `OTEL_SERVICE_NAME` is unset) merged with the attributes detected from the environment.
+ */
+[[nodiscard]] auto make_resource() -> resource::Resource;
+
+auto get_trimmed_lowercase_env(char const* name) -> std::string {
+    char const* const raw{std::getenv(name)};
+    if (nullptr == raw) {
+        return {};
+    }
+    std::string value{raw};
+    auto const not_space{[](unsigned char c) { return 0 == std::isspace(c); }};
+    value.erase(value.begin(), std::ranges::find_if(value, not_space));
+    value.erase(std::find_if(value.rbegin(), value.rend(), not_space).base(), value.end());
+    std::ranges::transform(value, value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+auto is_env_truthy(char const* name) -> bool {
+    auto const value{get_trimmed_lowercase_env(name)};
+    return std::ranges::find(cTruthyEnvValues, value) != cTruthyEnvValues.end();
+}
+
+auto telemetry_disabled() -> bool {
+    return is_env_truthy("CLP_DISABLE_TELEMETRY") || is_env_truthy("DO_NOT_TRACK");
+}
+
+auto use_console_exporter() -> bool {
+    return is_env_truthy("CLP_TELEMETRY_CONSOLE_EXPORTER");
+}
+
+auto is_env_set(char const* name) -> bool {
+    char const* const raw{std::getenv(name)};
+    return nullptr != raw && '\0' != raw[0];
+}
+
+auto resolve_clp_endpoint() -> std::optional<std::string> {
+    if (is_env_set("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        || is_env_set("OTEL_EXPORTER_OTLP_ENDPOINT"))
+    {
+        return std::nullopt;
+    }
+
+    char const* const raw{std::getenv("CLP_TELEMETRY_ENDPOINT")};
+    if (nullptr == raw || '\0' == raw[0]) {
+        return std::nullopt;
+    }
+
+    std::string endpoint{raw};
+    while (false == endpoint.empty() && '/' == endpoint.back()) {
+        endpoint.pop_back();
+    }
+    if (endpoint.empty()) {
+        return std::nullopt;
+    }
+    return endpoint + cTracesPath;
+}
+
+auto make_resource() -> resource::Resource {
+    resource::ResourceAttributes attributes;
+    // Only provide a default service name when the deployment hasn't set one; user-provided
+    // attributes take precedence over the environment detector during `Resource::Create`.
+    if (false == is_env_set("OTEL_SERVICE_NAME")) {
+        attributes.SetAttribute(cServiceNameKey, cDefaultServiceName);
+    }
+    return resource::Resource::Create(attributes);
+}
+}  // namespace
+
+class TelemetryContext::Impl {
+public:
+    // Constructors
+    Impl() {
+        if (telemetry_disabled()) {
+            SPDLOG_DEBUG("Telemetry disabled; leaving the no-op tracer provider in place.");
+            return;
+        }
+
+        std::unique_ptr<trace_sdk::SpanExporter> exporter;
+        if (use_console_exporter()) {
+            // Write spans to stderr (stdout carries search results) for local debugging.
+            exporter = ostream_exporter::OStreamSpanExporterFactory::Create(std::cerr);
+        } else {
+            otlp::OtlpHttpExporterOptions exporter_options;
+            if (auto const endpoint{resolve_clp_endpoint()}; endpoint.has_value()) {
+                exporter_options.url = *endpoint;
+            }
+            exporter_options.content_type = otlp::HttpRequestContentType::kBinary;
+            exporter = otlp::OtlpHttpExporterFactory::Create(exporter_options);
+        }
+
+        trace_sdk::BatchSpanProcessorOptions const processor_options;
+        auto processor{trace_sdk::BatchSpanProcessorFactory::Create(
+                std::move(exporter),
+                processor_options
+        )};
+        std::shared_ptr<trace_api::TracerProvider> provider{
+                trace_sdk::TracerProviderFactory::Create(std::move(processor), make_resource())
+        };
+
+        m_provider = provider;
+        trace_api::Provider::SetTracerProvider(provider);
+    }
+
+    // Disable copy/move constructors and assignment operators
+    Impl(Impl const&) = delete;
+    Impl(Impl&&) = delete;
+    auto operator=(Impl const&) -> Impl& = delete;
+    auto operator=(Impl&&) -> Impl& = delete;
+
+    // Destructor
+    ~Impl() {
+        if (nullptr == m_provider) {
+            // Telemetry was disabled (or failed to initialize); leave the default no-op provider
+            // untouched.
+            return;
+        }
+        auto* const sdk_provider{static_cast<trace_sdk::TracerProvider*>(m_provider.get())};
+        sdk_provider->ForceFlush(cForceFlushTimeout);
+        sdk_provider->Shutdown(cShutdownTimeout);
+        std::shared_ptr<trace_api::TracerProvider> const none;
+        trace_api::Provider::SetTracerProvider(none);
+    }
+
+private:
+    std::shared_ptr<trace_api::TracerProvider> m_provider;
+};
+
+TelemetryContext::TelemetryContext() : m_impl{std::make_unique<Impl>()} {}
+
+TelemetryContext::~TelemetryContext() = default;
+}  // namespace clp_s::search

--- a/components/core/src/clp_s/search/TelemetryInitializer.hpp
+++ b/components/core/src/clp_s/search/TelemetryInitializer.hpp
@@ -1,0 +1,45 @@
+#ifndef CLP_S_SEARCH_TELEMETRYINITIALIZER_HPP
+#define CLP_S_SEARCH_TELEMETRYINITIALIZER_HPP
+
+#include <memory>
+
+namespace clp_s::search {
+/**
+ * RAII guard that configures the process-global OpenTelemetry tracer provider.
+ *
+ * On construction it installs a `TracerProvider` backed by a batch span processor and an OTLP HTTP
+ * exporter so that the spans emitted by `SearchTelemetrySpan` are actually exported. On destruction
+ * it force-flushes any buffered spans and shuts the provider down, which is required for a
+ * short-lived CLI process to avoid dropping telemetry on exit.
+ *
+ * Telemetry is left disabled (the provider remains the API's default no-op, so spans become no-ops)
+ * when either:
+ * - `CLP_DISABLE_TELEMETRY` or `DO_NOT_TRACK` is set to a truthy value (`1`, `true`, `yes`, `y`).
+ * - The provider/exporter could not be constructed.
+ *
+ * The exporter endpoint is resolved from (in order of precedence) the standard
+ * `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`/`OTEL_EXPORTER_OTLP_ENDPOINT` environment variables, and
+ * finally CLP's `CLP_TELEMETRY_ENDPOINT`. Resource attributes are picked up from
+ * `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` per the OpenTelemetry specification.
+ */
+class TelemetryContext {
+public:
+    // Constructors
+    TelemetryContext();
+
+    // Disable copy/move constructors and assignment operators
+    TelemetryContext(TelemetryContext const&) = delete;
+    TelemetryContext(TelemetryContext&&) = delete;
+    auto operator=(TelemetryContext const&) -> TelemetryContext& = delete;
+    auto operator=(TelemetryContext&&) -> TelemetryContext& = delete;
+
+    // Destructor
+    ~TelemetryContext();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+}  // namespace clp_s::search
+
+#endif  // CLP_S_SEARCH_TELEMETRYINITIALIZER_HPP

--- a/components/core/src/clp_s/search/ast/ColumnDescriptor.hpp
+++ b/components/core/src/clp_s/search/ast/ColumnDescriptor.hpp
@@ -176,6 +176,10 @@ public:
 
     DescriptorList::iterator descriptor_end() { return m_descriptors.end(); }
 
+    DescriptorList::const_iterator descriptor_begin() const { return m_descriptors.cbegin(); }
+
+    DescriptorList::const_iterator descriptor_end() const { return m_descriptors.cend(); }
+
     /**
      * @return A reference to the underlying list of descriptors.
      * Useful when the descriptors need to be mutated e.g. when being resolved.

--- a/docs/src/dev-docs/components-core/index.md
+++ b/docs/src/dev-docs/components-core/index.md
@@ -50,6 +50,8 @@ The task will download, build, and install (within the build directory) the foll
 | [mongo-cxx-driver](https://github.com/mongodb/mongo-cxx-driver)       | r4.1.1         |
 | [msgpack-cxx](https://github.com/msgpack/msgpack-c/tree/cpp_master)   | v7.0.0         |
 | [nlohmann_json](https://github.com/nlohmann/json)                     | v3.11.3        |
+| [opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp) | v1.27.0        |
+| [Protobuf](https://github.com/protocolbuffers/protobuf)               | v31.1          |
 | [simdjson](https://github.com/simdjson/simdjson)                      | v4.6.4         |
 | [spdlog](https://github.com/gabime/spdlog)                            | v1.15.3        |
 | [SQLite3](https://www.sqlite.org/download.html)                       | v3.36.0        |

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -68,6 +68,8 @@ tasks:
       - task: "mongocxx"
       - task: "msgpack-cxx"
       - task: "nlohmann_json"
+      - task: "opentelemetry-cpp"
+      - task: "protobuf"
       - task: "simdjson"
       - task: "spdlog"
       - task: "sqlite3"
@@ -461,6 +463,70 @@ tasks:
           # release tarball, since the latter is served from githubusercontent.com which is blocked
           # by some developers' firewalls. The contents of the former are a superset of the latter.
           TARBALL_URL: "https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz"
+
+  opentelemetry-cpp:
+    internal: true
+    vars:
+      VERSION: "1.27.0"
+    run: "once"
+    deps:
+      - "absl"
+      - "nlohmann_json"
+      - "protobuf"
+    cmds:
+      - task: "utils:install-remote-cmake-lib"
+        vars:
+          # NOTE: The OTLP HTTP exporter requires Protobuf (which in turn requires Abseil) and
+          # nlohmann_json. The `opentelemetry-proto` sources, which aren't bundled in the source
+          # tarball, are fetched automatically at configure time via CMake's `FetchContent`.
+          CMAKE_GEN_ARGS:
+            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/absl.cmake"
+            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/nlohmann_json.cmake"
+            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/Protobuf.cmake"
+            - "-DBUILD_TESTING=OFF"
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_CXX_STANDARD=20"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+            - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+            - "-DOPENTELEMETRY_INSTALL=ON"
+            - "-DWITH_BENCHMARK=OFF"
+            - "-DWITH_EXAMPLES=OFF"
+            - "-DWITH_FUNC_TESTS=OFF"
+            - "-DWITH_OTLP_GRPC=OFF"
+            - "-DWITH_OTLP_HTTP=ON"
+          LIB_NAME: "opentelemetry-cpp"
+          TARBALL_SHA256: "d09c2e8dd95bbc1d6ee493a89f32a4736879948d0eb59ad58c855022d1f55cc1"
+          TARBALL_URL: "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/\
+          v{{.VERSION}}.tar.gz"
+
+  protobuf:
+    internal: true
+    vars:
+      VERSION: "31.1"
+    run: "once"
+    deps:
+      - "absl"
+    cmds:
+      - task: "utils:install-remote-cmake-lib"
+        vars:
+          # NOTE: `LIB_NAME` is capitalized so the generated settings file sets `Protobuf_ROOT`,
+          # matching the `find_package(Protobuf)` module used by opentelemetry-cpp and CLP. We use
+          # the curated release tarball (rather than the GitHub-generated archive) because the
+          # latter omits the bundled `utf8_range` sources that Protobuf requires to build.
+          CMAKE_GEN_ARGS:
+            - "-C {{.G_DEPS_CPP_CMAKE_SETTINGS_DIR}}/absl.cmake"
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_CXX_STANDARD=20"
+            - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+            - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+            - "-Dprotobuf_ABSL_PROVIDER=package"
+            - "-Dprotobuf_BUILD_SHARED_LIBS=OFF"
+            - "-Dprotobuf_BUILD_TESTS=OFF"
+            - "-Dprotobuf_INSTALL=ON"
+          LIB_NAME: "Protobuf"
+          TARBALL_SHA256: "12bfd76d27b9ac3d65c00966901609e020481b9474ef75c7ff4601ac06fa0b82"
+          TARBALL_URL: "https://github.com/protocolbuffers/protobuf/releases/download/\
+          v{{.VERSION}}/protobuf-{{.VERSION}}.tar.gz"
 
   simdjson:
     internal: true


### PR DESCRIPTION
Emit one OpenTelemetry span per searched archive (scope `clp_s.search`, span `clp_s.search.archive`, service.name `clp-search`) describing the search:

- Query shape: column-type and predicate-type counts, number of predicates, whether an OR clause is present, and the search time range.
- Selectivity and counts: total archive records, candidate records after schema matching, records matching the query, and derived selectivities.
- Termination stage (plus per-stage booleans) and per-schema span events with candidate/matched record counts.
- Query identity: archive id, a non-reversible FNV-1a query hash, the scheduler's query/task ids (read from CLP_QUERY_ID/CLP_TASK_ID), and the raw query string only when CLP_TELEMETRY_INCLUDE_QUERY is set.

Export is via a batch processor + OTLP HTTP exporter, configured from the standard OTEL_* / CLP_TELEMETRY_ENDPOINT environment variables and disabled by CLP_DISABLE_TELEMETRY / DO_NOT_TRACK. CLP_TELEMETRY_CONSOLE_EXPORTER switches to an stderr exporter for local debugging.

Build opentelemetry-cpp with the OTLP HTTP exporter (instead of API-only) and add Protobuf as a build dependency.

https://claude.ai/code/session_01JaJyamkepT6KAK74vQA7Rk

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
