### PR TITLE
feat(packaging): Propagate Docker network mode to package manager package builds.

### DIFF
--- a/components/core/tools/packaging/build.sh
+++ b/components/core/tools/packaging/build.sh
@@ -23,6 +23,9 @@
 #   --output DIR    Output directory for packages (default: ./packages)
 #   --clean         Remove build artifacts before building
 #   --help          Show this help message
+#
+# Optional env vars:
+#   DOCKER_NETWORK  Docker network mode for Docker build (e.g., `host`)
 
 set -o errexit
 set -o nounset

--- a/components/core/tools/packaging/build.sh
+++ b/components/core/tools/packaging/build.sh
@@ -269,6 +269,7 @@ for cur_format in "${format_list[@]}"; do
                 --platform "${docker_platform}" \
                 --build-arg "BASE_IMAGE=${base_image_tag}" \
                 --tag "${builder_image}" \
+                ${DOCKER_NETWORK:+--network "${DOCKER_NETWORK}"} \
                 "${dockerfile_dir}" \
                 --file "${dockerfile_dir}/Dockerfile"
         fi
@@ -283,6 +284,7 @@ for cur_format in "${format_list[@]}"; do
         # Safe to overwrite CFLAGS/CXXFLAGS since the container has no prior flags.
         docker run --rm \
             --platform "${docker_platform}" \
+            ${DOCKER_NETWORK:+--network "${DOCKER_NETWORK}"} \
             -v "${repo_root}:/clp" \
             -w /clp \
             -e "CORES=${cores}" \


### PR DESCRIPTION
# Description

Propagates `DOCKER_NETWORK` to the Docker commands used by `components/core/tools/packaging/build.sh`.

The base dependency image build scripts already support `DOCKER_NETWORK`, but the packaging flow did not pass it to:

* the packaging builder image `docker build`
* the package build `docker run`

This allows callers to use settings like `DOCKER_NETWORK=host` when package builds need host-network DNS or proxy access. If `DOCKER_NETWORK` is unset or empty, the Docker commands keep their existing default networking behavior.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Ran `components/core/tools/packaging/build.sh --format deb` in a restricted corporate network environment with `DOCKER_NETWORK=host` and verified that Debian packages were generated successfully. Also verified that leaving `DOCKER_NETWORK` unset preserves the existing Docker default networking behavior.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build tooling now accepts an optional DOCKER_NETWORK environment variable; when set, the network is applied to both image build and container run steps to enable custom Docker networking during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->