### PR TITLE
chore(clp-rust-utils): Replace deprecated `serde_yaml` with `yaml_serde` (resolves #2311).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,13 +922,13 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml",
  "sqlx",
  "strum",
  "thiserror",
  "tracing-appender",
  "tracing-subscriber",
  "utoipa",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -2182,6 +2182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,19 +3223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serial_test"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,12 +4082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4629,6 +4616,19 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "yoke"

--- a/components/clp-rust-utils/Cargo.toml
+++ b/components/clp-rust-utils/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.12.3"
 rmp-serde = "1.3.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
-yaml_serde = "0.10"
+yaml_serde = "=0.10.4"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "mysql"] }
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"

--- a/components/clp-rust-utils/Cargo.toml
+++ b/components/clp-rust-utils/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.12.3"
 rmp-serde = "1.3.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_yaml = "0.9.34"
+yaml_serde = "0.10"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "mysql"] }
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"

--- a/components/clp-rust-utils/Cargo.toml
+++ b/components/clp-rust-utils/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.12.3"
 rmp-serde = "1.3.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
-yaml_serde = "=0.10.4"
+yaml_serde = "0.10.4"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "mysql"] }
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"

--- a/components/clp-rust-utils/src/error.rs
+++ b/components/clp-rust-utils/src/error.rs
@@ -8,8 +8,8 @@ pub enum Error {
     #[error("`std::io::Error`: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("`serde_yaml::Error`: {0}")]
-    SerdeYaml(#[from] serde_yaml::Error),
+    #[error("`yaml_serde::Error`: {0}")]
+    SerdeYaml(#[from] yaml_serde::Error),
 
     #[error("`sqlx::Error`: {0}")]
     Sqlx(#[from] sqlx::Error),

--- a/components/clp-rust-utils/src/serde/yaml.rs
+++ b/components/clp-rust-utils/src/serde/yaml.rs
@@ -14,8 +14,8 @@ use crate::Error;
 /// Returns an [`Error`] if:
 ///
 /// * Forwards [`std::fs::File::open`]'s return values on failure.
-/// * Forwards [`serde_yaml::from_reader`]'s return values on failure.
+/// * Forwards [`yaml_serde::from_reader`]'s return values on failure.
 pub fn from_path<T: DeserializeOwned, P: AsRef<std::path::Path>>(path: P) -> Result<T, Error> {
     let file = std::fs::File::open(path)?;
-    Ok(serde_yaml::from_reader(file)?)
+    Ok(yaml_serde::from_reader(file)?)
 }


### PR DESCRIPTION
# Description

## Problem
The `serde_yaml` crate (v0.9.34) used in `clp-rust-utils` is deprecated and no longer maintained — the original repository has been archived by its author. The official YAML organization has forked it as [`yaml_serde`](https://github.com/yaml/yaml-serde) (crate name `yaml_serde`, v0.10.4), which continues active development under the `yaml` GitHub org. Using the unmaintained `serde_yaml` crate poses a supply-chain risk since it will not receive security patches or bug fixes.

## Solution
Replace the `serde_yaml` dependency with `yaml_serde` and update all references:

- https://github.com/y-scope/clp/blob/1b4df74091c030b6f080ca6af4fca80bb7173511/components/clp-rust-utils/Cargo.toml#L17 — change `serde_yaml = "0.9.34"` to `yaml_serde = "0.10"`
- https://github.com/y-scope/clp/blob/1b4df74091c030b6f080ca6af4fca80bb7173511/components/clp-rust-utils/src/error.rs#L11-L12 — update `serde_yaml::Error` → `yaml_serde::Error` in the error variant display string and `#[from]` derivation
- https://github.com/y-scope/clp/blob/1b4df74091c030b6f080ca6af4fca80bb7173511/components/clp-rust-utils/src/serde/yaml.rs#L17-L20 — update `serde_yaml::from_reader` → `yaml_serde::from_reader` in doc comment and call site

No behavioural changes — `yaml_serde` is a direct continuation of `serde_yaml` with full API compatibility.

# Impact Assessment

**Affected component**: `clp-rust-utils` crate — the only workspace crate that depends on `serde_yaml`/`yaml_serde`.

**Why needed**: The `serde_yaml` crate (v0.9.34) is deprecated and archived. It will not receive any future security patches or bug fixes, creating a supply-chain risk for the project.

**Implications**:
- The `yaml_serde` crate (v0.10.4) is the official fork maintained by the YAML organization and is API-compatible with `serde_yaml` — all public types, traits, and functions map directly (`serde_yaml::from_reader` → `yaml_serde::from_reader`, `serde_yaml::Error` → `yaml_serde::Error`, etc.).
- The internal `Error::SerdeYaml` variant and its display string now reference `yaml_serde::Error` instead of `serde_yaml::Error`; this is a cosmetic change in error messages only.
- `Cargo.lock` is updated to replace the `serde_yaml` dependency tree with `yaml_serde` + `libyaml-rs` (the new underlying YAML parser, replacing `unsafe-libyaml`).

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

### Unit & integration tests

**Task**: Verify all existing tests pass with the `yaml_serde` crate replacement.

**Command**:
```bash
cargo test -p clp-rust-utils
```

**Output**:
```
running 5 tests
test clp_config::package::config::tests::deserialize_logs_input_fs_config ... ok
test clp_config::package::config::tests::deserialize_logs_input_s3_default_config ... ok
test clp_config::package::config::tests::deserialize_logs_input_s3_config ... ok
test job_config::ingestion::tests::test_buffer_config_empty_object_uses_defaults ... ok
test job_config::ingestion::tests::test_buffer_config_partial_override ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 1 test
test test_clp_io_config_serialization ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 1 test
test test_s3_event_deserialization ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

**Explanation**: All 7 tests (5 unit, 1 config integration, 1 SQS integration) pass, confirming the crate swap is transparent to consumers.

### Full workspace build & package

**Task**: Verify the entire CLP package builds successfully with `yaml_serde`, including all Rust components that depend on `clp-rust-utils`.

**Command**:
```bash
task
```

**Output** (relevant excerpt):
```
   Compiling yaml_serde v0.10.4
   Compiling clp-rust-utils v0.12.1-dev (/home/junhao/workspace/clp/components/clp-rust-utils)
   Compiling api-server v0.12.1-dev (/home/junhao/workspace/clp/components/api-server)
   Compiling log-ingestor v0.12.1-dev (/home/junhao/workspace/clp/components/log-ingestor)
    Finished `release` profile [optimized] target(s) in 2m 48s
```

**Explanation**: The full build (C++ core + Rust components + Docker image packaging) completes successfully, confirming that `yaml_serde` integrates properly across the entire workspace.

### CLP package runtime validation

**Task**: Verify the package starts correctly and can compress logs.

**Command**:
```bash
cd build/clp-package
CLP_DB_PASS=test ./sbin/start-clp.sh
```

**Output**:
```
Traceback (most recent call last):
  ...
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

**Explanation**: This same error occurs on the unmodified `main` branch (verified by checking out `origin/main` and running the same command). It is a pre-existing `pydantic_core` environment issue inside the Docker container, unrelated to the `serde_yaml` → `yaml_serde` change. Since the Rust binaries (`api_server`, `log-ingestor`) that depend on `clp-rust-utils` compiled and linked successfully, and all unit/integration tests pass, the crate migration is validated.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the YAML serialization backend to a newer library and updated related error handling. No public API or surface changes; intended to maintain existing YAML read/write behaviour while moving to the new serialization implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->