### PR TITLE
fix(core): Add timeout to build_and_run_unit_tests.py script.

### DIFF
--- a/components/core/tools/scripts/utils/build-and-run-unit-tests.py
+++ b/components/core/tools/scripts/utils/build-and-run-unit-tests.py
@@ -25,7 +25,7 @@ root_logger.addHandler(logging_console_handler)
 logger = logging.getLogger(__name__)
 
 # One hour timeout to prevent changes with infinite loops from running forever
-UNIT_TEST_TIMEOUT = 60 * 60
+UNIT_TEST_TIMEOUT_SECONDS = 60 * 60
 
 
 def _config_cmake_project(src_dir: Path, build_dir: Path, use_shared_libs: bool) -> None:
@@ -67,7 +67,7 @@ def _run_unit_tests(build_dir: Path, test_spec: str | None) -> None:
     ]
     if test_spec is not None:
         cmd.append(test_spec)
-    subprocess.run(cmd, cwd=build_dir, check=True, timeout=UNIT_TEST_TIMEOUT)
+    subprocess.run(cmd, cwd=build_dir, check=True, timeout=UNIT_TEST_TIMEOUT_SECONDS)
 
 
 def main(argv: list[str]) -> int:

--- a/components/core/tools/scripts/utils/build-and-run-unit-tests.py
+++ b/components/core/tools/scripts/utils/build-and-run-unit-tests.py
@@ -24,6 +24,9 @@ root_logger.addHandler(logging_console_handler)
 # Create logger
 logger = logging.getLogger(__name__)
 
+# One hour timeout to prevent changes with infinite loops from running forever
+UNIT_TEST_TIMEOUT = 60 * 60
+
 
 def _config_cmake_project(src_dir: Path, build_dir: Path, use_shared_libs: bool) -> None:
     cmd = [
@@ -64,7 +67,7 @@ def _run_unit_tests(build_dir: Path, test_spec: str | None) -> None:
     ]
     if test_spec is not None:
         cmd.append(test_spec)
-    subprocess.run(cmd, cwd=build_dir, check=True)
+    subprocess.run(cmd, cwd=build_dir, check=True, timeout=UNIT_TEST_TIMEOUT)
 
 
 def main(argv: list[str]) -> int:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds a timeout to the unit tests subprocess launched by the `build_and_run_unit_tests.py` script to prevent tests on branches that introduce infinite loops from running forever. It seems like this has been an issue recently, since I noticed several instances of this script that had been running for days with their unitTest process consuming 100% of the CPU on one of our servers.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that unit tests run succesfully
* Validated that the timeout triggers succesfully and throws a TimeoutExpired exception (by modifying the timeout to 1 second)


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unit test execution now enforces a one-hour timeout to prevent indefinite or runaway test runs. This ensures test suites that hang are terminated automatically, improving CI stability and resource predictability while preserving normal test behavior for tests completing within the configured limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->