### PR TITLE
feat(helm)!: Replace global `workerConcurrency` with per-worker `slotsPerPod` concurrency settings (resolves #2297).

### DIFF
--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -216,8 +216,14 @@ image:
     repository: "bitnami/kubectl"
     digest: "sha256:98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"  # v1.36.0
 
-# Adjust worker concurrency
-workerConcurrency: 16
+# Adjust worker concurrency per component
+scheduling:
+  compressionWorker:
+    slotsPerPod: 16
+  queryWorker:
+    slotsPerPod: 16
+  reducer:
+    slotsPerPod: 16
 
 # Configure CLP settings
 clpConfig:

--- a/docs/src/user-docs/guides-k8s-deployment.md
+++ b/docs/src/user-docs/guides-k8s-deployment.md
@@ -216,7 +216,7 @@ image:
     repository: "bitnami/kubectl"
     digest: "sha256:98736aabcecb8d3cbcdcd7b132d14b1d67ed99bac2f06d471f06235933103df3"  # v1.36.0
 
-# Adjust worker concurrency per component
+# Adjust worker concurrency
 scheduling:
   compressionWorker:
     slotsPerPod: 16

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.3.2-dev.11"
+version: "0.3.2-dev.12"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.12.1-dev"

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -97,9 +97,9 @@ in controller.py, ensuring feature parity between Docker Compose and Helm deploy
 {{- $compressionWorkerReplicas := $compressionWorkerScheduling.replicas | default 1 | int -}}
 {{- $queryWorkerReplicas := .Values.scheduling.queryWorker.replicas | default 1 | int -}}
 {{- $reducerReplicas := .Values.scheduling.reducer.replicas | default 1 | int -}}
-{{- $compressionWorkerConcurrency := include "clp.compressionWorkerConcurrency" . | default 8 | int -}}
-{{- $queryWorkerConcurrency := include "clp.queryWorkerConcurrency" . | default 8 | int -}}
-{{- $reducerConcurrency := include "clp.reducerConcurrency" . | default 8 | int -}}
+{{- $compressionWorkerConcurrency := include "clp.compressionWorkerConcurrency" . | int -}}
+{{- $queryWorkerConcurrency := include "clp.queryWorkerConcurrency" . | int -}}
+{{- $reducerConcurrency := include "clp.reducerConcurrency" . | int -}}
 {{- printf `{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"controller"}}]},"scopeMetrics":[{"scope":{"name":"clp.controller"},"metrics":[{"name":"clp.deployment.compression_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.compression_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}}]}]}]}` $compressionWorkerReplicas $timestampNs $compressionWorkerConcurrency $timestampNs $queryWorkerReplicas $timestampNs $queryWorkerConcurrency $timestampNs $reducerReplicas $timestampNs $reducerConcurrency $timestampNs -}}
 {{- end -}}
 
@@ -110,7 +110,12 @@ Gets the effective concurrency for the compression worker.
 @return {string} The effective concurrency
 */}}
 {{- define "clp.compressionWorkerConcurrency" -}}
-{{- coalesce .Values.scheduling.compressionWorker.slotsPerPod .Values.workerConcurrency -}}
+{{- $slots := .Values.scheduling.compressionWorker.slotsPerPod -}}
+{{- if eq (typeOf $slots) "<nil>" -}}
+{{- .Values.workerConcurrency | default 8 -}}
+{{- else -}}
+{{- $slots -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -120,7 +125,12 @@ Gets the effective concurrency for the query worker.
 @return {string} The effective concurrency
 */}}
 {{- define "clp.queryWorkerConcurrency" -}}
-{{- coalesce .Values.scheduling.queryWorker.slotsPerPod .Values.workerConcurrency -}}
+{{- $slots := .Values.scheduling.queryWorker.slotsPerPod -}}
+{{- if eq (typeOf $slots) "<nil>" -}}
+{{- .Values.workerConcurrency | default 8 -}}
+{{- else -}}
+{{- $slots -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -130,7 +140,12 @@ Gets the effective concurrency for the reducer.
 @return {string} The effective concurrency
 */}}
 {{- define "clp.reducerConcurrency" -}}
-{{- coalesce .Values.scheduling.reducer.slotsPerPod .Values.workerConcurrency -}}
+{{- $slots := .Values.scheduling.reducer.slotsPerPod -}}
+{{- if eq (typeOf $slots) "<nil>" -}}
+{{- .Values.workerConcurrency | default 8 -}}
+{{- else -}}
+{{- $slots -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -97,9 +97,41 @@ in controller.py, ensuring feature parity between Docker Compose and Helm deploy
 {{- $compressionWorkerReplicas := $compressionWorkerScheduling.replicas | default 1 | int -}}
 {{- $queryWorkerReplicas := .Values.scheduling.queryWorker.replicas | default 1 | int -}}
 {{- $reducerReplicas := .Values.scheduling.reducer.replicas | default 1 | int -}}
-{{- $workerConcurrency := .Values.workerConcurrency | default 8 | int -}}
-{{- printf `{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"controller"}}]},"scopeMetrics":[{"scope":{"name":"clp.controller"},"metrics":[{"name":"clp.deployment.compression_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.compression_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}}]}]}]}` $compressionWorkerReplicas $timestampNs $workerConcurrency $timestampNs $queryWorkerReplicas $timestampNs $workerConcurrency $timestampNs $reducerReplicas $timestampNs $workerConcurrency $timestampNs -}}
+{{- $compressionWorkerConcurrency := include "clp.compressionWorkerConcurrency" . | default 8 | int -}}
+{{- $queryWorkerConcurrency := include "clp.queryWorkerConcurrency" . | default 8 | int -}}
+{{- $reducerConcurrency := include "clp.reducerConcurrency" . | default 8 | int -}}
+{{- printf `{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"controller"}}]},"scopeMetrics":[{"scope":{"name":"clp.controller"},"metrics":[{"name":"clp.deployment.compression_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.compression_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}}]}]}]}` $compressionWorkerReplicas $timestampNs $compressionWorkerConcurrency $timestampNs $queryWorkerReplicas $timestampNs $queryWorkerConcurrency $timestampNs $reducerReplicas $timestampNs $reducerConcurrency $timestampNs -}}
 {{- end -}}
+
+{{/*
+Gets the effective concurrency for the compression worker.
+
+@param {object} . Root template context
+@return {string} The effective concurrency
+*/}}
+{{- define "clp.compressionWorkerConcurrency" -}}
+{{- coalesce .Values.scheduling.compressionWorker.slotsPerPod .Values.workerConcurrency -}}
+{{- end }}
+
+{{/*
+Gets the effective concurrency for the query worker.
+
+@param {object} . Root template context
+@return {string} The effective concurrency
+*/}}
+{{- define "clp.queryWorkerConcurrency" -}}
+{{- coalesce .Values.scheduling.queryWorker.slotsPerPod .Values.workerConcurrency -}}
+{{- end }}
+
+{{/*
+Gets the effective concurrency for the reducer.
+
+@param {object} . Root template context
+@return {string} The effective concurrency
+*/}}
+{{- define "clp.reducerConcurrency" -}}
+{{- coalesce .Values.scheduling.reducer.slotsPerPod .Values.workerConcurrency -}}
+{{- end }}
 
 {{/*
 Provides environment variables for telemetry (except service.name).

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -97,56 +97,11 @@ in controller.py, ensuring feature parity between Docker Compose and Helm deploy
 {{- $compressionWorkerReplicas := $compressionWorkerScheduling.replicas | default 1 | int -}}
 {{- $queryWorkerReplicas := .Values.scheduling.queryWorker.replicas | default 1 | int -}}
 {{- $reducerReplicas := .Values.scheduling.reducer.replicas | default 1 | int -}}
-{{- $compressionWorkerConcurrency := include "clp.compressionWorkerConcurrency" . | int -}}
-{{- $queryWorkerConcurrency := include "clp.queryWorkerConcurrency" . | int -}}
-{{- $reducerConcurrency := include "clp.reducerConcurrency" . | int -}}
+{{- $compressionWorkerConcurrency := .Values.scheduling.compressionWorker.slotsPerPod | int -}}
+{{- $queryWorkerConcurrency := .Values.scheduling.queryWorker.slotsPerPod | int -}}
+{{- $reducerConcurrency := .Values.scheduling.reducer.slotsPerPod | int -}}
 {{- printf `{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"controller"}}]},"scopeMetrics":[{"scope":{"name":"clp.controller"},"metrics":[{"name":"clp.deployment.compression_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.compression_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}}]}]}]}` $compressionWorkerReplicas $timestampNs $compressionWorkerConcurrency $timestampNs $queryWorkerReplicas $timestampNs $queryWorkerConcurrency $timestampNs $reducerReplicas $timestampNs $reducerConcurrency $timestampNs -}}
 {{- end -}}
-
-{{/*
-Gets the effective concurrency for the compression worker.
-
-@param {object} . Root template context
-@return {string} The effective concurrency
-*/}}
-{{- define "clp.compressionWorkerConcurrency" -}}
-{{- $slots := .Values.scheduling.compressionWorker.slotsPerPod -}}
-{{- if eq (typeOf $slots) "<nil>" -}}
-{{- .Values.workerConcurrency | default 8 -}}
-{{- else -}}
-{{- $slots -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Gets the effective concurrency for the query worker.
-
-@param {object} . Root template context
-@return {string} The effective concurrency
-*/}}
-{{- define "clp.queryWorkerConcurrency" -}}
-{{- $slots := .Values.scheduling.queryWorker.slotsPerPod -}}
-{{- if eq (typeOf $slots) "<nil>" -}}
-{{- .Values.workerConcurrency | default 8 -}}
-{{- else -}}
-{{- $slots -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Gets the effective concurrency for the reducer.
-
-@param {object} . Root template context
-@return {string} The effective concurrency
-*/}}
-{{- define "clp.reducerConcurrency" -}}
-{{- $slots := .Values.scheduling.reducer.slotsPerPod -}}
-{{- if eq (typeOf $slots) "<nil>" -}}
-{{- .Values.workerConcurrency | default 8 -}}
-{{- else -}}
-{{- $slots -}}
-{{- end -}}
-{{- end }}
 
 {{/*
 Provides environment variables for telemetry (except service.name).

--- a/tools/deployment/package-helm/templates/_helpers.tpl
+++ b/tools/deployment/package-helm/templates/_helpers.tpl
@@ -97,10 +97,37 @@ in controller.py, ensuring feature parity between Docker Compose and Helm deploy
 {{- $compressionWorkerReplicas := $compressionWorkerScheduling.replicas | default 1 | int -}}
 {{- $queryWorkerReplicas := .Values.scheduling.queryWorker.replicas | default 1 | int -}}
 {{- $reducerReplicas := .Values.scheduling.reducer.replicas | default 1 | int -}}
-{{- $compressionWorkerConcurrency := .Values.scheduling.compressionWorker.slotsPerPod | int -}}
-{{- $queryWorkerConcurrency := .Values.scheduling.queryWorker.slotsPerPod | int -}}
-{{- $reducerConcurrency := .Values.scheduling.reducer.slotsPerPod | int -}}
+{{- $compressionWorkerConcurrency := include "clp.schedulingSlotsPerPod" (dict
+  "root" .
+  "component" "compressionWorker"
+) | int -}}
+{{- $queryWorkerConcurrency := include "clp.schedulingSlotsPerPod" (dict
+  "root" .
+  "component" "queryWorker"
+) | int -}}
+{{- $reducerConcurrency := include "clp.schedulingSlotsPerPod" (dict
+  "root" .
+  "component" "reducer"
+) | int -}}
 {{- printf `{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"controller"}}]},"scopeMetrics":[{"scope":{"name":"clp.controller"},"metrics":[{"name":"clp.deployment.compression_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.compression_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.query_worker_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_replicas","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}},{"name":"clp.deployment.reducer_concurrency","gauge":{"dataPoints":[{"asInt":"%d","timeUnixNano":"%d"}]}}]}]}]}` $compressionWorkerReplicas $timestampNs $compressionWorkerConcurrency $timestampNs $queryWorkerReplicas $timestampNs $queryWorkerConcurrency $timestampNs $reducerReplicas $timestampNs $reducerConcurrency $timestampNs -}}
+{{- end -}}
+
+{{/*
+Gets the effective slot count for a worker-like component.
+
+The `slotsPerPod` value is required for each component.
+
+@param {object} root Template context
+@param {string} component One of compressionWorker/queryWorker/reducer
+@return {int} Slot count for the component
+*/}}
+{{- define "clp.schedulingSlotsPerPod" -}}
+{{- $scheduling := index .root.Values.scheduling .component -}}
+{{- $slotsPerPod := $scheduling.slotsPerPod -}}
+{{- if not (hasKey $scheduling "slotsPerPod") -}}
+{{- fail (printf "scheduling.%s.slotsPerPod is required" .component) -}}
+{{- end -}}
+{{- $slotsPerPod | int -}}
 {{- end -}}
 
 {{/*

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -84,7 +84,10 @@ spec:
             "/opt/clp/lib/python3/site-packages/bin/celery",
             "-A", "job_orchestration.executor.compress",
             "worker",
-            "--concurrency", "{{ .Values.scheduling.compressionWorker.slotsPerPod }}",
+            "--concurrency", "{{ include "clp.schedulingSlotsPerPod" (dict
+              "root" .
+              "component" "compressionWorker"
+            ) }}",
             "--loglevel", "WARNING",
             "-Q", "compression",
             "-n", "compression-worker@%h"

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -84,7 +84,7 @@ spec:
             "/opt/clp/lib/python3/site-packages/bin/celery",
             "-A", "job_orchestration.executor.compress",
             "worker",
-            "--concurrency", "{{ .Values.workerConcurrency }}",
+            "--concurrency", "{{ include "clp.compressionWorkerConcurrency" . }}",
             "--loglevel", "WARNING",
             "-Q", "compression",
             "-n", "compression-worker@%h"

--- a/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/compression-worker-deployment.yaml
@@ -84,7 +84,7 @@ spec:
             "/opt/clp/lib/python3/site-packages/bin/celery",
             "-A", "job_orchestration.executor.compress",
             "worker",
-            "--concurrency", "{{ include "clp.compressionWorkerConcurrency" . }}",
+            "--concurrency", "{{ .Values.scheduling.compressionWorker.slotsPerPod }}",
             "--loglevel", "WARNING",
             "-Q", "compression",
             "-n", "compression-worker@%h"

--- a/tools/deployment/package-helm/templates/query-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-worker-deployment.yaml
@@ -84,7 +84,7 @@ spec:
             "/opt/clp/lib/python3/site-packages/bin/celery",
             "-A", "job_orchestration.executor.query",
             "worker",
-            "--concurrency", "{{ include "clp.queryWorkerConcurrency" . }}",
+            "--concurrency", "{{ .Values.scheduling.queryWorker.slotsPerPod }}",
             "--loglevel", "WARNING",
             "-Q", "query",
             "-n", "query-worker@%h"

--- a/tools/deployment/package-helm/templates/query-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-worker-deployment.yaml
@@ -84,7 +84,10 @@ spec:
             "/opt/clp/lib/python3/site-packages/bin/celery",
             "-A", "job_orchestration.executor.query",
             "worker",
-            "--concurrency", "{{ .Values.scheduling.queryWorker.slotsPerPod }}",
+            "--concurrency", "{{ include "clp.schedulingSlotsPerPod" (dict
+              "root" .
+              "component" "queryWorker"
+            ) }}",
             "--loglevel", "WARNING",
             "-Q", "query",
             "-n", "query-worker@%h"

--- a/tools/deployment/package-helm/templates/query-worker-deployment.yaml
+++ b/tools/deployment/package-helm/templates/query-worker-deployment.yaml
@@ -84,7 +84,7 @@ spec:
             "/opt/clp/lib/python3/site-packages/bin/celery",
             "-A", "job_orchestration.executor.query",
             "worker",
-            "--concurrency", "{{ .Values.workerConcurrency }}",
+            "--concurrency", "{{ include "clp.queryWorkerConcurrency" . }}",
             "--loglevel", "WARNING",
             "-Q", "query",
             "-n", "query-worker@%h"

--- a/tools/deployment/package-helm/templates/reducer-deployment.yaml
+++ b/tools/deployment/package-helm/templates/reducer-deployment.yaml
@@ -53,7 +53,10 @@ spec:
             "python3", "-u",
             "-m", "job_orchestration.reducer.reducer",
             "--config", "/etc/clp-config.yaml",
-            "--concurrency", "{{ .Values.scheduling.reducer.slotsPerPod }}",
+            "--concurrency", "{{ include "clp.schedulingSlotsPerPod" (dict
+              "root" .
+              "component" "reducer"
+            ) }}",
             "--upsert-interval", "{{ .Values.clpConfig.reducer.upsert_interval }}"
           ]
       volumes:

--- a/tools/deployment/package-helm/templates/reducer-deployment.yaml
+++ b/tools/deployment/package-helm/templates/reducer-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             "python3", "-u",
             "-m", "job_orchestration.reducer.reducer",
             "--config", "/etc/clp-config.yaml",
-            "--concurrency", "{{ .Values.workerConcurrency }}",
+            "--concurrency", "{{ include "clp.reducerConcurrency" . }}",
             "--upsert-interval", "{{ .Values.clpConfig.reducer.upsert_interval }}"
           ]
       volumes:

--- a/tools/deployment/package-helm/templates/reducer-deployment.yaml
+++ b/tools/deployment/package-helm/templates/reducer-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             "python3", "-u",
             "-m", "job_orchestration.reducer.reducer",
             "--config", "/etc/clp-config.yaml",
-            "--concurrency", "{{ include "clp.reducerConcurrency" . }}",
+            "--concurrency", "{{ .Values.scheduling.reducer.slotsPerPod }}",
             "--upsert-interval", "{{ .Values.clpConfig.reducer.upsert_interval }}"
           ]
       volumes:

--- a/tools/deployment/package-helm/templates/reducer-service.yaml
+++ b/tools/deployment/package-helm/templates/reducer-service.yaml
@@ -12,7 +12,7 @@ spec:
     {{- include "clp.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "reducer"
   ports:
-    {{- range $i := until (int .Values.workerConcurrency) }}
+    {{- range $i := until (int (include "clp.reducerConcurrency" .)) }}
     - name: "reducer-{{ $i }}"
       port: {{ add 14009 $i }}
     {{- end }}

--- a/tools/deployment/package-helm/templates/reducer-service.yaml
+++ b/tools/deployment/package-helm/templates/reducer-service.yaml
@@ -12,7 +12,11 @@ spec:
     {{- include "clp.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "reducer"
   ports:
-    {{- range $i := until (int .Values.scheduling.reducer.slotsPerPod) }}
+    {{- $reducerSlotsPerPod := include "clp.schedulingSlotsPerPod" (dict
+      "root" .
+      "component" "reducer"
+    ) | int }}
+    {{- range $i := until $reducerSlotsPerPod }}
     - name: "reducer-{{ $i }}"
       port: {{ add 14009 $i }}
     {{- end }}

--- a/tools/deployment/package-helm/templates/reducer-service.yaml
+++ b/tools/deployment/package-helm/templates/reducer-service.yaml
@@ -12,7 +12,7 @@ spec:
     {{- include "clp.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "reducer"
   ports:
-    {{- range $i := until (int (include "clp.reducerConcurrency" .)) }}
+    {{- range $i := until (int .Values.scheduling.reducer.slotsPerPod) }}
     - name: "reducer-{{ $i }}"
       port: {{ add 14009 $i }}
     {{- end }}

--- a/tools/deployment/package-helm/templates/service-account.yaml
+++ b/tools/deployment/package-helm/templates/service-account.yaml
@@ -1,9 +1,3 @@
-{{/*
-Fail fast if the deprecated workerConcurrency setting is used.
-*/}}
-{{- if hasKey .Values "workerConcurrency" -}}
-{{- fail "The global 'workerConcurrency' setting has been removed. Please use 'slotsPerPod' under 'scheduling.compressionWorker', 'scheduling.queryWorker', and 'scheduling.reducer' instead." -}}
-{{- end -}}
 apiVersion: "v1"
 kind: "ServiceAccount"
 metadata:

--- a/tools/deployment/package-helm/templates/service-account.yaml
+++ b/tools/deployment/package-helm/templates/service-account.yaml
@@ -1,3 +1,9 @@
+{{/*
+Fail fast if the deprecated workerConcurrency setting is used.
+*/}}
+{{- if hasKey .Values "workerConcurrency" -}}
+{{- fail "The global 'workerConcurrency' setting has been removed. Please use 'slotsPerPod' under 'scheduling.compressionWorker', 'scheduling.queryWorker', and 'scheduling.reducer' instead." -}}
+{{- end -}}
 apiVersion: "v1"
 kind: "ServiceAccount"
 metadata:

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -60,8 +60,7 @@ image:
 #     the same path).
 distributedDeployment: false
 
-# Number of concurrent processes per worker pod.
-workerConcurrency: 8
+
 
 # Per-component node scheduling and replica config.
 # Each component accepts: replicas (workers only), nodeSelector, affinity, tolerations,
@@ -86,13 +85,13 @@ scheduling:
   # Worker
   compressionWorker:
     replicas: 1
-    # slotsPerPod: 8
+    slotsPerPod: 8
   queryWorker:
     replicas: 1
-    # slotsPerPod: 2
+    slotsPerPod: 8
   reducer:
     replicas: 1
-    # slotsPerPod: 2
+    slotsPerPod: 8
   prestoWorker:
     replicas: 1
 

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -60,8 +60,6 @@ image:
 #     the same path).
 distributedDeployment: false
 
-
-
 # Per-component node scheduling and replica config.
 # Each component accepts: replicas (workers only), nodeSelector, affinity, tolerations,
 # topologySpreadConstraints.

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -86,10 +86,13 @@ scheduling:
   # Worker
   compressionWorker:
     replicas: 1
+    # slotsPerPod: 8
   queryWorker:
     replicas: 1
+    # slotsPerPod: 2
   reducer:
     replicas: 1
+    # slotsPerPod: 2
   prestoWorker:
     replicas: 1
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Currently, the Helm chart uses one global `workerConcurrency` setting for all worker types. Since compression workers, query workers, and reducers have different CPU and memory requirements, this makes cluster scaling difficult.

This PR replaces `workerConcurrency` with `slotsPerPod` setting for each worker type under `scheduling`, allowing `compressionWorker`, `queryWorker`, and `reducer` pods to be tuned independently for better resource utilization.

**Breaking changes:** `workerConcurrency` is removed. Any existing `values.yaml` or --set command-line overrides using `workerConcurrency` will be ignored and must be migrated to `scheduling.<worker>.slotsPerPod`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

```console
nathanhung@baker18:~/clp$ helm template test-clp ./tools/deployment/package-helm | grep -E "concurrency|port: 140"
      scheduler_concurrency: 4
      base_port: 14009
      port: 14009
      port: 14010
      port: 14011
      port: 14012
      port: 14013
      port: 14014
      port: 14015
      port: 14016
            "--concurrency", "8",
            "--concurrency", "8",
            "--concurrency", "8",
            - "{\"resourceMetrics\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"controller\"}}]},\"scopeMetrics\":[{\"scope\":{\"name\":\"clp.controller\"},\"metrics\":[{\"name\":\"clp.deployment.compression_worker_replicas\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"1\",\"timeUnixNano\":\"1781210113912693342\"}]}},{\"name\":\"clp.deployment.compression_worker_concurrency\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"8\",\"timeUnixNano\":\"1781210113912693342\"}]}},{\"name\":\"clp.deployment.query_worker_replicas\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"1\",\"timeUnixNano\":\"1781210113912693342\"}]}},{\"name\":\"clp.deployment.query_worker_concurrency\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"8\",\"timeUnixNano\":\"1781210113912693342\"}]}},{\"name\":\"clp.deployment.reducer_replicas\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"1\",\"timeUnixNano\":\"1781210113912693342\"}]}},{\"name\":\"clp.deployment.reducer_concurrency\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"8\",\"timeUnixNano\":\"1781210113912693342\"}]}}]}]}]}"
nathanhung@baker18:~/clp$ helm template test-clp ./tools/deployment/package-helm \
  --set scheduling.compressionWorker.slotsPerPod=4 \
  --set scheduling.queryWorker.slotsPerPod=2 \
  --set scheduling.reducer.slotsPerPod=1 | grep -E "concurrency|port: 140"
      scheduler_concurrency: 4
      base_port: 14009
      port: 14009
            "--concurrency", "4",
            "--concurrency", "2",
            "--concurrency", "1",
            - "{\"resourceMetrics\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"controller\"}}]},\"scopeMetrics\":[{\"scope\":{\"name\":\"clp.controller\"},\"metrics\":[{\"name\":\"clp.deployment.compression_worker_replicas\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"1\",\"timeUnixNano\":\"1781210117375789593\"}]}},{\"name\":\"clp.deployment.compression_worker_concurrency\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"4\",\"timeUnixNano\":\"1781210117375789593\"}]}},{\"name\":\"clp.deployment.query_worker_replicas\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"1\",\"timeUnixNano\":\"1781210117375789593\"}]}},{\"name\":\"clp.deployment.query_worker_concurrency\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"2\",\"timeUnixNano\":\"1781210117375789593\"}]}},{\"name\":\"clp.deployment.reducer_replicas\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"1\",\"timeUnixNano\":\"1781210117375789593\"}]}},{\"name\":\"clp.deployment.reducer_concurrency\",\"gauge\":{\"dataPoints\":[{\"asInt\":\"1\",\"timeUnixNano\":\"1781210117375789593\"}]}}]}]}]}"
nathanhung@baker18:~/clp$ helm template test-clp ./tools/deployment/package-helm \
  --set workerConcurrency=8
Error: execution error at (clp/templates/service-account.yaml:5:4): The global 'workerConcurrency' setting has been removed. Please use 'slotsPerPod' under 'scheduling.compressionWorker', 'scheduling.queryWorker', and 'scheduling.reducer' instead.

Use --debug flag to render out invalid YAML
```


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now supports separate concurrency (per-worker slots) for compression, query, and reducer workers for finer-grained resource allocation.
  * Runtime metrics, service port generation and deployed worker concurrency now reflect per-worker settings for more accurate behaviour and telemetry.
  * Chart version advanced to the next development release.

* **Documentation**
  * Kubernetes deployment guide example updated to show the new per-worker scheduling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->