### PR TITLE
fix(webui): Use `from_unixtime` in `WHERE` clause for sargable timestamp predicates (resolves #2321).

### DIFF
--- a/components/webui/client/src/sql-parser/index.ts
+++ b/components/webui/client/src/sql-parser/index.ts
@@ -157,9 +157,9 @@ const buildSearchQuery = ({
     timestampKey,
 }: BuildSearchQueryProps): string => {
     let queryString = `SELECT ${selectItemList} FROM ${databaseName}
-WHERE to_unixtime(${timestampKey}) BETWEEN
-${startTimestamp.valueOf() / MILLISECONDS_PER_SECOND}
-AND ${endTimestamp.valueOf() / MILLISECONDS_PER_SECOND}`;
+WHERE ${timestampKey} BETWEEN
+from_unixtime(${startTimestamp.valueOf() / MILLISECONDS_PER_SECOND})
+AND from_unixtime(${endTimestamp.valueOf() / MILLISECONDS_PER_SECOND})`;
 
     if ("undefined" !== typeof booleanExpression) {
         queryString += ` AND (${booleanExpression})`;
@@ -214,9 +214,9 @@ const buildTimelineQuery = ({
             ${bucketCount}) AS idx,
         COUNT(*) AS cnt
     FROM ${databaseName}
-    WHERE to_unixtime(${timestampKey}) BETWEEN
-        ${startTimestamp.valueOf() / MILLISECONDS_PER_SECOND}
-        AND ${endTimestamp.valueOf() / MILLISECONDS_PER_SECOND}
+    WHERE ${timestampKey} BETWEEN
+        from_unixtime(${startTimestamp.valueOf() / MILLISECONDS_PER_SECOND})
+        AND from_unixtime(${endTimestamp.valueOf() / MILLISECONDS_PER_SECOND})
         ${booleanExpressionQuery}
     GROUP BY 1
     ORDER BY 1


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The WebUI SQL query builder generates WHERE clauses like:
```sql
  WHERE to_unixtime(date) BETWEEN 1718000000 AND 1718003600
```

This kind of query limits optimization opportunity for Presto because the function `to_unixtime()` confuses the Presto CLP connector to recognize `date` column is a timestamp column which can be used for split pruning. 

When the query lands on Presto, it makes below metadata database query which scans all archive:
```sql
 SELECT `id` FROM `clp_default_archives` WHERE 1 = 1
```

User have reported this poorly optimized metadata query can lead to 10min+ execution time in Presto.

To resolve the issue,  this PR changes the SQL syntax in the WebUI query builder to the sargable form recommended by Presto:
```sql
 WHERE date BETWEEN from_unixtime(1718000000) AND from_unixtime(1718003600)
```
Above Presto query leads to a more effective metadata database query:
```sql
 SELECT `id` FROM `clp_default_archives` WHERE 1 = 1 AND (end_timestamp >= 1718003600 AND begin_timestamp <= 1718000000)
```
# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

### Set up of the validation
clp-package v0.12.0, Presto image v0.10.0, compressed with cockroachdb dataset.

Presto is configured with below `split-filter.json` for reproducing the issue.

```json
 {
  "clp.default": [
    {
      "columnName": "timestamp",
      "customOptions": {
        "rangeMapping": {
          "lowerBound": "begin_timestamp",
          "upperBound": "end_timestamp"
        }
      }
    }
  ]
}
```

For both cases, I run below query through the webui
<img width="1754" height="665" alt="image" src="https://github.com/user-attachments/assets/2694671d-2630-41f0-ba66-6721e33bed61" />

### Behavior in current web UI
Presto scans 48 splits and takes 10.4s
```
2026-06-11T19:25:19.407Z	DEBUG	Query-20260611_193415_00017_veqfi-427	com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider	Query for archive: SELECT `id` FROM `clp_default_archives` WHERE 1 = 1

2026-06-11T19:25:19.414Z	DEBUG	Query-20260611_193415_00017_veqfi-427	com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider	Number of splits: 48`
```

### Behavior in new web UI
Presto scans 6 splits and takes 4.18s
```
2026-06-11T19:30:27.692Z	DEBUG	Query-20260611_193950_00029_veqfi-490	com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider	Query for archive: SELECT `id` FROM `clp_default_archives` WHERE 1 = 1 AND (end_timestamp >= 1679711280000 AND begin_timestamp <= 1679718480000)

2026-06-11T19:30:27.697Z	DEBUG	Query-20260611_193950_00029_veqfi-490	com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider	Number of splits: 6
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timestamp filtering accuracy in search queries and timeline views for more precise results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->