### PR TITLE
fix(log-ingestor): Don't update `start_after` key when no objects are scanned in a scanning cycle (fixes #2332).

### DIFF
--- a/components/log-ingestor/src/ingestion_job/s3_scanner.rs
+++ b/components/log-ingestor/src/ingestion_job/s3_scanner.rs
@@ -93,7 +93,7 @@ impl<S3ClientManager: AwsClientManagerType<Client>, State: IngestionJobState + S
             &client,
             &self.config.base.bucket_name,
             &self.config.base.key_prefix,
-            self.start_after.take(),
+            &self.start_after,
             async move |page: Vec<ObjectMetadata>| -> Result<(bool, NonEmptyString)> {
                 let last_ingested_key =
                     page.last().expect("`page` should not be empty").key.clone();
@@ -102,7 +102,11 @@ impl<S3ClientManager: AwsClientManagerType<Client>, State: IngestionJobState + S
             },
         )
         .await?;
-        self.start_after = last_scanned_key;
+        if last_scanned_key.is_some() {
+            // NOTE: We should only update the last scanned key if the current scan results in new
+            // objects ingested.
+            self.start_after = last_scanned_key;
+        }
         Ok(())
     }
 

--- a/components/log-ingestor/src/ingestion_job/scan.rs
+++ b/components/log-ingestor/src/ingestion_job/scan.rs
@@ -36,7 +36,7 @@ pub async fn scan_prefix<
     client: &Client,
     bucket_name: &NonEmptyString,
     key_prefix: &NonEmptyString,
-    mut start_after: Option<NonEmptyString>,
+    start_after: &Option<NonEmptyString>,
     mut page_callback: CallbackType,
 ) -> Result<Option<NonEmptyString>> {
     let mut continuation_token: Option<String> = None;
@@ -50,8 +50,8 @@ pub async fn scan_prefix<
 
         if let Some(continuation_token) = continuation_token.take() {
             request = request.continuation_token(continuation_token);
-        } else if let Some(start_after) = start_after.take() {
-            request = request.start_after(start_after);
+        } else if let Some(start_after) = start_after {
+            request = request.start_after(start_after.as_str());
         }
 
         let response = request.send().await?;

--- a/components/log-ingestor/tests/test_ingestion_job.rs
+++ b/components/log-ingestor/tests/test_ingestion_job.rs
@@ -356,3 +356,71 @@ async fn test_s3_scanner() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[serial_test::serial]
+#[ignore = "Requires LocalStack or AWS environment"]
+async fn test_s3_scanner_single_object() -> Result<()> {
+    const SCANNING_INTERVAL_SEC: u64 = 1;
+
+    let job_id = Uuid::new_v4().as_u64_pair().0;
+    let prefix = get_testing_prefix_as_non_empty_string(job_id);
+
+    let aws_config = AwsConfig::from_env()?;
+
+    let aws_auth = AwsAuthentication::Credentials {
+        credentials: AwsCredentials {
+            access_key_id: aws_config.access_key_id.clone(),
+            secret_access_key: aws_config.secret_access_key.clone(),
+        },
+    };
+    let s3_client = clp_rust_utils::s3::create_new_client(
+        aws_config.region.as_str(),
+        Some(&aws_config.endpoint),
+        &aws_auth,
+    )
+    .await;
+
+    let s3_scanner_config = S3ScannerConfig {
+        base: BaseConfig {
+            region: Some(aws_config.region.clone()),
+            bucket_name: aws_config.bucket_name.clone(),
+            key_prefix: prefix.clone(),
+            endpoint_url: Some(aws_config.endpoint.clone()),
+            dataset: None,
+            timestamp_key: None,
+            unstructured: false,
+        },
+        buffer_config: BufferConfig::default(),
+        scanning_interval_sec: 1,
+        start_after: None,
+    };
+
+    let state = S3ScannerTestState::new();
+    let shared_buffer = state.get_shared_buffer();
+
+    let created_objects = upload_test_objects(
+        s3_client.clone(),
+        aws_config.bucket_name.clone(),
+        prefix.clone(),
+        1,
+    )
+    .await?;
+
+    let s3_scanner = S3Scanner::spawn(
+        job_id,
+        S3ClientWrapper::from(s3_client.clone()),
+        s3_scanner_config,
+        state,
+    );
+
+    // Wait for 10 scanning intervals
+    tokio::time::sleep(Duration::from_secs(10 * SCANNING_INTERVAL_SEC)).await;
+
+    s3_scanner.shutdown_and_join().await;
+
+    let received_objects = shared_buffer.lock().await.clone();
+    assert_eq!(received_objects, created_objects);
+
+    Ok(())
+}

--- a/components/log-ingestor/tests/test_scan.rs
+++ b/components/log-ingestor/tests/test_scan.rs
@@ -73,7 +73,7 @@ async fn test_scan_prefix_early_exit() -> Result<()> {
         &s3_client,
         &aws_config.bucket_name,
         &prefix,
-        None::<NonEmptyString>,
+        &None::<NonEmptyString>,
         async move |objects: Vec<ObjectMetadata>| -> Result<(bool, NonEmptyString)> {
             let page_last_key = objects
                 .last()
@@ -147,7 +147,7 @@ async fn test_scan_prefix_multi_page_filtering() -> Result<()> {
         &s3_client,
         &aws_config.bucket_name,
         &prefix,
-        None::<NonEmptyString>,
+        &None::<NonEmptyString>,
         async move |objects: Vec<ObjectMetadata>| -> Result<(bool, NonEmptyString)> {
             page_count_for_scan.fetch_add(1, Ordering::Relaxed);
             let last_key = objects


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR depends on #2286.

This PR fixes #2332.

In #2224, we introduced a reusable helper for prefix-based S3 object scanning. However, there was an uncaught bug in that PR: if the scanning API scans no results, the last-processed-key will be `None`. The caller, S3-scanner, will reset its `start_after` key to `None`, leaving the scanning progress untracked.

This PR fixes this issue by checking whether the returned key is `None`, and only updates `start_after` when a none-empty key is returned from `scan_prefix`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Add a unit test case to produce the scenario in #2332 and make sure:
  * Without this PR, the test case will fail with one object scanned multiple times.
  * With this PR, the test case will succeed.  

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced S3 scanning reliability by improving pagination cursor management across multiple scan operations, ensuring continuation tokens are correctly preserved and advanced only when scans yield results.

* **Tests**
  * Added integration test coverage for S3 scanner operation with single-object scenarios to verify scanner behaviour and ingestion accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->