### PR TITLE
feat(logging)!: Add context variables to query logs.

### DIFF
--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -21,6 +21,7 @@ from clp_py_utils.s3_utils import (
     s3_put,
 )
 from clp_py_utils.sql_adapter import SqlAdapter
+from structlog.contextvars import bound_contextvars
 
 from job_orchestration.executor.query.celery import app
 from job_orchestration.executor.query.utils import (
@@ -33,6 +34,25 @@ from job_orchestration.scheduler.scheduler_data import QueryTaskStatus
 
 # Setup logging
 logger = get_task_logger(__name__)
+
+
+def _get_extract_stream_task_log_context(
+    job_id: str,
+    task_id: int,
+    query_job_type: str,
+    archive_id: str,
+    dataset: str | None,
+) -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "job_id": job_id,
+        "task_id": task_id,
+        "query_job_type": query_job_type,
+        "archive_id": archive_id,
+    }
+    if dataset is not None:
+        context["dataset"] = dataset
+
+    return context
 
 
 def _make_clp_command_and_env_vars(
@@ -198,7 +218,7 @@ def extract_stream_entry_point(
     clp_logging_level = os.getenv("CLP_LOGGING_LEVEL")
     set_logging_level(logger, clp_logging_level)
 
-    logger.info(f"Started {task_name} task for job {job_id}")
+    logger.info(f"Started {task_name} task")
 
     start_time = datetime.datetime.now()
     task_status: QueryTaskStatus
@@ -303,24 +323,31 @@ def extract_stream(
     self: Task,
     job_id: str,
     task_id: int,
+    query_job_type: str,
     job_config: dict,
     archive_id: str,
     clp_metadata_db_conn_params: dict,
     results_cache_uri: str,
     dataset: str | None = None,
 ) -> dict[str, Any]:
-    try:
-        return extract_stream_entry_point(
-            job_id,
-            task_id,
-            job_config,
-            archive_id,
-            clp_metadata_db_conn_params,
-            results_cache_uri,
-            dataset,
+    with bound_contextvars(
+        **_get_extract_stream_task_log_context(
+            job_id, task_id, query_job_type, archive_id, dataset
         )
-    except SoftTimeLimitExceeded:
-        logger.exception(
-            f"Stream extraction task job_id={job_id} task_id={task_id} exceeded soft time limit."
-        )
-        raise
+    ):
+        try:
+            return extract_stream_entry_point(
+                job_id,
+                task_id,
+                job_config,
+                archive_id,
+                clp_metadata_db_conn_params,
+                results_cache_uri,
+                dataset,
+            )
+        except SoftTimeLimitExceeded:
+            logger.exception("Stream extraction task exceeded soft time limit.")
+            raise
+        except Exception:
+            logger.exception("Stream extraction task failed with an unexpected exception.")
+            raise

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -218,7 +218,7 @@ def extract_stream_entry_point(
     clp_logging_level = os.getenv("CLP_LOGGING_LEVEL")
     set_logging_level(logger, clp_logging_level)
 
-    logger.info(f"Started {task_name} task")
+    logger.info("Started %s task", task_name)
 
     start_time = datetime.datetime.now()
     task_status: QueryTaskStatus

--- a/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/extract_stream_task.py
@@ -331,9 +331,7 @@ def extract_stream(
     dataset: str | None = None,
 ) -> dict[str, Any]:
     with bound_contextvars(
-        **_get_extract_stream_task_log_context(
-            job_id, task_id, query_job_type, archive_id, dataset
-        )
+        **_get_extract_stream_task_log_context(job_id, task_id, query_job_type, archive_id, dataset)
     ):
         try:
             return extract_stream_entry_point(

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -55,7 +55,12 @@ def _get_search_task_log_context(
     if dataset is not None:
         context["dataset"] = dataset
 
-    search_config = SearchJobConfig.model_validate(msgpack.unpackb(job_config_blob))
+    try:
+        search_config = SearchJobConfig.model_validate(msgpack.unpackb(job_config_blob))
+    except (msgpack.UnpackException, ValueError):
+        # search_entry_point performs authoritative validation inside the task's exception boundary.
+        return context
+
     context["query"] = search_config.query_string
     context["query_hash"] = get_query_hash(search_config.query_string)
     return context

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -338,9 +338,7 @@ def search(
     dataset: str | None = None,
 ) -> dict[str, Any]:
     with bound_contextvars(
-        **_get_search_task_log_context(
-            job_id, task_id, job_config_blob, archive_id, dataset
-        )
+        **_get_search_task_log_context(job_id, task_id, job_config_blob, archive_id, dataset)
     ):
         try:
             return search_entry_point(

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -22,18 +22,43 @@ from clp_py_utils.s3_utils import (
 )
 from clp_py_utils.sql_adapter import SqlAdapter
 from clp_py_utils.telemetry_config import is_telemetry_disabled_by_env
+from structlog.contextvars import bound_contextvars
 
 from job_orchestration.executor.query.celery import app
 from job_orchestration.executor.query.utils import (
+    get_query_hash,
     report_task_failure,
     run_query_task,
 )
 from job_orchestration.executor.utils import load_worker_config
+from job_orchestration.scheduler.constants import QueryJobType
 from job_orchestration.scheduler.job_config import SearchJobConfig
 from job_orchestration.scheduler.scheduler_data import QueryTaskResult, QueryTaskStatus
 
 # Setup logging
 logger = get_task_logger(__name__)
+
+
+def _get_search_task_log_context(
+    job_id: str,
+    task_id: int,
+    job_config_blob: bytes,
+    archive_id: str,
+    dataset: str | None,
+) -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "job_id": job_id,
+        "task_id": task_id,
+        "query_job_type": QueryJobType.SEARCH_OR_AGGREGATION.to_str(),
+        "archive_id": archive_id,
+    }
+    if dataset is not None:
+        context["dataset"] = dataset
+
+    search_config = SearchJobConfig.model_validate(msgpack.unpackb(job_config_blob))
+    context["query"] = search_config.query_string
+    context["query_hash"] = get_query_hash(search_config.query_string)
+    return context
 
 
 def _make_core_clp_command_and_env_vars(
@@ -238,7 +263,7 @@ def search_entry_point(
     clp_logging_level = os.getenv("CLP_LOGGING_LEVEL")
     set_logging_level(logger, clp_logging_level)
 
-    logger.info(f"Started {task_name} task for job {job_id}")
+    logger.info(f"Started {task_name} task")
 
     start_time = datetime.datetime.now()
     sql_adapter = SqlAdapter(Database.model_validate(clp_metadata_db_conn_params))
@@ -312,16 +337,24 @@ def search(
     results_cache_uri: str,
     dataset: str | None = None,
 ) -> dict[str, Any]:
-    try:
-        return search_entry_point(
-            job_id,
-            task_id,
-            job_config_blob,
-            archive_id,
-            clp_metadata_db_conn_params,
-            results_cache_uri,
-            dataset,
+    with bound_contextvars(
+        **_get_search_task_log_context(
+            job_id, task_id, job_config_blob, archive_id, dataset
         )
-    except SoftTimeLimitExceeded:
-        logger.exception(f"Search task job_id={job_id} task_id={task_id} exceeded soft time limit.")
-        raise
+    ):
+        try:
+            return search_entry_point(
+                job_id,
+                task_id,
+                job_config_blob,
+                archive_id,
+                clp_metadata_db_conn_params,
+                results_cache_uri,
+                dataset,
+            )
+        except SoftTimeLimitExceeded:
+            logger.exception("Search task exceeded soft time limit.")
+            raise
+        except Exception:
+            logger.exception("Search task failed with an unexpected exception.")
+            raise

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -58,7 +58,6 @@ def _get_search_task_log_context(
     try:
         search_config = SearchJobConfig.model_validate(msgpack.unpackb(job_config_blob))
     except (msgpack.UnpackException, ValueError):
-        # search_entry_point performs authoritative validation inside the task's exception boundary.
         return context
 
     context["query"] = search_config.query_string

--- a/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
+++ b/components/job-orchestration/job_orchestration/executor/query/fs_search_task.py
@@ -263,7 +263,7 @@ def search_entry_point(
     clp_logging_level = os.getenv("CLP_LOGGING_LEVEL")
     set_logging_level(logger, clp_logging_level)
 
-    logger.info(f"Started {task_name} task")
+    logger.info("Started %s task", task_name)
 
     start_time = datetime.datetime.now()
     sql_adapter = SqlAdapter(Database.model_validate(clp_metadata_db_conn_params))

--- a/components/job-orchestration/job_orchestration/executor/query/utils.py
+++ b/components/job-orchestration/job_orchestration/executor/query/utils.py
@@ -96,10 +96,10 @@ def run_query_task(
     return_code = task_proc.returncode
     if 0 != return_code:
         task_status = QueryTaskStatus.FAILED
-        logger.error(f"{task_name} task failed - return_code={return_code}")
+        logger.error("%s task failed - return_code=%s", task_name, return_code)
     else:
         task_status = QueryTaskStatus.SUCCEEDED
-        logger.info(f"{task_name} task completed")
+        logger.info("%s task completed", task_name)
 
     clo_log_file.close()
     if 0 != return_code:

--- a/components/job-orchestration/job_orchestration/executor/query/utils.py
+++ b/components/job-orchestration/job_orchestration/executor/query/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import logging
 import os
 import signal
@@ -13,6 +14,10 @@ from clp_py_utils.sql_adapter import SqlAdapter
 
 from job_orchestration.executor.utils import log_file_contents
 from job_orchestration.scheduler.scheduler_data import QueryTaskResult, QueryTaskStatus
+
+
+def get_query_hash(query_string: str) -> str:
+    return hashlib.sha256(query_string.encode("utf-8")).hexdigest()
 
 
 def get_task_log_file_path(clp_logs_dir: Path, job_id: str, task_id: int) -> Path:
@@ -91,12 +96,10 @@ def run_query_task(
     return_code = task_proc.returncode
     if 0 != return_code:
         task_status = QueryTaskStatus.FAILED
-        logger.error(
-            f"{task_name} task {task_id} failed for job {job_id} - return_code={return_code}"
-        )
+        logger.error(f"{task_name} task failed - return_code={return_code}")
     else:
         task_status = QueryTaskStatus.SUCCEEDED
-        logger.info(f"{task_name} task {task_id} completed for job {job_id}")
+        logger.info(f"{task_name} task completed")
 
     clo_log_file.close()
     if 0 != return_code:

--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -718,9 +718,8 @@ def get_task_group_for_job(
             )
             for i in range(len(archives))
         )
-    error_msg = f"Unexpected job type: {job_type}"
-    logger.error(error_msg)
-    raise NotImplementedError(error_msg)
+    logger.error("Unexpected query job type")
+    raise NotImplementedError(f"Unexpected job type: {job_type}")
 
 
 def dispatch_query_job(
@@ -881,7 +880,7 @@ def handle_pending_query_jobs(
                     # NOTE: We're skipping the job for this iteration, but its status will remain
                     # unchanged. So this log will print again in the next iteration unless the user
                     # cancels the job.
-                    logger.error("Unexpected job type: %s, skipping job", job_type)
+                    logger.error("Unexpected query job type; skipping job")
                     continue
 
         futures = []
@@ -1175,7 +1174,7 @@ async def check_job_status_and_update_db(db_conn_pool, results_cache_uri):
                 elif job_type in (QueryJobType.EXTRACT_JSON, QueryJobType.EXTRACT_IR):
                     await handle_finished_stream_extraction_job(db_conn, job, returned_results)
                 else:
-                    logger.error("Unexpected job type: %s, skipping job", job_type)
+                    logger.error("Unexpected query job type; skipping job")
 
 
 async def handle_job_updates(db_conn_pool, results_cache_uri: str, jobs_poll_delay: float):

--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -104,7 +104,11 @@ def _get_query_job_log_context_from_job(job: QueryJob) -> dict[str, Any]:
 def _get_query_job_log_context_from_fields(
     job_id: str, job_type: int, job_config: dict[str, Any]
 ) -> dict[str, Any]:
-    query_job_type = QueryJobType(job_type)
+    try:
+        query_job_type = QueryJobType(job_type)
+    except ValueError:
+        return {"job_id": job_id, "query_job_type": str(job_type)}
+
     context: dict[str, Any] = {
         "job_id": job_id,
         "query_job_type": query_job_type.to_str(),

--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -49,10 +49,12 @@ from clp_py_utils.sql_adapter import ConnectionPoolWrapper, SqlAdapter
 from clp_py_utils.telemetry import init_telemetry, shutdown_telemetry
 from opentelemetry import metrics
 from pydantic import ValidationError
+from structlog.contextvars import bound_contextvars
 
 from job_orchestration.executor.query.celery import app
 from job_orchestration.executor.query.extract_stream_task import extract_stream
 from job_orchestration.executor.query.fs_search_task import search
+from job_orchestration.executor.query.utils import get_query_hash
 from job_orchestration.garbage_collector.constants import MIN_TO_SECONDS, SECOND_TO_MILLISECOND
 from job_orchestration.scheduler.constants import (
     QueryJobStatus,
@@ -86,6 +88,32 @@ TASK_RESULT_GET_INTERVAL = 0.005
 
 # Setup logging
 logger = get_logger("search-job-handler")
+
+
+def _get_query_job_log_context_from_job(job: QueryJob) -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "job_id": job.id,
+        "query_job_type": job.get_type().to_str(),
+    }
+    if isinstance(job, SearchJob):
+        context["query"] = job.search_config.query_string
+        context["query_hash"] = get_query_hash(job.search_config.query_string)
+    return context
+
+
+def _get_query_job_log_context_from_fields(
+    job_id: str, job_type: int, job_config: dict[str, Any]
+) -> dict[str, Any]:
+    query_job_type = QueryJobType(job_type)
+    context: dict[str, Any] = {
+        "job_id": job_id,
+        "query_job_type": query_job_type.to_str(),
+    }
+    if QueryJobType.SEARCH_OR_AGGREGATION == query_job_type:
+        context["query"] = job_config["query_string"]
+        context["query_hash"] = get_query_hash(job_config["query_string"])
+    return context
+
 
 # Dictionary of active jobs indexed by job id
 active_jobs: dict[str, QueryJob] = {}
@@ -269,7 +297,7 @@ class IrExtractionHandle(StreamExtractionHandle):
 
     def create_stream_extraction_job(self) -> QueryJob:
         logger.info(
-            f"Creating IR extraction job {self._job_id} for file_split: {self.__file_split_id}"
+            f"Creating IR extraction job for file_split: {self.__file_split_id}"
         )
         return ExtractIrJob(
             id=self._job_id,
@@ -315,7 +343,7 @@ class JsonExtractionHandle(StreamExtractionHandle):
         active_archive_json_extractions[archive_id].append(self._job_id)
 
     def create_stream_extraction_job(self) -> QueryJob:
-        logger.info(f"Creating json extraction job {self._job_id} on archive: {self._archive_id}")
+        logger.info(f"Creating json extraction job on archive: {self._archive_id}")
         return ExtractJsonJob(
             id=self._job_id,
             extract_json_config=self.__job_config,
@@ -454,52 +482,54 @@ async def handle_cancelling_search_jobs(db_conn_pool) -> None:
             job_id = str(cancelling_job["job_id"])
             if job_id in active_jobs:
                 job = active_jobs.pop(job_id)
+            else:
+                continue
+
+            with bound_contextvars(**_get_query_job_log_context_from_job(job)):
                 cancel_job_except_reducer(job)
                 # Perform any async tasks last so that it's easier to reason about synchronization
                 # issues between concurrent tasks
                 await release_reducer_for_job(job)
-            else:
-                continue
 
-            set_job_or_task_status(
-                db_conn,
-                QUERY_TASKS_TABLE_NAME,
-                job_id,
-                QueryTaskStatus.CANCELLED,
-                QueryTaskStatus.PENDING,
-                duration=0,
-            )
+                set_job_or_task_status(
+                    db_conn,
+                    QUERY_TASKS_TABLE_NAME,
+                    job_id,
+                    QueryTaskStatus.CANCELLED,
+                    QueryTaskStatus.PENDING,
+                    duration=0,
+                )
 
-            set_job_or_task_status(
-                db_conn,
-                QUERY_TASKS_TABLE_NAME,
-                job_id,
-                QueryTaskStatus.CANCELLED,
-                QueryTaskStatus.RUNNING,
-                duration="TIMESTAMPDIFF(MICROSECOND, start_time, NOW())/1000000.0",
-            )
+                set_job_or_task_status(
+                    db_conn,
+                    QUERY_TASKS_TABLE_NAME,
+                    job_id,
+                    QueryTaskStatus.CANCELLED,
+                    QueryTaskStatus.RUNNING,
+                    duration="TIMESTAMPDIFF(MICROSECOND, start_time, NOW())/1000000.0",
+                )
 
-            set_job_or_task_status_kwargs = {}
-            if job.start_time is not None:
-                set_job_or_task_status_kwargs["duration"] = (
-                    datetime.datetime.now() - job.start_time
-                ).total_seconds()
+                set_job_or_task_status_kwargs = {}
+                if job.start_time is not None:
+                    set_job_or_task_status_kwargs["duration"] = (
+                        datetime.datetime.now() - job.start_time
+                    ).total_seconds()
 
-            if set_job_or_task_status(
-                db_conn,
-                QUERY_JOBS_TABLE_NAME,
-                job_id,
-                QueryJobStatus.CANCELLED,
-                QueryJobStatus.CANCELLING,
+                if set_job_or_task_status(
+                    db_conn,
+                    QUERY_JOBS_TABLE_NAME,
+                    job_id,
+                    QueryJobStatus.CANCELLED,
+                    QueryJobStatus.CANCELLING,
                 **set_job_or_task_status_kwargs,
             ):
-                logger.info(f"Cancelled job {job_id}.")
-            else:
-                logger.error(f"Failed to cancel job {job_id}.")
+                    logger.info("Cancelled job.")
+                else:
+                    logger.error("Failed to cancel job.")
 
-            # Yield to the event loop between jobs so cancellation batches do not
-            # monopolize the scheduler when many jobs are being processed.
-            await asyncio.sleep(0)
+                # Yield to the event loop between jobs so cancellation batches do not
+                # monopolize the scheduler when many jobs are being processed.
+                await asyncio.sleep(0)
 
 
 def insert_query_tasks_into_db(db_conn, job_id, archive_ids: list[str]) -> list[int]:
@@ -678,6 +708,7 @@ def get_task_group_for_job(
                 job_id=job.id,
                 archive_id=archives[i]["archive_id"],
                 task_id=task_ids[i],
+                query_job_type=job_type.to_str(),
                 job_config=job.get_config().model_dump(),
                 dataset=archives[i].get("dataset"),
                 clp_metadata_db_conn_params=clp_metadata_db_conn_params,
@@ -756,7 +787,7 @@ async def acquire_reducer_for_job(job: SearchJob):
     job.state = InternalJobState.WAITING_FOR_DISPATCH
     job.reducer_acquisition_task = None
 
-    logger.info(f"Got reducer for job {job.id} at {reducer_host}:{reducer_port}")
+    logger.info(f"Got reducer at {reducer_host}:{reducer_port}")
 
 
 def dispatch_job_and_update_db(
@@ -816,85 +847,90 @@ def handle_pending_query_jobs(
             job_creation_time = job["creation_time"].timestamp()
 
             table_prefix = clp_metadata_db_conn_params["table_prefix"]
-
-            if QueryJobType.SEARCH_OR_AGGREGATION == job_type:
-                _handle_new_search_job(
-                    db_conn=db_conn,
-                    db_cursor=db_cursor,
-                    job_id=job_id,
-                    job_config=job_config,
-                    job_creation_time=job_creation_time,
-                    table_prefix=table_prefix,
-                    max_datasets_per_query=max_datasets_per_query,
-                    existing_datasets=existing_datasets,
-                    archive_retention_period=archive_retention_period,
-                    pending_search_jobs=pending_search_jobs,
-                    reducer_acquisition_tasks=reducer_acquisition_tasks,
-                )
-            elif job_type in (QueryJobType.EXTRACT_IR, QueryJobType.EXTRACT_JSON):
-                _handle_new_extraction_job(
-                    db_conn=db_conn,
-                    job_id=job_id,
-                    job_type=job_type,
-                    job_config=job_config,
-                    table_prefix=table_prefix,
-                    results_cache_uri=results_cache_uri,
-                    stream_collection_name=stream_collection_name,
-                    clp_metadata_db_conn_params=clp_metadata_db_conn_params,
-                )
-            else:
-                # NOTE: We're skipping the job for this iteration, but its status will remain
-                # unchanged. So this log will print again in the next iteration unless the user
-                # cancels the job.
-                logger.error(f"Unexpected job type: {job_type}, skipping job {job_id}")
-                continue
+            with bound_contextvars(
+                **_get_query_job_log_context_from_fields(job_id, job_type, job_config)
+            ):
+                if QueryJobType.SEARCH_OR_AGGREGATION == job_type:
+                    _handle_new_search_job(
+                        db_conn=db_conn,
+                        db_cursor=db_cursor,
+                        job_id=job_id,
+                        job_config=job_config,
+                        job_creation_time=job_creation_time,
+                        table_prefix=table_prefix,
+                        max_datasets_per_query=max_datasets_per_query,
+                        existing_datasets=existing_datasets,
+                        archive_retention_period=archive_retention_period,
+                        pending_search_jobs=pending_search_jobs,
+                        reducer_acquisition_tasks=reducer_acquisition_tasks,
+                    )
+                elif job_type in (QueryJobType.EXTRACT_IR, QueryJobType.EXTRACT_JSON):
+                    _handle_new_extraction_job(
+                        db_conn=db_conn,
+                        job_id=job_id,
+                        job_type=job_type,
+                        job_config=job_config,
+                        table_prefix=table_prefix,
+                        results_cache_uri=results_cache_uri,
+                        stream_collection_name=stream_collection_name,
+                        clp_metadata_db_conn_params=clp_metadata_db_conn_params,
+                    )
+                else:
+                    # NOTE: We're skipping the job for this iteration, but its status will remain
+                    # unchanged. So this log will print again in the next iteration unless the user
+                    # cancels the job.
+                    logger.error(f"Unexpected job type: {job_type}, skipping job")
+                    continue
 
         futures = []
         for job in pending_search_jobs:
-            job_id = job.id
-            if len(job.remaining_archives_for_search) > num_archives_to_search_per_sub_job:
-                archives_for_search = job.remaining_archives_for_search[
-                    :num_archives_to_search_per_sub_job
-                ]
-                job.remaining_archives_for_search = job.remaining_archives_for_search[
-                    num_archives_to_search_per_sub_job:
-                ]
-            else:
-                archives_for_search = job.remaining_archives_for_search
-                job.remaining_archives_for_search = []
+            with bound_contextvars(**_get_query_job_log_context_from_job(job)):
+                job_id = job.id
+                if len(job.remaining_archives_for_search) > num_archives_to_search_per_sub_job:
+                    archives_for_search = job.remaining_archives_for_search[
+                        :num_archives_to_search_per_sub_job
+                    ]
+                    job.remaining_archives_for_search = job.remaining_archives_for_search[
+                        num_archives_to_search_per_sub_job:
+                    ]
+                else:
+                    archives_for_search = job.remaining_archives_for_search
+                    job.remaining_archives_for_search = []
 
-            if job.start_time is None:
-                job.start_time = datetime.datetime.now()
-                set_job_or_task_status(
-                    db_conn,
-                    QUERY_JOBS_TABLE_NAME,
-                    job_id,
-                    QueryJobStatus.RUNNING,
-                    QueryJobStatus.PENDING,
-                    start_time=job.start_time,
-                    num_tasks=job.num_archives_to_search,
-                )
+                if job.start_time is None:
+                    job.start_time = datetime.datetime.now()
+                    set_job_or_task_status(
+                        db_conn,
+                        QUERY_JOBS_TABLE_NAME,
+                        job_id,
+                        QueryJobStatus.RUNNING,
+                        QueryJobStatus.PENDING,
+                        start_time=job.start_time,
+                        num_tasks=job.num_archives_to_search,
+                    )
 
-            futures.append(
-                process_pool.submit(
-                    DispatchExecutor.dispatch_job_and_update_db,
-                    job.get_cached_config_blob(),
-                    job.get_type(),
-                    job_id,
-                    archives_for_search,
+                futures.append(
+                    process_pool.submit(
+                        DispatchExecutor.dispatch_job_and_update_db,
+                        job.get_cached_config_blob(),
+                        job.get_type(),
+                        job_id,
+                        archives_for_search,
+                    )
                 )
-            )
 
         for future in concurrent.futures.as_completed(futures):
             job_id, num_archives_for_search, group_result_id = future.result()
             job = active_jobs[job_id]
-            job.current_sub_job_async_task_result = celery.result.GroupResult.restore(
-                group_result_id, app=app
-            )
-            job.state = InternalJobState.RUNNING
-            logger.info(
-                "Dispatched job %s with %d archives to search.", job_id, num_archives_for_search
-            )
+            with bound_contextvars(**_get_query_job_log_context_from_job(job)):
+                job.current_sub_job_async_task_result = celery.result.GroupResult.restore(
+                    group_result_id, app=app
+                )
+                job.state = InternalJobState.RUNNING
+                logger.info(
+                    "Dispatched job with %d archives to search.",
+                    num_archives_for_search,
+                )
 
     return reducer_acquisition_tasks
 
@@ -949,18 +985,18 @@ async def handle_finished_search_job(
         task_id = task_result.task_id
         task_status = task_result.status
 
-        task_duration_histogram.record(task_result.duration)
-        if not task_status == QueryTaskStatus.SUCCEEDED:
-            tasks_failed_counter.add(1)
-            new_job_status = QueryJobStatus.FAILED
-            logger.error(f"Search task job-{job_id}-task-{task_id} failed. ")
-        else:
-            tasks_completed_counter.add(1)
-            job.num_archives_searched += 1
-            logger.info(
-                f"Search task job-{job_id}-task-{task_id} succeeded in "
-                f"{task_result.duration} second(s)."
-            )
+        with bound_contextvars(task_id=task_id):
+            task_duration_histogram.record(task_result.duration)
+            if not task_status == QueryTaskStatus.SUCCEEDED:
+                tasks_failed_counter.add(1)
+                new_job_status = QueryJobStatus.FAILED
+                logger.error("Search task failed.")
+            else:
+                tasks_completed_counter.add(1)
+                job.num_archives_searched += 1
+                logger.info(
+                    f"Search task succeeded in {task_result.duration} second(s)."
+                )
 
     if new_job_status != QueryJobStatus.FAILED:
         max_num_results = job.search_config.max_num_results
@@ -979,7 +1015,7 @@ async def handle_finished_search_job(
     if new_job_status == QueryJobStatus.RUNNING:
         job.current_sub_job_async_task_result = None
         job.state = InternalJobState.WAITING_FOR_DISPATCH
-        logger.info(f"Job {job_id} waiting for more archives to search.")
+        logger.info("Job waiting for more archives to search.")
         set_job_or_task_status(
             db_conn,
             QUERY_JOBS_TABLE_NAME,
@@ -1017,11 +1053,11 @@ async def handle_finished_search_job(
     ):
         job_duration_histogram.record(duration)
         if new_job_status == QueryJobStatus.SUCCEEDED:
-            logger.info(f"Completed job {job_id}.")
+            logger.info("Completed job.")
         elif reducer_failed:
-            logger.error(f"Completed job {job_id} with failing reducer.")
+            logger.error("Completed job with failing reducer.")
         else:
-            logger.info(f"Completed job {job_id} with failing tasks.")
+            logger.info("Completed job with failing tasks.")
     del active_jobs[job_id]
 
 
@@ -1038,24 +1074,24 @@ async def handle_finished_stream_extraction_job(
     num_tasks = len(task_results)
     if 1 != num_tasks:
         logger.error(
-            f"Unexpected number of tasks for extraction job {job_id}. Expected 1, got {num_tasks}."
+            f"Unexpected number of tasks for extraction job. Expected 1, got {num_tasks}."
         )
         new_job_status = QueryJobStatus.FAILED
     else:
         task_result = QueryTaskResult.model_validate(task_results[0])
         task_id = task_result.task_id
 
-        task_duration_histogram.record(task_result.duration)
-        if not QueryTaskStatus.SUCCEEDED == task_result.status:
-            tasks_failed_counter.add(1)
-            logger.error(f"Extraction task job-{job_id}-task-{task_id} failed. ")
-            new_job_status = QueryJobStatus.FAILED
-        else:
-            tasks_completed_counter.add(1)
-            logger.info(
-                f"Extraction task job-{job_id}-task-{task_id} succeeded in "
-                f"{task_result.duration} second(s)."
-            )
+        with bound_contextvars(task_id=task_id):
+            task_duration_histogram.record(task_result.duration)
+            if not QueryTaskStatus.SUCCEEDED == task_result.status:
+                tasks_failed_counter.add(1)
+                logger.error("Extraction task failed.")
+                new_job_status = QueryJobStatus.FAILED
+            else:
+                tasks_completed_counter.add(1)
+                logger.info(
+                    f"Extraction task succeeded in {task_result.duration} second(s)."
+                )
 
     duration = (datetime.datetime.now() - job.start_time).total_seconds()
     if set_job_or_task_status(
@@ -1069,9 +1105,9 @@ async def handle_finished_stream_extraction_job(
     ):
         job_duration_histogram.record(duration)
         if new_job_status == QueryJobStatus.SUCCEEDED:
-            logger.info(f"Completed stream extraction job {job_id}.")
+            logger.info("Completed stream extraction job.")
         else:
-            logger.info(f"Completed stream extraction job {job_id} with failing tasks.")
+            logger.info("Completed stream extraction job with failing tasks.")
 
     waiting_jobs: list[str]
     if QueryJobType.EXTRACT_IR == job.get_type():
@@ -1083,16 +1119,19 @@ async def handle_finished_stream_extraction_job(
 
     waiting_jobs.remove(job_id)
     for waiting_job in waiting_jobs:
-        logger.info(f"Setting status to {new_job_status.to_str()} for waiting jobs: {waiting_job}.")
-        set_job_or_task_status(
-            db_conn,
-            QUERY_JOBS_TABLE_NAME,
-            waiting_job,
-            new_job_status,
-            QueryJobStatus.RUNNING,
-            num_tasks_completed=0,
-            duration=(datetime.datetime.now() - job.start_time).total_seconds(),
-        )
+        with bound_contextvars(job_id=waiting_job):
+            logger.info(
+                f"Setting waiting job status to {new_job_status.to_str()}."
+            )
+            set_job_or_task_status(
+                db_conn,
+                QUERY_JOBS_TABLE_NAME,
+                waiting_job,
+                new_job_status,
+                QueryJobStatus.RUNNING,
+                num_tasks_completed=0,
+                duration=(datetime.datetime.now() - job.start_time).total_seconds(),
+            )
 
     del active_jobs[job_id]
 
@@ -1105,39 +1144,42 @@ async def check_job_status_and_update_db(db_conn_pool, results_cache_uri):
             id for id, job in active_jobs.items() if InternalJobState.RUNNING == job.state
         ]:
             job = active_jobs[job_id]
-            try:
-                returned_results = try_getting_task_result(job.current_sub_job_async_task_result)
-            except Exception as e:
-                logger.error(f"Job `{job_id}` failed: {e}.")
-                # Clean up
-                if QueryJobType.SEARCH_OR_AGGREGATION == job.get_type():
-                    if job.reducer_handler_msg_queues is not None:
-                        msg = ReducerHandlerMessage(ReducerHandlerMessageType.FAILURE)
-                        await job.reducer_handler_msg_queues.put_to_handler(msg)
+            with bound_contextvars(**_get_query_job_log_context_from_job(job)):
+                try:
+                    returned_results = try_getting_task_result(
+                        job.current_sub_job_async_task_result
+                    )
+                except Exception as e:
+                    logger.error(f"Job failed: {e}.")
+                    # Clean up
+                    if QueryJobType.SEARCH_OR_AGGREGATION == job.get_type():
+                        if job.reducer_handler_msg_queues is not None:
+                            msg = ReducerHandlerMessage(ReducerHandlerMessageType.FAILURE)
+                            await job.reducer_handler_msg_queues.put_to_handler(msg)
 
-                del active_jobs[job_id]
-                set_job_or_task_status(
-                    db_conn,
-                    QUERY_JOBS_TABLE_NAME,
-                    job_id,
-                    QueryJobStatus.FAILED,
-                    QueryJobStatus.RUNNING,
-                    duration=(datetime.datetime.now() - job.start_time).total_seconds(),
-                )
-                continue
+                    del active_jobs[job_id]
+                    set_job_or_task_status(
+                        db_conn,
+                        QUERY_JOBS_TABLE_NAME,
+                        job_id,
+                        QueryJobStatus.FAILED,
+                        QueryJobStatus.RUNNING,
+                        duration=(datetime.datetime.now() - job.start_time).total_seconds(),
+                    )
+                    continue
 
-            if returned_results is None:
-                continue
-            job_type = job.get_type()
-            if QueryJobType.SEARCH_OR_AGGREGATION == job_type:
-                search_job: SearchJob = job
-                await handle_finished_search_job(
-                    db_conn, search_job, returned_results, results_cache_uri
-                )
-            elif job_type in (QueryJobType.EXTRACT_JSON, QueryJobType.EXTRACT_IR):
-                await handle_finished_stream_extraction_job(db_conn, job, returned_results)
-            else:
-                logger.error(f"Unexpected job type: {job_type}, skipping job {job_id}")
+                if returned_results is None:
+                    continue
+                job_type = job.get_type()
+                if QueryJobType.SEARCH_OR_AGGREGATION == job_type:
+                    search_job: SearchJob = job
+                    await handle_finished_search_job(
+                        db_conn, search_job, returned_results, results_cache_uri
+                    )
+                elif job_type in (QueryJobType.EXTRACT_JSON, QueryJobType.EXTRACT_IR):
+                    await handle_finished_stream_extraction_job(db_conn, job, returned_results)
+                else:
+                    logger.error(f"Unexpected job type: {job_type}, skipping job")
 
 
 async def handle_job_updates(db_conn_pool, results_cache_uri: str, jobs_poll_delay: float):
@@ -1355,7 +1397,7 @@ def _handle_new_search_job(
         # Deduplicate
         datasets = list(dict.fromkeys(datasets))
         if len(datasets) == 0:
-            logger.error("Job %s has an empty datasets list.", job_id)
+            logger.error("Job has an empty datasets list.")
             if not set_job_or_task_status(
                 db_conn,
                 QUERY_JOBS_TABLE_NAME,
@@ -1365,14 +1407,13 @@ def _handle_new_search_job(
                 start_time=datetime.datetime.now(),
                 duration=0,
             ):
-                logger.error("Failed to set job %s as failed.", job_id)
+                logger.error("Failed to set job as failed.")
             return
 
         # Enforce max_datasets_per_query limit
         if max_datasets_per_query is not None and len(datasets) > max_datasets_per_query:
             logger.error(
-                "Job %s requests %d datasets, exceeding max_datasets_per_query=%s.",
-                job_id,
+                "Job requests %d datasets, exceeding max_datasets_per_query=%s.",
                 len(datasets),
                 max_datasets_per_query,
             )
@@ -1385,7 +1426,7 @@ def _handle_new_search_job(
                 start_time=datetime.datetime.now(),
                 duration=0,
             ):
-                logger.error("Failed to set job %s as failed.", job_id)
+                logger.error("Failed to set job as failed.")
             return
 
         # NOTE: This assumes we never delete a dataset.
@@ -1404,7 +1445,7 @@ def _handle_new_search_job(
                     start_time=datetime.datetime.now(),
                     duration=0,
                 ):
-                    logger.error("Failed to set job %s as failed.", job_id)
+                    logger.error("Failed to set job as failed.")
                 return
 
     archive_end_ts_lower_bound: int | None = None
@@ -1433,7 +1474,7 @@ def _handle_new_search_job(
             num_tasks=0,
             duration=0,
         ):
-            logger.info("No matching archives, skipping job %s.", job_id)
+            logger.info("No matching archives, skipping job.")
         return
 
     new_search_job = SearchJob(
@@ -1504,7 +1545,7 @@ def _handle_new_extraction_job(
             num_tasks=0,
             duration=0,
         ):
-            logger.error("Failed to set job %s as failed.", job_id)
+            logger.error("Failed to set job as failed.")
         return
 
     # NOTE: The following two if blocks for `is_stream_extraction_active` and
@@ -1528,9 +1569,8 @@ def _handle_new_extraction_job(
     if job_handle.is_stream_extraction_active():
         job_handle.mark_job_as_waiting()
         logger.info(
-            "Stream %s is already being extracted, so mark job %s as running.",
+            "Stream %s is already being extracted, so mark job as running.",
             job_handle.get_stream_id(),
-            job_id,
         )
         if not set_job_or_task_status(
             db_conn,
@@ -1541,15 +1581,14 @@ def _handle_new_extraction_job(
             start_time=datetime.datetime.now(),
             num_tasks=0,
         ):
-            logger.error("Failed to set job %s as running.", job_id)
+            logger.error("Failed to set job as running.")
         return
 
     # Check if a required stream file has already been extracted
     if job_handle.is_stream_extracted(results_cache_uri, stream_collection_name):
         logger.info(
-            "Stream %s already extracted, so mark job %s as succeeded.",
+            "Stream %s already extracted, so mark job as succeeded.",
             job_handle.get_stream_id(),
-            job_id,
         )
         if not set_job_or_task_status(
             db_conn,
@@ -1561,7 +1600,7 @@ def _handle_new_extraction_job(
             num_tasks=0,
             duration=0,
         ):
-            logger.error("Failed to set job %s as succeeded.", job_id)
+            logger.error("Failed to set job as succeeded.")
         return
 
     new_stream_extraction_job = job_handle.create_stream_extraction_job()
@@ -1577,7 +1616,7 @@ def _handle_new_extraction_job(
 
     job_handle.mark_job_as_waiting()
     active_jobs[job_id] = new_stream_extraction_job
-    logger.info("Dispatched stream extraction job %s for archive: %s", job_id, archive_id)
+    logger.info("Dispatched stream extraction job for archive: %s", archive_id)
 
 
 if "__main__" == __name__:

--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -296,7 +296,7 @@ class IrExtractionHandle(StreamExtractionHandle):
         active_file_split_ir_extractions[file_split_id].append(self._job_id)
 
     def create_stream_extraction_job(self) -> QueryJob:
-        logger.info(f"Creating IR extraction job for file_split: {self.__file_split_id}")
+        logger.info("Creating IR extraction job for file_split: %s", self.__file_split_id)
         return ExtractIrJob(
             id=self._job_id,
             extract_ir_config=self.__job_config,
@@ -341,7 +341,7 @@ class JsonExtractionHandle(StreamExtractionHandle):
         active_archive_json_extractions[archive_id].append(self._job_id)
 
     def create_stream_extraction_job(self) -> QueryJob:
-        logger.info(f"Creating json extraction job on archive: {self._archive_id}")
+        logger.info("Creating json extraction job on archive: %s", self._archive_id)
         return ExtractJsonJob(
             id=self._job_id,
             extract_json_config=self.__job_config,
@@ -785,7 +785,7 @@ async def acquire_reducer_for_job(job: SearchJob):
     job.state = InternalJobState.WAITING_FOR_DISPATCH
     job.reducer_acquisition_task = None
 
-    logger.info(f"Got reducer at {reducer_host}:{reducer_port}")
+    logger.info("Got reducer at %s:%s", reducer_host, reducer_port)
 
 
 def dispatch_job_and_update_db(
@@ -877,7 +877,7 @@ def handle_pending_query_jobs(
                     # NOTE: We're skipping the job for this iteration, but its status will remain
                     # unchanged. So this log will print again in the next iteration unless the user
                     # cancels the job.
-                    logger.error(f"Unexpected job type: {job_type}, skipping job")
+                    logger.error("Unexpected job type: %s, skipping job", job_type)
                     continue
 
         futures = []
@@ -992,7 +992,7 @@ async def handle_finished_search_job(
             else:
                 tasks_completed_counter.add(1)
                 job.num_archives_searched += 1
-                logger.info(f"Search task succeeded in {task_result.duration} second(s).")
+                logger.info("Search task succeeded in %s second(s).", task_result.duration)
 
     if new_job_status != QueryJobStatus.FAILED:
         max_num_results = job.search_config.max_num_results
@@ -1069,7 +1069,9 @@ async def handle_finished_stream_extraction_job(
 
     num_tasks = len(task_results)
     if 1 != num_tasks:
-        logger.error(f"Unexpected number of tasks for extraction job. Expected 1, got {num_tasks}.")
+        logger.error(
+            "Unexpected number of tasks for extraction job. Expected 1, got %s.", num_tasks
+        )
         new_job_status = QueryJobStatus.FAILED
     else:
         task_result = QueryTaskResult.model_validate(task_results[0])
@@ -1083,7 +1085,7 @@ async def handle_finished_stream_extraction_job(
                 new_job_status = QueryJobStatus.FAILED
             else:
                 tasks_completed_counter.add(1)
-                logger.info(f"Extraction task succeeded in {task_result.duration} second(s).")
+                logger.info("Extraction task succeeded in %s second(s).", task_result.duration)
 
     duration = (datetime.datetime.now() - job.start_time).total_seconds()
     if set_job_or_task_status(
@@ -1112,7 +1114,7 @@ async def handle_finished_stream_extraction_job(
     waiting_jobs.remove(job_id)
     for waiting_job in waiting_jobs:
         with bound_contextvars(job_id=waiting_job):
-            logger.info(f"Setting waiting job status to {new_job_status.to_str()}.")
+            logger.info("Setting waiting job status to %s.", new_job_status.to_str())
             set_job_or_task_status(
                 db_conn,
                 QUERY_JOBS_TABLE_NAME,
@@ -1140,7 +1142,7 @@ async def check_job_status_and_update_db(db_conn_pool, results_cache_uri):
                         job.current_sub_job_async_task_result
                     )
                 except Exception as e:
-                    logger.error(f"Job failed: {e}.")
+                    logger.error("Job failed: %s.", e)
                     # Clean up
                     if QueryJobType.SEARCH_OR_AGGREGATION == job.get_type():
                         if job.reducer_handler_msg_queues is not None:
@@ -1169,7 +1171,7 @@ async def check_job_status_and_update_db(db_conn_pool, results_cache_uri):
                 elif job_type in (QueryJobType.EXTRACT_JSON, QueryJobType.EXTRACT_IR):
                     await handle_finished_stream_extraction_job(db_conn, job, returned_results)
                 else:
-                    logger.error(f"Unexpected job type: {job_type}, skipping job")
+                    logger.error("Unexpected job type: %s, skipping job", job_type)
 
 
 async def handle_job_updates(db_conn_pool, results_cache_uri: str, jobs_poll_delay: float):

--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -296,9 +296,7 @@ class IrExtractionHandle(StreamExtractionHandle):
         active_file_split_ir_extractions[file_split_id].append(self._job_id)
 
     def create_stream_extraction_job(self) -> QueryJob:
-        logger.info(
-            f"Creating IR extraction job for file_split: {self.__file_split_id}"
-        )
+        logger.info(f"Creating IR extraction job for file_split: {self.__file_split_id}")
         return ExtractIrJob(
             id=self._job_id,
             extract_ir_config=self.__job_config,
@@ -521,8 +519,8 @@ async def handle_cancelling_search_jobs(db_conn_pool) -> None:
                     job_id,
                     QueryJobStatus.CANCELLED,
                     QueryJobStatus.CANCELLING,
-                **set_job_or_task_status_kwargs,
-            ):
+                    **set_job_or_task_status_kwargs,
+                ):
                     logger.info("Cancelled job.")
                 else:
                     logger.error("Failed to cancel job.")
@@ -994,9 +992,7 @@ async def handle_finished_search_job(
             else:
                 tasks_completed_counter.add(1)
                 job.num_archives_searched += 1
-                logger.info(
-                    f"Search task succeeded in {task_result.duration} second(s)."
-                )
+                logger.info(f"Search task succeeded in {task_result.duration} second(s).")
 
     if new_job_status != QueryJobStatus.FAILED:
         max_num_results = job.search_config.max_num_results
@@ -1073,9 +1069,7 @@ async def handle_finished_stream_extraction_job(
 
     num_tasks = len(task_results)
     if 1 != num_tasks:
-        logger.error(
-            f"Unexpected number of tasks for extraction job. Expected 1, got {num_tasks}."
-        )
+        logger.error(f"Unexpected number of tasks for extraction job. Expected 1, got {num_tasks}.")
         new_job_status = QueryJobStatus.FAILED
     else:
         task_result = QueryTaskResult.model_validate(task_results[0])
@@ -1089,9 +1083,7 @@ async def handle_finished_stream_extraction_job(
                 new_job_status = QueryJobStatus.FAILED
             else:
                 tasks_completed_counter.add(1)
-                logger.info(
-                    f"Extraction task succeeded in {task_result.duration} second(s)."
-                )
+                logger.info(f"Extraction task succeeded in {task_result.duration} second(s).")
 
     duration = (datetime.datetime.now() - job.start_time).total_seconds()
     if set_job_or_task_status(
@@ -1120,9 +1112,7 @@ async def handle_finished_stream_extraction_job(
     waiting_jobs.remove(job_id)
     for waiting_job in waiting_jobs:
         with bound_contextvars(job_id=waiting_job):
-            logger.info(
-                f"Setting waiting job status to {new_job_status.to_str()}."
-            )
+            logger.info(f"Setting waiting job status to {new_job_status.to_str()}.")
             set_job_or_task_status(
                 db_conn,
                 QUERY_JOBS_TABLE_NAME,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->
- Adds scoped log context variables to query scheduler and worker logs. The logs now include `job_id`, `task_id`, `query_job_type`, `query`, `query_hash`, `archive_id` and `dataset` where available.
- This makes it easier to follow a query job across scheduler logs, worker logs, and subprocess log dumps.

> [!NOTE]
> BREAKING CHANGE:
> This PR changes the log text in query scheduler and worker.

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
- Ran successful wildcard, log-text, and variable queries on hive dataset
- Ran a failing query `'MapTask metrics system started'`
  - Query scheduler logs
```
{"event": "Got reducer at reducer:14011", "job_id": "1", "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "query": "482dbdc2", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:49.588343Z", "filename": "query_scheduler.py", "lineno": 790, "func_name": "acquire_reducer_for_job"}
{"event": "Dispatched job with 13 archives to search.", "job_id": "1", "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "query": "482dbdc2", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:50.881980Z", "filename": "query_scheduler.py", "lineno": 930, "func_name": "handle_pending_query_jobs"}
{"event": "Got reducer at reducer:14010", "job_id": "2", "query_hash": "f3547bd468cc4db2f442df239175976cc5969706ceb2319470f951ddd07a5270", "query": "job_1427088391284_0001", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:50.989890Z", "filename": "query_scheduler.py", "lineno": 790, "func_name": "acquire_reducer_for_job"}
{"event": "Got reducer at reducer:14012", "job_id": "3", "query_hash": "6395fbecb81e23edb51cbd01542c571d636f5879eeb76a6894cd255c3e4f0783", "query": "\"MapTask metrics system started\"", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:50.990248Z", "filename": "query_scheduler.py", "lineno": 790, "func_name": "acquire_reducer_for_job"}
{"event": "Got reducer at reducer:14015", "job_id": "4", "query_hash": "684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1", "query": "*", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:50.990609Z", "filename": "query_scheduler.py", "lineno": 790, "func_name": "acquire_reducer_for_job"}
{"event": "Dispatched job with 13 archives to search.", "job_id": "2", "query_hash": "f3547bd468cc4db2f442df239175976cc5969706ceb2319470f951ddd07a5270", "query": "job_1427088391284_0001", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:51.064868Z", "filename": "query_scheduler.py", "lineno": 930, "func_name": "handle_pending_query_jobs"}
{"event": "Dispatched job with 13 archives to search.", "job_id": "3", "query_hash": "6395fbecb81e23edb51cbd01542c571d636f5879eeb76a6894cd255c3e4f0783", "query": "\"MapTask metrics system started\"", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:51.115615Z", "filename": "query_scheduler.py", "lineno": 930, "func_name": "handle_pending_query_jobs"}
{"event": "Dispatched job with 13 archives to search.", "job_id": "4", "query_hash": "684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1", "query": "*", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-10T22:09:51.180628Z", "filename": "query_scheduler.py", "lineno": 930, "func_name": "handle_pending_query_jobs"}
```

  - Query worker logs
```
{"event": "Started search task", "job_id": "1", "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "archive_id": "90c97519-2cc1-4159-9952-143a7cb19d5b", "query": "482dbdc2", "query_job_type": "SEARCH_OR_AGGREGATION", "dataset": "default", "task_id": 8, "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:50.800981Z", "func_name": "search_entry_point", "lineno": 266, "filename": "fs_search_task.py"}
{"event": "Started search task", "archive_id": "075d7338-9d9f-4f1e-86f5-e0fb63010e2e", "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "task_id": 13, "query": "482dbdc2", "job_id": "1", "query_job_type": "SEARCH_OR_AGGREGATION", "dataset": "default", "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:50.802210Z", "func_name": "search_entry_point", "lineno": 266, "filename": "fs_search_task.py"}
{"event": "Started search task", "archive_id": "75e2226f-80b3-4a2f-b90d-55748ad69e7b", "job_id": "1", "dataset": "default", "query_job_type": "SEARCH_OR_AGGREGATION", "query": "482dbdc2", "task_id": 12, "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:50.802400Z", "func_name": "search_entry_point", "lineno": 266, "filename": "fs_search_task.py"}
{"event": "Started search task", "task_id": 11, "archive_id": "15873667-2da2-4dda-ae03-0bc6b6b7149d", "job_id": "1", "dataset": "default", "query_job_type": "SEARCH_OR_AGGREGATION", "query": "482dbdc2", "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:50.802965Z", "func_name": "search_entry_point", "lineno": 266, "filename": "fs_search_task.py"}
{"event": "Running: /opt/clp/bin/clp-s s /var/data/archives/default --archive-id 73af0489-cfa4-4f4f-8726-f7d77e873a80 482dbdc2 reducer --host reducer --port 14011 --job-id 1 --count", "query": "482dbdc2", "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "archive_id": "73af0489-cfa4-4f4f-8726-f7d77e873a80", "task_id": 1, "job_id": "1", "query_job_type": "SEARCH_OR_AGGREGATION", "dataset": "default", "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:50.804174Z", "func_name": "run_query_task", "lineno": 67, "filename": "utils.py"}
{"event": "Running: /opt/clp/bin/clp-s s /var/data/archives/default --archive-id 511a89cb-b7b6-4263-bb47-dbb15220c427 482dbdc2 reducer --host reducer --port 14011 --job-id 1 --count", "query": "482dbdc2", "query_hash": "2912be0eedb438f54549b2f09a5be5ff1570a07a89934c6c35e2b433bc5c2a88", "task_id": 3, "archive_id": "511a89cb-b7b6-4263-bb47-dbb15220c427", "job_id": "1", "dataset": "default", "query_job_type": "SEARCH_OR_AGGREGATION", "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:50.804354Z", "func_name": "run_query_task", "lineno": 67, "filename": "utils.py"}
{"event": "Started search task", "job_id": "4", "query_hash": "684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1", "archive_id": "73af0489-cfa4-4f4f-8726-f7d77e873a80", "query": "*", "query_job_type": "SEARCH_OR_AGGREGATION", "dataset": "default", "task_id": 40, "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:51.161782Z", "func_name": "search_entry_point", "lineno": 266, "filename": "fs_search_task.py"}
{"event": "Started search task", "dataset": "default", "task_id": 41, "query_job_type": "SEARCH_OR_AGGREGATION", "query": "*", "query_hash": "684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1", "job_id": "4", "archive_id": "4431ab20-0b5a-4aa6-b102-a92c7a83bd96", "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:51.164036Z", "func_name": "search_entry_point", "lineno": 266, "filename": "fs_search_task.py"}
{"event": "Waiting for search to finish", "query_hash": "6395fbecb81e23edb51cbd01542c571d636f5879eeb76a6894cd255c3e4f0783", "archive_id": "075d7338-9d9f-4f1e-86f5-e0fb63010e2e", "query_job_type": "SEARCH_OR_AGGREGATION", "dataset": "default", "job_id": "3", "query": "\"MapTask metrics system started\"", "task_id": 39, "logger": "job_orchestration.executor.query.fs_search_task", "level": "info", "timestamp": "2026-07-10T22:09:51.168518Z", "func_name": "run_query_task", "lineno": 92, "filename": "utils.py"}
```
- Ran a successful extraction task
   - Query scheduler logs:
```
{"event": "Creating json extraction job on archive: 75e2226f-80b3-4a2f-b90d-55748ad69e7b", "job_id": "6", "query_job_type":
"EXTRACT_JSON", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-11T02:08:54.449800Z", "filename": "qu
ery_scheduler.py", "lineno": 346, "func_name": "create_stream_extraction_job"}
{"event": "Dispatched stream extraction job for archive: 75e2226f-80b3-4a2f-b90d-55748ad69e7b", "job_id": "6", "query_job_ty
pe": "EXTRACT_JSON", "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-11T02:08:54.494076Z", "filename"
: "query_scheduler.py", "lineno": 1619, "func_name": "_handle_new_extraction_job"}
{"event": "Extraction task succeeded in 0.55007 second(s).", "job_id": "6", "task_id": 66, "query_job_type": "EXTRACT_JSON",
 "logger": "search-job-handler", "level": "info", "timestamp": "2026-07-11T02:08:55.107756Z", "filename": "query_scheduler.p
y", "lineno": 1092, "func_name": "handle_finished_stream_extraction_job"}
{"event": "Completed stream extraction job.", "job_id": "6", "query_job_type": "EXTRACT_JSON", "logger": "search-job-handler
", "level": "info", "timestamp": "2026-07-11T02:08:55.135333Z", "filename": "query_scheduler.py", "lineno": 1108, "func_name
": "handle_finished_stream_extraction_job"}
```
   - Query worker logs:
```
{"event": "Started Stream Extraction task", "archive_id": "75e2226f-80b3-4a2f-b90d-55748ad69e7b", "task_id": 66, "job_id": "6", "query_job_type": "EXTRACT_JSON", "dataset": "default", "logger": "job_orchestration.executor.query.extract_stream_task", "level": "info", "timestamp": "2026-07-11T02:08:54.491833Z", "func_name": "extract_stream_entry_point", "lineno": 221, "filename": "extract_stream_task.py"}
{"event": "Starting JSON extraction", "archive_id": "75e2226f-80b3-4a2f-b90d-55748ad69e7b", "task_id": 66, "job_id": "6", "query_job_type": "EXTRACT_JSON", "dataset": "default", "logger": "job_orchestration.executor.query.extract_stream_task", "level": "info", "timestamp": "2026-07-11T02:08:54.494984Z", "func_name": "_make_clp_s_command_and_env_vars", "lineno": 113, "filename": "extract_stream_task.py"}
{"event": "Running: /opt/clp/bin/clp-s x /var/data/archives/default /var/data/streams --archive-id 75e2226f-80b3-4a2f-b90d-55748ad69e7b --ordered --mongodb-uri mongodb://results_cache:27017/clp-query-results --mongodb-collection stream-files", "archive_id": "75e2226f-80b3-4a2f-b90d-55748ad69e7b", "task_id": 66, "job_id": "6", "query_job_type": "EXTRACT_JSON", "dataset": "default", "logger": "job_orchestration.executor.query.extract_stream_task", "level": "info", "timestamp": "2026-07-11T02:08:54.498669Z", "func_name": "run_query_task", "lineno": 67, "filename": "utils.py"}
{"event": "Waiting for Stream Extraction to finish", "archive_id": "75e2226f-80b3-4a2f-b90d-55748ad69e7b", "task_id": 66, "job_id": "6", "query_job_type": "EXTRACT_JSON", "dataset": "default", "logger": "job_orchestration.executor.query.extract_stream_task", "level": "info", "timestamp": "2026-07-11T02:08:54.505375Z", "func_name": "run_query_task", "lineno": 92, "filename": "utils.py"}
{"event": "Stream Extraction task completed", "archive_id": "75e2226f-80b3-4a2f-b90d-55748ad69e7b", "task_id": 66, "job_id": "6", "query_job_type": "EXTRACT_JSON", "dataset": "default", "logger": "job_orchestration.executor.query.extract_stream_task", "level": "info", "timestamp": "2026-07-11T02:08:55.041869Z", "func_name": "run_query_task", "lineno": 102, "filename": "utils.py"}
```


<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for search and stream extraction tasks, including clearer reporting when tasks exceed time limits or encounter unexpected failures.
  * Improved query task status reporting for successful and failed operations.

* **Monitoring**
  * Added more consistent, searchable context to query job and task logs, making troubleshooting and operational visibility more reliable.
  * Improved tracking of search queries and stream extraction activity throughout scheduling and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->