### PR TITLE
perf(clp-rust-utils): Switch Rust Services' logging to lossless non-blocking writer (fixes #2362).

### DIFF
--- a/components/clp-rust-utils/src/logging.rs
+++ b/components/clp-rust-utils/src/logging.rs
@@ -1,5 +1,5 @@
 use tracing_appender::{
-    non_blocking::WorkerGuard,
+    non_blocking::{NonBlockingBuilder, WorkerGuard},
     rolling::{RollingFileAppender, Rotation},
 };
 use tracing_subscriber::{self, fmt::writer::MakeWriterExt};
@@ -7,9 +7,9 @@ use tracing_subscriber::{self, fmt::writer::MakeWriterExt};
 /// Initializes the global tracing subscriber with JSON-formatted output to stdout.
 ///
 /// If the `CLP_LOGS_DIR` environment variable is set, logs are also written to a
-/// rolling file (`{log_filename}`) in that directory. The returned [`WorkerGuard`]
-/// must be held for the lifetime of the program to ensure file logs are flushed.
-pub fn set_up_logging(log_filename: &str) -> Option<WorkerGuard> {
+/// rolling file (`{log_filename}`) in that directory. The returned [`WorkerGuard`]s
+/// must be held for the lifetime of the program to ensure logs are flushed.
+pub fn set_up_logging(log_filename: &str) -> Vec<WorkerGuard> {
     let subscriber = tracing_subscriber::fmt()
         .event_format(
             tracing_subscriber::fmt::format()
@@ -22,18 +22,28 @@ pub fn set_up_logging(log_filename: &str) -> Option<WorkerGuard> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_ansi(false);
 
+    let (stdout_writer, stdout_guard) = NonBlockingBuilder::default()
+        .lossy(false)
+        .finish(std::io::stdout());
+
+    let mut guards = vec![stdout_guard];
+
     if let Ok(logs_directory) = std::env::var("CLP_LOGS_DIR") {
         let logs_directory = std::path::Path::new(logs_directory.as_str());
         let file_appender =
             RollingFileAppender::new(Rotation::HOURLY, logs_directory, log_filename);
-        let (non_blocking_writer, guard) = tracing_appender::non_blocking(file_appender);
+        let (file_writer, file_guard) = NonBlockingBuilder::default()
+            .lossy(false)
+            .finish(file_appender);
+        
+        guards.push(file_guard);
 
         subscriber
-            .with_writer(std::io::stdout.and(non_blocking_writer))
+            .with_writer(stdout_writer.and(file_writer))
             .init();
-        Some(guard)
     } else {
-        subscriber.with_writer(std::io::stdout).init();
-        None
+        subscriber.with_writer(stdout_writer).init();
     }
+
+    guards
 }

--- a/components/clp-rust-utils/src/logging.rs
+++ b/components/clp-rust-utils/src/logging.rs
@@ -4,12 +4,20 @@ use tracing_appender::{
 };
 use tracing_subscriber::{self, fmt::writer::MakeWriterExt};
 
+/// Opaque struct to hold the worker guards for the non-blocking loggers.
+/// These guards must be held for the lifetime of the program to ensure logs are flushed.
+pub struct LoggerGuards {
+    _stdout_guard: WorkerGuard,
+    _file_guard: Option<WorkerGuard>,
+}
+
 /// Initializes the global tracing subscriber with JSON-formatted output to stdout.
 ///
 /// If the `CLP_LOGS_DIR` environment variable is set, logs are also written to a
-/// rolling file (`{log_filename}`) in that directory. The returned [`WorkerGuard`]s
+/// rolling file (`{log_filename}`) in that directory. The returned [`LoggerGuards`]
 /// must be held for the lifetime of the program to ensure logs are flushed.
-pub fn set_up_logging(log_filename: &str) -> Vec<WorkerGuard> {
+#[must_use]
+pub fn set_up_logging(log_filename: &str) -> LoggerGuards {
     let subscriber = tracing_subscriber::fmt()
         .event_format(
             tracing_subscriber::fmt::format()
@@ -26,8 +34,6 @@ pub fn set_up_logging(log_filename: &str) -> Vec<WorkerGuard> {
         .lossy(false)
         .finish(std::io::stdout());
 
-    let mut guards = vec![stdout_guard];
-
     if let Ok(logs_directory) = std::env::var("CLP_LOGS_DIR") {
         let logs_directory = std::path::Path::new(logs_directory.as_str());
         let file_appender =
@@ -35,15 +41,21 @@ pub fn set_up_logging(log_filename: &str) -> Vec<WorkerGuard> {
         let (file_writer, file_guard) = NonBlockingBuilder::default()
             .lossy(false)
             .finish(file_appender);
-        
-        guards.push(file_guard);
 
         subscriber
             .with_writer(stdout_writer.and(file_writer))
             .init();
+
+        LoggerGuards {
+            _stdout_guard: stdout_guard,
+            _file_guard: Some(file_guard),
+        }
     } else {
         subscriber.with_writer(stdout_writer).init();
-    }
 
-    guards
+        LoggerGuards {
+            _stdout_guard: stdout_guard,
+            _file_guard: None,
+        }
+    }
 }

--- a/components/clp-rust-utils/src/logging.rs
+++ b/components/clp-rust-utils/src/logging.rs
@@ -4,7 +4,7 @@ use tracing_appender::{
 };
 use tracing_subscriber::{self, fmt::writer::MakeWriterExt};
 
-/// Opaque struct to hold the worker guards for the non-blocking loggers.
+/// Opaque struct to hold the worker guards for the background log writers.
 /// These guards must be held for the lifetime of the program to ensure logs are flushed.
 pub struct LoggerGuards {
     _stdout_guard: WorkerGuard,

--- a/docs/src/dev-docs/logging-developer-guide.md
+++ b/docs/src/dev-docs/logging-developer-guide.md
@@ -28,7 +28,7 @@ Existing Python services use stdlib loggers whose handlers are configured with s
 ## Rust
 
 Rust HTTP services should initialize `tracing` at process startup using
-[`clp_rust_utils::logging::set_up_logging`][clp-rust-logging] and keep the returned guard alive
+[`clp_rust_utils::logging::set_up_logging`][clp-rust-logging] and keep the returned guards alive
 for the lifetime of the process:
 
 ```rust

--- a/docs/src/dev-docs/logging-operator-guide.md
+++ b/docs/src/dev-docs/logging-operator-guide.md
@@ -45,8 +45,9 @@ For continuously running deployed services such as Python orchestration services
 * **Docker Compose**: Logs are available using `docker compose logs`. If `CLP_LOGS_DIR` is set,
 logs are additionally written to `<CLP_LOGS_DIR>/<component_name>.log`. This directory mounts to the host via `CLP_LOGS_DIR_HOST` (defaults to `./var/log`).
   :::{note}
-  For Rust services, `stdout` logging is always non-blocking. Setting `CLP_LOGS_DIR` additionally
-  enables file logging with hourly log rotation and a non-blocking file writer.
+  For Rust services, `stdout` logging is sent through a background writer configured to avoid
+  dropped log records. Setting `CLP_LOGS_DIR` additionally enables file logging with hourly log
+  rotation and the same lossless background writer behavior.
   :::
 * **Kubernetes/Helm**: Logs are accessible using `kubectl logs` or a cluster log collector (e.g., Fluent Bit). File
   logging is only enabled for templates that set `CLP_LOGS_DIR` and mount a log volume.

--- a/docs/src/dev-docs/logging-operator-guide.md
+++ b/docs/src/dev-docs/logging-operator-guide.md
@@ -45,8 +45,8 @@ For continuously running deployed services such as Python orchestration services
 * **Docker Compose**: Logs are available using `docker compose logs`. If `CLP_LOGS_DIR` is set,
 logs are additionally written to `<CLP_LOGS_DIR>/<component_name>.log`. This directory mounts to the host via `CLP_LOGS_DIR_HOST` (defaults to `./var/log`).
   :::{note}
-  For Rust services, setting `CLP_LOGS_DIR` enables file logging with hourly log rotation and a
-  non-blocking file writer.
+  For Rust services, `stdout` logging is always non-blocking. Setting `CLP_LOGS_DIR` additionally
+  enables file logging with hourly log rotation and a non-blocking file writer.
   :::
 * **Kubernetes/Helm**: Logs are accessible using `kubectl logs` or a cluster log collector (e.g., Fluent Bit). File
   logging is only enabled for templates that set `CLP_LOGS_DIR` and mount a log volume.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Switches the Rust logger to use lossless, non-blocking writers for both stdout and file outputs. This moves I/O to a background thread. Also cleans up the API by returning a `LoggerGuards` struct instead of an `Option`, and updates the docs.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

```
task tests:rust-all
task clean-core
task tests:integration
```

Performance test with a test file shows the new method is indeed almost 2x faster: 

```rust
use std::env;
use std::time::Instant;
use tracing_appender::non_blocking::NonBlockingBuilder;

fn main() {
    let args: Vec<String> = env::args().collect();
    let mode = args.get(1).map(|s| s.as_str()).unwrap_or("non-blocking");
    let num_logs = 100_000;

    let mut _guards = vec![];
    
    let subscriber = tracing_subscriber::fmt()
        .with_ansi(false)
        .with_target(false)
        .with_level(true);

    if mode == "blocking" {
        subscriber.with_writer(std::io::stdout).init();
    } else {
        let (non_blocking_stdout, stdout_guard) = NonBlockingBuilder::default()
            .lossy(false)
            .finish(std::io::stdout());
        _guards.push(stdout_guard);
        subscriber.with_writer(non_blocking_stdout).init();
    }

    let start = Instant::now();
    for i in 0..num_logs {
        tracing::info!("This is test log message number {} to test the logging overhead.", i);
    }
    let duration = start.elapsed();
    
    eprintln!("Mode: {}, Num logs: {}, Time on main thread: {:?}", mode, num_logs, duration);
}
```

```console 
nathan@c4a-standard-8vcpu-32gb-ubuntu2204:~/clp/scratch_logging$ cargo run --release -- blocking > out_blocking.log 2> result_blocking.txt
nathan@c4a-standard-8vcpu-32gb-ubuntu2204:~/clp/scratch_logging$ cat result_blocking.txt
    Finished `release` profile [optimized] target(s) in 0.01s
     Running `/home/nathan/clp/build/rust-targets/release/scratch_logging blocking`
Mode: blocking, Num logs: 100000, Time on main thread: 136.758603ms
nathan@c4a-standard-8vcpu-32gb-ubuntu2204:~/clp/scratch_logging$ cargo run --release -- non-blocking > out_non_blocking.log 2> result_non_blocking.txt
nathan@c4a-standard-8vcpu-32gb-ubuntu2204:~/clp/scratch_logging$ cat result_non_blocking.txt
    Finished `release` profile [optimized] target(s) in 0.01s
     Running `/home/nathan/clp/build/rust-targets/release/scratch_logging non-blocking`
Mode: non-blocking, Num logs: 100000, Time on main thread: 71.02241ms
nathan@c4a-standard-8vcpu-32gb-ubuntu2204:~/clp/scratch_logging$ ls -l |grep .log
-rw-rw-r-- 1 nathan nathan 10188890 Jul  3 22:49 out_blocking.log
-rw-rw-r-- 1 nathan nathan 10188890 Jul  3 22:49 out_non_blocking.log
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved logging setup so both console and optional file logging are kept active for the full process lifetime.
  * When log files are enabled, logs are rotated hourly with background handling to reduce dropped messages.

* **Documentation**
  * Clarified developer and operator guidance for Rust logging and log file behaviour.
  * Updated instructions to emphasise keeping the logging guard alive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->