### PR TITLE
perf(log-ingestor): Reduce compression-submission lock contention with `READ COMMITTED` and smaller update batches (fixes #2358).

### DIFF
--- a/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
+++ b/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
@@ -22,7 +22,7 @@ use clp_rust_utils::{
 };
 use const_format::formatcp;
 use non_empty_string::NonEmptyString;
-use sqlx::{Acquire as _, MySqlPool};
+use sqlx::{Connection, MySqlPool};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 use tokio::sync::mpsc;
 
@@ -1071,9 +1071,9 @@ impl ClpCompressionState {
     /// * [`anyhow::Error`] if one or more object metadata rows fail to be updated in the DB.
     /// * Forwards [`clp_rust_utils::serde::BrotliMsgpack::serialize`]'s return values on failure.
     /// * Forwards [`sqlx::query::Query::execute`]'s return values on failure.
-    /// * Forwards [`sqlx::Pool::acquire`]'s return values on failure.
-    /// * Forwards [`sqlx::Acquire::begin`]'s return values on failure.
+    /// * Forwards [`sqlx::Connection::begin`]'s return values on failure.
     /// * Forwards [`sqlx::Transaction::commit`]'s return values on failure.
+    /// * Forwards [`run_read_committed_tx`]'s return values on failure.
     ///
     /// # Panics
     ///
@@ -1082,7 +1082,6 @@ impl ClpCompressionState {
         &self,
         io_config: ClpIoConfig,
     ) -> anyhow::Result<CompressionJobId> {
-        const SET_READ_COMMITTED: &str = "SET TRANSACTION ISOLATION LEVEL READ COMMITTED";
         const COMPRESSION_JOB_SUBMISSION_QUERY: &str = formatcp!(
             r"INSERT INTO {table} (`clp_config`) VALUES (?)",
             table = CLP_COMPRESSION_JOB_TABLE_NAME
@@ -1095,58 +1094,61 @@ impl ClpCompressionState {
             }
         };
 
-        let mut conn = self.db_pool.acquire().await?;
-        sqlx::query(SET_READ_COMMITTED).execute(&mut *conn).await?;
-        let mut tx = conn.begin().await?;
+        // Run the submission at `READ COMMITTED` to avoid the gap/next-key locks that serialize
+        // concurrent submissions under the default `REPEATABLE READ`.
+        run_read_committed_tx(self.db_pool.clone(), async |conn| {
+            let mut tx = Connection::begin(conn).await?;
 
-        // Submit compression job
-        let result = sqlx::query(COMPRESSION_JOB_SUBMISSION_QUERY)
-            .bind(clp_rust_utils::serde::BrotliMsgpack::serialize(&io_config)?)
-            .execute(&mut *tx)
-            .await?;
-        let compression_job_id =
-            CompressionJobId::try_from(result.last_insert_id()).map_err(|_| {
-                anyhow::anyhow!("The retrieved ID overflows: {}", result.last_insert_id())
-            })?;
+            // Submit compression job
+            let result = sqlx::query(COMPRESSION_JOB_SUBMISSION_QUERY)
+                .bind(clp_rust_utils::serde::BrotliMsgpack::serialize(&io_config)?)
+                .execute(&mut *tx)
+                .await?;
+            let compression_job_id =
+                CompressionJobId::try_from(result.last_insert_id()).map_err(|_| {
+                    anyhow::anyhow!("The retrieved ID overflows: {}", result.last_insert_id())
+                })?;
 
-        // Update compression job ID for ingested objects.
-        // NOTE: We batch the update to avoid hitting the maximum placeholder limit of MySQL. The
-        // batch size is chosen to be 1000, which is conservative enough to avoid hitting the limit
-        // while keeping each UPDATE's lock footprint small under concurrency. If the number of
-        // placeholders per update changes, we may need to adjust the batch size accordingly.
-        for chunk in object_metadata_ids.chunks(1000) {
-            let mut query_builder = sqlx::QueryBuilder::<sqlx::MySql>::new(formatcp!(
-                r"UPDATE `{table}` ",
-                table = INGESTED_S3_OBJECT_METADATA_TABLE_NAME,
-            ));
-            query_builder
-                .push("SET `compression_job_id` = ")
-                .push_bind(compression_job_id);
-            query_builder
-                .push(", `status` = ")
-                .push_bind(IngestedS3ObjectMetadataStatus::Submitted);
-            query_builder.push(" WHERE `id` IN (");
-            let mut separated_ids = query_builder.separated(", ");
-            for id in chunk {
-                separated_ids.push_bind(id);
-            }
-            query_builder.push(")");
-            query_builder
-                .push(" AND `status` = ")
-                .push_bind(IngestedS3ObjectMetadataStatus::Buffered);
-
-            let result = query_builder.build().execute(&mut *tx).await?;
-            if result.rows_affected()
-                != u64::try_from(chunk.len()).expect("size conversion should always succeed")
-            {
-                return Err(anyhow::anyhow!(
-                    "Failed to update compression job ID for some objects."
+            // Update compression job ID for ingested objects.
+            // NOTE: We batch the update to avoid hitting the maximum placeholder limit of MySQL.
+            // The batch size of 1000 is conservative enough to avoid the limit while keeping each
+            // UPDATE's lock footprint small under concurrency. If the number of placeholders per
+            // update changes, we may need to adjust the batch size accordingly.
+            for chunk in object_metadata_ids.chunks(1000) {
+                let mut query_builder = sqlx::QueryBuilder::<sqlx::MySql>::new(formatcp!(
+                    r"UPDATE `{table}` ",
+                    table = INGESTED_S3_OBJECT_METADATA_TABLE_NAME,
                 ));
-            }
-        }
+                query_builder
+                    .push("SET `compression_job_id` = ")
+                    .push_bind(compression_job_id);
+                query_builder
+                    .push(", `status` = ")
+                    .push_bind(IngestedS3ObjectMetadataStatus::Submitted);
+                query_builder.push(" WHERE `id` IN (");
+                let mut separated_ids = query_builder.separated(", ");
+                for id in chunk {
+                    separated_ids.push_bind(id);
+                }
+                query_builder.push(")");
+                query_builder
+                    .push(" AND `status` = ")
+                    .push_bind(IngestedS3ObjectMetadataStatus::Buffered);
 
-        tx.commit().await?;
-        Ok(compression_job_id)
+                let result = query_builder.build().execute(&mut *tx).await?;
+                if result.rows_affected()
+                    != u64::try_from(chunk.len()).expect("size conversion should always succeed")
+                {
+                    return Err(anyhow::anyhow!(
+                        "Failed to update compression job ID for some objects."
+                    ));
+                }
+            }
+
+            tx.commit().await?;
+            Ok(compression_job_id)
+        })
+        .await
     }
 
     /// Waits for the compression job to finish and updates the status of submitted object metadata.
@@ -1511,6 +1513,53 @@ async fn update_job_status(
     tx.commit().await?;
     tracing::info!(job_id = ? job_id, status = ? status, "Ingestion job status updated.");
     Ok(())
+}
+
+/// Runs `tx` on a freshly acquired pooled connection whose next transaction uses the `READ
+/// COMMITTED` isolation level.
+///
+/// A `SET TRANSACTION ISOLATION LEVEL READ COMMITTED` statement is issued on the connection before
+/// `tx` runs. Because it omits `SESSION`/`GLOBAL`, it applies only to the next transaction started
+/// on that connection. `tx` is expected to begin exactly one transaction to consume the setting,
+/// and to commit or roll it back itself.
+///
+/// If `tx` returns an error, the connection is detached from the pool and closed rather than being
+/// released back into it. This ensures a failed attempt can never hand a later, unrelated borrower
+/// a connection still carrying the pending isolation change (or a half-open transaction).
+///
+/// # Type Parameters
+///
+/// * `ReturnType` - The return type of `tx`.
+/// * `TransactionType` - The type of `tx`, which is an async function that takes a mutable
+///   reference to the connection.
+///
+/// # Returns
+///
+/// The value returned by `tx` on success.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * Forwards [`sqlx::Pool::acquire`]'s return values on failure.
+/// * Forwards [`sqlx::query::Query::execute`]'s return values on failure.
+/// * Forwards `tx`'s return values on failure.
+async fn run_read_committed_tx<ReturnType, TransactionType>(
+    pool: MySqlPool,
+    tx: TransactionType,
+) -> anyhow::Result<ReturnType>
+where
+    for<'connection_lifetime> TransactionType:
+        AsyncFnOnce(&'connection_lifetime mut sqlx::MySqlConnection) -> anyhow::Result<ReturnType>,
+{
+    const SET_READ_COMMITTED: &str = "SET TRANSACTION ISOLATION LEVEL READ COMMITTED";
+    let mut conn = pool.acquire().await?;
+    sqlx::query(SET_READ_COMMITTED).execute(&mut *conn).await?;
+    let result = tx(&mut *conn).await;
+    if result.is_err() {
+        let _ = conn.detach().close().await;
+    }
+    result
 }
 
 #[cfg(test)]

--- a/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
+++ b/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
@@ -22,7 +22,7 @@ use clp_rust_utils::{
 };
 use const_format::formatcp;
 use non_empty_string::NonEmptyString;
-use sqlx::MySqlPool;
+use sqlx::{Acquire as _, MySqlPool};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 use tokio::sync::mpsc;
 
@@ -1071,7 +1071,8 @@ impl ClpCompressionState {
     /// * [`anyhow::Error`] if one or more object metadata rows fail to be updated in the DB.
     /// * Forwards [`clp_rust_utils::serde::BrotliMsgpack::serialize`]'s return values on failure.
     /// * Forwards [`sqlx::query::Query::execute`]'s return values on failure.
-    /// * Forwards [`sqlx::Pool::begin`]'s return values on failure.
+    /// * Forwards [`sqlx::Pool::acquire`]'s return values on failure.
+    /// * Forwards [`sqlx::Acquire::begin`]'s return values on failure.
     /// * Forwards [`sqlx::Transaction::commit`]'s return values on failure.
     ///
     /// # Panics
@@ -1081,6 +1082,7 @@ impl ClpCompressionState {
         &self,
         io_config: ClpIoConfig,
     ) -> anyhow::Result<CompressionJobId> {
+        const SET_READ_COMMITTED: &str = "SET TRANSACTION ISOLATION LEVEL READ COMMITTED";
         const COMPRESSION_JOB_SUBMISSION_QUERY: &str = formatcp!(
             r"INSERT INTO {table} (`clp_config`) VALUES (?)",
             table = CLP_COMPRESSION_JOB_TABLE_NAME
@@ -1093,7 +1095,9 @@ impl ClpCompressionState {
             }
         };
 
-        let mut tx = self.db_pool.begin().await?;
+        let mut conn = self.db_pool.acquire().await?;
+        sqlx::query(SET_READ_COMMITTED).execute(&mut *conn).await?;
+        let mut tx = conn.begin().await?;
 
         // Submit compression job
         let result = sqlx::query(COMPRESSION_JOB_SUBMISSION_QUERY)
@@ -1107,10 +1111,10 @@ impl ClpCompressionState {
 
         // Update compression job ID for ingested objects.
         // NOTE: We batch the update to avoid hitting the maximum placeholder limit of MySQL. The
-        // batch size is chosen to be 10000, which is conservative enough to avoid hitting the limit
-        // while also minimizing the number of batches for typical use cases. If the number of
+        // batch size is chosen to be 1000, which is conservative enough to avoid hitting the limit
+        // while keeping each UPDATE's lock footprint small under concurrency. If the number of
         // placeholders per update changes, we may need to adjust the batch size accordingly.
-        for chunk in object_metadata_ids.chunks(10000) {
+        for chunk in object_metadata_ids.chunks(1000) {
             let mut query_builder = sqlx::QueryBuilder::<sqlx::MySql>::new(formatcp!(
                 r"UPDATE `{table}` ",
                 table = INGESTED_S3_OBJECT_METADATA_TABLE_NAME,

--- a/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
+++ b/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
@@ -1094,8 +1094,8 @@ impl ClpCompressionState {
             }
         };
 
-        // Run the submission at `READ COMMITTED` to avoid the gap/next-key locks that serialize
-        // concurrent submissions under the default `REPEATABLE READ`.
+        // Run the submission transaction at `READ COMMITTED` to avoid the gap/next-key locks that
+        // serialize concurrent submissions under the default `REPEATABLE READ`.
         run_read_committed_tx(self.db_pool.clone(), async |conn| {
             let mut tx = Connection::begin(conn).await?;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

When an ingestion job flushes its buffered objects, `ClpCompressionState::submit_for_compression` runs a single transaction that inserts a `compression_jobs` row and then stamps `compression_job_id` and `status = 'submitted'` onto every buffered `ingested_s3_object_metadata` row via a batched `UPDATE ... WHERE id IN (...) AND status = 'buffered'`.

Under many concurrent ingestion jobs these submission transactions serialize heavily: the InnoDB default isolation level (REPEATABLE READ) takes gap / next-key locks over the index ranges scanned for the `IN (...)` set and the `status` predicate, so concurrent submissions block one another. This makes submission the dominant DB cost and the ingestion bottleneck (#2358).

This PR relieves the contention on the submission path with two changes:

- Run the submission transaction at **READ COMMITTED** isolation. READ COMMITTED does not take gap locks, which is what drives the cross-transaction serialization here; only the matching rows are locked, for a shorter duration.
- Reduce the metadata-update batch size from 10000 to 1000, keeping each `UPDATE`'s lock footprint small under concurrency.

## Microbenchmark result

We built a microbenchmark that drives the real DB persistence path with **50 concurrent ingestion jobs**, each ingesting object-metadata entries at a throttled rate (~15,000 entries/min/job), and measured the average DB time per `submit_for_compression` call.

Switching the submission transaction to `READ COMMITTED` substantially reduced that cost:

- **REPEATABLE READ (before):** ~30 s per submission call at comparable scale, and climbing as the metadata table grew.
- **READ COMMITTED (after):** ~12.5 s per submission call, roughly flat as the table grew — about a **2.4x** reduction — with end-to-end ingestion throughput improving from ~5,800 to ~8,400 rows/s.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Ensure log-ingestor can submit compression jobs as expected.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compression job submission reliability by running related updates inside a dedicated `READ COMMITTED` transaction context.
  * Reduced ingested-object metadata update batch size (from larger batches to smaller batches of 1,000) and added validation after each batch to detect unexpected row counts.
  * Updated transaction handling so isolation-level settings won’t affect subsequent database operations from the same connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->