### PR TITLE
fix(deps): Pin scikit-build-core build backend (fixes #2370).

### DIFF
--- a/python-wheels/yscope-clp-core/pyproject.toml
+++ b/python-wheels/yscope-clp-core/pyproject.toml
@@ -33,7 +33,6 @@ build = [
   "auditwheel>=6.6.0",
   "build>=1.4.0",
   "patchelf>=0.17.2.4",
-  "scikit-build-core==1.0.0",
 ]
 dev = [
   "mypy>=1.16.0",

--- a/python-wheels/yscope-clp-core/pyproject.toml
+++ b/python-wheels/yscope-clp-core/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.10"
 "Issue Tracker" = "https://github.com/y-scope/clp/issues"
 
 [build-system]
-requires = ["scikit-build-core"]
+requires = ["scikit-build-core==1.0.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -25,7 +25,7 @@ wheel.packages = ["yscope_clp_core"]
 wheel.py-api = "py3"
 cmake.version = ">=3.31.0"
 ninja.version = ">=1.10.0"
-cmake.verbose = true
+build.verbose = true
 logging.level = "DEBUG"
 
 [dependency-groups]
@@ -33,6 +33,7 @@ build = [
   "auditwheel>=6.6.0",
   "build>=1.4.0",
   "patchelf>=0.17.2.4",
+  "scikit-build-core==1.0.0",
 ]
 dev = [
   "mypy>=1.16.0",

--- a/python-wheels/yscope-clp-core/uv.lock
+++ b/python-wheels/yscope-clp-core/uv.lock
@@ -41,18 +41,6 @@ wheels = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
 name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -271,22 +259,6 @@ wheels = [
 ]
 
 [[package]]
-name = "scikit-build-core"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/e2/4c0431fe84f9d8c24c1fc77b27264f568c71724ca888f514766986f270b0/scikit_build_core-1.0.0.tar.gz", hash = "sha256:b82a8b41dd66926b96096a61e8fc8df22214bbec437d251c0fda1bfb9d7df558", size = 466325, upload-time = "2026-07-06T16:58:35.859Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/47/471ffd83e97c221bedb0c16ab8bdf6087683686c2bdbecda743b24c01002/scikit_build_core-1.0.0-py3-none-any.whl", hash = "sha256:3d52323489b3d83c87922e7bd5bd781cc4bcf0d43961eb565a78d28e74b98fef", size = 275217, upload-time = "2026-07-06T16:58:33.971Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -359,7 +331,6 @@ build = [
     { name = "auditwheel" },
     { name = "build" },
     { name = "patchelf" },
-    { name = "scikit-build-core" },
 ]
 dev = [
     { name = "mypy" },
@@ -373,7 +344,6 @@ build = [
     { name = "auditwheel", specifier = ">=6.6.0" },
     { name = "build", specifier = ">=1.4.0" },
     { name = "patchelf", specifier = ">=0.17.2.4" },
-    { name = "scikit-build-core", specifier = "==1.0.0" },
 ]
 dev = [
     { name = "mypy", specifier = ">=1.16.0" },

--- a/python-wheels/yscope-clp-core/uv.lock
+++ b/python-wheels/yscope-clp-core/uv.lock
@@ -41,6 +41,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -259,6 +271,22 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-build-core"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/e2/4c0431fe84f9d8c24c1fc77b27264f568c71724ca888f514766986f270b0/scikit_build_core-1.0.0.tar.gz", hash = "sha256:b82a8b41dd66926b96096a61e8fc8df22214bbec437d251c0fda1bfb9d7df558", size = 466325, upload-time = "2026-07-06T16:58:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/47/471ffd83e97c221bedb0c16ab8bdf6087683686c2bdbecda743b24c01002/scikit_build_core-1.0.0-py3-none-any.whl", hash = "sha256:3d52323489b3d83c87922e7bd5bd781cc4bcf0d43961eb565a78d28e74b98fef", size = 275217, upload-time = "2026-07-06T16:58:33.971Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -331,6 +359,7 @@ build = [
     { name = "auditwheel" },
     { name = "build" },
     { name = "patchelf" },
+    { name = "scikit-build-core" },
 ]
 dev = [
     { name = "mypy" },
@@ -344,6 +373,7 @@ build = [
     { name = "auditwheel", specifier = ">=6.6.0" },
     { name = "build", specifier = ">=1.4.0" },
     { name = "patchelf", specifier = ">=0.17.2.4" },
+    { name = "scikit-build-core", specifier = "==1.0.0" },
 ]
 dev = [
     { name = "mypy", specifier = ">=1.16.0" },


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Proposed PR title:
fix(deps): Pin scikit-build-core build backend (fixes #2370).
-->

# Description

Fixes https://github.com/y-scope/clp/issues/2370.

`python-wheels/yscope-clp-core` used the deprecated `scikit-build-core` setting `cmake.verbose` and left the build backend requirement unpinned. After `scikit-build-core` 1.0.0 was published, fresh `uv run --directory python-wheels/yscope-clp-core ...` invocations started resolving the new backend in the isolated editable-build environment and failing before Ruff or mypy could run.

This PR updates the setting to `build.verbose` and pins `scikit-build-core==1.0.0` in `[build-system].requires`, which is the PEP 517 control point for the isolated build backend environment. It intentionally does not add `scikit-build-core` to the package's `build` dependency group because that would only affect uv's project environment and lockfile, not the isolated build backend resolution that caused this failure.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

## Scenario 1: Lockfile is current and package lint/type checks pass

**Task:** Verify the `yscope-clp-core` lockfile is current and the package no longer fails during the editable build setup used by Python lint.

**Commands and output:**

```text
$ uv lock --directory python-wheels/yscope-clp-core --check
Using CPython 3.10.12 interpreter at: /usr/bin/python3.10
Resolved 17 packages in 0.55ms

$ UV_NO_CACHE=1 uv run --directory python-wheels/yscope-clp-core ruff check --fix .
Using CPython 3.10.12 interpreter at: /usr/bin/python3.10
Creating virtual environment at: .venv
   Building yscope-clp-core @ file:///home/junhao/workspace/5-clp/python-wheels/yscope-clp-core
Downloading mypy (12.9MiB)
Downloading ruff (10.7MiB)
 Downloaded ruff
 Downloaded mypy
      Built yscope-clp-core @ file:///home/junhao/workspace/5-clp/python-wheels/yscope-clp-core
Installed 14 packages in 7ms
All checks passed!

$ uv run --directory python-wheels/yscope-clp-core ruff format .
2 files left unchanged

$ uv run --directory python-wheels/yscope-clp-core ruff check .
All checks passed!

$ uv run --directory python-wheels/yscope-clp-core ruff format --diff .
2 files already formatted

$ uv run --directory python-wheels/yscope-clp-core mypy .
Success: no issues found in 2 source files

```

**Explanation:** `uv lock --check` confirms the lockfile matches the manifest. The package-level Ruff and mypy commands pass after `uv` builds `yscope-clp-core` with the pinned `scikit-build-core` backend from `[build-system].requires`.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package build setup to use a fixed tool version for more consistent wheel builds.
  * Adjusted verbose build output handling so install/build logs are more reliable and easier to inspect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->