### PR TITLE
fix(build): Prevent concurrent executions of core-build (fixes #2376).

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -173,9 +173,8 @@ tasks:
           INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
 
   core:
-    cmds:
-      - task: "core-generate"
-      - task: "core-build"
+    deps:
+      - "core-build"
 
   core-generate:
     internal: true
@@ -198,6 +197,8 @@ tasks:
   core-build:
     internal: true
     sources: *core_source_files
+    deps:
+      - "core-generate"
     generates:
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clg"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -178,7 +178,7 @@ tasks:
 
   core-generate:
     internal: true
-    run: once
+    run: "once"
     sources: &core_source_files
       - "{{.G_DEPS_CPP_CHECKSUM_FILE}}"
       - "{{.G_CORE_COMPONENT_DIR}}/cmake/**/*"
@@ -197,7 +197,7 @@ tasks:
 
   core-build:
     internal: true
-    run: once
+    run: "once"
     sources: *core_source_files
     deps:
       - "core-generate"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -178,6 +178,7 @@ tasks:
 
   core-generate:
     internal: true
+    run: once
     sources: &core_source_files
       - "{{.G_DEPS_CPP_CHECKSUM_FILE}}"
       - "{{.G_CORE_COMPONENT_DIR}}/cmake/**/*"
@@ -196,6 +197,7 @@ tasks:
 
   core-build:
     internal: true
+    run: once
     sources: *core_source_files
     deps:
       - "core-generate"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -173,12 +173,12 @@ tasks:
           INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
 
   core:
-    cmds:
-      - task: "core-generate"
-      - task: "core-build"
+    deps:
+      - "core-build"
 
   core-generate:
     internal: true
+    run: "once"
     sources: &core_source_files
       - "{{.G_DEPS_CPP_CHECKSUM_FILE}}"
       - "{{.G_CORE_COMPONENT_DIR}}/cmake/**/*"
@@ -197,7 +197,10 @@ tasks:
 
   core-build:
     internal: true
+    run: "once"
     sources: *core_source_files
+    deps:
+      - "core-generate"
     generates:
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clg"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -173,12 +173,12 @@ tasks:
           INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
 
   core:
-    deps:
-      - "core-build"
+    cmds:
+      - task: "core-generate"
+      - task: "core-build"
 
   core-generate:
     internal: true
-    run: "once"
     sources: &core_source_files
       - "{{.G_DEPS_CPP_CHECKSUM_FILE}}"
       - "{{.G_CORE_COMPONENT_DIR}}/cmake/**/*"
@@ -197,10 +197,7 @@ tasks:
 
   core-build:
     internal: true
-    run: "once"
     sources: *core_source_files
-    deps:
-      - "core-generate"
     generates:
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clg"
       - "{{.G_CORE_COMPONENT_BUILD_DIR}}/clo"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -39,7 +39,6 @@ tasks:
       - "yscope-log-viewer"
 
   core:
-    run: "once"
     deps:
       - "utils:clean-outdated-cpp-checksum-files"
       - "utils:init"

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -39,6 +39,7 @@ tasks:
       - "yscope-log-viewer"
 
   core:
+    run: "once"
     deps:
       - "utils:clean-outdated-cpp-checksum-files"
       - "utils:init"

--- a/taskfiles/tests/integration.yaml
+++ b/taskfiles/tests/integration.yaml
@@ -5,7 +5,7 @@ vars:
 
 tasks:
   default:
-    cmds:
+    deps:
       - task: "clp-py-project-imports"
       - task: "core"
       - task: "package"

--- a/taskfiles/tests/integration.yaml
+++ b/taskfiles/tests/integration.yaml
@@ -5,7 +5,7 @@ vars:
 
 tasks:
   default:
-    deps:
+    cmds:
       - task: "clp-py-project-imports"
       - task: "core"
       - task: "package"


### PR DESCRIPTION
# Description
Fixes race condition of `task tests:integration` sporadically fails with linker errors (like `undefined reference to 'main'`). 

The `core` task previously invoked `core-build` using `cmds` instead of `deps`. Because of this, `go-task` could not deduplicate the build when multiple parallel test targets triggered the `core` task at the same time. This caused two parallel `cmake --build` processes to run simultaneously and corrupt each other's object files.

This PR
* Converts the `core` task to use `deps` instead of `cmds` so the task runner can track it natively.
* Adds `core-generate` as a dependency of `core-build` to maintain strict ordering.
* Adds `run: once` to `core-generate` and `core-build` in `taskfile.yaml`, and to the `core` dependency task in `taskfiles/deps/main.yaml`, to guarantee they evaluate only once globally, regardless of differing environment configurations passed down by the parallel test wrappers.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

*Task now deduplicates the build step.*

Previously: 
```bash
task clean
task --dry tests:integration > /tmp/task-dry-run-check.log 2>&1
grep -c "utils:cmake:build.*/home/nathan/clp/build/core" /tmp/task-dry-run-check.log
```
gives
```
2
```

Now 
```bash
task clean
task --dry tests:integration > /tmp/task-dry-run-check.log 2>&1
grep -c "utils:cmake:build.*/home/nathan/clp/build/core" /tmp/task-dry-run-check.log
```
gives
```
1
```

*End to end test:*
```
task tests:integration > /tmp/clp-build-verify.log 2>&1
grep -c "cmake --build .*/home/nathan/clp/build/core" /tmp/clp-build-verify.log
```
gives `1`  (`cmake --build` only invoked once)

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Updated task execution to use explicit dependencies, ensuring generation runs before build.
  * Added single-run safeguards so related tasks execute only once per invocation.
* **Chores**
  * Updated task configuration to run the core workflow in a more controlled, deterministic way.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->