### PR TITLE
fix(ci): Set the macOS workflow's task concurrency for `lint:check-cpp-full` to the number of logical processors.

### DIFF
--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -106,9 +106,18 @@ jobs:
       # TODO: When enough files are passing clang-tidy, switch to a full pass on schedule only.
       # - run: >-
       #     task lint:check-cpp-${{(github.event_name == 'schedule') && 'full' || 'diff'}}
+      # Cap clang-tidy concurrency. `lint:check-cpp-full` fans out one `clang-tidy` process per C++
+      # source file through a Taskfile `deps: for:` loop, which has no built-in concurrency limit,
+      # so ~hundreds of `clang-tidy` processes (each holding a full preprocessed translation unit)
+      # spawn at once. The runners don't have a huge amount of memory, and as the number of source
+      # files and the project's complexity grow, peak memory grows until it exceeds what the runner
+      # has and the OS swaps/thrashes instead of making progress. Cap concurrency to the
+      # logical-processor count to keep it within memory; override via `CLP_CPP_LINT_CONCURRENCY`
+      # (e.g. "1" for maximum memory safety).
       - run: >-
-          CLP_CPP_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN)
-          task lint:check-cpp-full
+          task --concurrency
+          "${CLP_CPP_LINT_CONCURRENCY:-$(getconf _NPROCESSORS_ONLN)}"
+          lint:check-cpp-full
         shell: "bash"
 
       # Cache the source file checksums and the generated files (logs) for the

--- a/.github/workflows/clp-core-build-macos.yaml
+++ b/.github/workflows/clp-core-build-macos.yaml
@@ -106,17 +106,9 @@ jobs:
       # TODO: When enough files are passing clang-tidy, switch to a full pass on schedule only.
       # - run: >-
       #     task lint:check-cpp-${{(github.event_name == 'schedule') && 'full' || 'diff'}}
-      # Cap clang-tidy concurrency. `lint:check-cpp-full` fans out one `clang-tidy` process per C++
-      # source file through a Taskfile `deps: for:` loop, which has no built-in concurrency limit,
-      # so ~hundreds of `clang-tidy` processes (each holding a full preprocessed translation unit)
-      # spawn at once. The runners don't have a huge amount of memory, and as the number of source
-      # files and the project's complexity grow, peak memory grows until it exceeds what the runner
-      # has and the OS swaps/thrashes instead of making progress. Cap concurrency to the
-      # logical-processor count to keep it within memory; override via `CLP_CPP_LINT_CONCURRENCY`
-      # (e.g. "1" for maximum memory safety).
       - run: >-
-          task --concurrency
-          "${CLP_CPP_LINT_CONCURRENCY:-$(getconf _NPROCESSORS_ONLN)}"
+          task
+          --concurrency "$(getconf _NPROCESSORS_ONLN)"
           lint:check-cpp-full
         shell: "bash"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

## Problem

`clp-core-build-macos`'s `lint:check-cpp-full` step runs `clang-tidy` over every C++ source file by fanning out one process per file through a Taskfile `deps: for:` loop, which has no built-in concurrency limit. Each process holds a full preprocessed translation unit, so spawning ~hundreds at once peaks high in memory; the runners OOM/swap instead of making progress, and the full pass can't finish within the timeout. `clp-core-build-macos` hadn't succeeded on `main` since ~2026-06-30 — recent runs were cancelled after 6–9h (build + tests finish in ~16–22 min; the rest is all `lint:check-cpp-full`).

The step already carried `CLP_CPP_MAX_PARALLELISM_PER_BUILD_TASK=$(getconf _NPROCESSORS_ONLN)`, which looked like it limited lint parallelism — but that variable only governs the cmake/make **compilation** parallelism (`deps:core`, `core-build`), not `clang-tidy`, which is single-threaded per invocation and gets its parallelism entirely from the Taskfile `deps: for:` fan-out. So it was a no-op on the lint step; the concurrency was never actually capped.

This also stalls the lint cache: the `Update lint:check-cpp-static-full cache` step (main-only) only fires after a successful full pass, so the cancelled passes mean the cache stays a near-empty shell and every pass runs from scratch.

## Fix

Cap the Task fan-out to the logical-processor count at the call site, via Task's own `--concurrency` flag (a CLI-level cap, independent of the `yscope-dev-utils` submodule version), and drop the no-op `CLP_CPP_MAX_PARALLELISM_PER_BUILD_TASK` prefix:

```yaml
- run: >-
    task
    --concurrency "$(getconf _NPROCESSORS_ONLN)"
    lint:check-cpp-full
  shell: "bash"
```

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This isn't a breaking change. (CI-only; changes how `clang-tidy` is scheduled, not what is checked or any build output.)
* [x] No docs need to be updated.

# Validation performed

Ran this PR's branch through CI:

| Run | Cap? | Result |
|---|---|---|
| [29217894914](https://github.com/y-scope/clp/actions/runs/29217894914) | no | ❌ cancelled @ 8h59m |
| [29474344830](https://github.com/y-scope/clp/actions/runs/29474344830) (this branch) | yes | ✅ success — 45m36s (shared) / 45m35s (static) |

With the cap the pass completes in well under an hour on both matrix legs, vs. cancelled at 8h59m uncapped. A non-`main` run doesn't populate the cache (the save step is `main`-only), so the cache-skip benefit only materializes once this lands on `main` and a `main` run completes a full pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html