### PR TITLE
fix(helm)!: Align worker task time limits in Helm values with CLP config's defaults (fixes #2384).

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.4.1-dev.0"
+version: "0.4.1-dev.1"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.13.1-dev"

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -240,14 +240,14 @@ clpConfig:
 
   compression_worker:
     logging_level: "INFO"
-    task_soft_time_limit: 0  # A value of 0 disables the limit
-    task_time_limit: 0  # A value of 0 disables the limit
+    task_soft_time_limit: 600
+    task_time_limit: 1200
     telemetry_update_interval_ms: 60000
 
   query_worker:
     logging_level: "INFO"
-    task_soft_time_limit: 0  # A value of 0 disables the limit
-    task_time_limit: 0  # A value of 0 disables the limit
+    task_soft_time_limit: 600
+    task_time_limit: 1200
     telemetry_update_interval_ms: 60000
     query_trace_sampling_probability: 0.01
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The CLP defaults and helm values mismatch in #2271.
This PR aligns worker task time limits in Helm values with CLP config's defaults.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Helm charts installed correctly.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution time limits for compression and query processing tasks, helping prevent tasks from running indefinitely.
* **Chores**
  * Updated the deployment package version to the next development release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->