### PR TITLE
fix(deps): place yscope-log-viewer tar in build/deps

### DIFF
--- a/taskfiles/deps/yscope-log-viewer.yaml
+++ b/taskfiles/deps/yscope-log-viewer.yaml
@@ -22,5 +22,5 @@ tasks:
           CHECKSUM_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.md5"
           FILE_SHA256: "ba306d91cfc7129de6d1dfedf41210ced0391074cf0843dc6f6d6cf068e16b4e"
           OUTPUT_DIR: "{{.G_DEPS_YSCOPE_LOG_VIEWER_SRC_DIR}}"
-          TAR_FILE: "{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz"
+          TAR_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz"
           URL: "https://github.com/y-scope/yscope-log-viewer/archive/f9b46d2.tar.gz"


### PR DESCRIPTION
## Summary
- Update `taskfiles/deps/yscope-log-viewer.yaml` so the `TAR_FILE` path for downloading `yscope-log-viewer` points at `{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz` instead of `{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz`.
- This keeps dependency tarballs under the dependency output directory (`build/deps`) for consistency with other dependency tasks.

## Validation performed
- Verified the repository currently had `{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz` in `taskfiles/deps/yscope-log-viewer.yaml`.
- Changed it to `{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz` in commit `06212cb8`.
- Confirmed file content in branch `fix/log-viewer-tar-location-clean` and opened PR #2388.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the source archive location used during dependency setup, improving reliability when retrieving the bundled archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->