### PR TITLE
fix(deps): use build/deps for yscope-log-viewer tar path

### DIFF
--- a/taskfiles/deps/yscope-log-viewer.yaml
+++ b/taskfiles/deps/yscope-log-viewer.yaml
@@ -22,5 +22,5 @@ tasks:
           CHECKSUM_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.md5"
           FILE_SHA256: "ba306d91cfc7129de6d1dfedf41210ced0391074cf0843dc6f6d6cf068e16b4e"
           OUTPUT_DIR: "{{.G_DEPS_YSCOPE_LOG_VIEWER_SRC_DIR}}"
-          TAR_FILE: "{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz"
+          TAR_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz"
           URL: "https://github.com/y-scope/yscope-log-viewer/archive/f9b46d2.tar.gz"


### PR DESCRIPTION
## Summary
- Update the yscope-log-viewer dependency download tar path to the dependency directory.
- `taskfiles/deps/log-viewer.yaml` now sets:
  - `TAR_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz"`

## Validation
- Confirmed the `TAR_FILE` value in `taskfiles/deps/log-viewer.yaml` is `{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz`.
- Branch includes no other taskfile dependency path changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the dependency download process to use the correct archive location, improving reliability during setup and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->