### PR TITLE
fix(deps): use build/deps for yscope-log-viewer tar path (fixes #2395)

### DIFF
--- a/taskfiles/deps/yscope-log-viewer.yaml
+++ b/taskfiles/deps/yscope-log-viewer.yaml
@@ -22,5 +22,5 @@ tasks:
           CHECKSUM_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.md5"
           FILE_SHA256: "ba306d91cfc7129de6d1dfedf41210ced0391074cf0843dc6f6d6cf068e16b4e"
           OUTPUT_DIR: "{{.G_DEPS_YSCOPE_LOG_VIEWER_SRC_DIR}}"
-          TAR_FILE: "{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz"
+          TAR_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz"
           URL: "https://github.com/y-scope/yscope-log-viewer/archive/f9b46d2.tar.gz"


### PR DESCRIPTION
# Description

Fix yscope-log-viewer dependency archive output path by aligning tar/ checksum artifacts under `{{.G_DEPS_DIR}}`.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

- Task: `grep -n "^\s*TAR_FILE:" taskfiles/deps/log-viewer.yaml taskfiles/deps/yscope-log-viewer.yaml`
- Command output:
  - `taskfiles/deps/log-viewer.yaml:104:TAR_FILE: "{{.G_DEPS_DIR}}/log-viewer-{{.G_GIT_COMMIT_HASH_YSCOPE_LOG_VIEWER}}.tar.gz"`
  - `taskfiles/deps/yscope-log-viewer.yaml:11:TAR_FILE: "{{.G_DEPS_DIR}}/log-viewer-{{.G_GIT_COMMIT_HASH_YSCOPE_LOG_VIEWER}}.tar.gz"`

- Scope: only dependency taskfile tar path wiring (`TASKFILES/deps/log-viewer.yaml` and `TASKFILES/deps/yscope-log-viewer.yaml`) changed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
