### PR TITLE
fix(deps): Store the yscope-log-viewer tarball under `build/deps` (fixes #2395).

### DIFF
--- a/taskfiles/deps/yscope-log-viewer.yaml
+++ b/taskfiles/deps/yscope-log-viewer.yaml
@@ -22,5 +22,5 @@ tasks:
           CHECKSUM_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.md5"
           FILE_SHA256: "ba306d91cfc7129de6d1dfedf41210ced0391074cf0843dc6f6d6cf068e16b4e"
           OUTPUT_DIR: "{{.G_DEPS_YSCOPE_LOG_VIEWER_SRC_DIR}}"
-          TAR_FILE: "{{.G_BUILD_DIR}}/yscope-log-viewer.tar.gz"
+          TAR_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz"
           URL: "https://github.com/y-scope/yscope-log-viewer/archive/f9b46d2.tar.gz"


### PR DESCRIPTION
# Description
Fix yscope-log-viewer dependency download task so tar output path is placed under `{{.G_DEPS_DIR}}` instead of `{{.G_BUILD_DIR}}`.

# Checklist
- [x] The PR satisfies the contribution guidelines.
- [x] This is not a breaking change.
- [x] Necessary docs have been updated, OR no docs need updates.

# Validation performed
- Command: `grep -n "^\s*TAR_FILE:" taskfiles/deps/yscope-log-viewer.yaml`
- Output:
  - `TAR_FILE: "{{.G_DEPS_DIR}}/yscope-log-viewer.tar.gz"`
