### PR TITLE
feat(compression-coordinator): Add scaffolding `S3CompressionJobHandle` for driving an S3 compression job to completion.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,9 @@ dependencies = [
  "clp-rust-utils",
  "serde",
  "spider-core",
+ "sqlx",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/components/clp-rust-utils/src/task_io/compression.rs
+++ b/components/clp-rust-utils/src/task_io/compression.rs
@@ -9,8 +9,9 @@ use crate::clp_config::AwsAuthentication;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClpSCompressionOption {
     pub target_encoded_size: u64,
-    pub compression_level: i32,
+    pub compression_level: u8,
     pub timestamp_key: Option<String>,
+    pub unstructured: bool,
 }
 
 /// Input source for a compression task.

--- a/components/compression-coordinator/Cargo.toml
+++ b/components/compression-coordinator/Cargo.toml
@@ -12,4 +12,6 @@ async-trait = "0.1.89"
 clp-rust-utils = { path = "../clp-rust-utils" }
 serde = { version = "1.0.228", features = ["derive"] }
 spider-core = { git = "https://github.com/y-scope/spider.git", branch = "main" }
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "mysql"] }
 thiserror = "2.0.18"
+tracing = "0.1.44"

--- a/components/compression-coordinator/src/error.rs
+++ b/components/compression-coordinator/src/error.rs
@@ -2,4 +2,13 @@
 
 /// Errors returned by the compression coordinator.
 #[derive(Debug, thiserror::Error)]
-pub enum Error {}
+pub enum Error {
+    #[error("sqlx error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error("invalid dataset: {0}")]
+    InvalidDataset(String),
+
+    #[error("unsupported input config")]
+    UnsupportedInputConfig,
+}

--- a/components/compression-coordinator/src/job_handle.rs
+++ b/components/compression-coordinator/src/job_handle.rs
@@ -1,0 +1,315 @@
+//! Handle for driving a single S3 compression job to completion.
+
+use std::{sync::Arc, time::Duration};
+
+use clp_rust_utils::{
+    clp_config::package::config::Database,
+    dataset::VALID_DATASET_NAME_REGEX,
+    job_config::{ClpIoConfig, CompressionJobId, CompressionJobStatus, InputConfig},
+    task_io::compression::{ClpSCompressionOption, S3InputSource},
+};
+use spider_core::{
+    task::ExecutionPolicy,
+    types::id::{JobId as SpiderJobId, ResourceGroupId},
+};
+use sqlx::MySqlPool;
+
+use crate::{Error, compression_job_submitter::S3CompressionJobSubmitter};
+
+/// Options for a compression job running in Spider.
+pub struct SpiderOption {
+    pub compression_task_max_retry: u32,
+    pub commit_task_execution_policy: ExecutionPolicy,
+    pub initial_poll_backoff: Duration,
+    pub max_poll_backoff: Duration,
+}
+
+/// Handles the asynchronous submission of an S3 compression job and the retrieval of its result.
+///
+/// # Type Parameters
+///
+/// * `SubmitterType` - The type of the job submitter for Spider job submission.
+pub struct S3CompressionJobHandle<SubmitterType: S3CompressionJobSubmitter> {
+    _db_pool: MySqlPool,
+    _db_config: Database,
+    compression_job_id: CompressionJobId,
+    job_submitter: SubmitterType,
+    resource_group_id: ResourceGroupId,
+
+    _input_config: InputConfig,
+    clp_s_compression_option: ClpSCompressionOption,
+    dataset: Option<String>,
+    _target_archive_size: u64,
+
+    spider_option: Arc<SpiderOption>,
+}
+
+impl<SubmitterType: S3CompressionJobSubmitter> S3CompressionJobHandle<SubmitterType> {
+    /// Factory function.
+    ///
+    /// # Returns
+    ///
+    /// A newly created [`S3CompressionJobHandle`] for the given compression job, with the `clp-s`
+    /// compression options derived from `clp_io_config`'s output config.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`Error::UnsupportedInputConfig`] if `clp_io_config`'s input config is not an
+    ///   [`InputConfig::S3ObjectMetadataInputConfig`].
+    /// * [`Error::InvalidDataset`] if the configured dataset name is not a valid dataset name.
+    pub fn new(
+        db_pool: MySqlPool,
+        db_config: Database,
+        compression_job_id: CompressionJobId,
+        job_submitter: SubmitterType,
+        resource_group_id: ResourceGroupId,
+        clp_io_config: ClpIoConfig,
+        spider_option: Arc<SpiderOption>,
+    ) -> Result<Self, Error> {
+        let input_config = clp_io_config.input;
+        let InputConfig::S3ObjectMetadataInputConfig {
+            config: s3_object_metadata_config,
+        } = &input_config
+        else {
+            return Err(Error::UnsupportedInputConfig);
+        };
+        let dataset: Option<String> = s3_object_metadata_config.dataset.clone().map(String::from);
+        if let Some(dataset_name) = dataset.as_ref()
+            && !VALID_DATASET_NAME_REGEX.is_match(dataset_name)
+        {
+            return Err(Error::InvalidDataset(dataset_name.clone()));
+        }
+
+        let output_config = clp_io_config.output;
+        let clp_s_compression_option = ClpSCompressionOption {
+            target_encoded_size: output_config.target_segment_size
+                + output_config.target_dictionaries_size,
+            compression_level: output_config.compression_level,
+            timestamp_key: s3_object_metadata_config
+                .timestamp_key
+                .clone()
+                .map(String::from),
+            unstructured: s3_object_metadata_config.unstructured,
+        };
+
+        Ok(Self {
+            _db_pool: db_pool,
+            _db_config: db_config,
+            compression_job_id,
+            job_submitter,
+            resource_group_id,
+            _input_config: input_config,
+            clp_s_compression_option,
+            dataset,
+            _target_archive_size: output_config.target_archive_size,
+            spider_option,
+        })
+    }
+
+    /// Submits the compression job to Spider and drives it to completion.
+    ///
+    /// This method prepares the compression tasks' inputs, ensures the dataset's metadata tables
+    /// exist, submits the job, persists the Spider job ID it was assigned, and then waits for the
+    /// job to reach a terminal state. On any failure, the compression job is marked as
+    /// [`CompressionJobStatus::Failed`] before the error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`Self::submit_and_wait`]'s return values on failure.
+    pub async fn run(self) -> Result<(), Error> {
+        tracing::info!(compression_job_id = % self.compression_job_id, "Starting compression job.");
+
+        let result = self.submit_and_wait().await;
+        if let Err(err) = &result {
+            self.report_failure(err).await;
+        }
+
+        result
+    }
+
+    /// Resumes a compression job that was already submitted to Spider.
+    ///
+    ///
+    /// This method skips submission and waits for the Spider job identified by `spider_job_id` to
+    /// reach a terminal state. On failure, the compression job is marked as
+    /// [`CompressionJobStatus::Failed`] before the error is returned.
+    ///
+    /// NOTE: It's the caller's responsibility to ensure that the given Spider job ID is associated
+    /// with the compression job.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`Self::to_completion`]'s return values on failure.
+    pub async fn recover(self, spider_job_id: SpiderJobId) -> Result<(), Error> {
+        tracing::info!(
+            compression_job_id = % self.compression_job_id,
+            spider_job_id = % spider_job_id,
+            "Recovering compression job.",
+        );
+        match self.to_completion(spider_job_id).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                self.report_failure(&err).await;
+                Err(err)
+            }
+        }
+    }
+
+    /// Submits the compression job to Spider and waits for it to reach a terminal state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`Self::prepare_task_inputs`]'s return values on failure.
+    /// * Forwards [`Self::upsert_metadata_tables`]'s return values on failure.
+    /// * Forwards [`S3CompressionJobSubmitter::submit_s3_compression_job`]'s return values on
+    ///   failure.
+    /// * Forwards [`Self::persist_spider_job_id`]'s return values on failure.
+    /// * Forwards [`Self::to_completion`]'s return values on failure.
+    async fn submit_and_wait(&self) -> Result<(), Error> {
+        let input_sources = self.prepare_task_inputs().await?;
+
+        self.upsert_metadata_tables().await?;
+
+        let spider_job_id = self
+            .job_submitter
+            .submit_s3_compression_job(
+                self.compression_job_id,
+                self.resource_group_id,
+                self.clp_s_compression_option.clone(),
+                self.dataset.clone(),
+                input_sources,
+                self.spider_option.commit_task_execution_policy.clone(),
+            )
+            .await?;
+        tracing::info!(
+            compression_job_id = % self.compression_job_id,
+            spider_job_id = % spider_job_id,
+            "Compression job submitted.",
+        );
+
+        self.persist_spider_job_id(spider_job_id).await?;
+        tracing::info!(
+            compression_job_id = % self.compression_job_id,
+            spider_job_id = % spider_job_id,
+            "Compression job submission persisted.",
+        );
+
+        self.to_completion(spider_job_id).await
+    }
+
+    /// Reports a compression job failure.
+    ///
+    /// This method logs the original error and attempts to mark the compression job as
+    /// [`CompressionJobStatus::Failed`] in the CLP database. The stored status message includes the
+    /// original error message.
+    ///
+    /// If updating the job status fails, the status-update error is logged for observability and
+    /// otherwise ignored.
+    async fn report_failure(&self, err: &Error) {
+        tracing::error!(
+            compression_job_id = % self.compression_job_id,
+            error = % err,
+            "Compression job failed.",
+        );
+        let status_message = format!("Compression job failed: {err}");
+        if let Err(e) = self
+            .update_job_status(CompressionJobStatus::Failed, Some(status_message))
+            .await
+        {
+            tracing::error!(
+                compression_job_id = % self.compression_job_id,
+                error = % e,
+                "Failed to update job status on a job failure.",
+            );
+        }
+    }
+
+    /// Prepares the task inputs for the compression job.
+    ///
+    /// This method retrieves object metadata from the S3 object metadata table in the CLP database,
+    /// partitions the objects into compression task inputs, and derives an execution policy for
+    /// each task based on the number of objects it contains.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tuples on success, where each tuple contains:
+    ///
+    /// * An [`S3InputSource`] representing the input to a single compression task.
+    /// * The [`ExecutionPolicy`] for that task.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// TODO
+    async fn prepare_task_inputs(&self) -> Result<Vec<(S3InputSource, ExecutionPolicy)>, Error> {
+        todo!("implement me!")
+    }
+
+    /// Ensures that the required metadata tables exist for the configured dataset.
+    ///
+    /// This method creates the following tables in the CLP database if they do not already exist:
+    ///
+    /// * The archive metadata table.
+    /// * The column metadata table.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// TODO
+    async fn upsert_metadata_tables(&self) -> Result<(), Error> {
+        todo!("implement me!")
+    }
+
+    /// Persists the Spider job ID and marks the compression job as running.
+    ///
+    /// This method associates the given Spider job ID with the compression job in the CLP database
+    /// and updates the compression job status to [`CompressionJobStatus::Running`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// TODO
+    async fn persist_spider_job_id(&self, _spider_job_id: SpiderJobId) -> Result<(), Error> {
+        todo!("implement me!")
+    }
+
+    /// Waits for the associated Spider job to complete and finalizes the compression job.
+    ///
+    /// This method monitors the specified Spider job until it reaches a terminal state, then
+    /// updates the compression job according to the Spider job's result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// TODO
+    async fn to_completion(&self, _spider_job_id: SpiderJobId) -> Result<(), Error> {
+        todo!("implement me!")
+    }
+
+    /// Updates the compression job status in the CLP database.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// TODO
+    async fn update_job_status(
+        &self,
+        _job_status: CompressionJobStatus,
+        _status_message: Option<String>,
+    ) -> Result<(), Error> {
+        todo!("implement me!")
+    }
+}

--- a/components/compression-coordinator/src/lib.rs
+++ b/components/compression-coordinator/src/lib.rs
@@ -3,5 +3,6 @@
 
 pub mod compression_job_submitter;
 mod error;
+pub mod job_handle;
 
 pub use error::Error;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Adds `S3CompressionJobHandle`, the object that owns a single CLP compression job for its whole lifetime: it turns a `ClpIoConfig` into Spider task inputs, submits the job, records the Spider job ID against the CLP compression job, waits for the job to finish, and reports the outcome back to the CLP database.

This PR lands the orchestration flow and the type's public surface. The database-facing steps are declared and documented but left as `todo!()`, to be filled in by a follow-up; see **Deferred work** below.

**`S3CompressionJobHandle`**

The handle is generic over `SubmitterType: S3CompressionJobSubmitter`, so the Spider client added in the submitter-implementation PR can be swapped for a mock in tests without this type depending on a concrete client.

`new` validates and normalizes the job's configuration up front, so the rest of the flow can assume it is well-formed:

* The input config must be an `InputConfig::S3ObjectMetadataInputConfig`; any other variant is rejected with `Error::UnsupportedInputConfig`. This handle drives jobs whose inputs come from the S3 object metadata table, which is the only shape the coordinator produces today.
* A configured dataset name is checked against `VALID_DATASET_NAME_REGEX` and rejected with `Error::InvalidDataset`, so an invalid name fails before any Spider or database work is done rather than partway through the job.
* The output config is collapsed into the `ClpSCompressionOption` shared by every task in the job, so the per-task settings are computed once instead of at each submission site.

Two entry points consume the handle, and both take `self` by value so a handle cannot be driven twice:

* `run` performs the full flow: prepare the task inputs, ensure the dataset's metadata tables exist, submit the job to Spider, persist the returned Spider job ID, then wait for completion.
* `recover` skips submission and waits on a Spider job ID that was already persisted. This is the restart path: the Spider job ID is written to the database before the coordinator begins waiting, so a coordinator that dies mid-job can find the in-flight job and resume tracking it instead of resubmitting work that is already running.

Both funnel failures through `report_failure`, which marks the compression job as `CompressionJobStatus::Failed` with the originating error as its status message. A failure to record that status is logged rather than propagated, so a database problem while reporting cannot mask the error that actually caused the job to fail.

**`SpiderOption`**

Groups the Spider-side knobs that apply to a whole job — the compression tasks' retry limit, the commit task's execution policy, and the job-state poll backoffs. It is held behind an `Arc` because these settings are process-wide and identical across every concurrently running handle.

**`Error`**

The crate error type gains the variants this flow can produce: `Sqlx` for database failures, and `InvalidDataset` / `UnsupportedInputConfig` for the configuration rejections described above.

**`ClpSCompressionOption` changes**

Two changes to the task I/O type added in the scaffolding PR, both to match what `clp-s` actually accepts:

* `compression_level` narrows from `i32` to `u8`. The value is a zstd compression level, which is never negative and never exceeds the `u8` range, so the wider signed type allowed states the task could not act on.
* A new `unstructured` field carries the input config's `unstructured` flag through to the compression task, which needs it to select the correct `clp-s` mode.

This alters the msgpack payload exchanged with the Spider tasks. No released component consumes it yet, so no migration is required.

**Deferred work**

The following methods are declared, documented, and left as `todo!()`, since they all depend on the coordinator's database access layer:

* `prepare_task_inputs` — read object metadata from the S3 object metadata table, partition it into per-task inputs, and derive each task's execution policy.
* `upsert_metadata_tables` — create the dataset's archive and column metadata tables if absent.
* `persist_spider_job_id` — associate the Spider job ID with the compression job and mark it running.
* `to_completion` — wait for the Spider job to reach a terminal state and finalize the compression job accordingly.
* `update_job_status` — write a compression job's status and status message.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public support for initiating and resuming S3-based compression jobs.
  * Introduced an S3 job handling abstraction with improved failure reporting and status persistence.
  * Updated compression options to include an `unstructured` flag and tightened `compression_level` to an unsigned range.
* **Improvements**
  * Expanded coordinator error reporting for invalid datasets, unsupported configurations, and S3 mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->