### PR TITLE
ci(lint): Cap ruff below v0.16 to avoid newly stabilized CPY001 lint failures.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -6,7 +6,10 @@ clang-format~=21.1.2
 clang-tidy~=19.1
 
 # Python
-ruff>=0.4.4
+# Cap below v0.16 until we adopt its newly stabilized rules (e.g., CPY001 requires copyright
+# notices, which our Python files don't have yet).
+# Issue: https://github.com/y-scope/clp/issues/2422
+ruff>=0.4.4,<0.16
 
 # YAML
 yamale>=6.1.0


### PR DESCRIPTION
# Description

Fixes #2422.

Caps `ruff` below v0.16 in `lint-requirements.txt` (`ruff>=0.4.4` → `ruff>=0.4.4,<0.16`, which currently resolves to v0.15.22 — the version from the last green lint run) so CI lint stops failing on `CPY001 Missing copyright notice`.

## Root cause

Ruff 0.16.0 was released today (2026-07-23) and stabilized `CPY001` (`missing-copyright-notice`) out of preview, along with 11 other rules. Our shared lint config (`tools/yscope-dev-utils/exports/lint-configs/python/ruff.toml`) uses `select = ["ALL"]`, which excludes preview rules but automatically picks up newly stabilized ones. Combined with the floating `ruff>=0.4.4` pin, every lint run after the release installs v0.16.0 and fails on Python files without a copyright notice (`components/core/tools/scripts/db/init-db.py` and `components/core/tools/scripts/utils/build-and-run-unit-tests.py`) — with no code change on our side.

Evidence that this is version drift rather than a code regression:

* `main`'s last lint run ([green, 04:48 UTC today](https://github.com/y-scope/clp/actions/runs/29980502536)) installed ruff **0.15.22** on `c0c86763a6`.
* PR #2357's lint runs a few hours later (e.g., [this failing run](https://github.com/y-scope/clp/actions/runs/30042085890/job/89324199390)) installed ruff **0.16.0** on a branch whose Python code is identical to `c0c86763a6` (it merges that exact commit), and failed with the two `CPY001` errors.

Without this cap, `main` and every open PR will go red on their next lint run.

Note: the mypy errors that appear earlier in the failing logs are unrelated noise — the lint task invokes mypy with `|| true`, so they never fail the job.

## Follow-up

Adopting ruff 0.16 later is a deliberate decision: either add copyright notices (and address anything the other newly stabilized rules flag) or ignore `CPY` in the shared yscope-dev-utils config (a separate repo/submodule bump), then lift this cap.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* In `components/core/tools/scripts`: `uvx ruff@0.16.0 check .` reproduces the exact two `CPY001` errors from CI; `uvx ruff@0.15.22 check .` passes clean.
* Verified the new constraint `ruff>=0.4.4,<0.16` resolves to v0.15.22.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Constrained the Ruff version to a compatible range to support more consistent linting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->