### PR TITLE
fix(docker): Disable provenance for dependency image staging tags (fixes #2425).

### DIFF
--- a/.github/actions/clp-core-build-containers/action.yaml
+++ b/.github/actions/clp-core-build-containers/action.yaml
@@ -107,6 +107,9 @@ runs:
         labels: "${{steps.deps_image_meta.outputs.labels}}"
         tags: "${{steps.deps_image_meta.outputs.tags}}"
         outputs: "${{steps.get_image_props.outputs.output}}"
+        # Disable provenance to create a simple image instead of a manifest list.
+        # This allows `docker manifest create` to combine the per-arch images later.
+        provenance: false
 
     - if: "inputs.push_deps_image == 'false'"
       uses: "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Proposed PR title:
fix(docker): Disable provenance for dependency image staging tags (fixes #2425).
-->

# Description

Fixes https://github.com/y-scope/clp/issues/2425.

The dependency-image action currently leaves Buildx provenance enabled when it publishes the `main-amd64` and `main-arm64` staging tags. Buildx therefore wraps each platform image and its provenance attestation in an OCI image index, which causes the downstream `docker manifest create` jobs to reject the staging tags instead of publishing the multi-arch `main` tags.

This PR disables provenance for dependency-image builds, matching the [existing runtime-image publication path](https://github.com/y-scope/clp/blob/9002b138ddaf0c0d86486b9f8a03bb1ab7e8d645/.github/actions/clp-build-runtime-image/action.yaml#L81-L92), so the staging tags remain individual image manifests that the manylinux and musllinux merge jobs can combine.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

```text
$ task lint:fix-yaml
task: Task "lint:venv" is up to date
task: [lint:yaml] . "/home/junhao/.codex/worktrees/7a2b/clp/build/lint-venv/bin/activate"
yamllint --strict \
  --config-file "tools/yscope-dev-utils/exports/lint-configs/.yamllint.yml" \
  ".github" \
  "components/core/.clang-format" \
  "components/core/config" \
  "components/core/tools/" \
  "components/package-template/src/etc" \
  "docs" \
  "taskfile.yaml" \
  "taskfiles" \
  "tools/deployment/package" \
  "tools/deployment/presto-clp"

$ yq -e '.runs.steps[] | select(.uses == "docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4") | .with.provenance == false' .github/actions/clp-core-build-containers/action.yaml
true

$ go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'SC2046' .github/workflows/clp-artifact-build.yaml && printf 'actionlint: passed\n'
actionlint: passed

$ task >/dev/null 2>&1 && printf 'task: passed\n'
task: passed

$ git diff --check && printf 'git diff --check: passed\n'
git diff --check: passed
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-architecture container image publishing by ensuring images can be combined reliably into a single manifest.
  * Simplified generated container image metadata for more consistent build and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->