### PR TITLE
fix(api-server): Return relative query URL to fix path-prefixing (fixes #2429).

### DIFF
--- a/components/api-server/src/routes.rs
+++ b/components/api-server/src/routes.rs
@@ -118,7 +118,7 @@ async fn health() -> String {
             status = OK,
             body = QueryResultsUri,
             description = "The URI to fetch the results of the submitted query.",
-            example = json!({"query_results_uri":"/query_results/1"})
+            example = json!({"query_results_uri":"query_results/1"})
         ),
         (status = INTERNAL_SERVER_ERROR)
     )
@@ -138,7 +138,7 @@ async fn query(
             return Err(err.into());
         }
     };
-    let uri = format!("/query_results/{search_job_id}");
+    let uri = format!("query_results/{search_job_id}");
     Ok(Json(QueryResultsUri {
         query_results_uri: uri,
     }))

--- a/docs/src/_static/generated/api-server-openapi.json
+++ b/docs/src/_static/generated/api-server-openapi.json
@@ -65,7 +65,7 @@
                   "$ref": "#/components/schemas/QueryResultsUri"
                 },
                 "example": {
-                  "query_results_uri": "/query_results/1"
+                  "query_results_uri": "query_results/1"
                 }
               }
             }

--- a/docs/src/user-docs/guides-using-the-api-server.md
+++ b/docs/src/user-docs/guides-using-the-api-server.md
@@ -42,7 +42,7 @@ following commands to submit a query to clp-json and stream the results.
 
     ```json
     {
-      "query_results_uri": "/query_results/100"
+      "query_results_uri": "query_results/100"
     }
     ```
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

The API server currently returns a root-relative absolute URI (`/query_results/{id})` for the `query_results_uri field`, so ingress and Gateway configurations that use path prefixes (like `/api/v1`) are forced to define a separate top-level /query_results route, even though query results belong strictly to the API server.

This PR changes the API server to return a relative URI without a leading slash (e.g. `query_results/42`). Resolving this relative to `/api/v1/query` now correctly produces `/api/v1/query_results/42`. 

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Deployed a local cluster and verified that queries returned relative URIs  (taken from https://github.com/y-scope/clp/issues/2429)

1. Deploy the CLP API server.
```
task core && task --force rust && task --force docker-images:package
./tools/deployment/package-helm/set-up-test.sh --clp-package-image ghcr.io/y-scope/clp/clp-package-ubuntu-noble:latest
```
2. Configure a reverse proxy or Gateway route that:
  - Matches /api/v1 
  - Strips /api/v1
  - Forwards requests to the API server on port 3001
  - Does not define a separate top-level /query_results route

```
cat <<EOF > nginx-proxy.conf
events {}
http {
    server {
        listen 8080;
        
        # Matches /api/v1 and strips it before forwarding
        location /api/v1/ {
            rewrite ^/api/v1/(.*) /\$1 break;
            
            # Forwards to the API Server exposed by kind on port 30301
            proxy_pass http://host.docker.internal:30301;
        }
    }
}
EOF

docker run -d --name clp-proxy --add-host host.docker.internal:host-gateway -p 8080:8080 -v $(pwd)/nginx-proxy.conf:/etc/nginx/nginx.conf:ro nginx
```

3. Submit a valid query through the public endpoint:

```console
nathan@c4a:~/clpdev$ curl -s -X POST http://localhost:8080/api/v1/query \
  -H "Content-Type: application/json" \
  -d '{
    "query_string": "*",
    "datasets": ["default"],
    "ignore_case": false,
    "max_num_results": 100
  }'
{"query_results_uri":"query_results/2"}nathan@c4a:~/clpdev$
```


<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated query result links to use consistent relative paths.
  * Corrected the API example response to reflect the updated link format.

* **Documentation**
  * Updated API usage guidance for retrieving query results through the returned link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->