### PR TITLE
fix(clp-tdl-package): Remove the dangling comma before `WHERE` in the commit task's job-success `UPDATE`.

### DIFF
--- a/components/clp-tdl-package/src/task/compression/commit.rs
+++ b/components/clp-tdl-package/src/task/compression/commit.rs
@@ -194,7 +194,7 @@ async fn mark_job_succeeded(
     // time.
     let query_result = sqlx::query(
         "UPDATE compression_jobs SET status = ?, uncompressed_size = ?, compressed_size = ?, \
-         duration = TIMESTAMPDIFF(MICROSECOND, start_time, CURRENT_TIMESTAMP(3)) / 1000000, WHERE \
+         duration = TIMESTAMPDIFF(MICROSECOND, start_time, CURRENT_TIMESTAMP(3)) / 1000000 WHERE \
          id = ? AND status = ?",
     )
     .bind(CompressionJobStatus::Succeeded)


### PR DESCRIPTION
# Description

`mark_job_succeeded` in the clp-s compression commit task has a dangling comma before `WHERE` in its `UPDATE` statement (left behind when the `update_time` assignment was removed during #2415's review). The statement is a guaranteed SQL syntax error, so every commit task fails: the Spider job reports `executor crashed (exit_status = None)`, the CLP compression job ends `FAILED`, and the already-uploaded archive is left in S3 unregistered (no `clp_default_archives` row).

This removes the comma.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Ran the Spider-orchestrated compression E2E on Kubernetes (kind, MinIO stand-in; coordinator from `main` + #2417, worker = the published `clp-spider-worker:main` image with only `libclp.so` replaced by a build containing this fix).

Before the fix (worker image built from current `main`), the commit task failed on every attempt and the job ended `FAILED` with `outcome: "executor crashed (exit_status = None)"`. After the fix, the same job succeeds end-to-end, and the previously never-written `duration` column is populated:

```
mariadb> SELECT id, status, num_tasks, spider_id, duration FROM compression_jobs;
+----+--------+-----------+-----------+----------+
| id | status | num_tasks | spider_id | duration |
+----+--------+-----------+-----------+----------+
|  4 |      2 |         1 |         4 |    0.166 |
+----+--------+-----------+-----------+----------+
```

The committed archive appears in `clp_default_archives` with the matching S3 object, and a follow-up search through the api-server returns all ingested events from the archive.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing compression jobs from being marked as completed successfully.
  * Ensured final compression metrics, including sizes and duration, are recorded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->