### PR TITLE
WIP: ci(rust-checks): configurable runner via CLP_RUNNER_LINUX_LIGHT_X64

### DIFF
--- a/.github/workflows/clp-rust-checks.yaml
+++ b/.github/workflows/clp-rust-checks.yaml
@@ -28,7 +28,13 @@ concurrency:
 
 jobs:
   rust-checks:
-    runs-on: "ubuntu-22.04"
+    # CPU-bound (cargo build + nextest), but `tests:rust-all` starts LocalStack and reaches
+    # it through a host-published port, which is unreachable from the job's loopback on the
+    # self-hosted runners. Keep on GitHub-hosted via CLP_RUNNER_LINUX_LIGHT_X64 (empty ->
+    # fallback) until LocalStack-on-self-hosted is supported.
+    runs-on: >-
+      ${{vars.CLP_RUNNER_LINUX_LIGHT_X64 != ''
+        && fromJSON(vars.CLP_RUNNER_LINUX_LIGHT_X64) || 'ubuntu-22.04'}}
     steps:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:


### PR DESCRIPTION
Work in progress — making the `clp-rust-checks` runner selectable via the `CLP_RUNNER_LINUX_LIGHT_X64` repository variable (empty → `ubuntu-22.04` fallback), keeping the job on GitHub-hosted where LocalStack's published port works. Description to be expanded.