### PR TITLE
fix(build): fix task core on Ubuntu 26.04

### DIFF
--- a/docs/src/dev-docs/components-core/index.md
+++ b/docs/src/dev-docs/components-core/index.md
@@ -57,7 +57,7 @@ The task will download, build, and install (within the build directory) the foll
 | [SQLite3](https://www.sqlite.org/download.html)                          | v3.36.0        |
 | [utfcpp](https://github.com/nemtrif/utfcpp)                              | v4.0.6         |
 | [xxHash](https://github.com/Cyan4973/xxHash)                             | v0.8.3         |
-| [yaml-cpp](https://github.com/jbeder/yaml-cpp)                           | v0.7.0         |
+| [yaml-cpp](https://github.com/jbeder/yaml-cpp)                           | v0.9.0         |
 | [ystdlib-cpp](https://github.com/y-scope/ystdlib-cpp)                    | 9ed78cd        |
 | [zlib](https://github.com/madler/zlib)                                   | v1.3.1         |
 | [zstd](https://github.com/facebook/zstd)                                 | v1.5.7         |

--- a/taskfiles/deps/main.yaml
+++ b/taskfiles/deps/main.yaml
@@ -192,6 +192,7 @@ tasks:
             - "-DANTLR4_INSTALL=ON"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+            - "-DANTLR_BUILD_CPP_TESTS=OFF"
 
             # Set CMP0135 so that extracted files use the current timestamp as their modification
             # timestamp, which ensures the library gets rebuilt if the extracted files change.
@@ -634,9 +635,10 @@ tasks:
             - "-DBUILD_TESTING=OFF"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_INSTALL_MESSAGE=LAZY"
+            - "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
           LIB_NAME: "yaml-cpp"
-          TARBALL_SHA256: "43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3"
-          TARBALL_URL: "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz"
+          TARBALL_SHA256: "25cb043240f828a8c51beb830569634bc7ac603978e0f69d6b63558dadefd49a"
+          TARBALL_URL: "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9.0.tar.gz"
 
   ystdlib:
     internal: true


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Fix build errorors related to cmake version < 3.5 suppport and more strict g++ headers includes.
yaml-cpp-0.7.0  has cpp errors for `uint16_t` and `uint32_t` undefined.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated developer documentation to reflect the current YAML processing library version.

- **Chores**
  - Improved build configuration for more consistent compatibility across supported CMake environments.
  - Disabled unnecessary third-party C++ test builds, helping streamline build setup and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->