### PR TITLE
fix(build): Use shared Rust target directory by default (fixes #2442).

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,4 @@ rustflags = [
     "-Dclippy::nursery",
     "-Dclippy::pedantic",
 ]
+target-dir = "build/rust-targets"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!-- Proposed PR title: fix(build): Use shared Rust target directory by default (fixes #2442). -->

# Description

Fixes https://github.com/y-scope/clp/issues/2442.

Cargo commands launched outside the Taskfile environment, including IDE language servers and coding agents, currently fall back to the repository-local `target/` directory and duplicate artifacts already stored under `build/rust-targets`.

Restore `build/rust-targets` as Cargo's repository default in `.cargo/config.toml`. The generated toolchain environment continues to export [`CARGO_TARGET_DIR`](https://github.com/y-scope/clp/blob/979b93c4e0e6d0edbc1cf933c02c6eedc1cdf148/taskfiles/toolchains.yaml#L143) from [`G_RUST_BUILD_DIR`](https://github.com/y-scope/clp/blob/979b93c4e0e6d0edbc1cf933c02c6eedc1cdf148/taskfile.yaml#L39), so custom `G_BUILD_DIR` values still take precedence over the default.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

```text
$ task lint:fix-rust >/dev/null 2>&1 && printf 'task lint:fix-rust: passed\n'
task lint:fix-rust: passed

$ task tests:rust-all >/dev/null 2>&1 && printf 'task tests:rust-all: passed\n'
task tests:rust-all: passed

$ task >/dev/null 2>&1 && printf 'task: passed\n'
task: passed

$ printf 'default=' && env -u CARGO_TARGET_DIR cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])' && printf 'override=' && CARGO_TARGET_DIR=/tmp/clp-issue-2442-target cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])' && printf 'task-env=' && sed -n 's/^export CARGO_TARGET_DIR="\(.*\)"$/\1/p' build/toolchains/rust/env
default=/home/junhao/.codex/worktrees/de50/clp/build/rust-targets
override=/tmp/clp-issue-2442-target
task-env=/home/junhao/.codex/worktrees/de50/clp/build/rust-targets

$ git diff --check && printf 'git diff --check: passed\n'
git diff --check: passed
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust build output storage to use a dedicated build directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->