### PR TITLE
fix(compression-coordinator): Ensure running Spider jobs always have a `dispatch_time`.

### DIFF
--- a/components/compression-coordinator/src/coordination.rs
+++ b/components/compression-coordinator/src/coordination.rs
@@ -290,6 +290,9 @@ impl Coordinator {
 
     /// Marks the compression jobs identified by `job_ids` with the current dispatch time.
     ///
+    /// If the `dispatch_time` has already been set by the `job_handler`, we preserve the value and
+    /// skip the update. See [`S3CompressionJobHandle::persist_spider_job_id`] for details.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -305,7 +308,8 @@ impl Coordinator {
         let mut tx = self.db_pool.begin().await?;
         for chunk in job_ids.chunks(1000) {
             let mut query_builder = sqlx::QueryBuilder::<sqlx::MySql>::new(formatcp!(
-                "UPDATE `{table}` SET `dispatch_time` = CURRENT_TIMESTAMP() WHERE `id` IN (",
+                "UPDATE `{table}` SET `dispatch_time` = COALESCE(`dispatch_time`, \
+                 CURRENT_TIMESTAMP()) WHERE `id` IN (",
                 table = COMPRESSION_JOB_TABLE_NAME,
             ));
             let mut separated_ids = query_builder.separated(", ");

--- a/components/compression-coordinator/src/coordination.rs
+++ b/components/compression-coordinator/src/coordination.rs
@@ -290,9 +290,6 @@ impl Coordinator {
 
     /// Marks the compression jobs identified by `job_ids` with the current dispatch time.
     ///
-    /// If the `dispatch_time` has already been set by the `job_handler`, we preserve the value and
-    /// skip the update. See [`S3CompressionJobHandle::persist_spider_job_id`] for details.
-    ///
     /// # Errors
     ///
     /// Returns an error if:

--- a/components/compression-coordinator/src/job_handle.rs
+++ b/components/compression-coordinator/src/job_handle.rs
@@ -440,6 +440,12 @@ impl<SubmitterType: S3CompressionJobSubmitter> S3CompressionJobHandle<SubmitterT
     /// This method associates the given Spider job ID with the compression job in the CLP database
     /// and updates the compression job status to [`CompressionJobStatus::Running`].
     ///
+    /// This method also ensures that the job has a valid `dispatch_time`, which the coordinator
+    /// uses to mark jobs as dispatched. A coordinator restart may occur before the marker is
+    /// persisted, leaving the Spider job running without a valid `dispatch_time`. Therefore, this
+    /// method sets the field as part of row update if it has not already been set by the
+    /// coordinator.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -455,7 +461,8 @@ impl<SubmitterType: S3CompressionJobSubmitter> S3CompressionJobHandle<SubmitterT
             i32::try_from(num_tasks).map_err(|_| Error::TooManyCompressionTasks(num_tasks))?;
         sqlx::query(formatcp!(
             "UPDATE `{COMPRESSION_JOB_TABLE_NAME}` SET `spider_id` = ?, `status` = ?, `num_tasks` \
-             = ?, `start_time` = CURRENT_TIMESTAMP(3) WHERE `id` = ?"
+             = ?, `start_time` = CURRENT_TIMESTAMP(3), `dispatch_time` = \
+             COALESCE(`dispatch_time`, CURRENT_TIMESTAMP()) WHERE `id` = ?"
         ))
         .bind(spider_job_id.get())
         .bind(CompressionJobStatus::Running)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The compression coordinator can leave a `Running` job without a `dispatch_time` if it restarts after `persist_spider_job_id` changes the job from `Pending` to `Running`, but before the batched `mark_jobs_dispatched` update at the end of the polling interval.

On the next startup, the recovery process picks up `Running` jobs with a `spider_id` and resumes them via `to_completion()`, but does not populate the missing `dispatch_time`.

To keep `dispatch_time` representative of when the job was actually dispatched, `persist_spider_job_id` now also sets it if it has not already been set by the coordinator. This ensures the timestamp is recorded close to the actual dispatch rather than being reconstructed after a restart.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Benign SQL query string update that doesn't affect coordinator's functional correctness.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing job dispatch timestamps instead of overwriting them.
  * Ensured running compression jobs receive a dispatch timestamp when one is not already set.
  * Improved timestamp accuracy for jobs whose dispatch time is recorded by the job handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->