### PR TITLE
ci(lint): Run `cargo clippy` on the stable toolchain instead of nightly.

### DIFF
--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -852,9 +852,11 @@ tasks:
       . "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
       cargo +nightly fmt --all -- {{.CARGO_FMT_FLAGS}}
 
-  # Runs `cargo +nightly clippy` in the root Rust workspace directory with the specified flags.
+  # Runs `cargo clippy` in the root Rust workspace directory with the specified flags.
   #
-  # @param {string} CARGO_CLIPPY_FLAGS The flags to pass to the `cargo +nightly clippy` command.
+  # NOTE: Runs on stable, unlike `cargo-workspace-fmt`, since nightly's lint set changes daily.
+  #
+  # @param {string} CARGO_CLIPPY_FLAGS The flags to pass to the `cargo clippy` command.
   cargo-workspace-clippy:
     internal: true
     requires:
@@ -863,7 +865,7 @@ tasks:
     deps: ["toolchains:rust"]
     cmd: |-
       . "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
-      cargo +nightly clippy --all-targets --all-features {{.CARGO_CLIPPY_FLAGS}}
+      cargo clippy --all-targets --all-features {{.CARGO_CLIPPY_FLAGS}}
 
   venv:
     internal: true


### PR DESCRIPTION
# Description

`lint:check-rust-static` passes `-D warnings` to clippy running under a floating `nightly`; a lint that upstream adds or changes overnight then fails the lint job on code that no PR touched. The 2026-08-07 nightly (clippy 0.1.99) did this, and `main` has been red since: `double_must_use` fires 9 times on the `#[async_trait]` traits in `log-ingestor` and `compression-coordinator`, where the macro stamps `#[must_use]` on a method already returning a `#[must_use]` `Pin<Box<dyn Future>>`, and `assert_is_empty` fires 3 times in `compression-coordinator` tests.

Lint selection lives in `.cargo/config.toml` (`-Dclippy::all`, `-Dclippy::nursery`, `-Dclippy::pedantic`) and applies on either toolchain, and no crate carries a `#![feature(...)]` gate, so clippy itself does not require nightly. `cargo-workspace-fmt` still needs nightly for the unstable options in `.rustfmt.toml` and is left alone.

`rustup default stable` is already set in `toolchains:rust`, so removing `+nightly` selects stable. `lint:fix-rust-static` routes through `cargo-workspace-clippy` as well and is covered by the same change.

This unblocks the lint job without changing what the two lints point at. Both are new in 0.1.99 and reappear when stable reaches 1.99, so it buys a release train rather than settling the question. Dropping `async_trait` for native `async fn` in traits removes the `double_must_use` group at its source and is being reviewed separately; whether clippy should stay on stable afterwards is worth deciding on its own, not under a red `main`.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* `task lint:check-rust-static` on this branch with a from-scratch toolchain: exits 0, clean across all five workspace crates (clippy 0.1.97).
* `cargo +nightly clippy --all-targets --all-features -- -D warnings` on the same tree: exits 101 with the 12 errors above (clippy 0.1.99).
* `task lint:check-yaml`: exits 0.
* `cargo fmt` and `tests:rust-all` are unaffected by this change and were not re-run for it; the CI job covers both.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
