### PR TITLE
refactor(rust): Replace the `async_trait` macro with native `async fn` in traits.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,6 @@ name = "compression-coordinator"
 version = "0.13.1-dev"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "clp-rust-utils",
  "const_format",
@@ -2451,7 +2450,6 @@ name = "log-ingestor"
 version = "0.13.1-dev"
 dependencies = [
  "anyhow",
- "async-trait",
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "axum",

--- a/components/compression-coordinator/Cargo.toml
+++ b/components/compression-coordinator/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/bin/compression_coordinator.rs"
 
 [dependencies]
 anyhow = "1.0.100"
-async-trait = "0.1.89"
 clap = { version = "4.6.4", features = ["derive"] }
 clp-rust-utils = { path = "../clp-rust-utils" }
 const_format = "0.2.35"

--- a/components/compression-coordinator/src/compression_job_submitter/mod.rs
+++ b/components/compression-coordinator/src/compression_job_submitter/mod.rs
@@ -5,7 +5,6 @@ mod spider;
 
 use std::time::Duration;
 
-use async_trait::async_trait;
 use clp_rust_utils::job_config::CompressionJobId;
 use clp_rust_utils::task_io::compression::ClpSCompressionOption;
 use clp_rust_utils::task_io::compression::S3InputSource;
@@ -31,7 +30,6 @@ pub enum CompressionJobOutcome {
 }
 
 /// Drives CLP S3 compression jobs on a Spider (Huntsman) cluster.
-#[async_trait]
 pub trait S3CompressionJobSubmitter: Clone + Send + Sync {
     /// Builds the compression task graph for `input_sources` and registers it with Spider, without
     /// starting it.
@@ -54,7 +52,7 @@ pub trait S3CompressionJobSubmitter: Clone + Send + Sync {
     /// # Errors
     ///
     /// Implementations must document their error conditions.
-    async fn submit_s3_compression_job(
+    fn submit_s3_compression_job(
         &self,
         compression_job_id: CompressionJobId,
         resource_group_id: ResourceGroupId,
@@ -62,7 +60,7 @@ pub trait S3CompressionJobSubmitter: Clone + Send + Sync {
         dataset: Option<String>,
         input_sources: Vec<(S3InputSource, ExecutionPolicy)>,
         commit_task_execution_policy: ExecutionPolicy,
-    ) -> Result<JobId, Error>;
+    ) -> impl Future<Output = Result<JobId, Error>> + Send;
 
     /// Idempotently starts the job identified by `spider_job_id` (only if it hasn't already been
     /// started) and waits until it reaches a terminal state.
@@ -83,10 +81,10 @@ pub trait S3CompressionJobSubmitter: Clone + Send + Sync {
     /// # Errors
     ///
     /// Implementations must document their error conditions.
-    async fn run_s3_compression_job_to_completion(
+    fn run_s3_compression_job_to_completion(
         &self,
         spider_job_id: JobId,
         initial_poll_backoff: Duration,
         max_poll_backoff: Duration,
-    ) -> Result<CompressionJobOutcome, Error>;
+    ) -> impl Future<Output = Result<CompressionJobOutcome, Error>> + Send;
 }

--- a/components/compression-coordinator/src/compression_job_submitter/spider.rs
+++ b/components/compression-coordinator/src/compression_job_submitter/spider.rs
@@ -2,7 +2,6 @@
 
 use std::time::Duration;
 
-use async_trait::async_trait;
 use clp_rust_utils::job_config::CompressionJobId;
 use clp_rust_utils::task_io::compression::ClpSCompressionOption;
 use clp_rust_utils::task_io::compression::S3InputSource;
@@ -24,7 +23,6 @@ use crate::compression_job_submitter::CompressionJobOutcome;
 use crate::compression_job_submitter::S3CompressionJobSubmitter;
 use crate::error::Error;
 
-#[async_trait]
 impl S3CompressionJobSubmitter for SpiderClient {
     /// # Errors
     ///

--- a/components/compression-coordinator/src/partition.rs
+++ b/components/compression-coordinator/src/partition.rs
@@ -453,10 +453,10 @@ mod tests {
             );
         }
 
-        assert!(builder.partitioned_task_inputs.is_empty());
+        assert_eq!(builder.partitioned_task_inputs.len(), 0);
 
         let input_sources = builder.into_task_input_sources();
-        assert!(!input_sources.is_empty());
+        assert_ne!(input_sources.len(), 0);
         assert_partition_invariants(&input_sources, &key_to_size, TARGET_ARCHIVE_SIZE);
     }
 
@@ -479,7 +479,7 @@ mod tests {
             }
         }
 
-        assert!(!builder.partitioned_task_inputs.is_empty());
+        assert_ne!(builder.partitioned_task_inputs.len(), 0);
 
         let input_sources = builder.into_task_input_sources();
         assert_partition_invariants(&input_sources, &key_to_size, TARGET_ARCHIVE_SIZE);

--- a/components/log-ingestor/Cargo.toml
+++ b/components/log-ingestor/Cargo.toml
@@ -23,7 +23,6 @@ path = "tests/test.rs"
 [dependencies]
 anyhow = "1.0.100"
 axum = { version = "0.8.8", features = ["json"] }
-async-trait = "0.1.89"
 aws-sdk-s3 = "1.121.0"
 aws-sdk-sqs = "1.92.0"
 clap = { version = "4.5.56", features = ["derive"] }

--- a/components/log-ingestor/src/aws_client_manager.rs
+++ b/components/log-ingestor/src/aws_client_manager.rs
@@ -1,5 +1,6 @@
+use std::future::Future;
+
 use anyhow::Result;
-use async_trait::async_trait;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sqs::Client as SqsClient;
 use clp_rust_utils::aws::AWS_DEFAULT_REGION;
@@ -19,7 +20,6 @@ impl AwsClientType for S3Client {}
 /// # Type Parameters:
 ///
 /// * [`Client`]: The AWS SKD client type. Must implement the [`AwsClientType`].
-#[async_trait]
 pub trait AwsClientManagerType<Client: AwsClientType>: Send + Sync + Clone + 'static {
     /// Retrieves an AWS client instance. The specific behavior depends on the implementation.
     ///
@@ -30,7 +30,7 @@ pub trait AwsClientManagerType<Client: AwsClientType>: Send + Sync + Clone + 'st
     /// # Errors:
     ///
     /// Returns an [`anyhow::Error`] on failure.
-    async fn get(&self) -> Result<Client>;
+    fn get(&self) -> impl Future<Output = Result<Client>> + Send;
 }
 
 /// A simple wrapper around an `SqsClient` that implements the `AwsClientManagerType` trait.
@@ -39,10 +39,9 @@ pub struct SqsClientWrapper {
     client: SqsClient,
 }
 
-#[async_trait]
 impl AwsClientManagerType<SqsClient> for SqsClientWrapper {
-    async fn get(&self) -> Result<SqsClient> {
-        Ok(self.client.clone())
+    fn get(&self) -> impl Future<Output = Result<SqsClient>> + Send {
+        std::future::ready(Ok(self.client.clone()))
     }
 }
 
@@ -65,10 +64,9 @@ pub struct S3ClientWrapper {
     client: S3Client,
 }
 
-#[async_trait]
 impl AwsClientManagerType<S3Client> for S3ClientWrapper {
-    async fn get(&self) -> Result<S3Client> {
-        Ok(self.client.clone())
+    fn get(&self) -> impl Future<Output = Result<S3Client>> + Send {
+        std::future::ready(Ok(self.client.clone()))
     }
 }
 

--- a/components/log-ingestor/src/compression/buffer.rs
+++ b/components/log-ingestor/src/compression/buffer.rs
@@ -1,5 +1,6 @@
+use std::future::Future;
+
 use anyhow::Result;
-use async_trait::async_trait;
 use clp_rust_utils::s3::S3ObjectMetadataId;
 use sqlx::FromRow;
 
@@ -10,7 +11,6 @@ pub struct CompressionBufferEntry {
     pub size: u64,
 }
 
-#[async_trait]
 /// A trait for submitting buffered object metadata for processing.
 pub trait BufferSubmitter {
     /// Submits the buffered object metadata for processing.
@@ -22,7 +22,7 @@ pub trait BufferSubmitter {
     /// # Errors:
     ///
     /// Returns an [`anyhow::Error`] on failure.
-    async fn submit(&self, buffer: &[S3ObjectMetadataId]) -> Result<()>;
+    fn submit(&self, buffer: &[S3ObjectMetadataId]) -> impl Future<Output = Result<()>> + Send;
 }
 
 /// A buffer that accumulates object metadata IDs and submits when the size threshold is reached.

--- a/components/log-ingestor/src/compression/compression_job_submitter.rs
+++ b/components/log-ingestor/src/compression/compression_job_submitter.rs
@@ -1,5 +1,6 @@
+use std::future::Future;
+
 use anyhow::Result;
-use async_trait::async_trait;
 use clp_rust_utils::clp_config::AwsAuthentication;
 use clp_rust_utils::clp_config::S3Config;
 use clp_rust_utils::clp_config::package::config::ArchiveOutput;
@@ -27,23 +28,27 @@ pub struct CompressionJobSubmitter {
     state: ClpCompressionState,
 }
 
-#[async_trait]
 impl BufferSubmitter for CompressionJobSubmitter {
-    async fn submit(&self, buffer: &[S3ObjectMetadataId]) -> Result<()> {
+    fn submit(&self, buffer: &[S3ObjectMetadataId]) -> impl Future<Output = Result<()>> + Send {
         let mut io_config = self.io_config_template.clone();
-        match &mut io_config.input {
-            InputConfig::S3ObjectMetadataInputConfig { config } => {
-                config.s3_object_metadata_ids = buffer.to_vec();
-            }
-            InputConfig::S3InputConfig { .. } => {
-                unreachable!("log-ingestor compression only supports `S3ObjectMetadataInputConfig`")
-            }
-        }
+        let object_metadata_ids = buffer.to_vec();
         let state = self.state.clone();
-        tokio::spawn(submit_clp_compression_job_and_wait_for_completion(
-            state, io_config,
-        ));
-        Ok(())
+        async move {
+            match &mut io_config.input {
+                InputConfig::S3ObjectMetadataInputConfig { config } => {
+                    config.s3_object_metadata_ids = object_metadata_ids;
+                }
+                InputConfig::S3InputConfig { .. } => {
+                    unreachable!(
+                        "log-ingestor compression only supports `S3ObjectMetadataInputConfig`"
+                    )
+                }
+            }
+            tokio::spawn(submit_clp_compression_job_and_wait_for_completion(
+                state, io_config,
+            ));
+            Ok(())
+        }
     }
 }
 

--- a/components/log-ingestor/src/ingestion_job/state.rs
+++ b/components/log-ingestor/src/ingestion_job/state.rs
@@ -1,9 +1,9 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use clp_rust_utils::s3::ObjectMetadata;
 use tokio::sync::mpsc;
 
 /// An abstract, job-type-agnostic layer for managing ingestion job states.
-#[async_trait]
 pub trait IngestionJobState: Send + Sync + Clone + 'static {
     /// Starts the ingestion job.
     ///
@@ -15,7 +15,7 @@ pub trait IngestionJobState: Send + Sync + Clone + 'static {
     ///
     /// Implementations **must document** the specific error variants they may return and the
     /// conditions under which those errors occur.
-    async fn start(&self) -> anyhow::Result<()>;
+    fn start(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     /// Ends the ingestion job.
     ///
@@ -27,7 +27,7 @@ pub trait IngestionJobState: Send + Sync + Clone + 'static {
     ///
     /// Implementations **must document** the specific error variants they may return and the
     /// conditions under which those errors occur.
-    async fn end(&self) -> anyhow::Result<()>;
+    fn end(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     /// Fails the ingestion job.
     ///
@@ -40,11 +40,10 @@ pub trait IngestionJobState: Send + Sync + Clone + 'static {
     /// Implementations should not propagate errors produced while failing the job. If an error
     /// occurs, it should be logged and otherwise ignored, so the caller can prioritize propagating
     /// the *original* error that triggered the failure over any secondary error from this method.
-    async fn fail(&self, msg: String);
+    fn fail(&self, msg: String) -> impl Future<Output = ()> + Send;
 }
 
 /// An abstract layer for managing [`crate::ingestion_job::SqsListener`] states.
-#[async_trait]
 pub trait SqsListenerState: Send + Sync + Clone + 'static {
     /// Ingests the given object metadata into CLP and marks them as `Buffered`.
     ///
@@ -60,11 +59,13 @@ pub trait SqsListenerState: Send + Sync + Clone + 'static {
     ///
     /// Implementations **must document** the specific error variants they may return and the
     /// conditions under which those errors occur.
-    async fn ingest(&self, objects: Vec<ObjectMetadata>) -> anyhow::Result<()>;
+    fn ingest(
+        &self,
+        objects: Vec<ObjectMetadata>,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
 /// An abstract layer for managing [`crate::ingestion_job::S3Scanner`] states.
-#[async_trait]
 pub trait S3ScannerState: Send + Sync + Clone + 'static {
     /// Ingests the given object metadata into CLP and marks them as `Buffered`.
     ///
@@ -81,11 +82,11 @@ pub trait S3ScannerState: Send + Sync + Clone + 'static {
     ///
     /// Implementations **must document** the specific error variants they may return and the
     /// conditions under which those errors occur.
-    async fn ingest(
+    fn ingest(
         &self,
         objects: Vec<ObjectMetadata>,
         last_ingested_key: &str,
-    ) -> anyhow::Result<()>;
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
 /// An ingestion job state implementation that has no fault-tolerance.
@@ -101,20 +102,20 @@ impl ZeroFaultToleranceIngestionJobState {
     }
 }
 
-#[async_trait]
 impl IngestionJobState for ZeroFaultToleranceIngestionJobState {
-    async fn start(&self) -> anyhow::Result<()> {
-        Ok(())
+    fn start(&self) -> impl Future<Output = anyhow::Result<()>> + Send {
+        std::future::ready(Ok(()))
     }
 
-    async fn end(&self) -> anyhow::Result<()> {
-        Ok(())
+    fn end(&self) -> impl Future<Output = anyhow::Result<()>> + Send {
+        std::future::ready(Ok(()))
     }
 
-    async fn fail(&self, _msg: String) {}
+    fn fail(&self, _msg: String) -> impl Future<Output = ()> + Send {
+        std::future::ready(())
+    }
 }
 
-#[async_trait]
 impl SqsListenerState for ZeroFaultToleranceIngestionJobState {
     /// # Errors
     ///
@@ -127,7 +128,6 @@ impl SqsListenerState for ZeroFaultToleranceIngestionJobState {
     }
 }
 
-#[async_trait]
 impl S3ScannerState for ZeroFaultToleranceIngestionJobState {
     /// # Errors
     ///

--- a/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
+++ b/components/log-ingestor/src/ingestion_job_manager/clp_ingestion.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
 use clp_rust_utils::clp_config::AwsAuthentication;
 use clp_rust_utils::clp_config::package::config::ArchiveOutput;
 use clp_rust_utils::clp_config::package::config::Config as ClpConfig;
@@ -911,7 +910,6 @@ impl ClpIngestionState {
     }
 }
 
-#[async_trait]
 impl IngestionJobState for ClpIngestionState {
     /// # NOTE
     ///
@@ -978,7 +976,6 @@ impl IngestionJobState for ClpIngestionState {
     }
 }
 
-#[async_trait]
 impl S3ScannerState for ClpIngestionState {
     /// # Errors
     ///
@@ -1021,7 +1018,6 @@ impl S3ScannerState for ClpIngestionState {
     }
 }
 
-#[async_trait]
 impl SqsListenerState for ClpIngestionState {
     /// # Errors
     ///

--- a/components/log-ingestor/tests/test_compression_listener.rs
+++ b/components/log-ingestor/tests/test_compression_listener.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use async_trait::async_trait;
 use clp_rust_utils::s3::S3ObjectMetadataId;
 use log_ingestor::compression::Buffer;
 use log_ingestor::compression::BufferSubmitter;
@@ -32,7 +31,6 @@ impl TestBufferSubmitter {
     }
 }
 
-#[async_trait]
 impl BufferSubmitter for TestBufferSubmitter {
     async fn submit(&self, buffer: &[S3ObjectMetadataId]) -> Result<()> {
         self.store.lock().await.push(buffer.to_vec());

--- a/components/log-ingestor/tests/test_ingestion_job.rs
+++ b/components/log-ingestor/tests/test_ingestion_job.rs
@@ -1,9 +1,9 @@
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
-use async_trait::async_trait;
 use clp_rust_utils::clp_config::AwsAuthentication;
 use clp_rust_utils::clp_config::AwsCredentials;
 use clp_rust_utils::job_config::ingestion::s3::BaseConfig;
@@ -50,14 +50,13 @@ impl SqsListenerTestState {
     }
 }
 
-#[async_trait]
 impl IngestionJobState for SqsListenerTestState {
-    async fn start(&self) -> Result<()> {
-        Ok(())
+    fn start(&self) -> impl Future<Output = Result<()>> + Send {
+        std::future::ready(Ok(()))
     }
 
-    async fn end(&self) -> Result<()> {
-        Ok(())
+    fn end(&self) -> impl Future<Output = Result<()>> + Send {
+        std::future::ready(Ok(()))
     }
 
     async fn fail(&self, msg: String) {
@@ -65,7 +64,6 @@ impl IngestionJobState for SqsListenerTestState {
     }
 }
 
-#[async_trait]
 impl SqsListenerState for SqsListenerTestState {
     async fn ingest(&self, objects: Vec<ObjectMetadata>) -> Result<()> {
         self.shared_ingested_buffer.lock().await.extend(objects);
@@ -88,14 +86,13 @@ impl S3ScannerTestState {
     }
 }
 
-#[async_trait]
 impl IngestionJobState for S3ScannerTestState {
-    async fn start(&self) -> Result<()> {
-        Ok(())
+    fn start(&self) -> impl Future<Output = Result<()>> + Send {
+        std::future::ready(Ok(()))
     }
 
-    async fn end(&self) -> Result<()> {
-        Ok(())
+    fn end(&self) -> impl Future<Output = Result<()>> + Send {
+        std::future::ready(Ok(()))
     }
 
     async fn fail(&self, msg: String) {
@@ -103,7 +100,6 @@ impl IngestionJobState for S3ScannerTestState {
     }
 }
 
-#[async_trait]
 impl S3ScannerState for S3ScannerTestState {
     async fn ingest(
         &self,


### PR DESCRIPTION
# Description

`async_trait` rewrites each trait method to return `Pin<Box<dyn Future>>` and stamps `#[must_use]` on it (`async-trait-0.1.89/src/expand.rs:69`). Clippy 0.1.99 stopped suppressing lints through external macro expansion, so `double_must_use` fires 9 times on an attribute no crate here writes, and no edit to the trait definitions silences it. Removing the macro removes the attribute.

Native `async fn` in traits has been stable since 1.75 and none of these traits is used through `dyn`, so the migration is available. The methods are declared as `fn f(..) -> impl Future<Output = T> + Send` rather than `async fn`, because a plain `async fn` in a trait does not express the `Send` bound that `tokio::spawn` requires at the call sites in `listener.rs`, `s3_scanner.rs`, and `sqs_listener.rs`; that form fails to compile here with 7 `future cannot be sent between threads safely` errors. Impls that genuinely await still use `async fn`.

Removing the macro exposed five `unused_async` findings it had been masking, where an impl of an async method never awaits. Those impls now return a future directly instead of being `async fn`. `CompressionJobSubmitter::submit` is the one worth a close read: it spawns the compression job and returns without awaiting, and its `tokio::spawn` and `unreachable!` arm are kept inside an `async move` block so that they run when the returned future is polled, as they did before, rather than when `submit` is called. The clones ahead of that block have no side effects and are deliberately outside it, which is also what keeps `manual_async_fn` from firing.

Three `assert!(..is_empty())` calls in `compression-coordinator` tests become `assert_eq!(..len(), 0)` and `assert_ne!(..len(), 0)`, satisfying `assert_is_empty`, which is also new in 0.1.99.

`async-trait` is no longer a direct dependency of either crate. It remains in the lock file as a transitive dependency of the AWS SDK.

`main` has been red since the 2026-08-07 nightly, and this unblocks it. The lint job keeps running clippy on nightly, so future nightly lint changes can still fail it; that is left as is.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

On this branch at `db2ab96c` with a clean working tree, base `main` @ `986252b5`:

* `cargo +nightly clippy --all-targets --all-features -- -D warnings` (clippy 0.1.99): exits 0. The same command on `main` exits 101 with 12 errors.
* `task lint:check-rust` (`cargo fmt --check` plus clippy on stable, clippy 0.1.97): exits 0.
* `task tests:rust-all`: exits 0, 62 tests run, 62 passed, 0 skipped.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
