### PR TITLE
fix(clp-s): Add missing `cstdint` include statement to fix compilation with clang.

### DIFF
--- a/components/core/src/clp_s/search/ast/Literal.hpp
+++ b/components/core/src/clp_s/search/ast/Literal.hpp
@@ -2,6 +2,7 @@
 #define CLP_S_SEARCH_LITERAL_HPP
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
As title says. Clang is more aggressive with missing headers and this particular instance causes compilation to fail.
I've been manually patching it, so I'm not sure the exact clang version it started with, but I'm currently using clang 22 and it fails. Regardless of clang, this fix is also a general linting improvement as it follows IWYU.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Compilation with clang 22 passes.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability for search expression processing by ensuring required integer types are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->