### PR TITLE
fix(taskfile): Generate the `tests:rust-all` LocalStack container name via `uv` so that a missing `uuidgen` no longer yields an empty name (fixes #2465).

### DIFF
--- a/taskfiles/tests/main.yaml
+++ b/taskfiles/tests/main.yaml
@@ -10,8 +10,7 @@ tasks:
       LOG_INGESTOR_BUCKET: "clp-log-ingestor-test-bucket"
       LOG_INGESTOR_QUEUE: "clp-log-ingestor-test-queue"
       LOCALSTACK_CONTAINER_NAME:
-        # Normalize UUID casing: macOS generates uppercase while Linux generates lowercase.
-        sh: "uuidgen | tr '[:upper:]' '[:lower:]' | sed 's/^/clp-localstack-rust-/'"
+        sh: "uv run python -c \"import uuid; print('clp-localstack-rust-' + str(uuid.uuid4()))\""
       LOCALSTACK_PORT:
         sh: "tools/scripts/localstack/get-free-port.py"
     dir: "{{.ROOT_DIR}}"


### PR DESCRIPTION
# Description

Resolves `LOCALSTACK_CONTAINER_NAME` with a single `uv run python` command instead of a `uuidgen | tr | sed` pipeline, so that a missing interpreter fails the task rather than yielding an empty name. `uv` is already a prerequisite and already resolves the adjacent `LOCALSTACK_PORT`, so this adds no dependency.

Fixes #2465.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

On Ubuntu 26.04 (WSL2, aarch64) without `uuidgen` installed:

* `uv run python -c "import uuid; print('clp-localstack-rust-' + str(uuid.uuid4()))"` prints `clp-localstack-rust-a34aac8f-d8ad-4efd-a9e7-c0be446d5053` and exits 0.
* `task --dry tests:rust-all` shows the name reaching `start.py` and the deferred `stop.py`: `--name "clp-localstack-rust-69b62977-0ae5-490c-b7a5-81ee93354d32"`.
* `task lint:check-yaml` passes.

The full `tests:rust-all` suite was not run locally; the CI job covers it.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
