### PR TITLE
ci(lint): Pin the Rust nightly toolchain to `nightly-2026-08-06`.

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -45,6 +45,8 @@ vars:
 
   # Versions
   G_PACKAGE_VERSION: "0.13.1-dev"
+  # TODO: Unpin once clippy's `double_must_use` and `assert_is_empty` stop failing the workspace.
+  G_RUST_NIGHTLY: "nightly-2026-08-06"
 
   # Build parameters
   # NOTE: If CLP_CPP_MAX_PARALLELISM_PER_BUILD_TASK is set, it takes precedence. Otherwise, we cap

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -850,7 +850,7 @@ tasks:
     deps: ["rust-lint-configs", "toolchains:rust"]
     cmd: |-
       . "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
-      cargo +nightly fmt --all -- {{.CARGO_FMT_FLAGS}}
+      cargo +{{.G_RUST_NIGHTLY}} fmt --all -- {{.CARGO_FMT_FLAGS}}
 
   # Runs `cargo +nightly clippy` in the root Rust workspace directory with the specified flags.
   #
@@ -863,7 +863,7 @@ tasks:
     deps: ["toolchains:rust"]
     cmd: |-
       . "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
-      cargo +nightly clippy --all-targets --all-features {{.CARGO_CLIPPY_FLAGS}}
+      cargo +{{.G_RUST_NIGHTLY}} clippy --all-targets --all-features {{.CARGO_CLIPPY_FLAGS}}
 
   venv:
     internal: true

--- a/taskfiles/toolchains.yaml
+++ b/taskfiles/toolchains.yaml
@@ -146,7 +146,7 @@ tasks:
       # Disable Rustup's auto self update at the end to avoid unexpected checksum mismatches.
       - |-
         . "{{.G_RUST_TOOLCHAIN_ENV_FILE}}"
-        rustup toolchain install nightly --allow-downgrade --component clippy,rustfmt
+        rustup toolchain install {{.G_RUST_NIGHTLY}} --component clippy,rustfmt
         rustup toolchain install stable
         rustup default stable
         cargo install --locked cargo-nextest


### PR DESCRIPTION
# Description

Pins the nightly toolchain to `nightly-2026-08-06`, which predates the clippy update that broke `lint:check-rust-static` on `main` with no code change: 9 `double_must_use` on `#[async_trait]` methods and 3 `assert_is_empty` in `components/compression-coordinator/src/partition.rs`, all errors under `-D warnings`. `toolchains:rust` installed the `nightly` channel unpinned, so the break landed on its own between the [2026-08-07](https://github.com/y-scope/clp/actions/runs/31143642934) and [2026-08-08](https://github.com/y-scope/clp/actions/runs/31234644998) scheduled runs.

The `double_must_use` reports are all on macro-generated code, so this waits for clippy or `async-trait` to settle rather than editing the workspace around a nightly lint that may not outlive the next release.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

On Ubuntu 26.04 (WSL2, aarch64):

* `task lint:check-rust` and `task lint:check-yaml` pass on this branch.
* `cargo +nightly clippy --all-targets --all-features -- -D warnings` on `nightly-2026-08-10` (`rustc 1.99.0-nightly (969b803cb 2026-08-09)`) reproduces the 12 errors.

I did not bisect nightlies, so the pinned date is a known-good nightly rather than the newest known-good one.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Rust nightly toolchain to a specific version for more consistent development and validation results.
  * Updated formatting, linting, and toolchain setup tasks to use the configured Rust version automatically.
  * Removed automatic toolchain downgrades during installation, helping ensure the selected version is used as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->