### PR TITLE
build(clp_s::ffi::sfa): Add search dependencies and make OpenTelemetry and Libarchive optional for downstream WebAssembly.

### DIFF
--- a/components/core/cmake/Options/options.cmake
+++ b/components/core/cmake/Options/options.cmake
@@ -96,6 +96,12 @@ option(
 )
 
 option(
+    CLP_BUILD_CLP_S_SEARCH_ENABLE_OPENTELEMETRY_CPP
+    "Include open telemetry support for clp_s::search."
+    ON
+)
+
+option(
     CLP_BUILD_CLP_S_SEARCH_KQL
     "Build clp_s::search::kql."
     ON
@@ -311,6 +317,8 @@ endfunction()
 function(validate_clp_s_ffi_sfa_dependencies)
     validate_clp_dependencies_for_target(CLP_BUILD_CLP_S_FFI_SFA
         CLP_BUILD_CLP_S_ARCHIVEREADER
+        CLP_BUILD_CLP_S_SEARCH
+        CLP_BUILD_CLP_S_SEARCH_KQL
     )
 endfunction()
 
@@ -392,16 +400,21 @@ function(set_clp_s_search_dependencies)
     set_clp_need_flags(
         CLP_NEED_ABSL
         CLP_NEED_LOG_SURGEON
-        CLP_NEED_OPENTELEMETRY_CPP
         CLP_NEED_SIMDJSON
         CLP_NEED_SPDLOG
-        CLP_NEED_XXHASH
     )
 endfunction()
 
 function(set_clp_s_search_ast_dependencies)
     set_clp_need_flags(
         CLP_NEED_SIMDJSON
+    )
+endfunction()
+
+function(set_clp_s_search_enable_opentelemetry_cpp_dependencies)
+    set_clp_need_flags(
+        CLP_NEED_OPENTELEMETRY_CPP
+        CLP_NEED_XXHASH
     )
 endfunction()
 
@@ -536,6 +549,10 @@ function(validate_and_setup_all_clp_dependency_flags)
 
     if (CLP_BUILD_CLP_S_SEARCH_AST)
         set_clp_s_search_ast_dependencies()
+    endif()
+
+    if (CLP_BUILD_CLP_S_SEARCH_ENABLE_OPENTELEMETRY_CPP)
+        set_clp_s_search_enable_opentelemetry_cpp_dependencies()
     endif()
 
     if (CLP_BUILD_CLP_S_SEARCH_KQL)

--- a/components/core/src/clp_s/InputConfig.cpp
+++ b/components/core/src/clp_s/InputConfig.cpp
@@ -18,6 +18,7 @@
 #if CLP_BUILD_CLP_S_ENABLE_LIBARCHIVE
     #include <archive.h>
     #include <archive_entry.h>
+
     #include "../clp/LibarchiveFileReader.hpp"
     #include "../clp/LibarchiveReader.hpp"
 #endif

--- a/components/core/src/clp_s/InputConfig.cpp
+++ b/components/core/src/clp_s/InputConfig.cpp
@@ -18,6 +18,8 @@
 #if CLP_BUILD_CLP_S_ENABLE_LIBARCHIVE
     #include <archive.h>
     #include <archive_entry.h>
+    #include "../clp/LibarchiveFileReader.hpp"
+    #include "../clp/LibarchiveReader.hpp"
 #endif
 
 #include <simdjson.h>
@@ -27,8 +29,6 @@
 #include "../clp/ErrorCode.hpp"
 #include "../clp/ffi/ir_stream/protocol_constants.hpp"
 #include "../clp/FileReader.hpp"
-#include "../clp/LibarchiveFileReader.hpp"
-#include "../clp/LibarchiveReader.hpp"
 #include "../clp/ReaderInterface.hpp"
 #include "../clp/spdlog_with_specializations.hpp"
 #include "../clp/streaming_compression/Decompressor.hpp"

--- a/components/core/src/clp_s/ffi/CMakeLists.txt
+++ b/components/core/src/clp_s/ffi/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CLP_BUILD_CLP_S_FFI_SFA)
                 clp_s_ffi_sfa
                 PUBLIC
                 clp_s::archive_reader
+                clp_s::search
                 ystdlib::error_handling
                 PRIVATE
                 spdlog::spdlog

--- a/components/core/src/clp_s/search/CMakeLists.txt
+++ b/components/core/src/clp_s/search/CMakeLists.txt
@@ -21,9 +21,7 @@ set(
         QueryRunner.hpp
         SchemaMatch.cpp
         SchemaMatch.hpp
-        SearchTelemetry.cpp
         SearchTelemetry.hpp
-        TelemetryContext.cpp
         TelemetryContext.hpp
 )
 
@@ -50,6 +48,12 @@ if(CLP_BUILD_CLP_S_SEARCH)
                 spdlog::spdlog
         )
         if(CLP_BUILD_CLP_S_SEARCH_ENABLE_OPENTELEMETRY_CPP)
+                target_sources(
+                        clp_s_search
+                        PRIVATE
+                        SearchTelemetry.cpp
+                        TelemetryContext.cpp
+                )
                 target_link_libraries(
                         clp_s_search
                         PRIVATE
@@ -58,6 +62,13 @@ if(CLP_BUILD_CLP_S_SEARCH)
                         opentelemetry-cpp::resources
                         opentelemetry-cpp::trace
                         xxHash::xxhash
+                )
+        else()
+                target_sources(
+                        clp_s_search
+                        PRIVATE
+                        SearchTelemetryNoop.cpp
+                        TelemetryContextNoop.cpp
                 )
         endif()
 endif()

--- a/components/core/src/clp_s/search/CMakeLists.txt
+++ b/components/core/src/clp_s/search/CMakeLists.txt
@@ -47,11 +47,17 @@ if(CLP_BUILD_CLP_S_SEARCH)
                 clp::string_utils
                 clp_s::clp_dependencies
                 clp_s::io
-                opentelemetry-cpp::api
-                opentelemetry-cpp::otlp_http_exporter
-                opentelemetry-cpp::resources
-                opentelemetry-cpp::trace
                 spdlog::spdlog
-                xxHash::xxhash
         )
+        if(CLP_BUILD_CLP_S_SEARCH_ENABLE_OPENTELEMETRY_CPP)
+                target_link_libraries(
+                        clp_s_search
+                        PRIVATE
+                        opentelemetry-cpp::api
+                        opentelemetry-cpp::otlp_http_exporter
+                        opentelemetry-cpp::resources
+                        opentelemetry-cpp::trace
+                        xxHash::xxhash
+                )
+        endif()
 endif()

--- a/components/core/src/clp_s/search/SearchTelemetryNoop.cpp
+++ b/components/core/src/clp_s/search/SearchTelemetryNoop.cpp
@@ -1,0 +1,33 @@
+#include "SearchTelemetry.hpp"
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
+namespace clp_s::search {
+class SearchTelemetrySpan::Impl {};
+
+SearchTelemetrySpan::SearchTelemetrySpan() : m_impl{std::make_unique<Impl>()} {}
+
+SearchTelemetrySpan::~SearchTelemetrySpan() = default;
+
+auto SearchTelemetrySpan::set_archive_context(std::string_view) -> void {}
+
+auto SearchTelemetrySpan::set_error(std::string_view) -> void {}
+
+auto SearchTelemetrySpan::set_query_context(std::string_view) -> void {}
+
+auto SearchTelemetrySpan::set_query_shape_metrics(QueryShapeMetrics const&) -> void {}
+
+auto SearchTelemetrySpan::set_search_result_metrics(SearchResultMetrics const&) -> void {}
+
+auto SearchTelemetrySpan::set_termination_stage(std::string_view) -> void {}
+
+auto QueryShapeMetrics::create(
+        std::shared_ptr<ast::Expression> const&,
+        std::optional<epochtime_t>,
+        std::optional<epochtime_t>
+) -> QueryShapeMetrics {
+    return {};
+}
+}  // namespace clp_s::search

--- a/components/core/src/clp_s/search/SearchTelemetryNoop.cpp
+++ b/components/core/src/clp_s/search/SearchTelemetryNoop.cpp
@@ -1,8 +1,8 @@
-#include "SearchTelemetry.hpp"
-
 #include <memory>
 #include <optional>
 #include <string_view>
+
+#include "SearchTelemetry.hpp"
 
 namespace clp_s::search {
 class SearchTelemetrySpan::Impl {};

--- a/components/core/src/clp_s/search/TelemetryContextNoop.cpp
+++ b/components/core/src/clp_s/search/TelemetryContextNoop.cpp
@@ -1,0 +1,11 @@
+#include "TelemetryContext.hpp"
+
+#include <memory>
+
+namespace clp_s::search {
+class TelemetryContext::Impl {};
+
+TelemetryContext::TelemetryContext() : m_impl{std::make_unique<Impl>()} {}
+
+TelemetryContext::~TelemetryContext() = default;
+}  // namespace clp_s::search

--- a/components/core/src/clp_s/search/TelemetryContextNoop.cpp
+++ b/components/core/src/clp_s/search/TelemetryContextNoop.cpp
@@ -1,6 +1,6 @@
-#include "TelemetryContext.hpp"
-
 #include <memory>
+
+#include "TelemetryContext.hpp"
 
 namespace clp_s::search {
 class TelemetryContext::Impl {};


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This change prepares `clp_s::ffi::sfa` for downstream WebAssembly search functionalities by providing flags to disable OpenTelemetry and Libarchive support. Downstream `clp-ffi-js` will link against `clp_s::search` without the need to cross-compile these two libraries.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enable OpenTelemetry-based search telemetry.
  * Added support for configuring search dependencies through the build system.
  * Added no-op telemetry behavior when OpenTelemetry is disabled, preserving search functionality without telemetry overhead.
* **Build Improvements**
  * Improved dependency linking for search-related functionality.
  * Updated feature configuration so FFI SFA can use search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->