### PR TITLE
fix(integration-tests): Increase time limit for package startup.

### DIFF
--- a/integration-tests/tests/package_tests/utils/start_stop.py
+++ b/integration-tests/tests/package_tests/utils/start_stop.py
@@ -9,6 +9,9 @@ from tests.utils.classes import ClpAction, ClpVerificationResult, CmdArgs
 logger = logging.getLogger(__name__)
 
 
+STARTUP_TIMEOUT_SECONDS = 600.0
+
+
 class StartStopArgs(CmdArgs):
     """Command argument model for starting and stopping the CLP package."""
 
@@ -39,7 +42,7 @@ def start_clp_package(
         script_path=clp_package.path_config.start_clp_path,
         config=clp_package.temp_config_file_path,
     )
-    return ClpAction.from_args(args)
+    return ClpAction.from_args(args=args, timeout_seconds=STARTUP_TIMEOUT_SECONDS)
 
 
 def stop_clp_package(

--- a/integration-tests/tests/utils/classes.py
+++ b/integration-tests/tests/utils/classes.py
@@ -164,6 +164,9 @@ class ExternalAction:
     #: Command to pass to `subprocess.run()`.
     cmd: list[str]
 
+    #: Timeout length to pass to `subprocess.run()`.
+    timeout_seconds: float = DEFAULT_CMD_TIMEOUT_SECONDS
+
     #: The completed process returned from `subprocess.run()`.
     completed_proc: subprocess.CompletedProcess[str] = field(init=False)
 
@@ -191,7 +194,7 @@ class ExternalAction:
         """
         Passes `self.cmd` to `subprocess.run()` with preset parameters:
             capture_output=True:                    Output will be logged and analysed later.
-            timeout=DEFAULT_CMD_TIMEOUT_SECONDS:
+            timeout=self.timeout_seconds:
             check=False:                            Error will be handled during verification.
             text=True:                              Output should be str for analysis purposes.
 
@@ -207,12 +210,12 @@ class ExternalAction:
             return subprocess.run(
                 self.cmd,
                 capture_output=True,
-                timeout=DEFAULT_CMD_TIMEOUT_SECONDS,
+                timeout=self.timeout_seconds,
                 check=False,
                 text=True,
             )
         except subprocess.TimeoutExpired:
-            err_msg = f"Subprocess '{exe_name}' timed out after {DEFAULT_CMD_TIMEOUT_SECONDS}s."
+            err_msg = f"Subprocess '{exe_name}' timed out after {self.timeout_seconds}s."
             logger.exception(err_msg)
             pytest.fail(err_msg)
         except OSError as e:
@@ -333,14 +336,22 @@ class ClpAction(ExternalAction):
     args: CmdArgs | None = None
 
     @classmethod
-    def from_cmd(cls, cmd: list[str]) -> Self:
-        """:return: A `ClpAction` for the given raw `cmd`, with no associated `args`."""
-        return cls(cmd=cmd)
+    def from_cmd(cls, cmd: list[str], timeout_seconds: float = DEFAULT_CMD_TIMEOUT_SECONDS) -> Self:
+        """
+        :param cmd:
+        :param timeout_seconds:
+        :return: A `ClpAction` for the given raw `cmd`, with no associated `args`.
+        """
+        return cls(cmd=cmd, timeout_seconds=timeout_seconds)
 
     @classmethod
-    def from_args(cls, args: CmdArgs) -> Self:
-        """:return: A `ClpAction` whose `cmd` is derived from `args.to_cmd()`."""
-        return cls(cmd=args.to_cmd(), args=args)
+    def from_args(cls, args: CmdArgs, timeout_seconds: float = DEFAULT_CMD_TIMEOUT_SECONDS) -> Self:
+        """
+        :param args:
+        :param timeout_seconds:
+        :return: A `ClpAction` whose `cmd` is derived from `args.to_cmd()`.
+        """
+        return cls(cmd=args.to_cmd(), args=args, timeout_seconds=timeout_seconds)
 
     def __post_init__(self) -> None:
         """


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

#2475 will allow us to investigate the reasons for frequent `TimeoutExpired` errors on package startup during CI runs of the package integration tests. This PR increases the timeout limit for startup as a basic fix; will be updated as aforementioned investigation continues.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
