### PR TITLE
docs(helm): Add commented hints for configuring an external Spider database in `values.yaml`.

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.4.1-dev.6"
+version: "0.4.1-dev.7"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.13.1-dev"

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -392,6 +392,23 @@ spider:
       repository: "ghcr.io/y-scope/clp/clp-spider-worker"
       tag: "main"
   spiderConfig:
+    # List of third-party services bundled (deployed) as part of the Spider subchart.
+    # Remove a service from this list to use an external instance instead, and configure its
+    # connection details accordingly in the service-specific sections below.
+    bundled:
+      - "database"
+
+    # Connection config for the Spider database service; defaults to the Spider subchart's
+    # `values.yaml`. When "database" is in `bundled`, the host is automatically set to the bundled
+    # service name (ignored). When external, set these to the external service's address and
+    # credentials.
+    # database:
+    #   host: "localhost"
+    #   port: 3306
+    #   name: "spider-db"
+    #   username: "spider-user"
+    #   password: "spider-password"
+
     worker:
       extra_envs:
         - name: "CLP_CONFIG_PATH"


### PR DESCRIPTION
# Description

The chart's `values.yaml` already hints how to point CLP at an external database (the `clpConfig.bundled` list plus the host/port comments in `clpConfig.database`), but there is no equivalent hint for the Spider subchart: its analogous switches (`spiderConfig.bundled` / `spiderConfig.database`) only appear in the subchart's own `values.yaml`, so they're easy to miss when configuring an external-database deployment.

This PR surfaces the Spider subchart's `bundled` / `database` settings under `spider.spiderConfig` in the chart's `values.yaml`, mirroring the style of the existing `clpConfig` sections (an active `bundled` list, plus a commented `database` template for the external case that otherwise defaults to the subchart's `values.yaml`), so users can discover how to externalize Spider's database alongside CLP's.

The chart version is bumped to `0.4.1-dev.7` (required by the chart lint for any change under the chart directory).

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

The change is comments plus one explicit value — `spiderConfig.bundled: ["database"]` — which is identical to the Spider subchart's own default, so no rendered output changes; check 1 verifies that, and check 2 verbally describes the experiment in which the hinted configuration was exercised.

1. Render equivalence: `helm template` output is identical before and after this change.

2. The exact configuration the hints describe (uncommented, with real host/credentials) was exercised end to end on a single-node kind cluster: with `spiderConfig.bundled: []` and `spiderConfig.database` pointing at an external MariaDB container (CLP's database configured external as well). We run a full log-ingestor S3 ingestion → Spider-orchestrated compression → API-server search flow succeeded — with a single external database instance serving both CLP's `clp-db` and Spider's `spider-db` schemas.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Added Helm chart configuration for deploying the Spider service.
* Documented that the database is bundled by default.
* Added optional settings for connecting to an external database, including host, port, database name, username, and password.

## Chores

* Updated the Helm chart version to `0.4.1-dev.10`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

