### PR TITLE
fix(helm): Add the missing `max_concurrent_jobs` config option for `compression-coordinator` in the values file.

### DIFF
--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.4.1-dev.6"
+version: "0.4.1-dev.7"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.13.1-dev"

--- a/tools/deployment/package-helm/templates/configmap.yaml
+++ b/tools/deployment/package-helm/templates/configmap.yaml
@@ -81,6 +81,8 @@ data:
         .Values.clpConfig.compression_coordinator.database_connection_pool_size | int }}
       job_polling_interval_millisecs: {{
         .Values.clpConfig.compression_coordinator.job_polling_interval_millisecs | int }}
+      max_concurrent_jobs: {{
+        .Values.clpConfig.compression_coordinator.max_concurrent_jobs | int }}
       resource_group:
         name: {{ .Values.clpConfig.compression_coordinator.resource_group.name | quote }}
       result_polling:

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -200,6 +200,7 @@ clpConfig:
     database_connection_pool_size: 10
     job_polling_interval_millisecs: 100
     logging_level: "INFO"
+    max_concurrent_jobs: 1000
     resource_group:
       name: "compression-coordinator"
     result_polling:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

In #2435, we introduced a new config option named `max_concurrent_jobs` for `compression-coordinator`. However, the values file is not updated as a part of that PR. This PR fixes this issue by adding this missing option in the values file.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration for the maximum number of concurrent compression coordinator jobs, defaulting to 1,000.

- **Chores**
  - Updated the deployment package version to the latest development release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->