### PR TITLE
docs: Add the postgresql dataset back to the resources documentation.

### DIFF
--- a/docs/src/user-docs/resources-datasets.md
+++ b/docs/src/user-docs/resources-datasets.md
@@ -16,6 +16,7 @@ For evaluation results comparing CLP and other tools, see our
 | [cockroachdb][5]                   | JSON   | 9.79 GB           | 528.97 MB     |
 | [elasticsearch][6]                 | JSON   | 7.98 GB           | 165.91 MB     |
 | [spark-event-logs][7]              | JSON   | 1.98 GB           | 211.88 MB     |
+| [postgresql][8]                    | JSON   | 392.84 MB         | 14.59 MB      |
 
 *<sup>†</sup> We will upload the other parts soon.*
 
@@ -32,3 +33,5 @@ For evaluation results comparing CLP and other tools, see our
 [6]: https://zenodo.org/records/10516226
 
 [7]: https://zenodo.org/records/10516345
+
+[8]: https://zenodo.org/records/10516401

--- a/docs/src/user-docs/resources-datasets.md
+++ b/docs/src/user-docs/resources-datasets.md
@@ -35,4 +35,3 @@ For evaluation results comparing CLP and other tools, see our
 [7]: https://zenodo.org/records/10516345
 
 [8]: https://zenodo.org/records/10516401
-

--- a/docs/src/user-docs/resources-datasets.md
+++ b/docs/src/user-docs/resources-datasets.md
@@ -35,3 +35,4 @@ For evaluation results comparing CLP and other tools, see our
 [7]: https://zenodo.org/records/10516345
 
 [8]: https://zenodo.org/records/10516401
+


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Now that #2363 has been merged, clp-s fully supports the timestamp formats found in the postgresql dataset. As such, we can add back the postgresql dataset to the resources doc.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that the docs render correctly and links work
* Validated that postgresql does actually compress and decompress succesfully/accurately


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the PostgreSQL JSON dataset to the dataset catalogue.
  * Included download and uncompressed sizes.
  * Added the corresponding Zenodo reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->