### PR TITLE
perf(clp-package): Reduce overhead of retrieving Celery compression task results (fixes #2387).

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
@@ -6,13 +6,15 @@ from typing import Any
 import celery
 
 from job_orchestration.executor.compress.celery_compress import compress
-from job_orchestration.scheduler.compress.task_manager.task_manager import TaskManager
+from job_orchestration.scheduler.compress.task_manager.task_manager import (
+    TASK_GET_RESULT_DEFAULT_TIMEOUT_SECONDS,
+    TaskManager,
+)
 from job_orchestration.scheduler.task_result import CompressionTaskResult
 
 logger = logging.getLogger(__name__)
 
-TASK_RESULT_GET_INTERVAL_SECONDS = 0.005
-TASK_RESULT_DEFAULT_GET_TIMEOUT_SECONDS = 10
+TASK_GET_RESULT_INTERVAL_SECONDS = 0.005
 
 
 class CeleryTaskManager(TaskManager):
@@ -21,13 +23,13 @@ class CeleryTaskManager(TaskManager):
             self._celery_result: celery.result.GroupResult = celery_result
 
         def get_result(
-            self, timeout: float = TASK_RESULT_DEFAULT_GET_TIMEOUT_SECONDS
+            self, timeout: float = TASK_GET_RESULT_DEFAULT_TIMEOUT_SECONDS
         ) -> list[CompressionTaskResult] | None:
             if not self._celery_result.ready():
                 return None
             try:
                 results = self._celery_result.get(
-                    timeout=timeout, interval=TASK_RESULT_GET_INTERVAL_SECONDS
+                    timeout=timeout, interval=TASK_GET_RESULT_INTERVAL_SECONDS
                 )
                 return [CompressionTaskResult.model_validate(res) for res in results]
             except celery.exceptions.TimeoutError:

--- a/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
@@ -11,18 +11,25 @@ from job_orchestration.scheduler.task_result import CompressionTaskResult
 
 logger = logging.getLogger(__name__)
 
+TASK_RESULT_GET_INTERVAL_SECONDS = 0.005
+TASK_RESULT_DEFAULT_GET_TIMEOUT_SECONDS = 10
 
 class CeleryTaskManager(TaskManager):
     class ResultHandle(TaskManager.ResultHandle):
         def __init__(self, celery_result: celery.result.GroupResult) -> None:
             self._celery_result: celery.result.GroupResult = celery_result
 
-        def get_result(self, timeout: float = 0.1) -> list[CompressionTaskResult] | None:
+        def get_result(self, timeout: float = TASK_RESULT_DEFAULT_GET_TIMEOUT_SECONDS) -> list[CompressionTaskResult] | None:
+            if not self._celery_result.ready():
+                return None
             try:
-                results = self._celery_result.get(timeout=timeout)
+                results = self._celery_result.get(
+                    timeout=timeout, interval=TASK_RESULT_GET_INTERVAL_SECONDS
+                )
                 return [CompressionTaskResult.model_validate(res) for res in results]
             except celery.exceptions.TimeoutError:
-                return None
+                logger.exception("Timed out waiting for task result.")
+                raise
             except celery.exceptions.SoftTimeLimitExceeded:
                 logger.exception("Compression task exceeded soft time limit.")
                 raise

--- a/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
@@ -14,12 +14,15 @@ logger = logging.getLogger(__name__)
 TASK_RESULT_GET_INTERVAL_SECONDS = 0.005
 TASK_RESULT_DEFAULT_GET_TIMEOUT_SECONDS = 10
 
+
 class CeleryTaskManager(TaskManager):
     class ResultHandle(TaskManager.ResultHandle):
         def __init__(self, celery_result: celery.result.GroupResult) -> None:
             self._celery_result: celery.result.GroupResult = celery_result
 
-        def get_result(self, timeout: float = TASK_RESULT_DEFAULT_GET_TIMEOUT_SECONDS) -> list[CompressionTaskResult] | None:
+        def get_result(
+            self, timeout: float = TASK_RESULT_DEFAULT_GET_TIMEOUT_SECONDS
+        ) -> list[CompressionTaskResult] | None:
             if not self._celery_result.ready():
                 return None
             try:

--- a/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/celery_task_manager.py
@@ -33,7 +33,7 @@ class CeleryTaskManager(TaskManager):
                 )
                 return [CompressionTaskResult.model_validate(res) for res in results]
             except celery.exceptions.TimeoutError:
-                logger.exception("Timed out waiting for task result.")
+                logger.exception("Compression task timed out waiting for result.")
                 raise
             except celery.exceptions.SoftTimeLimitExceeded:
                 logger.exception("Compression task exceeded soft time limit.")

--- a/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/task_manager.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/task_manager.py
@@ -5,13 +5,17 @@ from typing import Any
 
 from job_orchestration.scheduler.task_result import CompressionTaskResult
 
+TASK_GET_RESULT_DEFAULT_TIMEOUT_SECONDS = 10
+
 
 class TaskManager(ABC):
     """Abstract base class for a scheduler framework."""
 
     class ResultHandle(ABC):
         @abstractmethod
-        def get_result(self, timeout: float) -> list[CompressionTaskResult] | None:
+        def get_result(
+            self, timeout: float = TASK_GET_RESULT_DEFAULT_TIMEOUT_SECONDS
+        ) -> list[CompressionTaskResult] | None:
             """
             Gets the result of a compression job.
             :param timeout: Maximum time (in seconds) to wait for retrieving the result. Depending

--- a/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/task_manager.py
+++ b/components/job-orchestration/job_orchestration/scheduler/compress/task_manager/task_manager.py
@@ -11,7 +11,7 @@ class TaskManager(ABC):
 
     class ResultHandle(ABC):
         @abstractmethod
-        def get_result(self, timeout: float = 0.1) -> list[CompressionTaskResult] | None:
+        def get_result(self, timeout: float) -> list[CompressionTaskResult] | None:
             """
             Gets the result of a compression job.
             :param timeout: Maximum time (in seconds) to wait for retrieving the result. Depending


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR significantly reduces the overhead of retrieving celery compression task results by copying the trick we used for mitigating a similar problem on the search side in #1899; by checking `result.ready()` before calling `result.get()` we significantly reduce overhead in polling cycles where tasks are not yet complete, and by calling `result.get()` with a low `interval` argument we reduce the time that celery spends polling for the result inside of `get()` (compared to the default 0.5 second polling interval).

Based on some small-scale benchmarks on old xeon servers, this reduces the overhead of checking/retrieving task results from ~1 second when the result is not ready yet and ~1 second when the result is ready, to <1ms when the result is not yet ready and ~5ms when the result is ready.

This PR introduces some minor behaviour changes in `CeleryTaskManager::ResultHandle::get_result` to make it line up with the behaviour of `try_getting_task_result` in `query_scheduler.py`. Specifically, since we're now checking `ready()` before calling `get()`, we now treat a `celery.exceptions.TimeoutError` as an actual exception and re-raise it; previously we were effectively using that exception to check for result readiness, but now that we check `ready()` this exception indicates something is actually wrong with the system.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Added some ad-hoc instrumentation to validate that the overhead of polling for/retrieving results is _significantly_ reduced by this change
* Validated that package compression flow through the cli seems to still work as expected


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task result handling when asynchronous work is still in progress.
  * Increased the default wait time for retrieving task results to 10 seconds.
  * Added more responsive polling while waiting for results.
  * Timeout errors are now logged and reported instead of being silently treated as unavailable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->