### PR TITLE
chore(lint): Allow `clippy::empty_enums` across the Rust workspace.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,4 +3,5 @@ rustflags = [
     "-Dclippy::all",
     "-Dclippy::nursery",
     "-Dclippy::pedantic",
+    "-Aclippy::empty_enums",
 ]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR disables `clippy::empty_enums` check across the Rust workspace. The check suggests to use `never_type` which is planned to become stable in the next formal Rust release. However, the current toolchain we use (v1.98) doesn't support it as a stable feature. We will defer the change until `never_type` is formally released and turns out to be stable. Before that, we will disable this check.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality configuration to allow empty enums while preserving existing linting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->