### PR TITLE
chore(deps): Bump Spider version to `v0.1.0-rc.1-huntsman`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3985,8 +3985,8 @@ dependencies = [
 
 [[package]]
 name = "spider-client"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.0-huntsman#f09c25d4992e1445329cfb465af15c6322a61fb2"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.1-huntsman#403e683ca18a2f7a6b8f2f6da9c291f0170cb896"
 dependencies = [
  "spider-core",
  "spider-proto-rust",
@@ -3998,8 +3998,8 @@ dependencies = [
 
 [[package]]
 name = "spider-core"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.0-huntsman#f09c25d4992e1445329cfb465af15c6322a61fb2"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.1-huntsman#403e683ca18a2f7a6b8f2f6da9c291f0170cb896"
 dependencies = [
  "non-empty-string",
  "rand 0.9.5",
@@ -4017,8 +4017,8 @@ dependencies = [
 
 [[package]]
 name = "spider-derive"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.0-huntsman#f09c25d4992e1445329cfb465af15c6322a61fb2"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.1-huntsman#403e683ca18a2f7a6b8f2f6da9c291f0170cb896"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4027,8 +4027,8 @@ dependencies = [
 
 [[package]]
 name = "spider-proto-rust"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.0-huntsman#f09c25d4992e1445329cfb465af15c6322a61fb2"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.1-huntsman#403e683ca18a2f7a6b8f2f6da9c291f0170cb896"
 dependencies = [
  "prost",
  "spider-core",
@@ -4042,8 +4042,8 @@ dependencies = [
 
 [[package]]
 name = "spider-tdl"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.0-huntsman#f09c25d4992e1445329cfb465af15c6322a61fb2"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.1-huntsman#403e683ca18a2f7a6b8f2f6da9c291f0170cb896"
 dependencies = [
  "const-str",
  "rmp-serde",
@@ -4055,8 +4055,8 @@ dependencies = [
 
 [[package]]
 name = "spider-tdl-derive"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.0-huntsman#f09c25d4992e1445329cfb465af15c6322a61fb2"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.1-huntsman#403e683ca18a2f7a6b8f2f6da9c291f0170cb896"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4065,8 +4065,8 @@ dependencies = [
 
 [[package]]
 name = "spider-utils"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.0-huntsman#f09c25d4992e1445329cfb465af15c6322a61fb2"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/y-scope/spider.git?tag=v0.1.0-rc.1-huntsman#403e683ca18a2f7a6b8f2f6da9c291f0170cb896"
 dependencies = [
  "non-empty-string",
  "rand 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serial_test = "4.0.1"
-spider-client = { git = "https://github.com/y-scope/spider.git", tag = "v0.1.0-rc.0-huntsman" }
-spider-core = { git = "https://github.com/y-scope/spider.git", tag = "v0.1.0-rc.0-huntsman" }
-spider-tdl = { git = "https://github.com/y-scope/spider.git", tag = "v0.1.0-rc.0-huntsman", features = ["derive"] }
+spider-client = { git = "https://github.com/y-scope/spider.git", tag = "v0.1.0-rc.1-huntsman" }
+spider-core = { git = "https://github.com/y-scope/spider.git", tag = "v0.1.0-rc.1-huntsman" }
+spider-tdl = { git = "https://github.com/y-scope/spider.git", tag = "v0.1.0-rc.1-huntsman", features = ["derive"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "mysql"] }
 strsim = "0.11.1"
 strum = "0.28.0"

--- a/taskfiles/deployment/compose.yaml
+++ b/taskfiles/deployment/compose.yaml
@@ -8,7 +8,7 @@ vars:
   G_SPIDER_COMPOSE_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/spider-compose.md5"
   G_SPIDER_COMPOSE_TASKFILE: "{{.ROOT_DIR}}/taskfiles/deployment/compose.yaml"
 
-  G_SPIDER_COMPOSE_IMAGE_REF: "ghcr.io/y-scope/spider/compose:v0.1.0-rc.0-huntsman"
+  G_SPIDER_COMPOSE_IMAGE_REF: "ghcr.io/y-scope/spider/compose:v0.1.0-rc.1-huntsman"
 
 tasks:
   download-spider:

--- a/tools/deployment/package-helm/Chart.lock
+++ b/tools/deployment/package-helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: spider
   repository: https://github.com/y-scope/spider/raw/gh-pages
-  version: 0.2.0-rc.0
-digest: sha256:d96b89deabaebc8914dc70662f5fd84cd5781ae98a059006dcd3835a8b0ad84d
-generated: "2026-08-23T17:53:33.984066456-04:00"
+  version: 0.2.0-rc.1
+digest: sha256:12067aac4f6ead7f8b5a9f4a8fb378f0447e5cf6b27d98fb4444daa2494b7072
+generated: "2026-08-26T17:57:39.112599575-04:00"

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.4.1-dev.8"
+version: "0.4.1-dev.9"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.13.1-dev"
@@ -17,6 +17,6 @@ keywords:
   - "search"
 dependencies:
   - name: "spider"
-    version: "0.2.0-rc.0"
+    version: "0.2.0-rc.1"
     repository: "https://github.com/y-scope/spider/raw/gh-pages"
     condition: "spider.enabled"

--- a/tools/docker-images/clp-spider-worker/Dockerfile
+++ b/tools/docker-images/clp-spider-worker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG SPIDER_WORKER_IMAGE=ghcr.io/y-scope/spider/worker:v0.1.0-rc.0-huntsman
+ARG SPIDER_WORKER_IMAGE=ghcr.io/y-scope/spider/worker:v0.1.0-rc.1-huntsman
 FROM ${SPIDER_WORKER_IMAGE}
 
 ARG SPIDER_TDL_PACKAGE_DIR=/opt/spider/packages


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR updates Spider's version to `v0.1.0-rc.1-humtsman` for Spider's performance fix.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated Spider components to the `v0.1.0-rc.1-huntsman` release.
  - Updated Compose and worker container images to the matching release.

- **Deployment**
  - Updated the Helm chart to the latest chart and Spider release versions.
  - Deployment configurations now consistently reference the new release across supported packaging and container workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->