### PR TITLE
fix(job-orchestration): Use a direct MongoDB connection when creating the search-results timestamp index.

### DIFF
--- a/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
+++ b/components/job-orchestration/job_orchestration/scheduler/query/query_scheduler.py
@@ -371,7 +371,7 @@ def _create_timestamp_index(results_cache_uri: str, job_id: str) -> None:
     :param job_id: ID of the search job whose results collection should be indexed.
     """
     try:
-        with pymongo.MongoClient(results_cache_uri) as mongo_client:
+        with pymongo.MongoClient(results_cache_uri, directConnection=True) as mongo_client:
             collection = mongo_client.get_default_database()[job_id]
             collection.create_index(
                 [("timestamp", pymongo.DESCENDING), ("_id", pymongo.ASCENDING)],


### PR DESCRIPTION
… the search-results timestamp index.

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

`_create_timestamp_index` opened a `pymongo.MongoClient` without `directConnection=True`. Without that option, PyMongo performs server discovery and prefers the hostnames the MongoDB server advertises rather than the host in the URI.

Since the results cache is a single standalone MongoDB instance, this PR sets `directConnection=True` so PyMongo connects straight to the host in `results_cache_uri` and skips discovery.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Query scheduler is no longer blocked by index creation.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating timestamp indexes for job result collections by using a direct database connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->