### PR TITLE
fix(ci): Add `clp-tdl-package` and `compression-coordinator` to the `clp-rust-checks` monitored paths.

### DIFF
--- a/components/clp-rust-utils/src/clp_config/package/config.rs
+++ b/components/clp-rust-utils/src/clp_config/package/config.rs
@@ -381,6 +381,20 @@ impl ArchiveOutput {
             .to_string_lossy()
             .into_owned()
     }
+
+    /// Derives the S3 object key of an archive in a dataset.
+    ///
+    /// # Returns
+    ///
+    /// The dataset's archive storage directory joined with `archive_id`, where a `None` dataset
+    /// resolves to `default`.
+    #[must_use]
+    pub fn dataset_archive_object_key(&self, dataset: Option<&str>, archive_id: &str) -> String {
+        format!(
+            "{}/{archive_id}",
+            self.dataset_archive_storage_directory(dataset)
+        )
+    }
 }
 
 impl Default for ArchiveOutput {
@@ -696,6 +710,38 @@ mod tests {
         assert_eq!(
             archive_output.dataset_archive_storage_directory(None),
             "prefix/default"
+        );
+    }
+
+    #[test]
+    fn dataset_archive_object_key_joins_prefix_dataset_and_id() {
+        use non_empty_string::NonEmptyString;
+
+        use crate::clp_config::AwsAuthentication;
+        use crate::clp_config::S3Config;
+        use crate::types::non_empty_string::ExpectedNonEmpty;
+
+        let archive_output = ArchiveOutput {
+            storage: ArchiveOutputStorage::S3 {
+                staging_directory: "var/data/staged-archives".to_owned(),
+                s3_config: S3Config {
+                    bucket: NonEmptyString::from_static_str("bucket"),
+                    region_code: None,
+                    key_prefix: NonEmptyString::from_static_str("LIB1/"),
+                    endpoint_url: None,
+                    aws_authentication: AwsAuthentication::Default,
+                },
+            },
+            ..ArchiveOutput::default()
+        };
+
+        assert_eq!(
+            archive_output.dataset_archive_object_key(None, "abc"),
+            "LIB1/default/abc"
+        );
+        assert_eq!(
+            archive_output.dataset_archive_object_key(Some("mydataset"), "abc"),
+            "LIB1/mydataset/abc"
         );
     }
 

--- a/components/clp-rust-utils/src/task_io.rs
+++ b/components/clp-rust-utils/src/task_io.rs
@@ -1,1 +1,2 @@
 pub mod compression;
+pub mod query;

--- a/components/clp-rust-utils/src/task_io/query.rs
+++ b/components/clp-rust-utils/src/task_io/query.rs
@@ -1,11 +1,11 @@
-//! Protocol types exchanged with the Spider tasks that run CLP-S query jobs.
+//! Protocol types exchanged with the Spider (Huntsman) tasks that run CLP query jobs.
 
 use std::num::NonZeroU32;
 
 use serde::Deserialize;
 use serde::Serialize;
 
-/// The job-wide CLP-S options shared by every archive-query task in a query job.
+/// `clp-s` tuning and engine options for a query job.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ClpSQueryOption {
     /// The query string passed positionally to `clp-s`.

--- a/components/clp-rust-utils/src/task_io/query.rs
+++ b/components/clp-rust-utils/src/task_io/query.rs
@@ -1,0 +1,39 @@
+//! Protocol types exchanged with the Spider tasks that run CLP-S query jobs.
+
+use std::num::NonZeroU32;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// The job-wide CLP-S options shared by every archive-search task in a query job.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ClpSQueryOption {
+    /// The query string passed positionally to `clp-s`.
+    pub query_string: String,
+
+    /// The maximum number of results retained by one archive-search invocation.
+    pub max_num_results: NonZeroU32,
+
+    /// The inclusive lower timestamp bound (`--tge`), in Unix epoch microseconds.
+    pub begin_timestamp: Option<i64>,
+
+    /// The inclusive upper timestamp bound (`--tle`), in Unix epoch microseconds.
+    pub end_timestamp: Option<i64>,
+
+    /// Whether `clp-s` performs a case-insensitive search.
+    pub ignore_case: bool,
+}
+
+/// The graph output of one successfully completed archive-search task.
+///
+/// Search results are written directly to the results cache and are not returned through Spider.
+/// This output only identifies the archive whose search invocation completed; it does not
+/// finalize the query job.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct QueryTaskOutput {
+    /// The resolved dataset containing the searched archive.
+    pub dataset: String,
+
+    /// The identifier of the searched archive.
+    pub archive_id: String,
+}

--- a/components/clp-rust-utils/src/task_io/query.rs
+++ b/components/clp-rust-utils/src/task_io/query.rs
@@ -2,34 +2,51 @@
 
 use std::num::NonZeroU32;
 
+use non_empty_string::NonEmptyString;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Where a query task's matches are written.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, tag = "type")]
+pub enum OutputHandle {
+    /// The results cache, addressed by a MongoDB URI whose path names the database. The collection
+    /// is the query job's ID.
+    #[serde(rename = "results_cache")]
+    ResultsCache { uri: NonEmptyString },
+
+    /// A file per archive. Not yet supported by the Spider query flow.
+    #[serde(rename = "file")]
+    File,
+}
+
 /// `clp-s` tuning and engine options for a query job.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ClpSQueryOption {
     /// The query string passed positionally to `clp-s`.
     pub query_string: String,
 
-    /// The maximum number of results retained by one archive-query invocation.
-    pub max_num_results: NonZeroU32,
+    /// The maximum number of results retained by one archive-query invocation, or `None` for no
+    /// limit.
+    pub max_num_results: Option<NonZeroU32>,
 
-    /// The inclusive lower timestamp bound (`--tge`), in Unix epoch microseconds.
+    /// The inclusive lower timestamp bound (`--tge`), in Unix epoch milliseconds.
     pub begin_timestamp: Option<i64>,
 
-    /// The inclusive upper timestamp bound (`--tle`), in Unix epoch microseconds.
+    /// The inclusive upper timestamp bound (`--tle`), in Unix epoch milliseconds.
     pub end_timestamp: Option<i64>,
 
     /// Whether `clp-s` performs a case-insensitive search.
     pub ignore_case: bool,
 }
 
-/// The graph output of one successfully completed archive-query task.
+/// The archive-query result reserved for a future query-commit task.
 ///
-/// Query results are written directly to the results cache and are not returned through Spider.
-/// This output only identifies the archive whose query invocation completed; it does not
-/// finalize the query job.
+/// Query results are written directly to the results cache and are not returned through Spider, so
+/// no task currently produces or consumes this type.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct QueryTaskOutput {
     /// The resolved dataset containing the queried archive.
     pub dataset: String,
@@ -42,16 +59,20 @@ pub struct QueryTaskOutput {
 mod tests {
     use std::num::NonZeroU32;
 
+    use non_empty_string::NonEmptyString;
+
     use super::ClpSQueryOption;
+    use super::OutputHandle;
     use super::QueryTaskOutput;
+    use crate::types::non_empty_string::ExpectedNonEmpty;
 
     #[test]
     fn clp_s_query_option_with_timestamp_bounds_round_trips_through_msgpack() {
         let expected = ClpSQueryOption {
             query_string: "level:error".to_owned(),
-            max_num_results: NonZeroU32::new(1_000).expect("1,000 is nonzero"),
-            begin_timestamp: Some(1_700_000_000_000_001),
-            end_timestamp: Some(1_700_000_000_000_999),
+            max_num_results: Some(NonZeroU32::new(1_000).expect("1,000 is nonzero")),
+            begin_timestamp: Some(1_700_000_000_001),
+            end_timestamp: Some(1_700_000_000_999),
             ignore_case: true,
         };
 
@@ -66,7 +87,7 @@ mod tests {
     fn clp_s_query_option_without_timestamp_bounds_round_trips_through_msgpack() {
         let expected = ClpSQueryOption {
             query_string: "*".to_owned(),
-            max_num_results: NonZeroU32::new(1).expect("1 is nonzero"),
+            max_num_results: Some(NonZeroU32::new(1).expect("1 is nonzero")),
             begin_timestamp: None,
             end_timestamp: None,
             ignore_case: false,
@@ -75,6 +96,47 @@ mod tests {
         let serialized = rmp_serde::to_vec(&expected).expect("query options should serialize");
         let actual: ClpSQueryOption =
             rmp_serde::from_slice(&serialized).expect("query options should deserialize");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn clp_s_query_option_without_max_num_results_round_trips_through_msgpack() {
+        let expected = ClpSQueryOption {
+            query_string: "*".to_owned(),
+            max_num_results: None,
+            begin_timestamp: None,
+            end_timestamp: None,
+            ignore_case: false,
+        };
+
+        let serialized = rmp_serde::to_vec(&expected).expect("query options should serialize");
+        let actual: ClpSQueryOption =
+            rmp_serde::from_slice(&serialized).expect("query options should deserialize");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn output_handle_results_cache_round_trips_through_msgpack() {
+        let expected = OutputHandle::ResultsCache {
+            uri: NonEmptyString::from_static_str("mongodb://results-cache:27017/clp-query-results"),
+        };
+
+        let serialized = rmp_serde::to_vec(&expected).expect("output handle should serialize");
+        let actual: OutputHandle =
+            rmp_serde::from_slice(&serialized).expect("output handle should deserialize");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn output_handle_file_round_trips_through_msgpack() {
+        let expected = OutputHandle::File;
+
+        let serialized = rmp_serde::to_vec(&expected).expect("output handle should serialize");
+        let actual: OutputHandle =
+            rmp_serde::from_slice(&serialized).expect("output handle should deserialize");
 
         assert_eq!(expected, actual);
     }

--- a/components/clp-rust-utils/src/task_io/query.rs
+++ b/components/clp-rust-utils/src/task_io/query.rs
@@ -5,13 +5,13 @@ use std::num::NonZeroU32;
 use serde::Deserialize;
 use serde::Serialize;
 
-/// The job-wide CLP-S options shared by every archive-search task in a query job.
+/// The job-wide CLP-S options shared by every archive-query task in a query job.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ClpSQueryOption {
     /// The query string passed positionally to `clp-s`.
     pub query_string: String,
 
-    /// The maximum number of results retained by one archive-search invocation.
+    /// The maximum number of results retained by one archive-query invocation.
     pub max_num_results: NonZeroU32,
 
     /// The inclusive lower timestamp bound (`--tge`), in Unix epoch microseconds.
@@ -24,16 +24,72 @@ pub struct ClpSQueryOption {
     pub ignore_case: bool,
 }
 
-/// The graph output of one successfully completed archive-search task.
+/// The graph output of one successfully completed archive-query task.
 ///
-/// Search results are written directly to the results cache and are not returned through Spider.
-/// This output only identifies the archive whose search invocation completed; it does not
+/// Query results are written directly to the results cache and are not returned through Spider.
+/// This output only identifies the archive whose query invocation completed; it does not
 /// finalize the query job.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct QueryTaskOutput {
-    /// The resolved dataset containing the searched archive.
+    /// The resolved dataset containing the queried archive.
     pub dataset: String,
 
-    /// The identifier of the searched archive.
+    /// The identifier of the queried archive.
     pub archive_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::ClpSQueryOption;
+    use super::QueryTaskOutput;
+
+    #[test]
+    fn clp_s_query_option_with_timestamp_bounds_round_trips_through_msgpack() {
+        let expected = ClpSQueryOption {
+            query_string: "level:error".to_owned(),
+            max_num_results: NonZeroU32::new(1_000).expect("1,000 is nonzero"),
+            begin_timestamp: Some(1_700_000_000_000_001),
+            end_timestamp: Some(1_700_000_000_000_999),
+            ignore_case: true,
+        };
+
+        let serialized = rmp_serde::to_vec(&expected).expect("query options should serialize");
+        let actual: ClpSQueryOption =
+            rmp_serde::from_slice(&serialized).expect("query options should deserialize");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn clp_s_query_option_without_timestamp_bounds_round_trips_through_msgpack() {
+        let expected = ClpSQueryOption {
+            query_string: "*".to_owned(),
+            max_num_results: NonZeroU32::new(1).expect("1 is nonzero"),
+            begin_timestamp: None,
+            end_timestamp: None,
+            ignore_case: false,
+        };
+
+        let serialized = rmp_serde::to_vec(&expected).expect("query options should serialize");
+        let actual: ClpSQueryOption =
+            rmp_serde::from_slice(&serialized).expect("query options should deserialize");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn query_task_output_round_trips_through_msgpack() {
+        let expected = QueryTaskOutput {
+            dataset: "default".to_owned(),
+            archive_id: "archive-id".to_owned(),
+        };
+
+        let serialized = rmp_serde::to_vec(&expected).expect("task output should serialize");
+        let actual: QueryTaskOutput =
+            rmp_serde::from_slice(&serialized).expect("task output should deserialize");
+
+        assert_eq!(expected, actual);
+    }
 }

--- a/components/clp-tdl-package/README.md
+++ b/components/clp-tdl-package/README.md
@@ -12,3 +12,8 @@ documented below.
 
 * `compression::clp_s_s3_compress`: Compress inputs from S3 using `clp-s`.
 * `compression::commit`: Commit compression task outcomes to the CLP metadata database.
+
+### Query
+
+* `query::clp_s_query_to_results_cache`: Query a single `clp-s` archive and write the matching log
+  events directly to the results cache.

--- a/components/clp-tdl-package/src/lib.rs
+++ b/components/clp-tdl-package/src/lib.rs
@@ -31,6 +31,6 @@ spider_tdl::register_tdl_package! {
     tasks: [
         task::compression::s3_compress_task,
         task::compression::commit_task,
-        task::query::clp_s_search_to_results_cache_task,
+        task::query::clp_s_query_to_results_cache_task,
     ],
 }

--- a/components/clp-tdl-package/src/lib.rs
+++ b/components/clp-tdl-package/src/lib.rs
@@ -1,4 +1,4 @@
-//! Spider TDL task package `clp`: the CLP compression tasks the Spider task executor loads.
+//! Spider TDL task package `clp`: the CLP tasks the Spider task executor loads.
 
 pub mod common;
 mod task;
@@ -28,5 +28,9 @@ fn package_init() -> Result<(), TdlError> {
 spider_tdl::register_tdl_package! {
     package_name: "clp",
     init: package_init,
-    tasks: [task::compression::s3_compress_task, task::compression::commit_task],
+    tasks: [
+        task::compression::s3_compress_task,
+        task::compression::commit_task,
+        task::query::clp_s_search_to_results_cache_task,
+    ],
 }

--- a/components/clp-tdl-package/src/lib.rs
+++ b/components/clp-tdl-package/src/lib.rs
@@ -1,4 +1,4 @@
-//! Spider TDL task package `clp`: the CLP tasks the Spider task executor loads.
+//! Spider TDL package `clp`, providing CLP compression and query tasks for Spider task executors.
 
 pub mod common;
 mod task;

--- a/components/clp-tdl-package/src/task/clp_s.rs
+++ b/components/clp-tdl-package/src/task/clp_s.rs
@@ -1,0 +1,116 @@
+//! Helpers shared by the tasks that invoke CLP's core binaries.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::ProvideCredentials;
+use clp_rust_utils::clp_config::AwsAuthentication;
+
+/// Resolves the path of a CLP binary under `clp_home`, joining `bin/{binary}`.
+///
+/// # Returns
+///
+/// The path to the named binary under the CLP installation.
+pub(super) fn clp_binary_path(clp_home: &Path, binary: &str) -> PathBuf {
+    clp_home.join("bin").join(binary)
+}
+
+/// Resolves the AWS credential env vars clp-s needs to access the S3 objects.
+///
+/// # Returns
+///
+/// The env-var name-value pairs with the following environment variables set:
+///
+/// * `AWS_ACCESS_KEY_ID`
+/// * `AWS_SECRET_ACCESS_KEY`
+/// * `AWS_SESSION_TOKEN` (if any)
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * The default AWS SDK credential provider chain has no provider.
+/// * Forwards [`ProvideCredentials::provide_credentials`]'s return values on failure.
+pub(super) fn s3_credential_env(
+    runtime: &tokio::runtime::Handle,
+    region: &str,
+    auth: &AwsAuthentication,
+) -> anyhow::Result<Vec<(&'static str, String)>> {
+    /// The env var holding the AWS access key ID.
+    const AWS_ACCESS_KEY_ID_ENV_VAR: &str = "AWS_ACCESS_KEY_ID";
+
+    /// The env var holding the AWS secret access key.
+    const AWS_SECRET_ACCESS_KEY_ENV_VAR: &str = "AWS_SECRET_ACCESS_KEY";
+
+    /// The env var holding the AWS session token.
+    const AWS_SESSION_TOKEN_ENV_VAR: &str = "AWS_SESSION_TOKEN";
+
+    let (access_key_id, secret_access_key, session_token) = match auth {
+        AwsAuthentication::Credentials { credentials } => (
+            credentials.access_key_id.clone(),
+            credentials.secret_access_key.clone(),
+            credentials.session_token.clone(),
+        ),
+        AwsAuthentication::Default => {
+            let sdk_config = runtime.block_on(
+                aws_config::defaults(BehaviorVersion::latest())
+                    .region(aws_sdk_s3::config::Region::new(region.to_string()))
+                    .load(),
+            );
+            let provider = sdk_config
+                .credentials_provider()
+                .context("default AWS SDK credential provider is unavailable")?;
+            let credentials = runtime
+                .block_on(provider.provide_credentials())
+                .context("failed to resolve credentials from the default AWS SDK provider chain")?;
+            (
+                credentials.access_key_id().to_string(),
+                credentials.secret_access_key().to_string(),
+                credentials
+                    .session_token()
+                    .map(std::string::ToString::to_string),
+            )
+        }
+    };
+
+    let mut env = vec![
+        (AWS_ACCESS_KEY_ID_ENV_VAR, access_key_id),
+        (AWS_SECRET_ACCESS_KEY_ENV_VAR, secret_access_key),
+    ];
+    if let Some(session_token) = session_token {
+        env.push((AWS_SESSION_TOKEN_ENV_VAR, session_token));
+    }
+    Ok(env)
+}
+
+#[cfg(test)]
+mod tests {
+    use clp_rust_utils::clp_config::AwsAuthentication;
+    use clp_rust_utils::clp_config::AwsCredentials;
+
+    use super::s3_credential_env;
+
+    #[test]
+    fn s3_credential_env_credentials() {
+        let runtime = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
+        let auth = AwsAuthentication::Credentials {
+            credentials: AwsCredentials {
+                access_key_id: "the-access-key".to_string(),
+                secret_access_key: "the-secret-key".to_string(),
+                session_token: Some("the-session-token".to_string()),
+            },
+        };
+
+        assert_eq!(
+            s3_credential_env(runtime.handle(), "us-east-1", &auth)
+                .expect("failed to resolve credentials"),
+            vec![
+                ("AWS_ACCESS_KEY_ID", "the-access-key".to_string()),
+                ("AWS_SECRET_ACCESS_KEY", "the-secret-key".to_string()),
+                ("AWS_SESSION_TOKEN", "the-session-token".to_string()),
+            ]
+        );
+    }
+}

--- a/components/clp-tdl-package/src/task/compression/compress.rs
+++ b/components/clp-tdl-package/src/task/compression/compress.rs
@@ -10,12 +10,8 @@ use std::process::Command;
 use std::process::Stdio;
 
 use anyhow::Context;
-use aws_config::BehaviorVersion;
-use aws_sdk_s3::config::ProvideCredentials;
 use clp_rust_utils::aws::AWS_DEFAULT_REGION;
-use clp_rust_utils::clp_config::AwsAuthentication;
 use clp_rust_utils::clp_config::S3Config;
-use clp_rust_utils::clp_config::package::config::ArchiveOutput;
 use clp_rust_utils::clp_config::package::config::ArchiveOutputStorage;
 use clp_rust_utils::clp_config::package::config::Database;
 use clp_rust_utils::clp_config::package::config::SpiderTaskExecutorConfig;
@@ -30,6 +26,8 @@ use non_empty_string::NonEmptyString;
 
 use crate::common::clp_home;
 use crate::common::runtime;
+use crate::task::clp_s::clp_binary_path;
+use crate::task::clp_s::s3_credential_env;
 
 /// Compresses the given S3 objects into archives, uploads them to S3, and returns their metadata
 /// for the commit task.
@@ -130,7 +128,9 @@ pub(super) fn compress(
             ArchiveFinisher {
                 client: client.clone(),
                 bucket: bucket.clone(),
-                key: create_archive_s3_key(&config.archive_output, dataset.as_deref(), &archive.id),
+                key: config
+                    .archive_output
+                    .dataset_archive_object_key(dataset.as_deref(), &archive.id),
                 indexer_bin: indexer_bin.clone(),
                 database: config.database.clone(),
                 dataset: dataset.clone(),
@@ -345,74 +345,6 @@ fn build_s3_logs_list(input_source: &S3InputSource) -> anyhow::Result<String> {
     Ok(list)
 }
 
-/// Resolves the AWS credential env vars clp-s needs to access the S3 objects.
-///
-/// # Returns
-///
-/// The env-var name-value pairs with the following environment variables set:
-///
-/// * `AWS_ACCESS_KEY_ID`
-/// * `AWS_SECRET_ACCESS_KEY`
-/// * `AWS_SESSION_TOKEN` (if any)
-///
-/// # Errors
-///
-/// Returns an error if:
-///
-/// * The default AWS SDK credential provider chain has no provider.
-/// * Forwards [`ProvideCredentials::provide_credentials`]'s return values on failure.
-fn s3_credential_env(
-    runtime: &tokio::runtime::Handle,
-    region: &str,
-    auth: &AwsAuthentication,
-) -> anyhow::Result<Vec<(&'static str, String)>> {
-    /// The env var holding the AWS access key ID.
-    const AWS_ACCESS_KEY_ID_ENV_VAR: &str = "AWS_ACCESS_KEY_ID";
-
-    /// The env var holding the AWS secret access key.
-    const AWS_SECRET_ACCESS_KEY_ENV_VAR: &str = "AWS_SECRET_ACCESS_KEY";
-
-    /// The env var holding the AWS session token.
-    const AWS_SESSION_TOKEN_ENV_VAR: &str = "AWS_SESSION_TOKEN";
-
-    let (access_key_id, secret_access_key, session_token) = match auth {
-        AwsAuthentication::Credentials { credentials } => (
-            credentials.access_key_id.clone(),
-            credentials.secret_access_key.clone(),
-            credentials.session_token.clone(),
-        ),
-        AwsAuthentication::Default => {
-            let sdk_config = runtime.block_on(
-                aws_config::defaults(BehaviorVersion::latest())
-                    .region(aws_sdk_s3::config::Region::new(region.to_string()))
-                    .load(),
-            );
-            let provider = sdk_config
-                .credentials_provider()
-                .context("default AWS SDK credential provider is unavailable")?;
-            let credentials = runtime
-                .block_on(provider.provide_credentials())
-                .context("failed to resolve credentials from the default AWS SDK provider chain")?;
-            (
-                credentials.access_key_id().to_string(),
-                credentials.secret_access_key().to_string(),
-                credentials
-                    .session_token()
-                    .map(std::string::ToString::to_string),
-            )
-        }
-    };
-
-    let mut env = vec![
-        (AWS_ACCESS_KEY_ID_ENV_VAR, access_key_id),
-        (AWS_SECRET_ACCESS_KEY_ENV_VAR, secret_access_key),
-    ];
-    if let Some(session_token) = session_token {
-        env.push((AWS_SESSION_TOKEN_ENV_VAR, session_token));
-    }
-    Ok(env)
-}
-
 /// Parses a single clp-s `--print-archive-stats` stdout line into an [`ArchiveMetadata`].
 ///
 /// NOTE: clp-s emits a superset of [`ArchiveMetadata`]'s fields per line; unknown fields are
@@ -585,15 +517,6 @@ fn build_log_converter_args(output_dir: &Path, inputs_from_path: &Path) -> Vec<O
     ]
 }
 
-/// Resolves the path of a CLP binary under `clp_home`, joining `bin/{binary}`.
-///
-/// # Returns
-///
-/// The path to the named binary under the CLP installation.
-fn clp_binary_path(clp_home: &Path, binary: &str) -> PathBuf {
-    clp_home.join("bin").join(binary)
-}
-
 /// Resolves the S3 config the archives are uploaded to from `config`.
 ///
 /// # Returns
@@ -612,23 +535,6 @@ fn extract_s3_output_config(config: &SpiderTaskExecutorConfig) -> anyhow::Result
             anyhow::bail!("S3 archive output is required for the S3 compression flow")
         }
     }
-}
-
-/// Builds the S3 object key for an archive by appending `archive_id` to
-/// [`ArchiveOutput::dataset_archive_storage_directory`].
-///
-/// # Returns
-///
-/// The archive's S3 object key.
-fn create_archive_s3_key(
-    archive_output: &ArchiveOutput,
-    dataset: Option<&str>,
-    archive_id: &str,
-) -> String {
-    format!(
-        "{}/{archive_id}",
-        archive_output.dataset_archive_storage_directory(dataset)
-    )
 }
 
 /// Uploads a local file to S3 through `PutObject`.
@@ -905,10 +811,6 @@ mod tests {
     use std::path::PathBuf;
 
     use clp_rust_utils::clp_config::AwsAuthentication;
-    use clp_rust_utils::clp_config::AwsCredentials;
-    use clp_rust_utils::clp_config::S3Config;
-    use clp_rust_utils::clp_config::package::config::ArchiveOutput;
-    use clp_rust_utils::clp_config::package::config::ArchiveOutputStorage;
     use clp_rust_utils::clp_config::package::config::ClpDbNames;
     use clp_rust_utils::clp_config::package::config::Database;
     use clp_rust_utils::task_io::compression::ArchiveMetadata;
@@ -921,9 +823,7 @@ mod tests {
     use super::build_indexer_args;
     use super::build_log_converter_args;
     use super::build_s3_logs_list;
-    use super::create_archive_s3_key;
     use super::parse_archive_stats;
-    use super::s3_credential_env;
 
     #[test]
     fn build_s3_logs_list_default_endpoint() -> anyhow::Result<()> {
@@ -945,28 +845,6 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    #[test]
-    fn s3_credential_env_credentials() {
-        let runtime = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
-        let auth = AwsAuthentication::Credentials {
-            credentials: AwsCredentials {
-                access_key_id: "the-access-key".to_string(),
-                secret_access_key: "the-secret-key".to_string(),
-                session_token: Some("the-session-token".to_string()),
-            },
-        };
-
-        assert_eq!(
-            s3_credential_env(runtime.handle(), "us-east-1", &auth)
-                .expect("failed to resolve credentials"),
-            vec![
-                ("AWS_ACCESS_KEY_ID", "the-access-key".to_string()),
-                ("AWS_SECRET_ACCESS_KEY", "the-secret-key".to_string()),
-                ("AWS_SESSION_TOKEN", "the-session-token".to_string()),
-            ]
-        );
     }
 
     #[test]
@@ -1102,30 +980,6 @@ mod tests {
                 OsString::from("--auth"),
                 OsString::from("s3"),
             ]
-        );
-    }
-
-    #[test]
-    fn archive_s3_key_joins_prefix_dataset_and_id() {
-        let archive_output = ArchiveOutput {
-            storage: ArchiveOutputStorage::S3 {
-                staging_directory: "var/data/staged-archives".to_owned(),
-                s3_config: S3Config {
-                    bucket: NonEmptyString::try_from("bucket".to_string())
-                        .expect("bucket is non-empty"),
-                    region_code: None,
-                    key_prefix: NonEmptyString::try_from("LIB1/".to_string())
-                        .expect("key prefix is non-empty"),
-                    endpoint_url: None,
-                    aws_authentication: AwsAuthentication::Default,
-                },
-            },
-            ..ArchiveOutput::default()
-        };
-
-        assert_eq!(
-            create_archive_s3_key(&archive_output, None, "abc"),
-            "LIB1/default/abc"
         );
     }
 

--- a/components/clp-tdl-package/src/task/mod.rs
+++ b/components/clp-tdl-package/src/task/mod.rs
@@ -1,3 +1,4 @@
 //! The task implementations this package registers with Spider.
 
 pub mod compression;
+pub mod query;

--- a/components/clp-tdl-package/src/task/mod.rs
+++ b/components/clp-tdl-package/src/task/mod.rs
@@ -1,4 +1,5 @@
 //! The task implementations this package registers with Spider.
 
+pub mod clp_s;
 pub mod compression;
 pub mod query;

--- a/components/clp-tdl-package/src/task/query/mod.rs
+++ b/components/clp-tdl-package/src/task/query/mod.rs
@@ -6,9 +6,9 @@ use spider_tdl::TaskContext;
 use spider_tdl::TdlError;
 use spider_tdl::task;
 
-/// Searches one CLP-S archive and writes its matches directly to the results cache.
-#[task(name = "search::clp_s_search_to_results_cache")]
-pub(crate) fn clp_s_search_to_results_cache_task(
+/// Queries one CLP-S archive and writes its matches directly to the results cache.
+#[task(name = "query::clp_s_query_to_results_cache")]
+pub(crate) fn clp_s_query_to_results_cache_task(
     ctx: TaskContext,
     query_job_id: i32,
     clp_s_query_option: ClpSQueryOption,

--- a/components/clp-tdl-package/src/task/query/mod.rs
+++ b/components/clp-tdl-package/src/task/query/mod.rs
@@ -1,20 +1,38 @@
-//! The query-task signatures registered with Spider.
+//! The query tasks: the `#[task]` wrappers Spider invokes and their implementations.
 
 use clp_rust_utils::task_io::query::ClpSQueryOption;
-use clp_rust_utils::task_io::query::QueryTaskOutput;
+use clp_rust_utils::task_io::query::OutputHandle;
+use non_empty_string::NonEmptyString;
 use spider_tdl::TaskContext;
 use spider_tdl::TdlError;
 use spider_tdl::task;
 
+mod search;
+
 /// Queries one CLP-S archive and writes its matches directly to the results cache.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * [`TdlError::ExecutionError`] if [`search::search`] fails.
 #[task(name = "query::clp_s_query_to_results_cache")]
 pub(crate) fn clp_s_query_to_results_cache_task(
     ctx: TaskContext,
     query_job_id: i32,
     clp_s_query_option: ClpSQueryOption,
-    dataset: String,
+    output_handle: OutputHandle,
+    dataset: Option<NonEmptyString>,
     archive_id: String,
-) -> Result<QueryTaskOutput, TdlError> {
-    let _ = (ctx, query_job_id, clp_s_query_option, dataset, archive_id);
-    todo!("Implement the CLP-S results-cache query task")
+) -> Result<(), TdlError> {
+    search::search(
+        &ctx,
+        crate::common::spider_task_executor_config(),
+        query_job_id,
+        &clp_s_query_option,
+        &output_handle,
+        dataset.as_ref().map(NonEmptyString::as_str),
+        archive_id,
+    )
+    .map_err(|e| TdlError::ExecutionError(format!("{e:#}")))
 }

--- a/components/clp-tdl-package/src/task/query/mod.rs
+++ b/components/clp-tdl-package/src/task/query/mod.rs
@@ -1,0 +1,20 @@
+//! The query-task signatures registered with Spider.
+
+use clp_rust_utils::task_io::query::ClpSQueryOption;
+use clp_rust_utils::task_io::query::QueryTaskOutput;
+use spider_tdl::TaskContext;
+use spider_tdl::TdlError;
+use spider_tdl::task;
+
+/// Searches one CLP-S archive and writes its matches directly to the results cache.
+#[task(name = "search::clp_s_search_to_results_cache")]
+pub(crate) fn clp_s_search_to_results_cache_task(
+    ctx: TaskContext,
+    query_job_id: i32,
+    clp_s_query_option: ClpSQueryOption,
+    dataset: String,
+    archive_id: String,
+) -> Result<QueryTaskOutput, TdlError> {
+    let _ = (ctx, query_job_id, clp_s_query_option, dataset, archive_id);
+    todo!("Implement the CLP-S results-cache query task")
+}

--- a/components/clp-tdl-package/src/task/query/search.rs
+++ b/components/clp-tdl-package/src/task/query/search.rs
@@ -1,0 +1,660 @@
+//! The `clp-s` search worker that queries a single archive into the results cache.
+
+use std::ffi::OsString;
+use std::io::Read;
+use std::num::NonZeroU32;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+use anyhow::Context;
+use clp_rust_utils::aws::AWS_DEFAULT_REGION;
+use clp_rust_utils::clp_config::package::config::ArchiveOutputStorage;
+use clp_rust_utils::clp_config::package::config::SpiderTaskExecutorConfig;
+use clp_rust_utils::clp_config::package::config::StorageEngine;
+use clp_rust_utils::dataset::resolve_dataset_name;
+use clp_rust_utils::s3::generate_s3_url;
+use clp_rust_utils::task_io::query::ClpSQueryOption;
+use clp_rust_utils::task_io::query::OutputHandle;
+use non_empty_string::NonEmptyString;
+
+use crate::common::clp_home;
+use crate::common::runtime;
+use crate::task::clp_s::clp_binary_path;
+use crate::task::clp_s::s3_credential_env;
+
+/// Queries one archive with clp-s, streaming the matches into the results cache.
+///
+/// A pure worker function called by a spider-tdl task wrapper, which formats any returned
+/// `anyhow::Error` into a user-space TDL error.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * The configured storage engine is not [`StorageEngine::ClpS`].
+/// * `output_handle` is not [`OutputHandle::ResultsCache`].
+/// * Forwards [`resolve_archive_input`]'s return values on failure.
+/// * Forwards [`run_clp_s_search`]'s return values on failure.
+pub(super) fn search(
+    ctx: &spider_tdl::TaskContext,
+    config: &SpiderTaskExecutorConfig,
+    query_job_id: i32,
+    clp_s_query_option: &ClpSQueryOption,
+    output_handle: &OutputHandle,
+    dataset: Option<&str>,
+    archive_id: String,
+) -> anyhow::Result<()> {
+    if StorageEngine::ClpS != config.package.storage_engine {
+        anyhow::bail!("the clp-s query task requires the `clp-s` storage engine");
+    }
+    let OutputHandle::ResultsCache { uri } = output_handle else {
+        anyhow::bail!("unsupported query output handler: only `results_cache` is supported");
+    };
+
+    let dataset = resolve_dataset_name(dataset);
+
+    tracing::info!(
+        job_id = % ctx.job_id,
+        task_id = % ctx.task_id,
+        task_instance_id = % ctx.task_instance_id,
+        query_job_id = % query_job_id,
+        dataset = % dataset,
+        archive_id = % archive_id,
+        "CLP-S query task started.",
+    );
+
+    let clp_home = clp_home();
+    let (archive_selector, credential_env) =
+        resolve_archive_input(&runtime(), clp_home, config, dataset, archive_id)?;
+    let args = build_clp_s_search_args(
+        &archive_selector,
+        clp_s_query_option,
+        uri.as_str(),
+        &query_job_id.to_string(),
+        dataset,
+    );
+    run_clp_s_search(&clp_binary_path(clp_home, "clp-s"), args, &credential_env)?;
+
+    tracing::info!(
+        job_id = % ctx.job_id,
+        task_id = % ctx.task_id,
+        task_instance_id = % ctx.task_instance_id,
+        query_job_id = % query_job_id,
+        "CLP-S query task completed successfully.",
+    );
+    Ok(())
+}
+
+/// How clp-s addresses the archive to search.
+enum ArchiveSelector {
+    /// A local dataset archives directory plus the `--archive-id` selecting one archive in it.
+    Directory { path: PathBuf, archive_id: String },
+
+    /// The URL of an S3-hosted archive, read with `--auth s3`.
+    ObjectUrl(String),
+}
+
+/// Resolves how clp-s addresses the archive, and the credential env vars it needs to read it.
+///
+/// # Returns
+///
+/// The archive selector and the credential env vars clp-s should run with, which are empty for
+/// filesystem-backed archive output.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * The archive's object key is empty.
+/// * Forwards [`generate_s3_url`]'s return values on failure.
+/// * Forwards [`s3_credential_env`]'s return values on failure.
+fn resolve_archive_input(
+    runtime: &tokio::runtime::Handle,
+    clp_home: &Path,
+    config: &SpiderTaskExecutorConfig,
+    dataset: &str,
+    archive_id: String,
+) -> anyhow::Result<(ArchiveSelector, Vec<(&'static str, String)>)> {
+    let s3_config = match &config.archive_output.storage {
+        ArchiveOutputStorage::Fs { .. } => {
+            return Ok((
+                ArchiveSelector::Directory {
+                    path: config.abs_archive_output_staging(clp_home).join(dataset),
+                    archive_id,
+                },
+                Vec::new(),
+            ));
+        }
+        ArchiveOutputStorage::S3 { s3_config, .. } => s3_config,
+    };
+
+    let object_key = config
+        .archive_output
+        .dataset_archive_object_key(Some(dataset), &archive_id);
+    let object_key = NonEmptyString::try_from(object_key)
+        .map_err(|_| anyhow::anyhow!("archive object key must not be empty"))?;
+    let url = generate_s3_url(
+        s3_config.endpoint_url.as_ref().map(NonEmptyString::as_str),
+        s3_config.region_code.as_ref().map(NonEmptyString::as_str),
+        &s3_config.bucket,
+        &object_key,
+    )?;
+    let region = s3_config
+        .region_code
+        .as_ref()
+        .map_or(AWS_DEFAULT_REGION, NonEmptyString::as_str);
+    let credential_env = s3_credential_env(runtime, region, &s3_config.aws_authentication)?;
+    Ok((ArchiveSelector::ObjectUrl(url), credential_env))
+}
+
+/// Builds the clp-s command-line arguments for a single-archive search writing to the results
+/// cache.
+///
+/// `--batch-size` is left unset so clp-s applies its own default.
+///
+/// # Returns
+///
+/// The ordered clp-s arguments.
+fn build_clp_s_search_args(
+    archive_selector: &ArchiveSelector,
+    clp_s_query_option: &ClpSQueryOption,
+    results_cache_uri: &str,
+    collection: &str,
+    dataset: &str,
+) -> Vec<OsString> {
+    let mut args = vec![OsString::from("s")];
+    match archive_selector {
+        ArchiveSelector::Directory { path, archive_id } => {
+            args.push(path.as_os_str().to_os_string());
+            args.push(OsString::from("--archive-id"));
+            args.push(OsString::from(archive_id));
+        }
+        ArchiveSelector::ObjectUrl(url) => {
+            args.push(OsString::from(url));
+            args.push(OsString::from("--auth"));
+            args.push(OsString::from("s3"));
+        }
+    }
+
+    args.push(OsString::from(&clp_s_query_option.query_string));
+    if let Some(begin_timestamp) = clp_s_query_option.begin_timestamp {
+        args.push(OsString::from("--tge"));
+        args.push(OsString::from(begin_timestamp.to_string()));
+    }
+    if let Some(end_timestamp) = clp_s_query_option.end_timestamp {
+        args.push(OsString::from("--tle"));
+        args.push(OsString::from(end_timestamp.to_string()));
+    }
+    if clp_s_query_option.ignore_case {
+        args.push(OsString::from("--ignore-case"));
+    }
+
+    let max_num_results = clp_s_query_option
+        .max_num_results
+        .map_or(u32::MAX, NonZeroU32::get);
+    args.extend([
+        OsString::from("results-cache"),
+        OsString::from("--uri"),
+        OsString::from(results_cache_uri),
+        OsString::from("--collection"),
+        OsString::from(collection),
+        OsString::from("--max-num-results"),
+        OsString::from(max_num_results.to_string()),
+        OsString::from("--dataset"),
+        OsString::from(dataset),
+    ]);
+    args
+}
+
+/// Runs clp-s with the given search arguments, blocking until it exits.
+///
+/// stdout is discarded; stderr is captured so it can be surfaced if clp-s fails.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * clp-s exits with a non-zero status.
+/// * Forwards [`Command::spawn`]'s return values on failure.
+/// * Forwards [`std::process::Child::wait`]'s return values on failure.
+///
+/// # Panics
+///
+/// Panics if clp-s's piped stderr is unexpectedly absent (should be unreachable).
+fn run_clp_s_search(
+    clp_s_bin: &Path,
+    args: Vec<OsString>,
+    credential_env: &[(&'static str, String)],
+) -> anyhow::Result<()> {
+    let mut child = Command::new(clp_s_bin)
+        .args(args)
+        .envs(credential_env.iter().cloned())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to spawn clp-s at {}", clp_s_bin.display()))?;
+
+    let mut stderr = child
+        .stderr
+        .take()
+        .expect("piped stderr should always be present");
+
+    let mut captured_stderr = String::new();
+    if let Err(e) = stderr.read_to_string(&mut captured_stderr) {
+        captured_stderr = format!("failed to read clp-s stderr: {e}");
+    }
+
+    let status = child
+        .wait()
+        .context("failed to wait for clp-s to exit")
+        .inspect_err(|e| {
+            tracing::error!(
+                error = % e,
+                stderr = % captured_stderr,
+                "Failed to wait clp-s."
+            );
+        })?;
+    if !status.success() {
+        tracing::error!(
+            status = status.code(),
+            stderr = % captured_stderr,
+            "clp-s exited on failure."
+        );
+        anyhow::bail!("clp-s exited with {status}: {captured_stderr}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::num::NonZeroU32;
+    use std::path::Path;
+    use std::path::PathBuf;
+
+    use clp_rust_utils::clp_config::AwsAuthentication;
+    use clp_rust_utils::clp_config::AwsCredentials;
+    use clp_rust_utils::clp_config::S3Config;
+    use clp_rust_utils::clp_config::package::config::ArchiveOutput;
+    use clp_rust_utils::clp_config::package::config::ArchiveOutputStorage;
+    use clp_rust_utils::clp_config::package::config::Package;
+    use clp_rust_utils::clp_config::package::config::SpiderTaskExecutorConfig;
+    use clp_rust_utils::clp_config::package::config::StorageEngine;
+    use clp_rust_utils::task_io::query::ClpSQueryOption;
+    use clp_rust_utils::task_io::query::OutputHandle;
+    use clp_rust_utils::types::non_empty_string::ExpectedNonEmpty;
+    use non_empty_string::NonEmptyString;
+    use spider_core::types::id::JobId;
+    use spider_core::types::id::ResourceGroupId;
+    use spider_core::types::id::TaskId;
+    use spider_tdl::TaskContext;
+
+    use super::ArchiveSelector;
+    use super::build_clp_s_search_args;
+    use super::resolve_archive_input;
+    use super::search;
+
+    /// # Returns
+    ///
+    /// A query option with no timestamp bounds, no result limit, and case-sensitive matching.
+    fn unbounded_query_option() -> ClpSQueryOption {
+        ClpSQueryOption {
+            query_string: "level: \"ERROR\"".to_string(),
+            max_num_results: None,
+            begin_timestamp: None,
+            end_timestamp: None,
+            ignore_case: false,
+        }
+    }
+
+    /// # Returns
+    ///
+    /// The AWS credentials the S3-backed test configs authenticate with.
+    fn test_aws_authentication() -> AwsAuthentication {
+        AwsAuthentication::Credentials {
+            credentials: AwsCredentials {
+                access_key_id: "the-access-key".to_string(),
+                secret_access_key: "the-secret-key".to_string(),
+                session_token: None,
+            },
+        }
+    }
+
+    /// # Returns
+    ///
+    /// An [`ArchiveSelector`] addressing `archive-id` under `/archives/ds1`.
+    fn directory_selector() -> ArchiveSelector {
+        ArchiveSelector::Directory {
+            path: PathBuf::from("/archives/ds1"),
+            archive_id: "archive-id".to_string(),
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A [`SpiderTaskExecutorConfig`] whose archive output is S3-backed with the given staging
+    /// directory and endpoint URL.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the static S3 config strings is empty.
+    fn s3_backed_config(
+        staging_directory: &str,
+        endpoint_url: Option<&'static str>,
+    ) -> SpiderTaskExecutorConfig {
+        SpiderTaskExecutorConfig {
+            package: Package {
+                storage_engine: StorageEngine::ClpS,
+            },
+            archive_output: ArchiveOutput {
+                storage: ArchiveOutputStorage::S3 {
+                    staging_directory: staging_directory.to_owned(),
+                    s3_config: S3Config {
+                        bucket: NonEmptyString::from_static_str("bucket"),
+                        region_code: None,
+                        key_prefix: NonEmptyString::from_static_str("LIB1/"),
+                        endpoint_url: endpoint_url.map(NonEmptyString::from_static_str),
+                        aws_authentication: test_aws_authentication(),
+                    },
+                },
+                ..ArchiveOutput::default()
+            },
+            ..SpiderTaskExecutorConfig::default()
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A [`TaskContext`] for a non-commit task.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`TaskContext::new`] returns an error.
+    fn task_context() -> TaskContext {
+        TaskContext::new(
+            JobId::random(),
+            TaskId::Index(0),
+            1,
+            ResourceGroupId::random(),
+            None,
+        )
+        .expect("a non-commit task context without graph outputs is valid")
+    }
+
+    #[test]
+    fn build_clp_s_search_args_fs_with_timestamps_and_ignore_case() {
+        let clp_s_query_option = ClpSQueryOption {
+            query_string: "level: \"ERROR\"".to_string(),
+            max_num_results: Some(NonZeroU32::new(7).expect("7 is nonzero")),
+            begin_timestamp: Some(1_310_138_944_000),
+            end_timestamp: Some(1_311_208_074_120),
+            ignore_case: true,
+        };
+
+        assert_eq!(
+            build_clp_s_search_args(
+                &directory_selector(),
+                &clp_s_query_option,
+                "mongodb://results-cache:27017/clp-query-results",
+                "42",
+                "ds1",
+            ),
+            vec![
+                OsString::from("s"),
+                OsString::from("/archives/ds1"),
+                OsString::from("--archive-id"),
+                OsString::from("archive-id"),
+                OsString::from("level: \"ERROR\""),
+                OsString::from("--tge"),
+                OsString::from("1310138944000"),
+                OsString::from("--tle"),
+                OsString::from("1311208074120"),
+                OsString::from("--ignore-case"),
+                OsString::from("results-cache"),
+                OsString::from("--uri"),
+                OsString::from("mongodb://results-cache:27017/clp-query-results"),
+                OsString::from("--collection"),
+                OsString::from("42"),
+                OsString::from("--max-num-results"),
+                OsString::from("7"),
+                OsString::from("--dataset"),
+                OsString::from("ds1"),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_clp_s_search_args_fs_without_timestamps_or_ignore_case() {
+        assert_eq!(
+            build_clp_s_search_args(
+                &directory_selector(),
+                &unbounded_query_option(),
+                "mongodb://results-cache:27017/clp-query-results",
+                "42",
+                "default",
+            ),
+            vec![
+                OsString::from("s"),
+                OsString::from("/archives/ds1"),
+                OsString::from("--archive-id"),
+                OsString::from("archive-id"),
+                OsString::from("level: \"ERROR\""),
+                OsString::from("results-cache"),
+                OsString::from("--uri"),
+                OsString::from("mongodb://results-cache:27017/clp-query-results"),
+                OsString::from("--collection"),
+                OsString::from("42"),
+                OsString::from("--max-num-results"),
+                OsString::from("4294967295"),
+                OsString::from("--dataset"),
+                OsString::from("default"),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_clp_s_search_args_s3_uses_object_url_and_no_archive_id() {
+        assert_eq!(
+            build_clp_s_search_args(
+                &ArchiveSelector::ObjectUrl(
+                    "https://bucket.s3.amazonaws.com/LIB1/ds1/archive-id".to_string()
+                ),
+                &unbounded_query_option(),
+                "mongodb://results-cache:27017/clp-query-results",
+                "42",
+                "ds1",
+            ),
+            vec![
+                OsString::from("s"),
+                OsString::from("https://bucket.s3.amazonaws.com/LIB1/ds1/archive-id"),
+                OsString::from("--auth"),
+                OsString::from("s3"),
+                OsString::from("level: \"ERROR\""),
+                OsString::from("results-cache"),
+                OsString::from("--uri"),
+                OsString::from("mongodb://results-cache:27017/clp-query-results"),
+                OsString::from("--collection"),
+                OsString::from("42"),
+                OsString::from("--max-num-results"),
+                OsString::from("4294967295"),
+                OsString::from("--dataset"),
+                OsString::from("ds1"),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_clp_s_search_args_never_passes_batch_size() {
+        let args = build_clp_s_search_args(
+            &directory_selector(),
+            &unbounded_query_option(),
+            "mongodb://results-cache:27017/clp-query-results",
+            "42",
+            "ds1",
+        );
+
+        assert!(!args.contains(&OsString::from("--batch-size")));
+    }
+
+    #[test]
+    fn resolve_archive_input_fs_joins_dataset_and_returns_no_credentials() -> anyhow::Result<()> {
+        let runtime = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
+        let config = SpiderTaskExecutorConfig {
+            package: Package {
+                storage_engine: StorageEngine::ClpS,
+            },
+            archive_output: ArchiveOutput {
+                storage: ArchiveOutputStorage::Fs {
+                    directory: "var/data/archives".to_owned(),
+                },
+                ..ArchiveOutput::default()
+            },
+            ..SpiderTaskExecutorConfig::default()
+        };
+
+        let (selector, credential_env) = resolve_archive_input(
+            runtime.handle(),
+            Path::new("/clp"),
+            &config,
+            "ds1",
+            "archive-id".to_string(),
+        )?;
+
+        let ArchiveSelector::Directory { path, archive_id } = selector else {
+            panic!("expected a directory selector");
+        };
+        assert_eq!(path, PathBuf::from("/clp/var/data/archives/ds1"));
+        assert_eq!(archive_id, "archive-id");
+        assert_eq!(credential_env, &[]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_archive_input_s3_builds_object_url_and_credentials() -> anyhow::Result<()> {
+        let runtime = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
+        let config = s3_backed_config("var/data/staged-archives", None);
+
+        let (selector, credential_env) = resolve_archive_input(
+            runtime.handle(),
+            Path::new("/clp"),
+            &config,
+            "ds1",
+            "archive-id".to_string(),
+        )?;
+
+        let ArchiveSelector::ObjectUrl(url) = selector else {
+            panic!("expected an object-URL selector");
+        };
+        assert_eq!(url, "https://bucket.s3.amazonaws.com/LIB1/ds1/archive-id");
+        assert_eq!(
+            credential_env,
+            vec![
+                ("AWS_ACCESS_KEY_ID", "the-access-key".to_string()),
+                ("AWS_SECRET_ACCESS_KEY", "the-secret-key".to_string()),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_archive_input_s3_ignores_staging_directory() -> anyhow::Result<()> {
+        const STAGING_DIRECTORY: &str = "/wrong-staging-directory";
+
+        let runtime = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
+        let config = s3_backed_config(STAGING_DIRECTORY, None);
+
+        let (selector, _) = resolve_archive_input(
+            runtime.handle(),
+            Path::new("/clp"),
+            &config,
+            "ds1",
+            "archive-id".to_string(),
+        )?;
+        let args = build_clp_s_search_args(
+            &selector,
+            &unbounded_query_option(),
+            "mongodb://results-cache:27017/clp-query-results",
+            "42",
+            "ds1",
+        );
+
+        assert!(
+            !args
+                .iter()
+                .any(|arg| arg.to_string_lossy().contains(STAGING_DIRECTORY))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_archive_input_s3_custom_endpoint_uses_path_style_url() -> anyhow::Result<()> {
+        let runtime = tokio::runtime::Runtime::new().expect("failed to create Tokio runtime");
+        let config = s3_backed_config("var/data/staged-archives", Some("http://minio:9000"));
+
+        let (selector, _) = resolve_archive_input(
+            runtime.handle(),
+            Path::new("/clp"),
+            &config,
+            "ds1",
+            "archive-id".to_string(),
+        )?;
+
+        let ArchiveSelector::ObjectUrl(url) = selector else {
+            panic!("expected an object-URL selector");
+        };
+        assert_eq!(url, "http://minio:9000/bucket/LIB1/ds1/archive-id");
+
+        Ok(())
+    }
+
+    #[test]
+    fn search_rejects_file_output_handle() {
+        let config = SpiderTaskExecutorConfig {
+            package: Package {
+                storage_engine: StorageEngine::ClpS,
+            },
+            ..SpiderTaskExecutorConfig::default()
+        };
+
+        let error = search(
+            &task_context(),
+            &config,
+            42,
+            &unbounded_query_option(),
+            &OutputHandle::File,
+            None,
+            "archive-id".to_string(),
+        )
+        .expect_err("the file output handler is unsupported");
+
+        assert!(error.to_string().contains("results_cache"));
+    }
+
+    #[test]
+    fn search_rejects_non_clp_s_storage_engine() {
+        let config = SpiderTaskExecutorConfig::default();
+        assert_eq!(config.package.storage_engine, StorageEngine::Clp);
+
+        let error = search(
+            &task_context(),
+            &config,
+            42,
+            &unbounded_query_option(),
+            &OutputHandle::ResultsCache {
+                uri: NonEmptyString::from_static_str(
+                    "mongodb://results-cache:27017/clp-query-results",
+                ),
+            },
+            None,
+            "archive-id".to_string(),
+        )
+        .expect_err("the clp storage engine is unsupported");
+
+        assert!(error.to_string().contains("clp-s"));
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

`clp-tdl-package` (#2404) and `compression-coordinator` (#2401) joined the Rust workspace after `clp-rust-checks`'s `monitored_paths` was last updated, so neither was ever listed. This PR fixes the issue by adding the two missing paths.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a query task for searching individual CLP-S archives and writing matching log events to the results cache.
  - Supports query text, time-range filters, case-insensitive matching, maximum result limits, local archives, and S3-stored archives.
  - Added support for configurable archive storage locations and AWS credential handling.

- **Documentation**
  - Added usage documentation for the new CLP-S query task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->