### PR TITLE
feat(clp-s)!: Deduplicate cached search results using compound MongoDB IDs.

### DIFF
--- a/components/clp-mcp-server/clp_mcp_server/clp_connector.py
+++ b/components/clp-mcp-server/clp_mcp_server/clp_connector.py
@@ -160,8 +160,7 @@ class ClpConnector:
         collection = self._results_cache[str(query_id)]
         results = []
 
-        async for raw_doc in collection.find({}, limit=SEARCH_MAX_NUM_RESULTS):
-            doc = dict(raw_doc)
+        async for doc in collection.find({}, limit=SEARCH_MAX_NUM_RESULTS):
             result_id = doc["_id"]
             doc["archive_id"] = result_id["archive_id"]
             doc["log_event_idx"] = result_id["log_event_idx"]

--- a/components/clp-mcp-server/clp_mcp_server/clp_connector.py
+++ b/components/clp-mcp-server/clp_mcp_server/clp_connector.py
@@ -160,12 +160,16 @@ class ClpConnector:
         collection = self._results_cache[str(query_id)]
         results = []
 
-        async for doc in collection.find({}, limit=SEARCH_MAX_NUM_RESULTS):
+        async for raw_doc in collection.find({}, limit=SEARCH_MAX_NUM_RESULTS):
+            doc = dict(raw_doc)
+            result_id = doc["_id"]
+            doc["archive_id"] = result_id["archive_id"]
+            doc["log_event_idx"] = result_id["log_event_idx"]
             doc["link"] = (
                 f"{self._webui_addr}/streamFile?type=json"
                 f"&streamId={doc['archive_id']}"
                 f"&dataset={CLP_DEFAULT_DATASET_NAME}"
-                f"&logEventIdx={doc['log_event_ix']}"
+                f"&logEventIdx={doc['log_event_idx']}"
             )
             doc["_id"] = None
             results.append(doc)

--- a/components/clp-mcp-server/clp_mcp_server/clp_connector.py
+++ b/components/clp-mcp-server/clp_mcp_server/clp_connector.py
@@ -163,11 +163,8 @@ class ClpConnector:
         async for raw_doc in collection.find({}, limit=SEARCH_MAX_NUM_RESULTS):
             doc = dict(raw_doc)
             result_id = doc["_id"]
-            if isinstance(result_id, dict):
-                doc["archive_id"] = result_id["archive_id"]
-                doc["log_event_idx"] = result_id["log_event_idx"]
-            else:
-                doc["log_event_idx"] = doc.pop("log_event_ix")
+            doc["archive_id"] = result_id["archive_id"]
+            doc["log_event_idx"] = result_id["log_event_idx"]
             doc["link"] = (
                 f"{self._webui_addr}/streamFile?type=json"
                 f"&streamId={doc['archive_id']}"

--- a/components/clp-mcp-server/clp_mcp_server/clp_connector.py
+++ b/components/clp-mcp-server/clp_mcp_server/clp_connector.py
@@ -163,8 +163,11 @@ class ClpConnector:
         async for raw_doc in collection.find({}, limit=SEARCH_MAX_NUM_RESULTS):
             doc = dict(raw_doc)
             result_id = doc["_id"]
-            doc["archive_id"] = result_id["archive_id"]
-            doc["log_event_idx"] = result_id["log_event_idx"]
+            if isinstance(result_id, dict):
+                doc["archive_id"] = result_id["archive_id"]
+                doc["log_event_idx"] = result_id["log_event_idx"]
+            else:
+                doc["log_event_idx"] = doc.pop("log_event_ix")
             doc["link"] = (
                 f"{self._webui_addr}/streamFile?type=json"
                 f"&streamId={doc['archive_id']}"

--- a/components/clp-mcp-server/tests/test_clp_connector.py
+++ b/components/clp-mcp-server/tests/test_clp_connector.py
@@ -125,24 +125,6 @@ async def test_read_results_returns_docs(mock_clp_config: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_read_results_supports_legacy_docs(mock_clp_config: SimpleNamespace) -> None:
-    """Tests reading legacy results with top-level archive and log-event fields."""
-    connector = ClpConnector(mock_clp_config)
-    mock_docs = [
-        {"_id": "1", "archive_id": "archA", "log_event_ix": 1},
-        {"_id": "2", "archive_id": "archB", "log_event_ix": 2},
-    ]
-    mock_collection = AsyncMock()
-    mock_collection.find = MagicMock(return_value=_aiter(mock_docs))
-
-    with patch.object(connector, "_results_cache", {"12": mock_collection}):
-        results = await connector.read_results("12")
-
-    assert [result["archive_id"] for result in results] == ["archA", "archB"]
-    assert [result["log_event_idx"] for result in results] == [1, 2]
-
-
-@pytest.mark.asyncio
 async def test_read_results_adds_link_field(mock_clp_config: Any) -> None:
     """Ensures read_results adds a 'link' field."""
     connector = ClpConnector(mock_clp_config)

--- a/components/clp-mcp-server/tests/test_clp_connector.py
+++ b/components/clp-mcp-server/tests/test_clp_connector.py
@@ -125,7 +125,7 @@ async def test_read_results_returns_docs(mock_clp_config: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_read_results_supports_legacy_docs(mock_clp_config: Any) -> None:
+async def test_read_results_supports_legacy_docs(mock_clp_config: SimpleNamespace) -> None:
     """Tests reading legacy results with top-level archive and log-event fields."""
     connector = ClpConnector(mock_clp_config)
     mock_docs = [

--- a/components/clp-mcp-server/tests/test_clp_connector.py
+++ b/components/clp-mcp-server/tests/test_clp_connector.py
@@ -125,6 +125,24 @@ async def test_read_results_returns_docs(mock_clp_config: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_read_results_supports_legacy_docs(mock_clp_config: Any) -> None:
+    """Tests reading legacy results with top-level archive and log-event fields."""
+    connector = ClpConnector(mock_clp_config)
+    mock_docs = [
+        {"_id": "1", "archive_id": "archA", "log_event_ix": 1},
+        {"_id": "2", "archive_id": "archB", "log_event_ix": 2},
+    ]
+    mock_collection = AsyncMock()
+    mock_collection.find = MagicMock(return_value=_aiter(mock_docs))
+
+    with patch.object(connector, "_results_cache", {"12": mock_collection}):
+        results = await connector.read_results("12")
+
+    assert [result["archive_id"] for result in results] == ["archA", "archB"]
+    assert [result["log_event_idx"] for result in results] == [1, 2]
+
+
+@pytest.mark.asyncio
 async def test_read_results_adds_link_field(mock_clp_config: Any) -> None:
     """Ensures read_results adds a 'link' field."""
     connector = ClpConnector(mock_clp_config)

--- a/components/clp-mcp-server/tests/test_clp_connector.py
+++ b/components/clp-mcp-server/tests/test_clp_connector.py
@@ -111,9 +111,9 @@ async def test_read_results_returns_docs(mock_clp_config: Any) -> None:
     """Tests reading results returns expected documents."""
     connector = ClpConnector(mock_clp_config)
     mock_docs = [
-        {"_id": "1", "archive_id": "archA", "log_event_ix": 1},
-        {"_id": "2", "archive_id": "archB", "log_event_ix": 2},
-        {"_id": "3", "archive_id": "archC", "log_event_ix": 3},
+        {"_id": {"archive_id": "archA", "log_event_idx": 1}},
+        {"_id": {"archive_id": "archB", "log_event_idx": 2}},
+        {"_id": {"archive_id": "archC", "log_event_idx": 3}},
     ]
     mock_collection = AsyncMock()
     mock_collection.find = MagicMock(return_value=_aiter(mock_docs))
@@ -129,8 +129,8 @@ async def test_read_results_adds_link_field(mock_clp_config: Any) -> None:
     """Ensures read_results adds a 'link' field."""
     connector = ClpConnector(mock_clp_config)
     mock_docs = [
-        {"_id": "1", "archive_id": "archA", "log_event_ix": 10},
-        {"_id": "2", "archive_id": "archB", "log_event_ix": 20},
+        {"_id": {"archive_id": "archA", "log_event_idx": 10}},
+        {"_id": {"archive_id": "archB", "log_event_idx": 20}},
     ]
     mock_collection = AsyncMock()
     mock_collection.find = MagicMock(return_value=_aiter(mock_docs))
@@ -142,8 +142,8 @@ async def test_read_results_adds_link_field(mock_clp_config: Any) -> None:
     for original, result in zip(mock_docs, results, strict=True):
         expected_link = (
             f"http://{mock_clp_config.webui.host}:{mock_clp_config.webui.port}"
-            f"/streamFile?type=json&streamId={original['archive_id']}"
-            f"&dataset=default&logEventIdx={original['log_event_ix']}"
+            f"/streamFile?type=json&streamId={original['_id']['archive_id']}"
+            f"&dataset=default&logEventIdx={original['_id']['log_event_idx']}"
         )
         assert result["link"] == expected_link
 

--- a/components/clp-mcp-server/tests/test_clp_connector.py
+++ b/components/clp-mcp-server/tests/test_clp_connector.py
@@ -142,8 +142,8 @@ async def test_read_results_adds_link_field(mock_clp_config: Any) -> None:
     for original, result in zip(mock_docs, results, strict=True):
         expected_link = (
             f"http://{mock_clp_config.webui.host}:{mock_clp_config.webui.port}"
-            f"/streamFile?type=json&streamId={original['_id']['archive_id']}"
-            f"&dataset=default&logEventIdx={original['_id']['log_event_idx']}"
+            f"/streamFile?type=json&streamId={original['archive_id']}"
+            f"&dataset=default&logEventIdx={original['log_event_idx']}"
         )
         assert result["link"] == expected_link
 

--- a/components/core/src/clp/clo/CMakeLists.txt
+++ b/components/core/src/clp/clo/CMakeLists.txt
@@ -166,8 +166,14 @@ set(
         ../../reducer/types.hpp
 )
 
+set(
+        CLP_S_MONGODB_UTILS_SOURCES
+        ../../clp_s/MongoDBUtils.cpp
+        ../../clp_s/MongoDBUtils.hpp
+)
+
 if(CLP_BUILD_EXECUTABLES)
-        add_executable(clo ${CLO_SOURCES} ${REDUCER_SOURCES})
+        add_executable(clo ${CLO_SOURCES} ${CLP_S_MONGODB_UTILS_SOURCES} ${REDUCER_SOURCES})
         target_compile_features(clo PRIVATE cxx_std_20)
         target_include_directories(clo
                 PRIVATE

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -5,7 +5,6 @@
 #include <string_view>
 
 #include <mongocxx/exception/bulk_write_exception.hpp>
-#include <mongocxx/options/insert.hpp>
 #include <msgpack.hpp>
 #include <spdlog/spdlog.h>
 
@@ -55,6 +54,7 @@ ResultsCacheOutputHandler::ResultsCacheOutputHandler(
 )
         : m_batch_size(batch_size),
           m_max_num_results(max_num_results) {
+    m_insert_options.ordered(false);
     try {
         auto mongo_uri = mongocxx::uri(uri);
         m_client = mongocxx::client(mongo_uri);
@@ -161,9 +161,7 @@ ErrorCode ResultsCacheOutputHandler::flush() {
 
 auto ResultsCacheOutputHandler::insert_results() -> bool {
     try {
-        mongocxx::options::insert options;
-        options.ordered(false);
-        m_collection.insert_many(m_results, options);
+        m_collection.insert_many(m_results, m_insert_options);
     } catch (mongocxx::bulk_write_exception const& exception) {
         if (false == clp_s::contains_only_duplicate_key_write_errors(exception)) {
             SPDLOG_ERROR("Failed to insert search results - {}", exception.what());

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -4,8 +4,12 @@
 #include <string>
 #include <string_view>
 
+#include <mongocxx/exception/bulk_write_exception.hpp>
+#include <mongocxx/options/insert.hpp>
 #include <msgpack.hpp>
 #include <spdlog/spdlog.h>
+
+#include <clp_s/MongoDBUtils.hpp>
 
 #include "../../reducer/CountOperator.hpp"
 #include "../../reducer/network_utils.hpp"
@@ -106,16 +110,23 @@ ErrorCode ResultsCacheOutputHandler::flush() {
                     std::move(
                             bsoncxx::builder::basic::make_document(
                                     bsoncxx::builder::basic::kvp(
-                                            cResultsCacheKeys::SearchOutput::OrigFileId,
-                                            std::move(result.orig_file_id)
+                                            cResultsCacheKeys::SearchOutput::Id,
+                                            bsoncxx::builder::basic::make_document(
+                                                    bsoncxx::builder::basic::kvp(
+                                                            cResultsCacheKeys::SearchOutput::
+                                                                    OrigFileId,
+                                                            result.orig_file_id
+                                                    ),
+                                                    bsoncxx::builder::basic::kvp(
+                                                            cResultsCacheKeys::SearchOutput::
+                                                                    LogEventIdx,
+                                                            result.log_event_ix
+                                                    )
+                                            )
                                     ),
                                     bsoncxx::builder::basic::kvp(
                                             cResultsCacheKeys::SearchOutput::OrigFilePath,
                                             std::move(result.orig_file_path)
-                                    ),
-                                    bsoncxx::builder::basic::kvp(
-                                            cResultsCacheKeys::SearchOutput::LogEventIx,
-                                            result.log_event_ix
                                     ),
                                     bsoncxx::builder::basic::kvp(
                                             cResultsCacheKeys::SearchOutput::Timestamp,
@@ -128,27 +139,42 @@ ErrorCode ResultsCacheOutputHandler::flush() {
                             )
                     )
             );
-            count++;
-
-            if (count == m_batch_size) {
-                m_collection.insert_many(m_results);
-                m_results.clear();
-                count = 0;
-            }
         } catch (mongocxx::exception const& e) {
+            SPDLOG_ERROR("Failed to build search result - {}", e.what());
             return ErrorCode::ErrorCode_Failure_DB_Bulk_Write;
+        }
+
+        count++;
+        if (count == m_batch_size) {
+            if (false == insert_results()) {
+                return ErrorCode::ErrorCode_Failure_DB_Bulk_Write;
+            }
+            count = 0;
         }
     }
 
-    try {
-        if (false == m_results.empty()) {
-            m_collection.insert_many(m_results);
-            m_results.clear();
-        }
-    } catch (mongocxx::exception const& e) {
+    if (false == m_results.empty() && false == insert_results()) {
         return ErrorCode::ErrorCode_Failure_DB_Bulk_Write;
     }
     return ErrorCode::ErrorCode_Success;
+}
+
+auto ResultsCacheOutputHandler::insert_results() -> bool {
+    try {
+        mongocxx::options::insert options;
+        options.ordered(false);
+        m_collection.insert_many(m_results, options);
+    } catch (mongocxx::bulk_write_exception const& exception) {
+        if (false == clp_s::contains_only_duplicate_key_write_errors(exception)) {
+            SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
+            return false;
+        }
+    } catch (mongocxx::exception const& exception) {
+        SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
+        return false;
+    }
+    m_results.clear();
+    return true;
 }
 
 CountOutputHandler::CountOutputHandler(int reducer_socket_fd)

--- a/components/core/src/clp/clo/OutputHandler.cpp
+++ b/components/core/src/clp/clo/OutputHandler.cpp
@@ -163,7 +163,7 @@ auto ResultsCacheOutputHandler::insert_results() -> bool {
     try {
         m_collection.insert_many(m_results, m_insert_options);
     } catch (mongocxx::bulk_write_exception const& exception) {
-        if (false == clp_s::contains_only_duplicate_key_write_errors(exception)) {
+        if (false == clp_s::contains_only_duplicate_key_write_errors(exception, m_results.size())) {
             SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
             return false;
         }

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -10,6 +10,7 @@
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/exception.hpp>
+#include <mongocxx/options/insert.hpp>
 #include <mongocxx/uri.hpp>
 
 #include "../../reducer/Pipeline.hpp"
@@ -217,6 +218,7 @@ private:
 
     mongocxx::client m_client;
     mongocxx::collection m_collection;
+    mongocxx::options::insert m_insert_options;
     std::vector<bsoncxx::document::value> m_results;
     uint64_t m_batch_size;
     uint64_t m_max_num_results;

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -211,7 +211,7 @@ private:
     /**
      * Inserts the pending results as an unordered batch. Duplicate-key errors are treated as
      * success so that retries converge on the complete result set.
-     * @return true on success or duplicate-key-only errors, false otherwise.
+     * @return Whether insertion succeeded or produced only duplicate-key errors.
      */
     [[nodiscard]] auto insert_results() -> bool;
 

--- a/components/core/src/clp/clo/OutputHandler.hpp
+++ b/components/core/src/clp/clo/OutputHandler.hpp
@@ -208,6 +208,13 @@ private:
         return m_latest_results.size() >= m_max_num_results;
     }
 
+    /**
+     * Inserts the pending results as an unordered batch. Duplicate-key errors are treated as
+     * success so that retries converge on the complete result set.
+     * @return true on success or duplicate-key-only errors, false otherwise.
+     */
+    [[nodiscard]] auto insert_results() -> bool;
+
     mongocxx::client m_client;
     mongocxx::collection m_collection;
     std::vector<bsoncxx::document::value> m_results;

--- a/components/core/src/clp/clo/constants.hpp
+++ b/components/core/src/clp/clo/constants.hpp
@@ -12,9 +12,10 @@ constexpr char IsLastChunk[]{"is_last_chunk"};
 }  // namespace IrOutput
 
 namespace SearchOutput {
+constexpr char Id[]{"_id"};
 constexpr char OrigFileId[]{"orig_file_id"};
 constexpr char OrigFilePath[]{"orig_file_path"};
-constexpr char LogEventIx[]{"log_event_ix"};
+constexpr char LogEventIdx[]{"log_event_idx"};
 constexpr char Timestamp[]{"timestamp"};
 constexpr char Message[]{"message"};
 }  // namespace SearchOutput

--- a/components/core/src/clp_s/CMakeLists.txt
+++ b/components/core/src/clp_s/CMakeLists.txt
@@ -492,6 +492,8 @@ set(
         ErrorCode.hpp
         kv_ir_search.cpp
         kv_ir_search.hpp
+        MongoDBUtils.cpp
+        MongoDBUtils.hpp
         OutputHandlerImpl.cpp
         OutputHandlerImpl.hpp
         ResultsCacheUtils.cpp

--- a/components/core/src/clp_s/MongoDBUtils.cpp
+++ b/components/core/src/clp_s/MongoDBUtils.cpp
@@ -1,6 +1,5 @@
 #include "MongoDBUtils.hpp"
 
-#include <algorithm>
 #include <cstdint>
 
 #include <bsoncxx/types.hpp>
@@ -79,8 +78,10 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
 }
 }  // namespace
 
-auto contains_only_duplicate_key_write_errors(mongocxx::bulk_write_exception const& exception)
-        -> bool {
+auto contains_only_duplicate_key_write_errors(
+        mongocxx::bulk_write_exception const& exception,
+        size_t num_documents
+) -> bool {
     auto const& raw_server_error = exception.raw_server_error();
     if (false == raw_server_error.has_value()) {
         return false;
@@ -102,6 +103,26 @@ auto contains_only_duplicate_key_write_errors(mongocxx::bulk_write_exception con
     if (write_errors.empty()) {
         return false;
     }
-    return std::all_of(write_errors.begin(), write_errors.end(), is_duplicate_key_write_error);
+
+    size_t num_write_errors{0};
+    for (auto const& write_error : write_errors) {
+        if (false == is_duplicate_key_write_error(write_error)) {
+            return false;
+        }
+        ++num_write_errors;
+    }
+
+    auto const num_inserted_element = reply["nInserted"];
+    if (false == static_cast<bool>(num_inserted_element)
+        || bsoncxx::type::k_int32 != num_inserted_element.type())
+    {
+        return false;
+    }
+    auto const num_inserted = num_inserted_element.get_int32().value;
+    if (num_inserted < 0) {
+        return false;
+    }
+
+    return static_cast<size_t>(num_inserted) + num_write_errors == num_documents;
 }
 }  // namespace clp_s

--- a/components/core/src/clp_s/MongoDBUtils.cpp
+++ b/components/core/src/clp_s/MongoDBUtils.cpp
@@ -1,0 +1,106 @@
+#include "MongoDBUtils.hpp"
+
+#include <algorithm>
+
+#include <bsoncxx/types.hpp>
+#include <mongocxx/exception/bulk_write_exception.hpp>
+
+namespace clp_s {
+namespace {
+constexpr int32_t cDuplicateKeyErrorCode{11'000};
+
+/**
+ * Checks whether an aggregated bulk-write reply contains any command errors.
+ * @param reply The raw MongoDB bulk-write reply.
+ * @return true if the reply contains a command error, false otherwise.
+ */
+[[nodiscard]] auto has_command_errors(bsoncxx::document::view const& reply) -> bool;
+
+/**
+ * Checks whether a bulk-write reply contains any write-concern errors.
+ * @param reply The raw MongoDB bulk-write reply.
+ * @return true if the reply contains a write-concern error, false otherwise.
+ */
+[[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool;
+
+/**
+ * Checks whether an entry from a bulk-write reply's `writeErrors` array is a duplicate-key error.
+ * @param write_error The write-error entry to inspect.
+ * @return true if the entry has MongoDB's duplicate-key error code, false otherwise.
+ */
+[[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error) -> bool;
+
+[[nodiscard]] auto has_command_errors(bsoncxx::document::view const& reply) -> bool {
+    auto const errors_element = reply["errorReplies"];
+    if (false == static_cast<bool>(errors_element)) {
+        return false;
+    }
+    if (bsoncxx::type::k_array != errors_element.type()) {
+        return true;
+    }
+    auto const errors = errors_element.get_array().value;
+    return errors.begin() != errors.end();
+}
+
+[[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool {
+    if (static_cast<bool>(reply["writeConcernError"])) {
+        return true;
+    }
+
+    auto const errors_element = reply["writeConcernErrors"];
+    if (false == static_cast<bool>(errors_element)) {
+        return false;
+    }
+    if (bsoncxx::type::k_array != errors_element.type()) {
+        return true;
+    }
+    auto const errors = errors_element.get_array().value;
+    return errors.begin() != errors.end();
+}
+
+[[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error)
+        -> bool {
+    if (bsoncxx::type::k_document != write_error.type()) {
+        return false;
+    }
+
+    auto const code = write_error.get_document().value["code"];
+    if (false == static_cast<bool>(code)) {
+        return false;
+    }
+    if (bsoncxx::type::k_int32 == code.type()) {
+        return cDuplicateKeyErrorCode == code.get_int32().value;
+    }
+    if (bsoncxx::type::k_int64 == code.type()) {
+        return cDuplicateKeyErrorCode == code.get_int64().value;
+    }
+    return false;
+}
+}  // namespace
+
+auto contains_only_duplicate_key_write_errors(mongocxx::bulk_write_exception const& exception)
+        -> bool {
+    auto const& raw_server_error = exception.raw_server_error();
+    if (false == raw_server_error.has_value()) {
+        return false;
+    }
+
+    auto const reply = raw_server_error->view();
+    if (has_command_errors(reply) || has_write_concern_errors(reply)) {
+        return false;
+    }
+
+    auto const write_errors_element = reply["writeErrors"];
+    if (false == static_cast<bool>(write_errors_element)
+        || bsoncxx::type::k_array != write_errors_element.type())
+    {
+        return false;
+    }
+
+    auto const write_errors = write_errors_element.get_array().value;
+    if (write_errors.begin() == write_errors.end()) {
+        return false;
+    }
+    return std::all_of(write_errors.begin(), write_errors.end(), is_duplicate_key_write_error);
+}
+}  // namespace clp_s

--- a/components/core/src/clp_s/MongoDBUtils.cpp
+++ b/components/core/src/clp_s/MongoDBUtils.cpp
@@ -39,7 +39,7 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
         return true;
     }
     auto const errors = errors_element.get_array().value;
-    return errors.begin() != errors.end();
+    return false == errors.empty();
 }
 
 [[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool {
@@ -55,7 +55,7 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
         return true;
     }
     auto const errors = errors_element.get_array().value;
-    return errors.begin() != errors.end();
+    return false == errors.empty();
 }
 
 [[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error)
@@ -98,7 +98,7 @@ auto contains_only_duplicate_key_write_errors(mongocxx::bulk_write_exception con
     }
 
     auto const write_errors = write_errors_element.get_array().value;
-    if (write_errors.begin() == write_errors.end()) {
+    if (write_errors.empty()) {
         return false;
     }
     return std::all_of(write_errors.begin(), write_errors.end(), is_duplicate_key_write_error);

--- a/components/core/src/clp_s/MongoDBUtils.cpp
+++ b/components/core/src/clp_s/MongoDBUtils.cpp
@@ -1,6 +1,7 @@
 #include "MongoDBUtils.hpp"
 
 #include <algorithm>
+#include <cstdint>
 
 #include <bsoncxx/types.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>

--- a/components/core/src/clp_s/MongoDBUtils.cpp
+++ b/components/core/src/clp_s/MongoDBUtils.cpp
@@ -12,21 +12,21 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
 /**
  * Checks whether an aggregated bulk-write reply contains any command errors.
  * @param reply The raw MongoDB bulk-write reply.
- * @return true if the reply contains a command error, false otherwise.
+ * @return Whether the reply contains a command error.
  */
 [[nodiscard]] auto has_command_errors(bsoncxx::document::view const& reply) -> bool;
 
 /**
  * Checks whether a bulk-write reply contains any write-concern errors.
  * @param reply The raw MongoDB bulk-write reply.
- * @return true if the reply contains a write-concern error, false otherwise.
+ * @return Whether the reply contains a write-concern error.
  */
 [[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool;
 
 /**
  * Checks whether an entry from a bulk-write reply's `writeErrors` array is a duplicate-key error.
  * @param write_error The write-error entry to inspect.
- * @return true if the entry has MongoDB's duplicate-key error code, false otherwise.
+ * @return Whether the entry has MongoDB's duplicate-key error code.
  */
 [[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error) -> bool;
 

--- a/components/core/src/clp_s/MongoDBUtils.hpp
+++ b/components/core/src/clp_s/MongoDBUtils.hpp
@@ -1,6 +1,8 @@
 #ifndef CLP_S_MONGODBUTILS_HPP
 #define CLP_S_MONGODBUTILS_HPP
 
+#include <cstddef>
+
 #include <mongocxx/exception/bulk_write_exception.hpp>
 
 namespace clp_s {
@@ -8,13 +10,16 @@ namespace clp_s {
  * Returns whether the bulk write failed only because some documents already exist.
  *
  * Command and write-concern errors are rejected since they mean MongoDB did not confirm the outcome
- * of the entire batch. At least one write error must be present, and every write error must be a
- * duplicate-key error.
+ * of the entire batch. The number of inserted documents and write errors must account for every
+ * submitted document, and every write error must be a duplicate-key error.
  * @param exception The exception containing the raw MongoDB bulk-write reply.
- * @return Whether the reply contains only duplicate-key write errors.
+ * @param num_documents The number of documents submitted in the bulk write.
+ * @return Whether the reply accounts for every document using successful inserts and duplicate-key
+ * errors only.
  */
 [[nodiscard]] auto contains_only_duplicate_key_write_errors(
-        mongocxx::bulk_write_exception const& exception
+        mongocxx::bulk_write_exception const& exception,
+        size_t num_documents
 ) -> bool;
 }  // namespace clp_s
 

--- a/components/core/src/clp_s/MongoDBUtils.hpp
+++ b/components/core/src/clp_s/MongoDBUtils.hpp
@@ -11,7 +11,7 @@ namespace clp_s {
  * outcome of the entire batch. At least one write error must be present, and every write error
  * must be a duplicate-key error.
  * @param exception The exception containing the raw MongoDB bulk-write reply.
- * @return true if the reply contains only duplicate-key write errors, false otherwise.
+ * @return Whether the reply contains only duplicate-key write errors.
  */
 [[nodiscard]] auto contains_only_duplicate_key_write_errors(
         mongocxx::bulk_write_exception const& exception

--- a/components/core/src/clp_s/MongoDBUtils.hpp
+++ b/components/core/src/clp_s/MongoDBUtils.hpp
@@ -1,0 +1,21 @@
+#ifndef CLP_S_MONGODBUTILS_HPP
+#define CLP_S_MONGODBUTILS_HPP
+
+#include <mongocxx/exception/bulk_write_exception.hpp>
+
+namespace clp_s {
+/**
+ * Returns whether the bulk write failed only because some documents already exist.
+ *
+ * Command and write-concern errors are rejected since they mean MongoDB did not confirm the
+ * outcome of the entire batch. At least one write error must be present, and every write error
+ * must be a duplicate-key error.
+ * @param exception The exception containing the raw MongoDB bulk-write reply.
+ * @return true if the reply contains only duplicate-key write errors, false otherwise.
+ */
+[[nodiscard]] auto contains_only_duplicate_key_write_errors(
+        mongocxx::bulk_write_exception const& exception
+) -> bool;
+}  // namespace clp_s
+
+#endif  // CLP_S_MONGODBUTILS_HPP

--- a/components/core/src/clp_s/MongoDBUtils.hpp
+++ b/components/core/src/clp_s/MongoDBUtils.hpp
@@ -7,9 +7,9 @@ namespace clp_s {
 /**
  * Returns whether the bulk write failed only because some documents already exist.
  *
- * Command and write-concern errors are rejected since they mean MongoDB did not confirm the
- * outcome of the entire batch. At least one write error must be present, and every write error
- * must be a duplicate-key error.
+ * Command and write-concern errors are rejected since they mean MongoDB did not confirm the outcome
+ * of the entire batch. At least one write error must be present, and every write error must be a
+ * duplicate-key error.
  * @param exception The exception containing the raw MongoDB bulk-write reply.
  * @return Whether the reply contains only duplicate-key write errors.
  */

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -153,7 +153,7 @@ ErrorCode ResultsCacheOutputHandler::finish() {
                                                     ),
                                                     bsoncxx::builder::basic::kvp(
                                                             constants::results_cache::search::
-                                                                    cLogEventIx,
+                                                                    cLogEventIdx,
                                                             result.log_event_idx
                                                     )
                                             )
@@ -169,14 +169,6 @@ ErrorCode ResultsCacheOutputHandler::finish() {
                                     bsoncxx::builder::basic::kvp(
                                             constants::results_cache::search::cTimestamp,
                                             result.timestamp
-                                    ),
-                                    bsoncxx::builder::basic::kvp(
-                                            constants::results_cache::search::cArchiveId,
-                                            std::move(result.archive_id)
-                                    ),
-                                    bsoncxx::builder::basic::kvp(
-                                            constants::results_cache::search::cLogEventIx,
-                                            result.log_event_idx
                                     ),
                                     bsoncxx::builder::basic::kvp(
                                             std::string{constants::results_cache::search::cDataset},

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -105,7 +105,7 @@ ErrorCode ResultsCacheOutputHandler::finish() {
                                                     bsoncxx::builder::basic::kvp(
                                                             constants::results_cache::search::
                                                                     cArchiveId,
-                                                            result.archive_id
+                                                            std::move(result.archive_id)
                                                     ),
                                                     bsoncxx::builder::basic::kvp(
                                                             constants::results_cache::search::

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -47,7 +47,7 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
 
     auto const command_status = reply["ok"];
     if (false == static_cast<bool>(command_status)) {
-        return true;
+        return false;
     }
     if (bsoncxx::type::k_double == command_status.type()) {
         return 1.0 == command_status.get_double().value;

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -1,6 +1,5 @@
 #include "OutputHandlerImpl.hpp"
 
-#include <algorithm>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -8,7 +7,6 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
-#include <bsoncxx/types.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
 #include <mongocxx/exception/bulk_write_exception.hpp>
@@ -18,6 +16,7 @@
 #include <msgpack.hpp>
 #include <spdlog/spdlog.h>
 
+#include <clp_s/MongoDBUtils.hpp>
 #include <clp_s/ResultsCacheUtils.hpp>
 
 #include "../clp/networking/socket_utils.hpp"
@@ -32,122 +31,6 @@ using std::string;
 using std::string_view;
 
 namespace clp_s {
-namespace {
-constexpr int32_t cDuplicateKeyErrorCode{11'000};
-
-/**
- * Checks whether an aggregated bulk-write reply contains any command errors.
- * @param reply The raw MongoDB bulk-write reply.
- * @return true if the reply contains a command error, false otherwise.
- */
-[[nodiscard]] auto has_command_errors(bsoncxx::document::view const& reply) -> bool;
-
-/**
- * Checks whether a bulk-write reply contains any write-concern errors.
- * @param reply The raw MongoDB bulk-write reply.
- * @return true if the reply contains a write-concern error, false otherwise.
- */
-[[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool;
-
-/**
- * Checks whether an entry from a bulk-write reply's `writeErrors` array is a duplicate-key error.
- * @param write_error The write-error entry to inspect.
- * @return true if the entry has MongoDB's duplicate-key error code, false otherwise.
- */
-[[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error) -> bool;
-
-/**
- * Returns whether the bulk write failed only because some documents already exist.
- *
- * The C++ driver exposes per-write failures through `raw_server_error()`. In this aggregated reply,
- * command errors are stored in `errorReplies`, write-concern errors in `writeConcernErrors`, and
- * individual write failures in `writeErrors`.
- *
- * Command and write-concern errors are rejected since they mean MongoDB did not confirm the
- * outcome of the entire batch. At least one write error must be present, and every write error
- * must be a duplicate-key error.
- * @param exception The exception containing the raw MongoDB bulk-write reply.
- * @return true if the reply contains only duplicate-key write errors, false otherwise.
- */
-[[nodiscard]] auto contains_only_duplicate_key_write_errors(
-        mongocxx::bulk_write_exception const& exception
-) -> bool;
-
-[[nodiscard]] auto has_command_errors(bsoncxx::document::view const& reply) -> bool {
-    auto const errors_element = reply["errorReplies"];
-    if (false == static_cast<bool>(errors_element)) {
-        return false;
-    }
-    if (bsoncxx::type::k_array != errors_element.type()) {
-        return true;
-    }
-    auto const errors = errors_element.get_array().value;
-    return errors.begin() != errors.end();
-}
-
-[[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool {
-    if (static_cast<bool>(reply["writeConcernError"])) {
-        return true;
-    }
-
-    auto const errors_element = reply["writeConcernErrors"];
-    if (false == static_cast<bool>(errors_element)) {
-        return false;
-    }
-    if (bsoncxx::type::k_array != errors_element.type()) {
-        return true;
-    }
-    auto const errors = errors_element.get_array().value;
-    return errors.begin() != errors.end();
-}
-
-[[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error)
-        -> bool {
-    if (bsoncxx::type::k_document != write_error.type()) {
-        return false;
-    }
-
-    auto const code = write_error.get_document().value["code"];
-    if (false == static_cast<bool>(code)) {
-        return false;
-    }
-    if (bsoncxx::type::k_int32 == code.type()) {
-        return cDuplicateKeyErrorCode == code.get_int32().value;
-    }
-    if (bsoncxx::type::k_int64 == code.type()) {
-        return cDuplicateKeyErrorCode == code.get_int64().value;
-    }
-    return false;
-}
-
-[[nodiscard]] auto contains_only_duplicate_key_write_errors(
-        mongocxx::bulk_write_exception const& exception
-) -> bool {
-    auto const& raw_server_error = exception.raw_server_error();
-    if (false == raw_server_error.has_value()) {
-        return false;
-    }
-
-    auto const reply = raw_server_error->view();
-    if (has_command_errors(reply) || has_write_concern_errors(reply)) {
-        return false;
-    }
-
-    auto const write_errors_element = reply["writeErrors"];
-    if (false == static_cast<bool>(write_errors_element)
-        || bsoncxx::type::k_array != write_errors_element.type())
-    {
-        return false;
-    }
-
-    auto const write_errors = write_errors_element.get_array().value;
-    if (write_errors.begin() == write_errors.end()) {
-        return false;
-    }
-    return std::all_of(write_errors.begin(), write_errors.end(), is_duplicate_key_write_error);
-}
-}  // namespace
-
 void FileOutputHandler::write(
         string_view message,
         epochtime_t timestamp,

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -40,6 +40,35 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
  * @param reply The raw MongoDB bulk-write reply.
  * @return true if the reply contains no command error, false otherwise.
  */
+[[nodiscard]] auto is_successful_command_reply(bsoncxx::document::view const& reply) -> bool;
+
+/**
+ * Checks whether a bulk-write reply contains any write-concern errors.
+ * @param reply The raw MongoDB bulk-write reply.
+ * @return true if the reply contains a write-concern error, false otherwise.
+ */
+[[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool;
+
+/**
+ * Checks whether an entry from a bulk-write reply's `writeErrors` array is a duplicate-key error.
+ * @param write_error The write-error entry to inspect.
+ * @return true if the entry has MongoDB's duplicate-key error code, false otherwise.
+ */
+[[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error) -> bool;
+
+/**
+ * Returns whether the bulk write failed only because some documents already exist.
+ *
+ * Command and write-concern errors are rejected since they mean MongoDB did not confirm the
+ * outcome of the entire batch. At least one write error must be present, and every write error
+ * must be a duplicate-key error.
+ * @param exception The exception containing the raw MongoDB bulk-write reply.
+ * @return true if the reply contains only duplicate-key write errors, false otherwise.
+ */
+[[nodiscard]] auto contains_only_duplicate_key_write_errors(
+        mongocxx::bulk_write_exception const& exception
+) -> bool;
+
 [[nodiscard]] auto is_successful_command_reply(bsoncxx::document::view const& reply) -> bool {
     if (static_cast<bool>(reply["code"]) || static_cast<bool>(reply["errmsg"])) {
         return false;
@@ -61,11 +90,6 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
     return false;
 }
 
-/**
- * Checks whether a bulk-write reply contains any write-concern errors.
- * @param reply The raw MongoDB bulk-write reply.
- * @return true if the reply contains a write-concern error, false otherwise.
- */
 [[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool {
     if (static_cast<bool>(reply["writeConcernError"])) {
         return true;
@@ -82,11 +106,6 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
     return errors.begin() != errors.end();
 }
 
-/**
- * Checks whether an entry from a bulk-write reply's `writeErrors` array is a duplicate-key error.
- * @param write_error The write-error entry to inspect.
- * @return true if the entry has MongoDB's duplicate-key error code, false otherwise.
- */
 [[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error)
         -> bool {
     if (bsoncxx::type::k_document != write_error.type()) {
@@ -106,15 +125,6 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
     return false;
 }
 
-/**
- * Returns whether the bulk write failed only because some documents already exist.
- *
- * Command and write-concern errors are rejected since they mean MongoDB did not confirm the
- * outcome of the entire batch. At least one write error must be present, and every write error
- * must be a duplicate-key error.
- * @param exception The exception containing the raw MongoDB bulk-write reply.
- * @return true if the reply contains only duplicate-key write errors, false otherwise.
- */
 [[nodiscard]] auto contains_only_duplicate_key_write_errors(
         mongocxx::bulk_write_exception const& exception
 ) -> bool {

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -1,5 +1,6 @@
 #include "OutputHandlerImpl.hpp"
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -34,6 +35,86 @@ namespace clp_s {
 namespace {
 constexpr int32_t cDuplicateKeyErrorCode{11'000};
 
+/**
+ * Checks whether a bulk-write reply reports a successful command.
+ * @param reply The raw MongoDB bulk-write reply.
+ * @return true if the reply contains no command error, false otherwise.
+ */
+[[nodiscard]] auto is_successful_command_reply(bsoncxx::document::view const& reply) -> bool {
+    if (static_cast<bool>(reply["code"]) || static_cast<bool>(reply["errmsg"])) {
+        return false;
+    }
+
+    auto const command_status = reply["ok"];
+    if (false == static_cast<bool>(command_status)) {
+        return true;
+    }
+    if (bsoncxx::type::k_double == command_status.type()) {
+        return 1.0 == command_status.get_double().value;
+    }
+    if (bsoncxx::type::k_int32 == command_status.type()) {
+        return 1 == command_status.get_int32().value;
+    }
+    if (bsoncxx::type::k_int64 == command_status.type()) {
+        return 1 == command_status.get_int64().value;
+    }
+    return false;
+}
+
+/**
+ * Checks whether a bulk-write reply contains any write-concern errors.
+ * @param reply The raw MongoDB bulk-write reply.
+ * @return true if the reply contains a write-concern error, false otherwise.
+ */
+[[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool {
+    if (static_cast<bool>(reply["writeConcernError"])) {
+        return true;
+    }
+
+    auto const errors_element = reply["writeConcernErrors"];
+    if (false == static_cast<bool>(errors_element)) {
+        return false;
+    }
+    if (bsoncxx::type::k_array != errors_element.type()) {
+        return true;
+    }
+    auto const errors = errors_element.get_array().value;
+    return errors.begin() != errors.end();
+}
+
+/**
+ * Checks whether an entry from a bulk-write reply's `writeErrors` array is a duplicate-key error.
+ * @param write_error The write-error entry to inspect.
+ * @return true if the entry has MongoDB's duplicate-key error code, false otherwise.
+ */
+[[nodiscard]] auto is_duplicate_key_write_error(bsoncxx::array::element const& write_error)
+        -> bool {
+    if (bsoncxx::type::k_document != write_error.type()) {
+        return false;
+    }
+
+    auto const code = write_error.get_document().value["code"];
+    if (false == static_cast<bool>(code)) {
+        return false;
+    }
+    if (bsoncxx::type::k_int32 == code.type()) {
+        return cDuplicateKeyErrorCode == code.get_int32().value;
+    }
+    if (bsoncxx::type::k_int64 == code.type()) {
+        return cDuplicateKeyErrorCode == code.get_int64().value;
+    }
+    return false;
+}
+
+/**
+ * Returns whether the bulk write failed only because some documents already exist.
+ *
+ * Command and write-concern errors are rejected since they mean MongoDB did not confirm the
+ * outcome of the entire batch. At least one write error must be present, and every write error
+ * must be a duplicate-key error.
+ * @param exception The exception containing the raw MongoDB bulk-write reply.
+ * @return true if the reply contains only duplicate-key write errors, false otherwise.
+ */
 [[nodiscard]] auto contains_only_duplicate_key_write_errors(
         mongocxx::bulk_write_exception const& exception
 ) -> bool {
@@ -42,36 +123,23 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
         return false;
     }
 
-    auto const write_errors_element = raw_server_error->view()["writeErrors"];
+    auto const reply = raw_server_error->view();
+    if (false == is_successful_command_reply(reply) || has_write_concern_errors(reply)) {
+        return false;
+    }
+
+    auto const write_errors_element = reply["writeErrors"];
     if (false == static_cast<bool>(write_errors_element)
         || bsoncxx::type::k_array != write_errors_element.type())
     {
         return false;
     }
 
-    bool found_write_error{false};
-    for (auto const& write_error_element : write_errors_element.get_array().value) {
-        if (bsoncxx::type::k_document != write_error_element.type()) {
-            return false;
-        }
-        auto const code_element = write_error_element.get_document().value["code"];
-        if (false == static_cast<bool>(code_element)) {
-            return false;
-        }
-        if (bsoncxx::type::k_int32 == code_element.type()) {
-            if (cDuplicateKeyErrorCode != code_element.get_int32().value) {
-                return false;
-            }
-        } else if (bsoncxx::type::k_int64 == code_element.type()) {
-            if (cDuplicateKeyErrorCode != code_element.get_int64().value) {
-                return false;
-            }
-        } else {
-            return false;
-        }
-        found_write_error = true;
+    auto const write_errors = write_errors_element.get_array().value;
+    if (write_errors.begin() == write_errors.end()) {
+        return false;
     }
-    return found_write_error;
+    return std::all_of(write_errors.begin(), write_errors.end(), is_duplicate_key_write_error);
 }
 }  // namespace
 
@@ -204,24 +272,6 @@ ErrorCode ResultsCacheOutputHandler::finish() {
     return ErrorCode::ErrorCodeSuccess;
 }
 
-auto ResultsCacheOutputHandler::insert_results() -> bool {
-    try {
-        mongocxx::options::insert options;
-        options.ordered(false);
-        m_collection.insert_many(m_results, options);
-    } catch (mongocxx::bulk_write_exception const& exception) {
-        if (false == contains_only_duplicate_key_write_errors(exception)) {
-            SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
-            return false;
-        }
-    } catch (mongocxx::exception const& exception) {
-        SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
-        return false;
-    }
-    m_results.clear();
-    return true;
-}
-
 void ResultsCacheOutputHandler::write(
         string_view message,
         epochtime_t timestamp,
@@ -252,6 +302,24 @@ void ResultsCacheOutputHandler::write(
                 )
         );
     }
+}
+
+auto ResultsCacheOutputHandler::insert_results() -> bool {
+    try {
+        mongocxx::options::insert options;
+        options.ordered(false);
+        m_collection.insert_many(m_results, options);
+    } catch (mongocxx::bulk_write_exception const& exception) {
+        if (false == contains_only_duplicate_key_write_errors(exception)) {
+            SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
+            return false;
+        }
+    } catch (mongocxx::exception const& exception) {
+        SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
+        return false;
+    }
+    m_results.clear();
+    return true;
 }
 
 CountReducerOutputHandler::CountReducerOutputHandler(int reducer_socket_fd)

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -189,7 +189,7 @@ auto ResultsCacheOutputHandler::insert_results() -> bool {
     try {
         m_collection.insert_many(m_results, m_insert_options);
     } catch (mongocxx::bulk_write_exception const& exception) {
-        if (false == contains_only_duplicate_key_write_errors(exception)) {
+        if (false == contains_only_duplicate_key_write_errors(exception, m_results.size())) {
             SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
             return false;
         }

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -36,11 +36,11 @@ namespace {
 constexpr int32_t cDuplicateKeyErrorCode{11'000};
 
 /**
- * Checks whether a bulk-write reply reports a successful command.
+ * Checks whether an aggregated bulk-write reply contains any command errors.
  * @param reply The raw MongoDB bulk-write reply.
- * @return true if the reply contains no command error, false otherwise.
+ * @return true if the reply contains a command error, false otherwise.
  */
-[[nodiscard]] auto is_successful_command_reply(bsoncxx::document::view const& reply) -> bool;
+[[nodiscard]] auto has_command_errors(bsoncxx::document::view const& reply) -> bool;
 
 /**
  * Checks whether a bulk-write reply contains any write-concern errors.
@@ -59,6 +59,10 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
 /**
  * Returns whether the bulk write failed only because some documents already exist.
  *
+ * The C++ driver exposes per-write failures through `raw_server_error()`. In this aggregated reply,
+ * command errors are stored in `errorReplies`, write-concern errors in `writeConcernErrors`, and
+ * individual write failures in `writeErrors`.
+ *
  * Command and write-concern errors are rejected since they mean MongoDB did not confirm the
  * outcome of the entire batch. At least one write error must be present, and every write error
  * must be a duplicate-key error.
@@ -69,25 +73,16 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
         mongocxx::bulk_write_exception const& exception
 ) -> bool;
 
-[[nodiscard]] auto is_successful_command_reply(bsoncxx::document::view const& reply) -> bool {
-    if (static_cast<bool>(reply["code"]) || static_cast<bool>(reply["errmsg"])) {
+[[nodiscard]] auto has_command_errors(bsoncxx::document::view const& reply) -> bool {
+    auto const errors_element = reply["errorReplies"];
+    if (false == static_cast<bool>(errors_element)) {
         return false;
     }
-
-    auto const command_status = reply["ok"];
-    if (false == static_cast<bool>(command_status)) {
-        return false;
+    if (bsoncxx::type::k_array != errors_element.type()) {
+        return true;
     }
-    if (bsoncxx::type::k_double == command_status.type()) {
-        return 1.0 == command_status.get_double().value;
-    }
-    if (bsoncxx::type::k_int32 == command_status.type()) {
-        return 1 == command_status.get_int32().value;
-    }
-    if (bsoncxx::type::k_int64 == command_status.type()) {
-        return 1 == command_status.get_int64().value;
-    }
-    return false;
+    auto const errors = errors_element.get_array().value;
+    return errors.begin() != errors.end();
 }
 
 [[nodiscard]] auto has_write_concern_errors(bsoncxx::document::view const& reply) -> bool {
@@ -134,7 +129,7 @@ constexpr int32_t cDuplicateKeyErrorCode{11'000};
     }
 
     auto const reply = raw_server_error->view();
-    if (false == is_successful_command_reply(reply) || has_write_concern_errors(reply)) {
+    if (has_command_errors(reply) || has_write_concern_errors(reply)) {
         return false;
     }
 

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -245,28 +245,21 @@ ErrorCode ResultsCacheOutputHandler::finish() {
                             )
                     )
             );
-            count++;
-
-            if (count == m_batch_size) {
-                if (false == insert_results()) {
-                    return ErrorCode::ErrorCodeFailureDbBulkWrite;
-                }
-                count = 0;
-            }
         } catch (mongocxx::exception const& e) {
-            SPDLOG_ERROR("Failed to build or insert search results - {}", e.what());
+            SPDLOG_ERROR("Failed to build search result - {}", e.what());
             return ErrorCode::ErrorCodeFailureDbBulkWrite;
         }
-    }
 
-    try {
-        if (false == m_results.empty()) {
+        count++;
+        if (count == m_batch_size) {
             if (false == insert_results()) {
                 return ErrorCode::ErrorCodeFailureDbBulkWrite;
             }
+            count = 0;
         }
-    } catch (mongocxx::exception const& e) {
-        SPDLOG_ERROR("Failed to insert final search-results batch - {}", e.what());
+    }
+
+    if (false == m_results.empty() && false == insert_results()) {
         return ErrorCode::ErrorCodeFailureDbBulkWrite;
     }
     return ErrorCode::ErrorCodeSuccess;

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -12,7 +12,6 @@
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
-#include <mongocxx/options/insert.hpp>
 #include <msgpack.hpp>
 #include <spdlog/spdlog.h>
 
@@ -86,6 +85,7 @@ ResultsCacheOutputHandler::ResultsCacheOutputHandler(
           m_max_num_results{max_num_results},
           m_dataset{dataset} {
     m_collection = connect_to_results_cache(uri, collection, m_client);
+    m_insert_options.ordered(false);
     m_results.reserve(m_batch_size);
 }
 
@@ -187,9 +187,7 @@ void ResultsCacheOutputHandler::write(
 
 auto ResultsCacheOutputHandler::insert_results() -> bool {
     try {
-        mongocxx::options::insert options;
-        options.ordered(false);
-        m_collection.insert_many(m_results, options);
+        m_collection.insert_many(m_results, m_insert_options);
     } catch (mongocxx::bulk_write_exception const& exception) {
         if (false == contains_only_duplicate_key_write_errors(exception)) {
             SPDLOG_ERROR("Failed to insert search results - {}", exception.what());

--- a/components/core/src/clp_s/OutputHandlerImpl.cpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.cpp
@@ -7,10 +7,13 @@
 
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/types.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
+#include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
+#include <mongocxx/options/insert.hpp>
 #include <msgpack.hpp>
 #include <spdlog/spdlog.h>
 
@@ -28,6 +31,50 @@ using std::string;
 using std::string_view;
 
 namespace clp_s {
+namespace {
+constexpr int32_t cDuplicateKeyErrorCode{11'000};
+
+[[nodiscard]] auto contains_only_duplicate_key_write_errors(
+        mongocxx::bulk_write_exception const& exception
+) -> bool {
+    auto const& raw_server_error = exception.raw_server_error();
+    if (false == raw_server_error.has_value()) {
+        return false;
+    }
+
+    auto const write_errors_element = raw_server_error->view()["writeErrors"];
+    if (false == static_cast<bool>(write_errors_element)
+        || bsoncxx::type::k_array != write_errors_element.type())
+    {
+        return false;
+    }
+
+    bool found_write_error{false};
+    for (auto const& write_error_element : write_errors_element.get_array().value) {
+        if (bsoncxx::type::k_document != write_error_element.type()) {
+            return false;
+        }
+        auto const code_element = write_error_element.get_document().value["code"];
+        if (false == static_cast<bool>(code_element)) {
+            return false;
+        }
+        if (bsoncxx::type::k_int32 == code_element.type()) {
+            if (cDuplicateKeyErrorCode != code_element.get_int32().value) {
+                return false;
+            }
+        } else if (bsoncxx::type::k_int64 == code_element.type()) {
+            if (cDuplicateKeyErrorCode != code_element.get_int64().value) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+        found_write_error = true;
+    }
+    return found_write_error;
+}
+}  // namespace
+
 void FileOutputHandler::write(
         string_view message,
         epochtime_t timestamp,
@@ -97,6 +144,21 @@ ErrorCode ResultsCacheOutputHandler::finish() {
                     std::move(
                             bsoncxx::builder::basic::make_document(
                                     bsoncxx::builder::basic::kvp(
+                                            constants::results_cache::search::cId,
+                                            bsoncxx::builder::basic::make_document(
+                                                    bsoncxx::builder::basic::kvp(
+                                                            constants::results_cache::search::
+                                                                    cArchiveId,
+                                                            result.archive_id
+                                                    ),
+                                                    bsoncxx::builder::basic::kvp(
+                                                            constants::results_cache::search::
+                                                                    cLogEventIx,
+                                                            result.log_event_idx
+                                                    )
+                                            )
+                                    ),
+                                    bsoncxx::builder::basic::kvp(
                                             constants::results_cache::search::cOrigFilePath,
                                             std::move(result.original_path)
                                     ),
@@ -126,24 +188,46 @@ ErrorCode ResultsCacheOutputHandler::finish() {
             count++;
 
             if (count == m_batch_size) {
-                m_collection.insert_many(m_results);
-                m_results.clear();
+                if (false == insert_results()) {
+                    return ErrorCode::ErrorCodeFailureDbBulkWrite;
+                }
                 count = 0;
             }
         } catch (mongocxx::exception const& e) {
+            SPDLOG_ERROR("Failed to build or insert search results - {}", e.what());
             return ErrorCode::ErrorCodeFailureDbBulkWrite;
         }
     }
 
     try {
         if (false == m_results.empty()) {
-            m_collection.insert_many(m_results);
-            m_results.clear();
+            if (false == insert_results()) {
+                return ErrorCode::ErrorCodeFailureDbBulkWrite;
+            }
         }
     } catch (mongocxx::exception const& e) {
+        SPDLOG_ERROR("Failed to insert final search-results batch - {}", e.what());
         return ErrorCode::ErrorCodeFailureDbBulkWrite;
     }
     return ErrorCode::ErrorCodeSuccess;
+}
+
+auto ResultsCacheOutputHandler::insert_results() -> bool {
+    try {
+        mongocxx::options::insert options;
+        options.ordered(false);
+        m_collection.insert_many(m_results, options);
+    } catch (mongocxx::bulk_write_exception const& exception) {
+        if (false == contains_only_duplicate_key_write_errors(exception)) {
+            SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
+            return false;
+        }
+    } catch (mongocxx::exception const& exception) {
+        SPDLOG_ERROR("Failed to insert search results - {}", exception.what());
+        return false;
+    }
+    m_results.clear();
+    return true;
 }
 
 void ResultsCacheOutputHandler::write(

--- a/components/core/src/clp_s/OutputHandlerImpl.hpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.hpp
@@ -203,7 +203,7 @@ private:
     /**
      * Inserts the pending results as an unordered batch. Duplicate-key errors are treated as
      * success so that retries converge on the complete result set.
-     * @return true on success or duplicate-key-only errors, false otherwise.
+     * @return Whether insertion succeeded or produced only duplicate-key errors.
      */
     [[nodiscard]] auto insert_results() -> bool;
 

--- a/components/core/src/clp_s/OutputHandlerImpl.hpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.hpp
@@ -18,6 +18,7 @@
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
+#include <mongocxx/options/insert.hpp>
 
 #include <clp_s/AggregationSink.hpp>
 #include <clp_s/aggregators.hpp>
@@ -209,6 +210,7 @@ private:
 
     mongocxx::client m_client;
     mongocxx::collection m_collection;
+    mongocxx::options::insert m_insert_options;
     std::vector<bsoncxx::document::value> m_results;
     uint64_t m_batch_size;
     uint64_t m_max_num_results;

--- a/components/core/src/clp_s/OutputHandlerImpl.hpp
+++ b/components/core/src/clp_s/OutputHandlerImpl.hpp
@@ -200,6 +200,13 @@ public:
     void write(std::string_view message) override { write(message, 0, {}, 0); }
 
 private:
+    /**
+     * Inserts the pending results as an unordered batch. Duplicate-key errors are treated as
+     * success so that retries converge on the complete result set.
+     * @return true on success or duplicate-key-only errors, false otherwise.
+     */
+    [[nodiscard]] auto insert_results() -> bool;
+
     mongocxx::client m_client;
     mongocxx::collection m_collection;
     std::vector<bsoncxx::document::value> m_results;

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -53,6 +53,7 @@ constexpr char cIsLastChunk[]{"is_last_chunk"};
 }  // namespace results_cache::decompression
 
 namespace results_cache::search {
+constexpr char cId[]{"_id"};
 constexpr char cOrigFilePath[]{"orig_file_path"};
 constexpr char cLogEventIx[]{"log_event_ix"};
 constexpr char cTimestamp[]{"timestamp"};

--- a/components/core/src/clp_s/archive_constants.hpp
+++ b/components/core/src/clp_s/archive_constants.hpp
@@ -55,7 +55,7 @@ constexpr char cIsLastChunk[]{"is_last_chunk"};
 namespace results_cache::search {
 constexpr char cId[]{"_id"};
 constexpr char cOrigFilePath[]{"orig_file_path"};
-constexpr char cLogEventIx[]{"log_event_ix"};
+constexpr char cLogEventIdx[]{"log_event_idx"};
 constexpr char cTimestamp[]{"timestamp"};
 constexpr char cMessage[]{"message"};
 constexpr char cArchiveId[]{"archive_id"};

--- a/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
@@ -128,7 +128,7 @@ def _collect_and_sweep_expired_search_results(
             deleted_job_ids.append(job_id)
 
     if len(deleted_job_ids) != 0:
-        logger.debug("Deleted search results of job(s): %s.", deleted_job_ids)
+        logger.debug(f"Deleted search results of job(s): {deleted_job_ids}.")
     else:
         logger.debug("No search results matched the expiry criteria.")
 
@@ -139,7 +139,7 @@ async def search_result_garbage_collector(clp_config: ClpConfig) -> None:
 
     sweep_interval_secs = clp_config.garbage_collector.sweep_interval.search_result * MIN_TO_SECONDS
 
-    logger.info("%s started.", SEARCH_RESULT_GARBAGE_COLLECTOR_NAME)
+    logger.info(f"{SEARCH_RESULT_GARBAGE_COLLECTOR_NAME} started.")
     try:
         while True:
             _collect_and_sweep_expired_search_results(
@@ -149,5 +149,5 @@ async def search_result_garbage_collector(clp_config: ClpConfig) -> None:
             )
             await asyncio.sleep(sweep_interval_secs)
     except Exception:
-        logger.exception("%s exited with failure.", SEARCH_RESULT_GARBAGE_COLLECTOR_NAME)
+        logger.exception(f"{SEARCH_RESULT_GARBAGE_COLLECTOR_NAME} exited with failure.")
         raise

--- a/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
@@ -32,17 +32,17 @@ def _get_expired_job_ids(
     database_config: Database, job_ids: list[int], retention_period_minutes: int
 ) -> list[int]:
     """
-    Filter query-job IDs by whether their retention periods have ended.
+    Filters query job IDs by whether their retention periods have ended.
 
-    MariaDB computes each query's completion time as `start_time + duration`. A query-job ID is
+    MariaDB computes each query's completion time as `start_time + duration`. A query job ID is
     included when the time since completion is greater than `retention_period_minutes`. For a
     terminated query without a completion time, `creation_time` is used instead.
 
     :param database_config: Configuration for the orchestration database.
-    :param job_ids: Query-job IDs to filter.
+    :param job_ids: Query job IDs to filter.
     :param retention_period_minutes: Length of the retention period following query completion, in
         minutes.
-    :return: Query-job IDs completed more than `retention_period_minutes` ago.
+    :return: Query job IDs completed more than `retention_period_minutes` ago.
     """
     if len(job_ids) == 0:
         return []
@@ -100,9 +100,9 @@ def _collect_and_sweep_expired_search_results(
     results_metadata_collection_name: str,
 ) -> None:
     """
-    Remove search results whose query completion time is older than the retention cutoff.
+    Removes search results whose query completion time is older than the retention cutoff.
 
-    Numeric MongoDB collection names are interpreted as query-job IDs. Collections selected by
+    Numeric MongoDB collection names are interpreted as query job IDs. Collections selected by
     `_get_expired_job_ids` are dropped along with their result metadata documents.
 
     :param result_cache_config: MongoDB result-cache and retention configuration.

--- a/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
@@ -19,6 +19,7 @@ from job_orchestration.garbage_collector.constants import (
     MIN_TO_SECONDS,
     SEARCH_RESULT_GARBAGE_COLLECTOR_NAME,
 )
+from job_orchestration.scheduler.constants import QueryJobStatus
 
 # Constants
 MONGODB_ID_KEY: Final[str] = "_id"
@@ -34,7 +35,8 @@ def _get_expired_job_ids(
     Filter query-job IDs by whether their retention periods have ended.
 
     MariaDB computes each query's completion time as `start_time + duration`. A query-job ID is
-    included when the time since completion is greater than `retention_period_minutes`.
+    included when the time since completion is greater than `retention_period_minutes`. For a
+    terminated query without a completion time, `creation_time` is used instead.
 
     :param database_config: Configuration for the orchestration database.
     :param job_ids: Query-job IDs to filter.
@@ -58,15 +60,27 @@ def _get_expired_job_ids(
                 SELECT id
                 FROM `{QUERY_JOBS_TABLE_NAME}`
                 WHERE id IN ({job_id_placeholders})
-                AND TIMESTAMPADD(
-                    MICROSECOND,
-                    CAST(duration * 1000000 AS SIGNED),
-                    start_time
-                ) < TIMESTAMPADD(MINUTE, %s, CURRENT_TIMESTAMP(3))
+                AND (
+                    TIMESTAMPADD(
+                        MICROSECOND,
+                        CAST(duration * 1000000 AS SIGNED),
+                        start_time
+                    ) < TIMESTAMPADD(MINUTE, %s, CURRENT_TIMESTAMP(3))
+                    OR (
+                        (start_time IS NULL OR duration IS NULL)
+                        AND status IN (
+                            {QueryJobStatus.SUCCEEDED},
+                            {QueryJobStatus.FAILED},
+                            {QueryJobStatus.CANCELLED},
+                            {QueryJobStatus.KILLED}
+                        )
+                        AND creation_time < TIMESTAMPADD(MINUTE, %s, CURRENT_TIMESTAMP(3))
+                    )
+                )
                 """
             db_cursor.execute(
                 query,
-                [*job_ids_batch, -retention_period_minutes],
+                [*job_ids_batch, -retention_period_minutes, -retention_period_minutes],
             )
             rows = cast("list[tuple[int]]", db_cursor.fetchall())
             expired_job_ids.extend(row[0] for row in rows)

--- a/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
@@ -1,33 +1,76 @@
 import asyncio
-from typing import Final
+from contextlib import closing
+from typing import Any, cast, Final
 
 import pymongo
 import pymongo.database
-from bson import ObjectId
-from clp_py_utils.clp_config import ClpConfig, ResultsCache
+from clp_py_utils.clp_config import (
+    ClpConfig,
+    Database,
+    QUERY_JOBS_TABLE_NAME,
+    ResultsCache,
+)
 from clp_py_utils.clp_logging import configure_logging, get_logger
+from clp_py_utils.sql_adapter import SqlAdapter
 
 from job_orchestration.garbage_collector.constants import (
     MIN_TO_SECONDS,
     SEARCH_RESULT_GARBAGE_COLLECTOR_NAME,
 )
-from job_orchestration.garbage_collector.utils import get_expiry_epoch_secs
 
 # Constants
 MONGODB_ID_KEY: Final[str] = "_id"
+MAX_NUM_JOB_IDS_PER_QUERY: Final[int] = 1000
 
 logger = get_logger(SEARCH_RESULT_GARBAGE_COLLECTOR_NAME)
 
 
-def _get_latest_doc_timestamp(collection: pymongo.collection.Collection) -> int:
-    latest_doc = collection.find_one(sort=[(MONGODB_ID_KEY, pymongo.DESCENDING)])
-    if latest_doc is None:
-        return 0
+def _get_expired_job_ids(
+    database_config: Database, job_ids: list[int], retention_period_minutes: int
+) -> list[int]:
+    """
+    Filter query-job IDs by whether their retention periods have ended.
 
-    object_id = latest_doc[MONGODB_ID_KEY]
-    if isinstance(object_id, ObjectId):
-        return int(object_id.generation_time.timestamp())
-    raise ValueError(f"{object_id} is not an ObjectID")
+    MariaDB computes each query's completion time as `creation_time + duration`. A query-job ID is
+    included when the time since completion is greater than `retention_period_minutes`.
+
+    :param database_config: Configuration for the orchestration database.
+    :param job_ids: Query-job IDs to filter.
+    :param retention_period_minutes: Length of the retention period following query completion, in
+        minutes.
+    :return: Query-job IDs completed more than `retention_period_minutes` ago.
+    """
+    if len(job_ids) == 0:
+        return []
+
+    expired_job_ids: list[int] = []
+    sql_adapter = SqlAdapter(database_config)
+    with (
+        closing(sql_adapter.create_connection(True)) as db_conn,
+        closing(db_conn.cursor()) as db_cursor,
+    ):
+        for begin_ix in range(0, len(job_ids), MAX_NUM_JOB_IDS_PER_QUERY):
+            job_ids_batch = job_ids[begin_ix : begin_ix + MAX_NUM_JOB_IDS_PER_QUERY]
+            job_id_placeholders = ",".join(["%s"] * len(job_ids_batch))
+            query = (
+                f"""
+                SELECT id
+                FROM `{QUERY_JOBS_TABLE_NAME}`
+                WHERE id IN ({job_id_placeholders})
+                AND TIMESTAMPADD(
+                    MICROSECOND,
+                    CAST(duration * 1000000 AS SIGNED),
+                    creation_time
+                ) < TIMESTAMPADD(MINUTE, %s, CURRENT_TIMESTAMP(3))
+                """  # noqa: S608
+            )
+            db_cursor.execute(
+                query,
+                [*job_ids_batch, -retention_period_minutes],
+            )
+            rows = cast("list[tuple[int]]", db_cursor.fetchall())
+            expired_job_ids.extend(row[0] for row in rows)
+    return expired_job_ids
 
 
 def _delete_result_metadata(
@@ -38,46 +81,59 @@ def _delete_result_metadata(
 
 
 def _collect_and_sweep_expired_search_results(
-    result_cache_config: ResultsCache, results_metadata_collection_name: str
-):
-    expiry_epoch = get_expiry_epoch_secs(result_cache_config.retention_period)
+    result_cache_config: ResultsCache,
+    database_config: Database,
+    results_metadata_collection_name: str,
+) -> None:
+    """
+    Remove search results whose query completion time is older than the retention cutoff.
 
-    logger.debug(f"Searching for search jobs finished before {expiry_epoch}.")
+    Numeric MongoDB collection names are interpreted as query-job IDs. Collections selected by
+    `_get_expired_job_ids` are dropped along with their result metadata documents.
+
+    :param result_cache_config: MongoDB result-cache and retention configuration.
+    :param database_config: Configuration for the orchestration database.
+    :param results_metadata_collection_name: Name of the result metadata collection.
+    """
+    retention_period = result_cache_config.retention_period
+    if retention_period is None:
+        return
+
     deleted_job_ids: list[int] = []
-    with pymongo.MongoClient(result_cache_config.get_uri()) as results_cache_client:
+    results_cache_client: pymongo.MongoClient[dict[str, Any]] = pymongo.MongoClient(
+        result_cache_config.get_uri()
+    )
+    with results_cache_client:
         results_cache_db = results_cache_client.get_default_database()
-        collection_names = results_cache_db.list_collection_names()
-        for job_id in collection_names:
-            if not job_id.isdigit():
-                continue
-
-            job_results_collection = results_cache_db.get_collection(job_id)
-            collection_timestamp = _get_latest_doc_timestamp(job_results_collection)
-            if collection_timestamp >= expiry_epoch:
-                continue
-
-            _delete_result_metadata(results_cache_db, results_metadata_collection_name, job_id)
-            job_results_collection.drop()
-            deleted_job_ids.append(int(job_id))
+        job_ids = [int(name) for name in results_cache_db.list_collection_names() if name.isdigit()]
+        expired_job_ids = _get_expired_job_ids(database_config, job_ids, retention_period)
+        for job_id in expired_job_ids:
+            job_id_str = str(job_id)
+            _delete_result_metadata(results_cache_db, results_metadata_collection_name, job_id_str)
+            results_cache_db.get_collection(job_id_str).drop()
+            deleted_job_ids.append(job_id)
 
     if len(deleted_job_ids) != 0:
-        logger.debug(f"Deleted search results of job(s): {deleted_job_ids}.")
+        logger.debug("Deleted search results of job(s): %s.", deleted_job_ids)
     else:
         logger.debug("No search results matched the expiry criteria.")
 
 
 async def search_result_garbage_collector(clp_config: ClpConfig) -> None:
+    """Run search-result collection and sweeping at the configured interval."""
     configure_logging(logger, SEARCH_RESULT_GARBAGE_COLLECTOR_NAME)
 
     sweep_interval_secs = clp_config.garbage_collector.sweep_interval.search_result * MIN_TO_SECONDS
 
-    logger.info(f"{SEARCH_RESULT_GARBAGE_COLLECTOR_NAME} started.")
+    logger.info("%s started.", SEARCH_RESULT_GARBAGE_COLLECTOR_NAME)
     try:
         while True:
             _collect_and_sweep_expired_search_results(
-                clp_config.results_cache, clp_config.webui.results_metadata_collection_name
+                clp_config.results_cache,
+                clp_config.database,
+                clp_config.webui.results_metadata_collection_name,
             )
             await asyncio.sleep(sweep_interval_secs)
     except Exception:
-        logger.exception(f"{SEARCH_RESULT_GARBAGE_COLLECTOR_NAME} exited with failure.")
+        logger.exception("%s exited with failure.", SEARCH_RESULT_GARBAGE_COLLECTOR_NAME)
         raise

--- a/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
@@ -49,11 +49,10 @@ def _get_expired_job_ids(
         closing(sql_adapter.create_connection(True)) as db_conn,
         closing(db_conn.cursor()) as db_cursor,
     ):
-        for begin_ix in range(0, len(job_ids), MAX_NUM_JOB_IDS_PER_QUERY):
-            job_ids_batch = job_ids[begin_ix : begin_ix + MAX_NUM_JOB_IDS_PER_QUERY]
+        for begin_idx in range(0, len(job_ids), MAX_NUM_JOB_IDS_PER_QUERY):
+            job_ids_batch = job_ids[begin_idx : begin_idx + MAX_NUM_JOB_IDS_PER_QUERY]
             job_id_placeholders = ",".join(["%s"] * len(job_ids_batch))
-            query = (
-                f"""
+            query = f"""
                 SELECT id
                 FROM `{QUERY_JOBS_TABLE_NAME}`
                 WHERE id IN ({job_id_placeholders})
@@ -62,8 +61,7 @@ def _get_expired_job_ids(
                     CAST(duration * 1000000 AS SIGNED),
                     creation_time
                 ) < TIMESTAMPADD(MINUTE, %s, CURRENT_TIMESTAMP(3))
-                """  # noqa: S608
-            )
+                """
             db_cursor.execute(
                 query,
                 [*job_ids_batch, -retention_period_minutes],

--- a/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/search_result_garbage_collector.py
@@ -1,3 +1,5 @@
+"""Garbage-collect cached search results."""
+
 import asyncio
 from contextlib import closing
 from typing import Any, cast, Final
@@ -31,7 +33,7 @@ def _get_expired_job_ids(
     """
     Filter query-job IDs by whether their retention periods have ended.
 
-    MariaDB computes each query's completion time as `creation_time + duration`. A query-job ID is
+    MariaDB computes each query's completion time as `start_time + duration`. A query-job ID is
     included when the time since completion is greater than `retention_period_minutes`.
 
     :param database_config: Configuration for the orchestration database.
@@ -59,7 +61,7 @@ def _get_expired_job_ids(
                 AND TIMESTAMPADD(
                     MICROSECOND,
                     CAST(duration * 1000000 AS SIGNED),
-                    creation_time
+                    start_time
                 ) < TIMESTAMPADD(MINUTE, %s, CURRENT_TIMESTAMP(3))
                 """
             db_cursor.execute(

--- a/components/job-orchestration/job_orchestration/garbage_collector/utils.py
+++ b/components/job-orchestration/job_orchestration/garbage_collector/utils.py
@@ -1,7 +1,6 @@
 import os
 import pathlib
 import shutil
-import time
 from datetime import datetime, timezone
 
 from bson import ObjectId
@@ -13,8 +12,6 @@ from clp_py_utils.clp_config import (
 )
 from clp_py_utils.s3_utils import s3_delete_objects
 
-from job_orchestration.garbage_collector.constants import MIN_TO_SECONDS
-
 
 def validate_storage_type(output_config: ArchiveOutput, storage_engine: str) -> None:
     storage_type = output_config.storage.type
@@ -25,18 +22,6 @@ def validate_storage_type(output_config: ArchiveOutput, storage_engine: str) -> 
             )
     elif StorageType.FS != storage_type:
         raise ValueError(f"Unsupported Storage type: {storage_type}")
-
-
-def get_expiry_epoch_secs(retention_minutes: int) -> int:
-    """
-    Returns a cutoff `expiry_epoch` based on the current timestamp and `retention_minutes`. Any
-    candidate with a timestamp (`ts`) less than `expiry_epoch` is considered expired.
-    The `expiry_epoch` is calculated as `expiry_epoch = cur_time - retention_secs`.
-
-    :param retention_minutes: Retention period in minutes.
-    :return: The UTC epoch representing the expiry cutoff time.
-    """
-    return int(time.time() - retention_minutes * MIN_TO_SECONDS)
 
 
 def get_oid_with_expiry_time(expiry_epoch_secs: int) -> ObjectId:

--- a/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/typings.tsx
+++ b/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/typings.tsx
@@ -25,7 +25,7 @@ interface SearchResult {
     archive_id: string;
     dataset: string;
     filePath: string;
-    log_event_ix: number;
+    log_event_idx: number;
     message: string;
     orig_file_id: string;
     orig_file_path: string;
@@ -90,7 +90,7 @@ const searchResultsTableColumns: NonNullable<TableProps<SearchResult>["columns"]
         render: (_, record) => (
             <Message
                 dataset={record.dataset}
-                logEventIdx={record.log_event_ix}
+                logEventIdx={record.log_event_idx}
                 message={record.message}
                 streamId={getStreamId(record)}
                 fileText={

--- a/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
+++ b/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
@@ -16,15 +16,7 @@ interface ClpSSearchResultId {
     log_event_idx: number;
 }
 
-interface LegacyObjectId {
-    $oid: string;
-}
-
 type RawSearchResult =
-    (Omit<SearchResult, "_id" | "log_event_idx"> & {
-        _id: LegacyObjectId | string;
-        log_event_ix: number;
-    }) |
     (Omit<SearchResult, "_id" | "log_event_idx" | "orig_file_id"> & {
         _id: ClpSearchResultId;
     }) |
@@ -61,16 +53,6 @@ const useSearchResults = () => {
         },
         parse: (data) => {
             const doc = JSON.parse(data) as RawSearchResult;
-
-            if ("log_event_ix" in doc) {
-                return {
-                    ...doc,
-                    _id: "object" === typeof doc._id ?
-                        doc._id.$oid :
-                        doc._id,
-                    log_event_idx: doc.log_event_ix,
-                };
-            }
 
             if ("orig_file_id" in doc._id) {
                 return {

--- a/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
+++ b/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
@@ -6,6 +6,25 @@ import {SEARCH_UI_STATE} from "../../../../SearchState/typings";
 import {SearchResult} from "./typings";
 
 
+interface SearchResultId {
+    archive_id: string;
+    log_event_idx: number;
+}
+
+interface LegacyObjectId {
+    $oid: string;
+}
+
+type RawSearchResult =
+    (Omit<SearchResult, "_id" | "log_event_idx"> & {
+        _id: LegacyObjectId | string;
+        log_event_ix: number;
+    }) |
+    (Omit<SearchResult, "_id" | "archive_id" | "log_event_idx"> & {
+        _id: SearchResultId;
+    });
+
+
 /**
  * Custom hook to stream search results for the current searchJobId from the API server's SSE
  * endpoint. When the stream ends, the search UI state is updated to `DONE` (or `FAILED` if the
@@ -33,15 +52,23 @@ const useSearchResults = () => {
             }
         },
         parse: (data) => {
-            // MongoDB ObjectIds are serialized as `{"$oid": "..."}` in the SSE stream.
-            const doc = JSON.parse(data) as Omit<SearchResult, "_id"> &
-                {_id: string | {$oid: string}};
+            const doc = JSON.parse(data) as RawSearchResult;
+
+            if ("log_event_ix" in doc) {
+                return {
+                    ...doc,
+                    _id: "object" === typeof doc._id ?
+                        doc._id.$oid :
+                        doc._id,
+                    log_event_idx: doc.log_event_ix,
+                };
+            }
 
             return {
                 ...doc,
-                _id: "object" === typeof doc._id ?
-                    doc._id.$oid :
-                    doc._id,
+                archive_id: doc._id.archive_id,
+                _id: JSON.stringify(doc._id),
+                log_event_idx: doc._id.log_event_idx,
             };
         },
         rawDocs: true,

--- a/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
+++ b/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
@@ -6,7 +6,12 @@ import {SEARCH_UI_STATE} from "../../../../SearchState/typings";
 import {SearchResult} from "./typings";
 
 
-interface SearchResultId {
+interface ClpSearchResultId {
+    log_event_idx: number;
+    orig_file_id: string;
+}
+
+interface ClpSSearchResultId {
     archive_id: string;
     log_event_idx: number;
 }
@@ -20,8 +25,11 @@ type RawSearchResult =
         _id: LegacyObjectId | string;
         log_event_ix: number;
     }) |
+    (Omit<SearchResult, "_id" | "log_event_idx" | "orig_file_id"> & {
+        _id: ClpSearchResultId;
+    }) |
     (Omit<SearchResult, "_id" | "archive_id" | "log_event_idx"> & {
-        _id: SearchResultId;
+        _id: ClpSSearchResultId;
     });
 
 
@@ -61,6 +69,15 @@ const useSearchResults = () => {
                         doc._id.$oid :
                         doc._id,
                     log_event_idx: doc.log_event_ix,
+                };
+            }
+
+            if ("orig_file_id" in doc._id) {
+                return {
+                    ...doc,
+                    _id: JSON.stringify(doc._id),
+                    log_event_idx: doc._id.log_event_idx,
+                    orig_file_id: doc._id.orig_file_id,
                 };
             }
 

--- a/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
+++ b/components/webui/packages/client/src/pages/SearchPage/SearchResults/SearchResultsTable/Native/SearchResultsVirtualTable/useSearchResults.ts
@@ -16,11 +16,16 @@ interface ClpSSearchResultId {
     log_event_idx: number;
 }
 
+type SearchResultWithoutId = Omit<
+    SearchResult,
+    "_id" | "archive_id" | "log_event_idx" | "orig_file_id"
+>;
+
 type RawSearchResult =
-    (Omit<SearchResult, "_id" | "log_event_idx" | "orig_file_id"> & {
+    (SearchResultWithoutId & {
         _id: ClpSearchResultId;
     }) |
-    (Omit<SearchResult, "_id" | "archive_id" | "log_event_idx"> & {
+    (SearchResultWithoutId & {
         _id: ClpSSearchResultId;
     });
 
@@ -58,6 +63,7 @@ const useSearchResults = () => {
                 return {
                     ...doc,
                     _id: JSON.stringify(doc._id),
+                    archive_id: "",
                     log_event_idx: doc._id.log_event_idx,
                     orig_file_id: doc._id.orig_file_id,
                 };
@@ -65,9 +71,10 @@ const useSearchResults = () => {
 
             return {
                 ...doc,
-                archive_id: doc._id.archive_id,
                 _id: JSON.stringify(doc._id),
+                archive_id: doc._id.archive_id,
                 log_event_idx: doc._id.log_event_idx,
+                orig_file_id: "",
             };
         },
         rawDocs: true,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR removes duplicated entries in MongoDB by:
- Using `{archive_id, log_event_idx}` as the MongoDB result document `_id` for `clp-s`.
- Using `{origin_file_id, log_event_idx}` as the MongoDB result document `_id` for `clo`.
- Preventing duplicate result documents when searches are retried and treating a query as success if all insertions either succeeds or fails with duplicate key error.
- Removing redundant top-level `archive_id`/`origin_file_id` and `log_event_idx` fields.
- Expiring results based on query completion time, calculated from MariaDB’s existing `start_time` and `duration`. When the `start_time` and `duration` are missing, removed any complete job in terminated state and `creation_timestamp` before expire cutoff.
- Updating WebUI and MCP result parsing for the new `_id` structure. No backward compatibility support is provided. WebUI supports both `clo` and `clp-s` result, while MCP supports only `clp-s` result.

> [!Note]
> This PR is a breaking change because the MongoDB schema changes.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated. 

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [ ] GitHub workflows pass.
* [x] Repeated searches do not insert duplicate MongoDB documents for both `clp-s` and `clp-o`.
* [x] Runs end-to-end compression and search job on `clp-s` to confirm that:
  * Repeated search do not insert duplicate MongDB documents.
  * Result cache is deleted by garbage collection based on `start_time + duration`.
  * WebUI raw-results endpoint streamed expected log events.

I am unable to run end-to-end search with MCP server. After I ran `search_by_kql`, which created a query that was verified to complete successfully, the response was "Please call `get_instructions()` first", which I did before calling `search_by_kql`.

# Performance evaluation

This is reported by @LinZhihao-723. The evaluation confirmed that the compound `_id` costs nothing measurable at any concurrency tested.

Measured 2025-09-03 (commit [3165049](https://github.com/y-scope/clp/pull/2509/commits/31650498ec064355c011ccb255bac709ab5ca683)). Two stock builds replay 128 pre-built archives into a fresh MongoDB collection from a pool of exactly N OS threads: `BASELINE` = merge-base `2a5fbee5`, server-assigned ObjectId, `PR` = the evaluated commit. Query `level: "FATAL"`, `--max-num-results 2500 --batch-size 1000`, 320,000 documents per pass; 1 discarded warmup + 5 measured reps per (arm, N); **no secondary unique index anywhere**; MongoDB 8.0.21 standalone; i9-14900K / 32 threads / 47 GiB / WSL2. All measured cells held exactly 320,000 documents.

## PR versus baseline

| N | BASELINE wall (s) | PR wall (s) | Δ wall | BASELINE e2e mean (s) | PR e2e mean (s) | Δ e2e | per-rep ranges |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 16.3142 | 16.3512 | **+0.2%** | 0.1280 | 0.1278 | −0.2% | overlap |
| 2 | 8.1691 | 8.2075 | **+0.5%** | 0.1286 | 0.1284 | −0.2% | overlap |
| 4 | 4.3009 | 4.2349 | **−1.5%** | 0.1337 | 0.1328 | −0.7% | overlap |
| 8 | 2.4526 | 2.4679 | **+0.6%** | 0.1526 | 0.1532 | +0.4% | overlap |
| 16 | 1.7886 | 1.8101 | **+1.2%** | 0.2181 | 0.2319 | +6.3% | overlap |

The five measured walls per cell overlap in **all five cells**. The largest delta (−1.5% at N=4, in the PR's favour) is smaller than the spread of either arm's own five reps at that N, and the sign is not consistent across N. Scalability curves are identical (BASELINE 1.00/2.00/3.79/6.65/9.12×, PR 1.00/1.99/3.86/6.63/9.03×), with the same knee between N=8 and N=16: the ceiling is the shared MongoDB write path, not an `_id` effect.

## `insert` vs. `upsert`

See https://github.com/y-scope/clp/pull/2509#discussion_r3960936653.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search-result handling across current and legacy result formats.
  * Corrected event-index mapping so result links and displayed messages open the intended log events.
  * Improved reliability when storing duplicate search results during retries.
  * Enhanced error handling and logging for failed result-storage operations.

* **Maintenance**
  * Search-result cleanup now uses job completion times and retention settings to remove expired data more accurately.
  * Standardized search-result identifiers for more consistent display and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->