### PR TITLE
refactor(deployment): Use flow-style YAML for `bundled` lists so that emptying them yields `[]` instead of `null`.

### DIFF
--- a/components/package-template/src/etc/clp-config.template.json.yaml
+++ b/components/package-template/src/etc/clp-config.template.json.yaml
@@ -37,12 +37,13 @@ telemetry:
 #credentials_file_path: "etc/credentials.yaml"
 #
 ## Remove any bundled services below if you wish to use your own.
-#bundled:
-#  - "database"
-#  - "queue"
-#  - "redis"
-#  - "results_cache"
-#  - "otel_collector"
+#bundled: [
+#  "database",
+#  "queue",
+#  "redis",
+#  "results_cache",
+#  "otel_collector",
+#]
 #
 #database:
 #  type: "mariadb"  # "mariadb" or "mysql"

--- a/components/package-template/src/etc/clp-config.template.text.yaml
+++ b/components/package-template/src/etc/clp-config.template.text.yaml
@@ -42,12 +42,13 @@ log_ingestor: null
 #credentials_file_path: "etc/credentials.yaml"
 #
 ## Remove any bundled services below if you wish to use your own.
-#bundled:
-#  - "database"
-#  - "queue"
-#  - "redis"
-#  - "results_cache"
-#  - "otel_collector"
+#bundled: [
+#  "database",
+#  "queue",
+#  "redis",
+#  "results_cache",
+#  "otel_collector",
+#]
 #
 #database:
 #  type: "mariadb"  # "mariadb" or "mysql"

--- a/docs/src/user-docs/guides-docker-compose-deployment.md
+++ b/docs/src/user-docs/guides-docker-compose-deployment.md
@@ -72,12 +72,13 @@ To configure CLP for multi-host deployment, you'll need to:
      project) vs. external.
 
      ```yaml
-     bundled:
+     bundled: [
        # Remove services you want to run on specific hosts or use external instances
-       - database      # Remove if running on a dedicated host or using external MySQL-compatible DB
-       - queue         # Remove if running on a dedicated host or using external RabbitMQ
-       - redis         # Remove if running on a dedicated host or using external Redis
-       - results_cache # Remove if running on a dedicated host or using external MongoDB
+       "database",       # Remove if running on a dedicated host or using external MariaDB/MySQL
+       "queue",          # Remove if running on a dedicated host or using external RabbitMQ
+       "redis",          # Remove if running on a dedicated host or using external Redis
+       "results_cache",  # Remove if running on a dedicated host or using external MongoDB
+     ]
      ```
 
    * For each service, set the `host` and `port` fields to the actual hostname/IP and port where you

--- a/docs/src/user-docs/guides-external-database.md
+++ b/docs/src/user-docs/guides-external-database.md
@@ -207,12 +207,13 @@ mysql -h <mariadb-hostname-or-ip> -u clp-user -p clp-db
 
    ```yaml
    # Remove "database" and "results_cache" from this list to use external instances.
-   bundled:
-     # - "database"
-     - "queue"
-     - "redis"
-     # - "results_cache"
-     - "otel_collector"
+   bundled: [
+     # "database",
+     "queue",
+     "redis",
+     # "results_cache",
+     "otel_collector",
+   ]
    ```
 
 2. Configure the connection details for your external databases in `etc/clp-config.yaml`:
@@ -252,13 +253,14 @@ initialization jobs (`db-table-creator` and `results-cache-indices-creator`).
    ```yaml
    clpConfig:
      # Remove "database" and "results_cache" from this list to use external instances.
-     bundled:
-       # - "database"
-       - "queue"
-       - "redis"
-       # - "results_cache"
-       - "otel_collector"
-       - "presto"
+     bundled: [
+       # "database",
+       "queue",
+       "redis",
+       # "results_cache",
+       "otel_collector",
+       "presto",
+     ]
    ```
 
 2. Configure the connection details for your external databases in the values file:

--- a/tools/deployment/package-helm/Chart.yaml
+++ b/tools/deployment/package-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "clp"
-version: "0.4.1-dev.10"
+version: "0.4.1-dev.11"
 description: "A Helm chart for CLP's (Compressed Log Processor) package deployment"
 type: "application"
 appVersion: "0.13.1-dev"

--- a/tools/deployment/package-helm/values.yaml
+++ b/tools/deployment/package-helm/values.yaml
@@ -153,13 +153,14 @@ clpConfig:
   # List of third-party services bundled (deployed) as part of the chart.
   # Remove a service from this list to use an external instance instead, and configure its host/port
   # accordingly in the service-specific sections below.
-  bundled:
-    - "database"
-    - "queue"
-    - "redis"
-    - "results_cache"
-    - "otel_collector"
-    - "presto"
+  bundled: [
+    "database",
+    "queue",
+    "redis",
+    "results_cache",
+    "otel_collector",
+    "presto",
+  ]
 
   package:
     storage_engine: "clp-s"
@@ -396,8 +397,9 @@ spider:
     # List of third-party services bundled (deployed) as part of the Spider subchart.
     # Remove a service from this list to use an external instance instead, and configure its
     # connection details accordingly in the service-specific sections below.
-    bundled:
-      - "database"
+    bundled: [
+      "database",
+    ]
 
     # Connection config for the Spider database service; defaults to the Spider subchart's
     # `values.yaml`. When "database" is in `bundled`, the host is automatically set to the bundled


### PR DESCRIPTION
# Description

A `bundled` list written in block style becomes `null` when every entry is commented out, e.g.:

```yaml
bundled:
  # - "database"
  # - "queue"
  ...
```

In Helm, this causes silent wrong behaviour:
- Helm treats `null` in an overriding values file as "delete this key", which silently restores the chart's default `bundled` list, which is the opposite of what user intended.

In Docker Compose, this fails the startup by `./sbin/start-clp.sh` because of the validation check in `clp_config.py`, which rejects `null` for the `bundled` list (`Input should be a valid list [type=list_type, input_value=None]`).

The solution to this is to use flow-style YAML, which shows as below:
```yaml
bundled: [
  # "database",
  # "queue",
  ...
]
```
This way, there's no problem as users can just comment the bundled list entries on/off to use external or internal services, without considering this syntax problem.

This PR refactors all references in the CLP repo to use flow-style YAML.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed


## 1. The rendered chart is unchanged

1. Render the chart before and after the change and diff:

   ```bash
   helm template test tools/deployment/package-helm --set spider.enabled=true
   ```

   Expected: output is byte-identical.

## 2. Emptying the list now yields an all-external configuration instead of restoring defaults

1. Render with an overlay whose `bundled` list has every entry commented out:

   ```bash
   helm template test tools/deployment/package-helm -f all-external.yaml | grep -c 'kind: "StatefulSet"'   # -> 0
   ```

   Expected: `0` bundled StatefulSets (on `main`, the equivalent block-style overlay coalesces to `null` and renders all bundled services).

## 3. E2E: default Helm deployment starts with the flow-style values

1. Install with default values and wait for pods:

   ```bash
   helm install test tools/deployment/package-helm
   kubectl get pods
   ```

   Expected: all bundled services deploy and become ready (`database`, `queue`, `redis`, `results-cache`, `otel-collector` pods `Running`); 

## 4. E2E: Docker Compose starts with the flow-style config template

1. Uncomment the template's `bundled: [...]` block in `etc/clp-config.yaml` and start CLP:

   ```bash
   ./sbin/start-clp.sh
   ```

   Expected:

   ```text
   2026-08-31T19:27:13.303 INFO [controller] Started CLP.
   ```

   with all 13 service containers up (`database`, `queue`, `redis`, `results-cache`, etc. `healthy`) 


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples to use concise inline lists for bundled services.
  * Clarified Docker Compose and Kubernetes deployment examples without changing service selections.

* **Chores**
  * Updated the Helm chart version to `0.4.1-dev.11`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
