### PR TITLE
ci: Consolidate calculation of container image build and usage conditions into a single workflow job.

### DIFF
--- a/.github/actions/clp-build-runtime-image/action.yaml
+++ b/.github/actions/clp-build-runtime-image/action.yaml
@@ -2,25 +2,43 @@ name: "clp-build-runtime-image"
 description: "Builds a container image to be used for running CLP."
 
 inputs:
+  # Registry properties
   image_registry:
     default: "ghcr.io"
     description: "Container image registry"
-    required: false
-  image_registry_username:
-    default: "${{github.actor}}"
-    description: "Container image registry username"
     required: false
   image_registry_password:
     default: ""
     description: "Container image registry password"
     required: false
+  image_registry_username:
+    default: "${{github.actor}}"
+    description: "Container image registry username"
+    required: false
+
+  # Image properties
   arch:
     description: "Target architecture (amd64 or arm64)"
     default: "amd64"
     required: false
+  dockerfile_path:
+    description: "Path to the Dockerfile"
+    required: true
+  image_name:
+    description: "Container image name"
+    required: true
   platform_version_codename:
     description: >-
       Platform version codename (e.g. jammy, noble) used as the runtime image base version.
+    required: true
+
+  # Image handling
+  pull:
+    default: "false"
+    description: "Whether to pull the base image"
+    required: false
+  push:
+    description: "Whether to push the built image"
     required: true
 
 runs:
@@ -49,12 +67,8 @@ runs:
       id: "compute-meta"
       shell: "bash"
       run: |
-        base_path="./tools/docker-images"
-        image_name="clp-package"
-        dockerfile_path="$base_path/$image_name/Dockerfile"
-
-        echo "DOCKERFILE=$dockerfile_path" >> "$GITHUB_OUTPUT"
-        echo "IMAGE_NAME=$image_name" >> "$GITHUB_OUTPUT"
+        echo "DOCKERFILE=${{inputs.dockerfile_path}}" >> "$GITHUB_OUTPUT"
+        echo "IMAGE_NAME=${{inputs.image_name}}" >> "$GITHUB_OUTPUT"
 
     - name: "Extract GitHub Metadata"
       id: "extract-gh-meta"
@@ -79,7 +93,6 @@ runs:
         fi
 
     - name: "Build and Push"
-      if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
       uses: "docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4"
       with:
         context: "./"
@@ -88,7 +101,8 @@ runs:
         # Disable provenance to create a simple image instead of a manifest list.
         # This allows `docker manifest create` to combine the per-arch images later.
         provenance: false
-        push: true
+        pull: "${{inputs.pull == 'true'}}"
+        push: "${{inputs.push == 'true'}}"
         tags: "${{steps.extract-gh-meta.outputs.tags}}"
         labels: "${{steps.extract-gh-meta.outputs.labels}}"
         build-args: |

--- a/.github/workflows/clp-artifact-build.yaml
+++ b/.github/workflows/clp-artifact-build.yaml
@@ -1008,7 +1008,10 @@ jobs:
           image_registry_username: "${{github.actor}}"
           image_registry_password: "${{secrets.GITHUB_TOKEN}}"
           arch: "${{matrix.arch}}"
+          dockerfile_path: "./tools/docker-images/clp-package/Dockerfile"
+          image_name: "clp-package"
           platform_version_codename: "jammy"
+          push: "${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}"
 
   package-image-multiarch-manifest:
     name: "package-image-multiarch-manifest"
@@ -1049,17 +1052,34 @@ jobs:
           done
 
   spider-worker-image:
-    name: "spider-worker-image"
-    # Run if the dependency-image job succeeded or was skipped because the image is unchanged.
+    name: "spider-worker-image-${{matrix.arch}}"
     if: >-
       !cancelled() && !failure() && (
-        needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
-        || needs.ubuntu-jammy-x86_64-deps-image.result == 'success'
+        needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false' ||
+        (needs.ubuntu-jammy-x86_64-deps-image.result == 'success'
+        && (needs.ubuntu-jammy-aarch64-deps-image.result == 'success'
+        || needs.ubuntu-jammy-aarch64-deps-image.result == 'skipped'))
       )
     needs:
       - "filter-relevant-changes"
+      - "ubuntu-jammy-aarch64-deps-image"
       - "ubuntu-jammy-x86_64-deps-image"
-    runs-on: *runner
+    strategy:
+      matrix:
+        # Only build arm64 images on push to main to save CI resources on PRs.
+        arch: >-
+          ${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+          && fromJSON('["amd64", "arm64"]') || fromJSON('["amd64"]')}}
+    runs-on: >-
+      ${{
+        matrix.arch == 'amd64'
+        && (github.repository_owner == 'y-scope'
+            && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+            || 'ubuntu-24.04')
+        || (github.repository_owner == 'y-scope'
+            && fromJSON('["self-hosted", "arm64", "ubuntu-noble"]')
+            || 'ubuntu-24.04-arm')
+      }}
     permissions:
       # To check out the repository.
       contents: "read"
@@ -1078,7 +1098,10 @@ jobs:
       - name: "Build the CLP artifacts required for Spider worker"
         uses: "./.github/actions/run-on-image"
         with:
-          image_name: "${{env.DEPS_IMAGE_NAME_PREFIX_X86}}ubuntu-jammy"
+          image_name: >-
+            ${{format('{0}ubuntu-jammy',
+            matrix.arch == 'amd64' && env.DEPS_IMAGE_NAME_PREFIX_X86
+            || env.DEPS_IMAGE_NAME_PREFIX_AARCH64)}}
           use_published_image: >-
             ${{needs.filter-relevant-changes.outputs.ubuntu_jammy_image_changed == 'false'
             || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')}}
@@ -1087,9 +1110,29 @@ jobs:
             HOME=/tmp
             task core clp-tdl-package
 
+      - uses: "./.github/actions/clp-build-runtime-image"
+        with:
+          image_registry: "ghcr.io"
+          image_registry_username: "${{github.actor}}"
+          image_registry_password: "${{secrets.GITHUB_TOKEN}}"
+          arch: "${{matrix.arch}}"
+          dockerfile_path: "./tools/docker-images/clp-spider-worker/Dockerfile"
+          image_name: "clp-spider-worker"
+          platform_version_codename: "jammy"
+          pull: true
+          push: "${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}"
+
+  spider-worker-image-multiarch-manifest:
+    name: "spider-worker-image-multiarch-manifest"
+    if: >-
+      github.event_name != 'pull_request'
+      && github.ref == 'refs/heads/main'
+      && needs.spider-worker-image.result == 'success'
+    needs: "spider-worker-image"
+    runs-on: *runner
+    steps:
       - name: "Login to Image Registry"
         uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121"  # v4.1.0
-        if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
         with:
           registry: "ghcr.io"
           username: "${{github.actor}}"
@@ -1104,21 +1147,17 @@ jobs:
           echo "repository=${lowercase_repo}" >> "$GITHUB_OUTPUT"
         shell: "bash"
 
-      - id: "spider_worker_image_meta"
-        uses: "docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804"  # v5.7.0
-        with:
-          images: >-
-            ghcr.io/${{steps.sanitize_repo_name.outputs.repository}}/clp-spider-worker
-          tags: "type=raw,value=${{github.ref_name}}"
-
-      # Publish on non-PR runs of `main`, including scheduled and manually dispatched runs.
-      # NOTE: Pull requests still build the image to validate the Dockerfile.
-      - uses: "docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4"  # v6.15.0
-        with:
-          context: "."
-          file: "tools/docker-images/clp-spider-worker/Dockerfile"
-          provenance: false
-          pull: true
-          push: "${{github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}"
-          tags: "${{steps.spider_worker_image_meta.outputs.tags}}"
-          labels: "${{steps.spider_worker_image_meta.outputs.labels}}"
+      - name: "Create and Push Multi-arch Manifest"
+        shell: "bash"
+        run: |
+          image_base="ghcr.io/${{steps.sanitize_repo_name.outputs.repository}}/clp-spider-worker"
+          tags=("${{github.ref_name}}")
+          if [ "${{github.event_name}}" = "schedule" ]; then
+            tags+=("nightly")
+          fi
+          for tag in "${tags[@]}"; do
+            docker manifest create "${image_base}:${tag}" \
+              "${image_base}:${tag}-amd64" \
+              "${image_base}:${tag}-arm64"
+            docker manifest push "${image_base}:${tag}"
+          done


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The current set of conditions used for building spread out all over the clp-artifacts-build workflow, making it hard to understand how and why a certain container image will be built.

Similarly, the current set of conditions for determining when a published container image should be used were also spread out.

This PR:

* updates `filter-relevant-changes` job to also compute flags for when a container image should be built and when a published image should be used.
* renames `filter-relevant-changes` to `calc-build-triggers` to reflect its updated purpose.
* removes some redundant comments that are more confusing than reading the code (imo).
* updates the docs.
  * NOTE: The docs are missing details about some jobs like the `spider-worker-image` job. These updates are being made in #2498.

Consolidating the conditions into a single job will be useful in a future PR where we need to publish container images on semver branches, in addition to main.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Validated that all jobs in the clp-build-artifact that should run on PRs ran.
* Merged the PR in my fork and validated that all jobs in clp-build-artifact that should run on main ran.
* Edited a file in CLP's core and validated that the core dependency images weren't rebuilt.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved build automation to determine which platform images and package or worker artifacts should be published or reused.
  - Updated build dependencies, image selection, publishing, and manifest generation based on calculated build triggers.
  - Ensured Ubuntu Jammy aarch64 dependencies are built whenever publishing is enabled, including scheduled and eligible main-branch builds.

- **Documentation**
  - Updated workflow documentation and diagrams to reflect the revised build-trigger process, publishing decisions, and image-selection behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->